### PR TITLE
a11y: name icon-only controls and make the seek bar keyboard-operable

### DIFF
--- a/lib/features/library/widgets/track_tile.dart
+++ b/lib/features/library/widgets/track_tile.dart
@@ -127,10 +127,16 @@ class TrackTile extends ConsumerWidget {
         ),
       ),
       trailing: selectionActive
-          ? Checkbox(
-              value: selected,
-              onChanged:
-                  onSelectToggle == null ? null : (_) => onSelectToggle!(),
+          // The row itself already carries the selected state (and toggles on
+          // tap), so the box is the visual echo of it: a second, unnamed
+          // checkbox node next to every title would only make the list harder
+          // to move through, not clearer.
+          ? ExcludeSemantics(
+              child: Checkbox(
+                value: selected,
+                onChanged:
+                    onSelectToggle == null ? null : (_) => onSelectToggle!(),
+              ),
             )
           : Row(
               mainAxisSize: MainAxisSize.min,
@@ -198,9 +204,13 @@ class _StatusGlyph extends StatelessWidget {
           semanticLabel: 'Downloaded',
         );
       case DownloadStatus.downloading:
-        return SizedBox.square(
-          dimension: 16,
-          child: CircularProgressIndicator(strokeWidth: 2, value: progress),
+        // The other three states name themselves; this one is a bare ring.
+        return Semantics(
+          label: 'Downloading',
+          child: SizedBox.square(
+            dimension: 16,
+            child: CircularProgressIndicator(strokeWidth: 2, value: progress),
+          ),
         );
       case DownloadStatus.queued:
         return Icon(

--- a/lib/features/player/cast/cast_devices_sheet.dart
+++ b/lib/features/player/cast/cast_devices_sheet.dart
@@ -194,22 +194,30 @@ class _Body extends ConsumerWidget {
         if (state.isConnected)
           CastVolumeControls(state: state, service: service),
         for (final device in devices)
-          ListTile(
-            leading: Icon(
-              state.connectedDevice == device
-                  ? Icons.cast_connected
-                  : Icons.cast,
-            ),
-            title: Text(device.name),
-            trailing: state.connectedDevice == device
-                ? TextButton(
-                    onPressed: service.disconnect,
-                    child: const Text('Disconnect'),
-                  )
-                : null,
-            onTap: state.connectedDevice == device
-                ? null
-                : () => service.connect(device),
+          Builder(
+            builder: (BuildContext context) {
+              final bool isConnected = state.connectedDevice == device;
+              return ListTile(
+                // The connected row is deliberately not tappable (there is
+                // nothing to connect to twice). Marking it selected is what
+                // makes that read as "this is the one you're on" rather than
+                // as an inert row, and the glyph says the same thing for
+                // anyone who only hears the leading icon.
+                selected: isConnected,
+                leading: Icon(
+                  isConnected ? Icons.cast_connected : Icons.cast,
+                  semanticLabel: isConnected ? 'Connected' : null,
+                ),
+                title: Text(device.name),
+                trailing: isConnected
+                    ? TextButton(
+                        onPressed: service.disconnect,
+                        child: const Text('Disconnect'),
+                      )
+                    : null,
+                onTap: isConnected ? null : () => service.connect(device),
+              );
+            },
           ),
       ],
     );
@@ -290,6 +298,9 @@ class _CastVolumeControlsState extends State<CastVolumeControls> {
                     : null,
                 color: muteColor,
                 icon: Icon(muted ? Icons.volume_off : Icons.volume_up),
+                // Selected while muted, so mute reads as the toggle it is
+                // rather than as two buttons that swap places.
+                isSelected: muted,
                 tooltip: muted ? 'Unmute' : 'Mute',
               ),
               Expanded(
@@ -297,6 +308,13 @@ class _CastVolumeControlsState extends State<CastVolumeControls> {
                   value: sliderValue,
                   onChanged: supported ? _onChanged : null,
                   onChangeEnd: supported ? _onChangeEnd : null,
+                  // Names the slider for anyone who lands on it directly
+                  // instead of reading the heading above it first. Semantics
+                  // only: the value indicator `label` can also drive is shown
+                  // `onlyForDiscrete`, and this slider is continuous.
+                  label: 'Cast volume',
+                  semanticFormatterCallback: (double value) =>
+                      '${(value * 100).round()}%',
                 ),
               ),
             ],

--- a/lib/features/player/mini_player.dart
+++ b/lib/features/player/mini_player.dart
@@ -77,40 +77,54 @@ class MiniPlayer extends ConsumerWidget {
                   ),
                   child: Row(
                     children: [
-                      SizedBox.square(
-                        dimension: 44,
-                        child: AlbumArtwork(
-                          artworkUri: track.artworkUri,
-                          borderRadius: BorderRadius.circular(AppRadii.sm),
+                      // The cover carries no information the lines beside it
+                      // don't already say, so it stays out of the reading
+                      // order rather than announcing an image before them.
+                      ExcludeSemantics(
+                        child: SizedBox.square(
+                          dimension: 44,
+                          child: AlbumArtwork(
+                            artworkUri: track.artworkUri,
+                            borderRadius: BorderRadius.circular(AppRadii.sm),
+                          ),
                         ),
                       ),
                       const SizedBox(width: AppSpacing.md),
                       Expanded(
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              track.title,
-                              style: theme.textTheme.titleSmall?.copyWith(
-                                fontWeight: FontWeight.w600,
+                        // One node for the whole metadata block, so the bar
+                        // announces "<title>, <artist> • <source>" once
+                        // instead of three fragments in a row. The play/pause
+                        // button stays outside it and keeps its own node.
+                        child: MergeSemantics(
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                track.title,
+                                style: theme.textTheme.titleSmall?.copyWith(
+                                  fontWeight: FontWeight.w600,
+                                ),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
                               ),
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                            if (subtitle != null || sourceName != null)
-                              _MiniSubtitle(
-                                subtitle: subtitle,
-                                sourceName: sourceName,
-                              ),
-                          ],
+                              if (subtitle != null || sourceName != null)
+                                _MiniSubtitle(
+                                  subtitle: subtitle,
+                                  sourceName: sourceName,
+                                ),
+                            ],
+                          ),
                         ),
                       ),
                       if (isCasting) ...[
+                        // Icon-only, and the only thing on the bar that says
+                        // the audio is going somewhere else — so it is named.
                         Icon(
                           Icons.cast_connected,
                           size: 18,
                           color: theme.colorScheme.primary,
+                          semanticLabel: 'Casting',
                         ),
                         const SizedBox(width: AppSpacing.sm),
                       ],
@@ -242,11 +256,16 @@ class _PlayPauseButton extends ConsumerWidget {
     // A spinner for both preparing and mid-stream buffering, so the mini-player
     // shows activity (never looks frozen) while the stream catches up.
     if (state.isBusy) {
-      return const SizedBox.square(
-        dimension: 24,
-        child: Padding(
-          padding: EdgeInsets.all(AppSpacing.xs),
-          child: CircularProgressIndicator(strokeWidth: 2),
+      // The spinner stands where play/pause normally is: without a name it
+      // reads as the transport control having simply vanished.
+      return Semantics(
+        label: 'Buffering',
+        child: const SizedBox.square(
+          dimension: 24,
+          child: Padding(
+            padding: EdgeInsets.all(AppSpacing.xs),
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
         ),
       );
     }

--- a/lib/features/player/widgets/playback_progress_bar.dart
+++ b/lib/features/player/widgets/playback_progress_bar.dart
@@ -203,6 +203,14 @@ class _PlaybackProgressBarState extends State<PlaybackProgressBar> {
                 max: hasDuration ? totalMs.toDouble() : 1.0,
                 onChanged: canSeek ? _onChanged : null,
                 onChangeEnd: canSeek ? _onChangeEnd : null,
+                // The wave path names itself (see [WavySeekBar]); without this
+                // the Material fallback would announce a bare percentage with
+                // nothing saying what it measures. `label` is semantics-only
+                // here: the value indicator it can also drive is shown
+                // `onlyForDiscrete`, and this slider is continuous.
+                label: _positionLabel,
+                semanticFormatterCallback: (double value) =>
+                    _semanticValue(value, hasDuration ? totalMs : 0),
               ),
             ),
         },
@@ -223,6 +231,17 @@ class _PlaybackProgressBarState extends State<PlaybackProgressBar> {
         ),
       ],
     );
+  }
+
+  /// The name both renderers announce, so the bar reads the same whichever
+  /// style is in use.
+  static const String _positionLabel = 'Playback position';
+
+  /// The spoken position, in the same `elapsed of total` shape [WavySeekBar]
+  /// uses. An unknown duration says so rather than implying a length.
+  static String _semanticValue(double milliseconds, int totalMs) {
+    if (totalMs <= 0) return 'Unknown';
+    return '${_formatMs(milliseconds)} of ${_formatMs(totalMs.toDouble())}';
   }
 
   static String _formatMs(double milliseconds) =>

--- a/lib/features/player/widgets/queue_sheet.dart
+++ b/lib/features/player/widgets/queue_sheet.dart
@@ -361,7 +361,10 @@ class _UpNextTile extends StatelessWidget {
               index: index,
               child: const Padding(
                 padding: EdgeInsets.only(left: AppSpacing.xs),
-                child: Icon(Icons.drag_handle),
+                child: Icon(
+                  Icons.drag_handle,
+                  semanticLabel: 'Reorder',
+                ),
               ),
             ),
           ],

--- a/lib/features/player/widgets/wavy_seek_bar.dart
+++ b/lib/features/player/widgets/wavy_seek_bar.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
+import '../../../app/dimens.dart';
 import '../../../shared/widgets/wavy_progress_indicator.dart';
 
 /// A seekable playback position control drawn as a gentle wave.
@@ -14,6 +16,12 @@ import '../../../shared/widgets/wavy_progress_indicator.dart';
 /// elapsed and total time and can seek with the increase/decrease actions,
 /// stepping by [_semanticStepFraction] of the track (never less than
 /// [_minSemanticStep], so a long song doesn't take a hundred taps to cross).
+///
+/// A real [Slider] is also keyboard-operable, which matters wherever there is a
+/// keyboard — a desktop window, but equally an Android tablet with a keyboard
+/// case — so that is replaced too: the bar takes Tab focus, draws a focus ring
+/// while it holds it, and seeks by the same step on the left/right arrow keys
+/// (mirrored under RTL, exactly as [Slider] does).
 class WavySeekBar extends StatelessWidget {
   const WavySeekBar({
     required this.value,
@@ -69,10 +77,59 @@ class WavySeekBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // The focus node is owned by [Focus] itself; the [Builder] below reads it
+    // back so the ring and the slider's `focused` flag follow it without this
+    // widget having to hold state of its own.
+    return Focus(
+      canRequestFocus: _enabled,
+      skipTraversal: !_enabled,
+      // The seek semantics below already declare the slider role, its value and
+      // its focus state; a second, bare focus node would only add an empty
+      // wrapper node around it.
+      includeSemantics: false,
+      onKeyEvent: (FocusNode node, KeyEvent event) => _onKeyEvent(
+        context,
+        event,
+      ),
+      child: Builder(
+        builder: (BuildContext context) {
+          final FocusNode node = Focus.of(context);
+          return _seekSemantics(
+            node: node,
+            child: _bar(context, node),
+          );
+        },
+      ),
+    );
+  }
+
+  /// Seeks by one [_semanticStep] on the arrow keys, so the bar is operable
+  /// from the keyboard the way [Slider] is. Left/right are read against the
+  /// text direction, so "right" always means "later" on screen.
+  KeyEventResult _onKeyEvent(BuildContext context, KeyEvent event) {
+    if (!_enabled) return KeyEventResult.ignored;
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+    final bool rtl = Directionality.of(context) == TextDirection.rtl;
+    final bool forward;
+    if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
+      forward = !rtl;
+    } else if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
+      forward = rtl;
+    } else {
+      return KeyEventResult.ignored;
+    }
+    final double step = forward ? _semanticStep : -_semanticStep;
+    onChangeEnd?.call((value + step).clamp(0.0, max));
+    return KeyEventResult.handled;
+  }
+
+  Widget _bar(BuildContext context, FocusNode node) {
     final theme = Theme.of(context);
     final double fraction = max > 0 ? (value / max).clamp(0.0, 1.0) : 0.0;
 
-    final Widget bar = LayoutBuilder(
+    return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
         final double width = constraints.maxWidth;
 
@@ -96,23 +153,43 @@ class WavySeekBar extends StatelessWidget {
         return GestureDetector(
           behavior: HitTestBehavior.opaque,
           onTapDown: _enabled
-              ? (details) => onChanged!(positionAt(details.localPosition.dx))
+              ? (details) {
+                  // Clicking the bar hands it the keyboard too, so the arrow
+                  // keys keep seeking from where the pointer left off.
+                  node.requestFocus();
+                  onChanged!(positionAt(details.localPosition.dx));
+                }
               : null,
           onTapUp: _enabled
               ? (details) =>
                   onChangeEnd?.call(positionAt(details.localPosition.dx))
               : null,
           onHorizontalDragStart: _enabled
-              ? (details) => onChanged!(positionAt(details.localPosition.dx))
+              ? (details) {
+                  node.requestFocus();
+                  onChanged!(positionAt(details.localPosition.dx));
+                }
               : null,
           onHorizontalDragUpdate: _enabled
               ? (details) => onChanged!(positionAt(details.localPosition.dx))
               : null,
           onHorizontalDragEnd:
               _enabled ? (details) => onChangeEnd?.call(value) : null,
-          child: SizedBox(
+          child: Container(
             height: _hitHeight,
             width: double.infinity,
+            // A visible focus ring is the keyboard's equivalent of the pointer's
+            // marker: without it, Tab moves through the transport with nothing
+            // on screen saying where it landed.
+            decoration: node.hasFocus
+                ? BoxDecoration(
+                    borderRadius: BorderRadius.circular(AppRadii.sm),
+                    border: Border.all(
+                      color: theme.colorScheme.secondary,
+                      width: 2,
+                    ),
+                  )
+                : null,
             child: WavyProgressIndicator(
               value: fraction,
               activeColor: theme.colorScheme.secondary,
@@ -130,13 +207,11 @@ class WavySeekBar extends StatelessWidget {
         );
       },
     );
-
-    return _seekSemantics(child: bar);
   }
 
   /// Declares the slider role a real [Slider] would have provided, with the
   /// spoken value and — when seeking is possible — the two seek actions.
-  Widget _seekSemantics({required Widget child}) {
+  Widget _seekSemantics({required FocusNode node, required Widget child}) {
     if (!_enabled) {
       return Semantics(
         label: 'Playback position',
@@ -157,6 +232,8 @@ class WavySeekBar extends StatelessWidget {
       slider: true,
       container: true,
       excludeSemantics: true,
+      focusable: true,
+      focused: node.hasFocus,
       label: 'Playback position',
       value: '${semanticFormatter(value)} of ${semanticFormatter(max)}',
       increasedValue: '${semanticFormatter(increased)} of '
@@ -165,6 +242,9 @@ class WavySeekBar extends StatelessWidget {
           '${semanticFormatter(max)}',
       onIncrease: () => onChangeEnd?.call(increased),
       onDecrease: () => onChangeEnd?.call(decreased),
+      // The same "move focus here" action a real [Slider] offers, so assistive
+      // tech can hand the bar the keyboard and then use the arrow keys.
+      onFocus: node.requestFocus,
       child: child,
     );
   }

--- a/lib/features/settings/source/provider_summary_cards.dart
+++ b/lib/features/settings/source/provider_summary_cards.dart
@@ -98,65 +98,76 @@ class ProviderSummaryCard extends StatelessWidget {
     final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
 
     return Card(
-      child: InkWell(
-        onTap: onManage,
-        child: Padding(
-          padding: const EdgeInsets.all(AppSpacing.md),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: <Widget>[
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  _LeadingIcon(icon: icon),
-                  const SizedBox(width: AppSpacing.md),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
-                        Row(
-                          children: <Widget>[
-                            Flexible(
-                              child: Text(
-                                title,
-                                style: theme.textTheme.titleMedium?.copyWith(
-                                  fontWeight: FontWeight.w600,
+      // The card's text already merges into its tap target, so it announces as
+      // one thing — "Jellyfin, Connected, Signed in as …" — but without a role
+      // to go with it. Declaring the button here (the same way the hand-built
+      // play button does) is what tells a screen reader the card can be
+      // activated, rather than leaving it as a block of text that happens to
+      // respond to a tap. Nothing is added to what it says: the announcement
+      // stays exactly the title, status and detail already on screen, which is
+      // what keeps server addresses and credentials out of it.
+      child: Semantics(
+        button: true,
+        child: InkWell(
+          onTap: onManage,
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    _LeadingIcon(icon: icon),
+                    const SizedBox(width: AppSpacing.md),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          Row(
+                            children: <Widget>[
+                              Flexible(
+                                child: Text(
+                                  title,
+                                  style: theme.textTheme.titleMedium?.copyWith(
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
                                 ),
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
                               ),
-                            ),
-                            if (badgeLabel != null) ...<Widget>[
-                              const SizedBox(width: AppSpacing.sm),
-                              _Badge(label: badgeLabel!),
+                              if (badgeLabel != null) ...<Widget>[
+                                const SizedBox(width: AppSpacing.sm),
+                                _Badge(label: badgeLabel!),
+                              ],
                             ],
-                          ],
-                        ),
-                        const SizedBox(height: 3),
-                        _StatusLine(label: statusLabel, tone: statusTone),
-                        if (detail != null) ...<Widget>[
-                          const SizedBox(height: 2),
-                          Text(
-                            detail!,
-                            style: theme.textTheme.bodySmall?.copyWith(
-                              color: detailIsError
-                                  ? theme.colorScheme.error
-                                  : muted,
-                            ),
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
                           ),
+                          const SizedBox(height: 3),
+                          _StatusLine(label: statusLabel, tone: statusTone),
+                          if (detail != null) ...<Widget>[
+                            const SizedBox(height: 2),
+                            Text(
+                              detail!,
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: detailIsError
+                                    ? theme.colorScheme.error
+                                    : muted,
+                              ),
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ],
                         ],
-                      ],
+                      ),
                     ),
-                  ),
+                  ],
+                ),
+                if (actions.isNotEmpty) ...<Widget>[
+                  const SizedBox(height: AppSpacing.md),
+                  _ActionRow(actions: actions),
                 ],
-              ),
-              if (actions.isNotEmpty) ...<Widget>[
-                const SizedBox(height: AppSpacing.md),
-                _ActionRow(actions: actions),
               ],
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/shared/widgets/confirm_dialog.dart
+++ b/lib/shared/widgets/confirm_dialog.dart
@@ -8,6 +8,12 @@ import 'package:flutter/material.dart';
 /// "Remove", "Delete", "Delete from server") — never a vague "OK". When
 /// [destructive] is true (the default) the action button is tinted with the
 /// error colour so it reads as a deliberate, irreversible-feeling choice.
+///
+/// Keyboard users get the same care: the actions are laid out (and so traversed)
+/// Cancel then action, and the dialog opens with one of them already focused so
+/// Enter always has an obvious meaning. For a destructive dialog that is
+/// `Cancel` — the safe half of the choice — so a stray Enter or Space can never
+/// be the thing that deletes.
 Future<bool> showConfirmDialog(
   BuildContext context, {
   required String title,
@@ -25,10 +31,12 @@ Future<bool> showConfirmDialog(
         content: Text(message),
         actions: <Widget>[
           TextButton(
+            autofocus: destructive,
             onPressed: () => Navigator.of(dialogContext).pop(false),
             child: Text(cancelLabel),
           ),
           FilledButton(
+            autofocus: !destructive,
             style: destructive
                 ? FilledButton.styleFrom(
                     backgroundColor: theme.colorScheme.error,

--- a/test/features/library/track_tile_semantics_test.dart
+++ b/test/features/library/track_tile_semantics_test.dart
@@ -1,0 +1,220 @@
+import 'dart:ui' show Tristate;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/download_progress.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/download_repository.dart';
+import 'package:linthra/data/repositories/download_repository_provider.dart';
+import 'package:linthra/features/downloads/download_providers.dart';
+import 'package:linthra/features/library/widgets/track_tile.dart';
+import 'package:linthra/features/player/now_playing.dart';
+
+import 'fake_remote_track_downloader.dart';
+
+/// A track row is the thing a listener meets most often, and everything it says
+/// beyond the title and artist is carried by a glyph: whether this is the song
+/// playing, whether it is saved offline, whether it is selected. Each of those
+/// has to survive being heard rather than seen.
+const Track _remote = Track(
+  id: 'a',
+  title: 'Careful',
+  uri: 'jellyfin:a',
+  artistName: 'NF',
+  albumName: 'Perception',
+);
+
+Future<void> _pump(
+  WidgetTester tester, {
+  NowPlaying? nowPlaying,
+  DownloadStatus status = DownloadStatus.notDownloaded,
+  bool selectionActive = false,
+  bool selected = false,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        remoteTrackDownloaderProvider
+            .overrideWithValue(FakeRemoteTrackDownloader()),
+        if (nowPlaying != null)
+          nowPlayingProvider.overrideWithValue(nowPlaying),
+        trackDownloadStatusProvider.overrideWith(
+          (ref, String key) => Stream<DownloadStatus>.value(status),
+        ),
+        // The in-flight row also watches byte progress; a known fraction keeps
+        // the ring determinate instead of reaching for a real repository.
+        trackDownloadProgressProvider.overrideWith(
+          (ref, String key) => Stream<DownloadProgress?>.value(
+            status == DownloadStatus.downloading
+                ? const DownloadProgress(
+                    trackId: 'a',
+                    receivedBytes: 1,
+                    totalBytes: 2,
+                  )
+                : null,
+          ),
+        ),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: ListView(
+            children: <Widget>[
+              TrackTile(
+                tracks: const <Track>[_remote],
+                index: 0,
+                selectable: true,
+                selectionActive: selectionActive,
+                selected: selected,
+                onSelectToggle: () {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+  // Not pumpAndSettle: a playing indicator and a download ring both animate
+  // forever. Two frames: one to deliver the overridden status stream, one to
+  // rebuild the row on it.
+  await tester.pump();
+  await tester.pump();
+}
+
+/// The row merges into a single node, so everything it says arrives as one
+/// announcement: the playback state, then the title and artist, then the
+/// offline state. This reads that node.
+SemanticsNode _row(WidgetTester tester) =>
+    tester.getSemantics(find.text('Careful'));
+
+void main() {
+  group('TrackTile semantics', () {
+    testWidgets('the playing row says it is playing', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(
+        tester,
+        nowPlaying: const NowPlaying(currentTrack: _remote, isPlaying: true),
+      );
+
+      expect(_row(tester).label, contains('Now playing'));
+      expect(_row(tester).label, isNot(contains('paused')));
+      handle.dispose();
+    });
+
+    testWidgets('a paused row says paused rather than playing', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(
+        tester,
+        nowPlaying: const NowPlaying(currentTrack: _remote, isPlaying: false),
+      );
+
+      expect(_row(tester).label, contains('Now playing, paused'));
+      handle.dispose();
+    });
+
+    testWidgets('a row that is not playing says nothing about playback',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(tester, nowPlaying: const NowPlaying());
+
+      expect(_row(tester).label, isNot(contains('Now playing')));
+      // The title and artist are still there — only the state is absent.
+      expect(_row(tester).label, contains('Careful'));
+      handle.dispose();
+    });
+
+    testWidgets('a saved row says it is downloaded', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(tester, status: DownloadStatus.downloaded);
+
+      expect(_row(tester).label, contains('Downloaded'));
+      handle.dispose();
+    });
+
+    testWidgets('a downloading row says so — the ring used to be silent',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(tester, status: DownloadStatus.downloading);
+
+      expect(_row(tester).label, contains('Downloading'));
+      handle.dispose();
+    });
+
+    testWidgets('a queued row says queued', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(tester, status: DownloadStatus.queued);
+
+      expect(_row(tester).label, contains('Queued'));
+      handle.dispose();
+    });
+
+    testWidgets('a failed row says the download failed', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(tester, status: DownloadStatus.failed);
+
+      expect(_row(tester).label, contains('Download failed'));
+      handle.dispose();
+    });
+
+    testWidgets('a row with nothing to report adds no offline state',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(tester, status: DownloadStatus.notDownloaded);
+
+      // Exactly the visible text, nothing invented on top of it.
+      expect(_row(tester).label, 'Careful\nNF • Perception');
+      handle.dispose();
+    });
+
+    testWidgets('a selected row is exposed as selected, once', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(tester, selectionActive: true, selected: true);
+
+      expect(_row(tester).flagsCollection.isSelected, Tristate.isTrue);
+
+      // The box beside the title mirrors that state visually; it must not
+      // also appear as a second, unnamed toggle in the reading order.
+      expect(find.byType(Checkbox), findsOneWidget);
+      expect(
+        find.semantics.byFlag(SemanticsFlag.hasCheckedState),
+        findsNothing,
+      );
+      handle.dispose();
+    });
+
+    testWidgets('an unselected row in selection mode says so', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(tester, selectionActive: true);
+
+      expect(_row(tester).flagsCollection.isSelected, Tristate.isFalse);
+      // The row carries the state either way, so an unselected row is
+      // announced as unselected rather than as having no state at all.
+      expect(
+        _row(tester).flagsCollection.isSelected,
+        isNot(Tristate.none),
+      );
+      handle.dispose();
+    });
+
+    testWidgets('the overflow menu is named', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(tester);
+
+      expect(
+        tester.getSemantics(find.byTooltip('More actions')),
+        matchesSemantics(
+          tooltip: 'More actions',
+          isButton: true,
+          isFocusable: true,
+          isEnabled: true,
+          hasEnabledState: true,
+          hasTapAction: true,
+          hasFocusAction: true,
+          hasExpandedState: true,
+        ),
+      );
+      handle.dispose();
+    });
+  });
+}

--- a/test/features/player/cast/cast_devices_semantics_test.dart
+++ b/test/features/player/cast/cast_devices_semantics_test.dart
@@ -1,0 +1,173 @@
+import 'dart:ui' show Tristate;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/cast_state.dart';
+import 'package:linthra/features/player/cast/cast_devices_sheet.dart';
+import 'package:linthra/features/player/cast/cast_providers.dart';
+
+import 'fake_cast_service.dart';
+
+/// Choosing where the music plays is a connection-management surface: which
+/// device is in use, and whether the receiver is muted, are both carried by a
+/// glyph. The connected row is also deliberately not tappable, which without a
+/// state to explain it just reads as a row that stopped working.
+const CastDevice _living = CastDevice(id: 'd1', name: 'Living Room');
+const CastDevice _kitchen = CastDevice(id: 'd2', name: 'Kitchen');
+
+Future<void> _pumpSheet(WidgetTester tester, CastState state) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        castServiceProvider.overrideWithValue(FakeCastService(initial: state)),
+      ],
+      child: const MaterialApp(home: Scaffold(body: CastDevicesSheet())),
+    ),
+  );
+  // Not pumpAndSettle: the connecting/searching states spin forever.
+  await tester.pump();
+}
+
+/// The slider's own semantics node. [Slider] is a semantic boundary that sits
+/// below its widget, so it is found by role rather than by widget type.
+SemanticsNode _sliderNode() => find.semantics
+    .byPredicate(
+      (SemanticsNode node) => node.flagsCollection.isSlider,
+      describeMatch: (_) => 'the cast volume slider',
+    )
+    .evaluate()
+    .single;
+
+void main() {
+  group('CastDevicesSheet semantics', () {
+    testWidgets('the connected device is exposed as selected, and named',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pumpSheet(
+        tester,
+        const CastState(
+          availability: CastAvailability.connected,
+          devices: <CastDevice>[_living, _kitchen],
+          connectedDevice: _living,
+        ),
+      );
+
+      final SemanticsNode connected =
+          tester.getSemantics(find.text('Living Room'));
+      expect(connected.flagsCollection.isSelected, Tristate.isTrue);
+      // The glyph is the only other thing that marks the row; it says so.
+      expect(connected.label, contains('Connected'));
+
+      final SemanticsNode other = tester.getSemantics(find.text('Kitchen'));
+      expect(other.flagsCollection.isSelected, Tristate.isFalse);
+      expect(other.label, isNot(contains('Connected')));
+      handle.dispose();
+    });
+
+    testWidgets('with nothing connected, no row claims to be', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pumpSheet(
+        tester,
+        const CastState(
+          availability: CastAvailability.idle,
+          devices: <CastDevice>[_living, _kitchen],
+        ),
+      );
+
+      expect(
+        tester
+            .getSemantics(find.text('Living Room'))
+            .flagsCollection
+            .isSelected,
+        Tristate.isFalse,
+      );
+      expect(
+        tester.getSemantics(find.text('Living Room')).label,
+        isNot(contains('Connected')),
+      );
+      handle.dispose();
+    });
+
+    testWidgets('the volume slider is named and reports a usable value',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pumpSheet(
+        tester,
+        const CastState(
+          availability: CastAvailability.connected,
+          devices: <CastDevice>[_living],
+          connectedDevice: _living,
+          volume: 0.4,
+          supportsVolumeControl: true,
+        ),
+      );
+
+      final SemanticsNode slider = _sliderNode();
+      expect(slider.label, 'Cast volume');
+      // A percentage, not a raw 0–1 fraction.
+      expect(slider.value, '40%');
+      handle.dispose();
+    });
+
+    testWidgets('mute reads as a toggle rather than two swapping buttons',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pumpSheet(
+        tester,
+        const CastState(
+          availability: CastAvailability.connected,
+          devices: <CastDevice>[_living],
+          connectedDevice: _living,
+          volume: 0.4,
+          supportsVolumeControl: true,
+          muted: true,
+        ),
+      );
+
+      final SemanticsNode mute = tester.getSemantics(find.byTooltip('Unmute'));
+      expect(mute.flagsCollection.isSelected, Tristate.isTrue);
+      handle.dispose();
+    });
+
+    testWidgets('an unmuted receiver says it is not muted', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pumpSheet(
+        tester,
+        const CastState(
+          availability: CastAvailability.connected,
+          devices: <CastDevice>[_living],
+          connectedDevice: _living,
+          volume: 0.4,
+          supportsVolumeControl: true,
+        ),
+      );
+
+      final SemanticsNode mute = tester.getSemantics(find.byTooltip('Mute'));
+      // Still a toggle, just an off one — not a button with no state.
+      expect(mute.flagsCollection.isSelected, Tristate.isFalse);
+      handle.dispose();
+    });
+
+    testWidgets('a device that cannot be volume-controlled says so, disabled',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pumpSheet(
+        tester,
+        const CastState(
+          availability: CastAvailability.connected,
+          devices: <CastDevice>[_living],
+          connectedDevice: _living,
+        ),
+      );
+
+      final SemanticsNode slider = _sliderNode();
+      expect(slider.flagsCollection.isEnabled, Tristate.isFalse);
+      // Named even while disabled, so the reason the note gives has something
+      // to attach to.
+      expect(slider.label, 'Cast volume');
+      handle.dispose();
+    });
+  });
+}

--- a/test/features/player/mini_player_semantics_test.dart
+++ b/test/features/player/mini_player_semantics_test.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/cast_state.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/features/player/cast/cast_providers.dart';
+import 'package:linthra/features/player/mini_player.dart';
+import 'package:linthra/features/player/player_providers.dart';
+
+import 'cast/fake_cast_service.dart';
+import 'fake_playback_controller.dart';
+
+/// The mini-player is on screen on every tab, so what it announces is the most
+/// frequently heard thing in the app. Its icon-only states (casting, buffering)
+/// have to name themselves, and the metadata beside them should read as one
+/// line rather than three fragments.
+const _track = Track(
+  id: '1',
+  title: 'Song One',
+  uri: '/music/song1.mp3',
+  artistName: 'Artist A',
+  albumName: 'Album B',
+);
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required PlaybackState state,
+  CastState? cast,
+}) async {
+  // The fake only publishes on demand, so the cast state is pushed after the
+  // first frame the way a real session would arrive.
+  final FakeCastService castService =
+      FakeCastService(initial: cast ?? CastState.unavailable);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        playbackControllerProvider
+            .overrideWithValue(FakePlaybackController(initial: state)),
+        castServiceProvider.overrideWithValue(castService),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(
+          body: SizedBox.expand(),
+          bottomNavigationBar: MiniPlayer(),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+  if (cast != null) {
+    castService.emit(cast);
+    // One frame to deliver the stream event, one to rebuild on it.
+    await tester.pump();
+    await tester.pump();
+  }
+}
+
+void main() {
+  group('MiniPlayer semantics', () {
+    testWidgets('the metadata reads as one node, without the cover',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(
+        tester,
+        state: const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: _track,
+        ),
+      );
+
+      // Title and subtitle are merged, so the bar announces the song once.
+      expect(
+        tester
+            .getSemantics(find.text('Song One'))
+            .label
+            .replaceAll('\n', ' ')
+            .trim(),
+        contains('Song One'),
+      );
+      expect(
+        tester.getSemantics(find.text('Song One')).label,
+        contains('Artist A'),
+      );
+
+      // The artwork adds nothing the lines already say.
+      expect(find.bySemanticsLabel('Album artwork'), findsNothing);
+      handle.dispose();
+    });
+
+    testWidgets('the play/pause button names the action it performs',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(
+        tester,
+        state: const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: _track,
+        ),
+      );
+
+      expect(find.byTooltip('Pause'), findsOneWidget);
+      expect(
+        tester.getSemantics(find.byTooltip('Pause')),
+        matchesSemantics(
+          tooltip: 'Pause',
+          isButton: true,
+          isFocusable: true,
+          isEnabled: true,
+          hasEnabledState: true,
+          hasTapAction: true,
+          hasFocusAction: true,
+        ),
+      );
+      handle.dispose();
+    });
+
+    testWidgets('a buffering transport says so instead of going quiet',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(
+        tester,
+        state: const PlaybackState(
+          status: PlaybackStatus.loading,
+          currentTrack: _track,
+        ),
+      );
+
+      // The spinner stands in for play/pause; unnamed it would read as the
+      // control having disappeared.
+      expect(find.byType(CircularProgressIndicator), findsWidgets);
+      expect(find.bySemanticsLabel('Buffering'), findsOneWidget);
+      handle.dispose();
+    });
+
+    testWidgets('the casting indicator is named', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(
+        tester,
+        state: const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: _track,
+        ),
+        cast: const CastState(
+          availability: CastAvailability.connected,
+          connectedDevice: CastDevice(id: 'd1', name: 'Living Room'),
+        ),
+      );
+
+      expect(find.bySemanticsLabel('Casting'), findsOneWidget);
+      handle.dispose();
+    });
+
+    testWidgets('no casting indicator when nothing is casting', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(
+        tester,
+        state: const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: _track,
+        ),
+      );
+
+      expect(find.bySemanticsLabel('Casting'), findsNothing);
+      handle.dispose();
+    });
+  });
+}

--- a/test/features/player/now_playing_talkback_test.dart
+++ b/test/features/player/now_playing_talkback_test.dart
@@ -357,6 +357,10 @@ void main() {
           isSlider: true,
           hasIncreaseAction: true,
           hasDecreaseAction: true,
+          // The bar is keyboard-operable like a real Slider, so it also
+          // reports as focusable and offers the focus action.
+          isFocusable: true,
+          hasFocusAction: true,
         ),
       );
 

--- a/test/features/player/playback_progress_bar_test.dart
+++ b/test/features/player/playback_progress_bar_test.dart
@@ -386,5 +386,47 @@ void main() {
       expect(find.text('1:15'), findsOneWidget);
       expect(find.text('4:00'), findsOneWidget);
     });
+
+    testWidgets('announces the same name and value as the wave',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pumpBar(
+        tester,
+        position: const Duration(seconds: 75),
+        style: PlaybackProgressStyle.slider,
+      );
+
+      // Without this the fallback announced a bare percentage, with nothing
+      // saying what it measured.
+      final SemanticsNode slider = _sliderNode();
+      expect(slider.label, 'Playback position');
+      expect(slider.value, '1:15 of 4:00');
+      handle.dispose();
+    });
+
+    testWidgets('an unknown duration says so rather than implying a length',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pumpBar(
+        tester,
+        duration: Duration.zero,
+        style: PlaybackProgressStyle.slider,
+      );
+
+      final SemanticsNode slider = _sliderNode();
+      expect(slider.label, 'Playback position');
+      expect(slider.value, 'Unknown');
+      handle.dispose();
+    });
   });
 }
+
+/// The Material slider's own node. [Slider] is a semantic boundary below its
+/// widget, so it is found by role rather than by widget type.
+SemanticsNode _sliderNode() => find.semantics
+    .byPredicate(
+      (SemanticsNode node) => node.flagsCollection.isSlider,
+      describeMatch: (_) => 'the seek slider',
+    )
+    .evaluate()
+    .single;

--- a/test/features/player/queue_sheet_test.dart
+++ b/test/features/player/queue_sheet_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/playlist.dart';
@@ -140,6 +141,43 @@ void main() {
       // One handle per up-next track (B and C), not the current one.
       expect(find.byIcon(Icons.drag_handle), findsNWidgets(2));
       expect(find.byType(ReorderableDragStartListener), findsNWidgets(2));
+    });
+
+    testWidgets('the drag handle is named, and the row still reads whole',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('A'), _track('B')]);
+
+      await _open(tester, controller);
+
+      // An unnamed handle is the one control on the row nothing announces.
+      final SemanticsNode row = tester.getSemantics(find.text('Song B'));
+      expect(row.label, contains('Reorder'));
+      // The row is still the tap target that plays the track, and the remove
+      // action stays its own named button beside it.
+      expect(row.flagsCollection.isButton, isTrue);
+      expect(find.byTooltip('Remove from queue'), findsOneWidget);
+
+      handle.dispose();
+    });
+
+    testWidgets('the playing row says it is the one playing', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('A'), _track('B')]);
+
+      await _open(tester, controller);
+
+      expect(
+        tester.getSemantics(find.text('Song A')).label,
+        contains('Now playing'),
+      );
+      expect(
+        tester.getSemantics(find.text('Song B')).label,
+        isNot(contains('Now playing')),
+      );
+      handle.dispose();
     });
 
     testWidgets('dragging an upcoming track to the end lands it last',

--- a/test/features/player/wavy_seek_bar_keyboard_test.dart
+++ b/test/features/player/wavy_seek_bar_keyboard_test.dart
@@ -1,0 +1,189 @@
+import 'dart:ui' show Tristate;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/features/player/widgets/wavy_seek_bar.dart';
+import 'package:linthra/shared/widgets/wavy_progress_indicator.dart';
+
+/// The seek bar replaces a real [Slider], so it has to replace the keyboard
+/// support a [Slider] would have brought with it: reachable with Tab, seekable
+/// with the arrow keys, and honest about being focused. Without this there is
+/// no way to seek at all on a desktop window without a pointer.
+void main() {
+  const Duration total = Duration(minutes: 4);
+  final double maxMs = total.inMilliseconds.toDouble();
+  // 5% of a four-minute track.
+  const double stepMs = 12000;
+
+  String formatMs(double ms) {
+    final Duration d = Duration(milliseconds: ms.round());
+    return '${d.inMinutes}:${(d.inSeconds % 60).toString().padLeft(2, '0')}';
+  }
+
+  Future<List<double>> pumpBar(
+    WidgetTester tester, {
+    required double value,
+    double max = 0,
+    bool enabled = true,
+    TextDirection textDirection = TextDirection.ltr,
+  }) async {
+    final List<double> seeks = <double>[];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Directionality(
+          textDirection: textDirection,
+          child: Scaffold(
+            body: Column(
+              children: <Widget>[
+                // A neighbour before the bar, so Tab order can be observed.
+                TextButton(onPressed: () {}, child: const Text('before')),
+                WavySeekBar(
+                  value: value,
+                  max: max,
+                  onChanged: enabled ? (_) {} : null,
+                  onChangeEnd: enabled ? seeks.add : null,
+                  semanticFormatter: formatMs,
+                ),
+                TextButton(onPressed: () {}, child: const Text('after')),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    return seeks;
+  }
+
+  /// The bar's own focus node, read the way the widget itself reads it.
+  FocusNode barFocusNode(WidgetTester tester) => Focus.of(
+        tester.element(
+          find.descendant(
+            of: find.byType(WavySeekBar),
+            matching: find.byType(WavyProgressIndicator),
+          ),
+        ),
+      );
+
+  testWidgets('takes keyboard focus in visual order between its neighbours',
+      (tester) async {
+    await pumpBar(tester, value: 60000, max: maxMs);
+
+    // Start on the button above the bar, then walk forward.
+    Focus.of(tester.element(find.text('before'))).requestFocus();
+    await tester.pump();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+    expect(barFocusNode(tester).hasFocus, isTrue,
+        reason: 'Tab should reach the seek bar after the control above it');
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+    expect(barFocusNode(tester).hasFocus, isFalse);
+    expect(
+      Focus.of(tester.element(find.text('after'))).hasFocus,
+      isTrue,
+      reason: 'and continue to the control below it',
+    );
+
+    // Shift+Tab comes back the same way.
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+    await tester.pump();
+    expect(barFocusNode(tester).hasFocus, isTrue);
+  });
+
+  testWidgets('arrow keys seek by one step in each direction', (tester) async {
+    final List<double> seeks = await pumpBar(tester, value: 60000, max: maxMs);
+    barFocusNode(tester).requestFocus();
+    await tester.pump();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pump();
+    expect(seeks.single, 60000 + stepMs);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+    await tester.pump();
+    expect(seeks.last, 60000 - stepMs);
+  });
+
+  testWidgets('arrow keys are mirrored under right-to-left', (tester) async {
+    final List<double> seeks = await pumpBar(
+      tester,
+      value: 60000,
+      max: maxMs,
+      textDirection: TextDirection.rtl,
+    );
+    barFocusNode(tester).requestFocus();
+    await tester.pump();
+
+    // "Right" is earlier when the track runs right-to-left.
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pump();
+    expect(seeks.single, 60000 - stepMs);
+  });
+
+  testWidgets('a seek never leaves the track', (tester) async {
+    final List<double> seeks = await pumpBar(tester, value: 0, max: maxMs);
+    barFocusNode(tester).requestFocus();
+    await tester.pump();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+    await tester.pump();
+    expect(seeks.single, 0);
+  });
+
+  testWidgets('an unseekable bar is skipped by the keyboard entirely',
+      (tester) async {
+    // No duration yet: nothing to seek to, so it must not swallow a Tab stop.
+    await pumpBar(tester, value: 0, enabled: false);
+
+    final FocusNode node = barFocusNode(tester);
+    expect(node.canRequestFocus, isFalse);
+    expect(node.skipTraversal, isTrue);
+
+    Focus.of(tester.element(find.text('before'))).requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+    expect(node.hasFocus, isFalse);
+    expect(Focus.of(tester.element(find.text('after'))).hasFocus, isTrue);
+  });
+
+  testWidgets('reports focus, and the focus action, to assistive tech',
+      (tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    await pumpBar(tester, value: 60000, max: maxMs);
+
+    final Finder bar = find.byType(WavySeekBar);
+    expect(
+      tester.getSemantics(bar),
+      matchesSemantics(
+        label: 'Playback position',
+        value: '1:00 of 4:00',
+        isSlider: true,
+        isFocusable: true,
+        hasIncreaseAction: true,
+        hasDecreaseAction: true,
+        hasFocusAction: true,
+      ),
+    );
+
+    // The focus action is what a screen reader uses to hand it the keyboard.
+    tester.semantics.performAction(
+      find.semantics.byLabel('Playback position'),
+      SemanticsAction.focus,
+    );
+    await tester.pump();
+    expect(barFocusNode(tester).hasFocus, isTrue);
+    expect(
+      tester.getSemantics(bar).flagsCollection.isFocused,
+      Tristate.isTrue,
+    );
+
+    handle.dispose();
+  });
+}

--- a/test/features/settings/plex/plex_settings_secrets_semantics_test.dart
+++ b/test/features/settings/plex/plex_settings_secrets_semantics_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/app/external_link_launcher_provider.dart';
+import 'package:linthra/core/services/external_link_launcher.dart';
+import 'package:linthra/core/sources/plex/plex_api.dart';
+import 'package:linthra/core/sources/plex/plex_pin_auth.dart';
+import 'package:linthra/data/repositories/in_memory_plex_session_store.dart';
+import 'package:linthra/data/repositories/plex_session_store_provider.dart';
+import 'package:linthra/features/settings/plex/plex_settings_providers.dart';
+import 'package:linthra/features/settings/plex/plex_settings_section.dart';
+
+import '../../../core/sources/plex/fake_plex_client.dart';
+import '../../../core/sources/plex/fake_plex_tv_client.dart';
+
+/// Server-connection screens are the one place in Linthra that holds a secret,
+/// and semantics is an easy place to leak one: a label built from the server
+/// address and the token is invisible on screen and spoken out loud. This walks
+/// the whole semantics tree of the Plex section — the surface with the most
+/// sensitive field, a bare access token — and asserts the token never appears
+/// in anything a screen reader would read.
+const String _token = 'super-secret-plex-token';
+
+const PlexDirectory _musicSection =
+    PlexDirectory(key: '5', title: 'Music', type: 'artist');
+
+class _NoopLauncher implements ExternalLinkLauncher {
+  @override
+  Future<bool> open(Uri url) async => true;
+}
+
+Future<void> _pump(WidgetTester tester) async {
+  final FakePlexClient client =
+      FakePlexClient(sections: const <PlexDirectory>[_musicSection]);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        plexClientProvider.overrideWithValue(client),
+        plexSessionStoreProvider.overrideWithValue(InMemoryPlexSessionStore()),
+        plexPinAuthProvider.overrideWith(
+          (ref) => PlexPinAuth(
+            tvClient: FakePlexTvClient(),
+            serverClient: client,
+            identity: ref.watch(plexClientIdentityProvider),
+            wait: (_) async {},
+          ),
+        ),
+        externalLinkLauncherProvider.overrideWithValue(_NoopLauncher()),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(child: PlexSettingsSection()),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+/// Everything the semantics tree would say out loud, flattened.
+List<String> _spokenStrings(WidgetTester tester) {
+  final List<String> spoken = <String>[];
+  void visit(SemanticsNode node) {
+    spoken
+      ..add(node.label)
+      ..add(node.value)
+      ..add(node.hint)
+      ..add(node.tooltip)
+      ..add(node.increasedValue)
+      ..add(node.decreasedValue);
+    node.visitChildren((SemanticsNode child) {
+      visit(child);
+      return true;
+    });
+  }
+
+  for (final SemanticsNode root in tester.binding.rootElement!
+      .findRenderObject()!
+      .debugSemantics!
+      .debugListChildrenInOrder(DebugSemanticsDumpOrder.traversalOrder)) {
+    visit(root);
+  }
+  return spoken.where((String s) => s.isNotEmpty).toList();
+}
+
+void main() {
+  group('Plex settings semantics never expose the token', () {
+    testWidgets('an entered token is obscured in semantics too',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(tester);
+
+      await tester.tap(find.text('Manual setup (advanced)'));
+      await tester.pump();
+      await tester.enterText(
+        find.byType(TextField).at(0),
+        'https://plex.example.com:32400',
+      );
+      await tester.enterText(find.byType(TextField).at(1), _token);
+      await tester.pump();
+
+      final List<String> spoken = _spokenStrings(tester);
+      expect(
+        spoken.any((String s) => s.contains(_token)),
+        isFalse,
+        reason: 'the token must never be spoken: $spoken',
+      );
+      // The field is announced as an obscured text field, not as empty.
+      expect(
+        find.semantics.byFlag(SemanticsFlag.isObscured),
+        findsOneWidget,
+      );
+      handle.dispose();
+    });
+
+    testWidgets('revealing the token is a deliberate, named action',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(tester);
+
+      await tester.tap(find.text('Manual setup (advanced)'));
+      await tester.pump();
+
+      // Icon-only eye toggle: it has to say which way it goes.
+      expect(find.byTooltip('Show token'), findsOneWidget);
+      expect(find.byTooltip('Hide token'), findsNothing);
+
+      await tester.tap(find.byTooltip('Show token'));
+      await tester.pump();
+      expect(find.byTooltip('Hide token'), findsOneWidget);
+      handle.dispose();
+    });
+  });
+}

--- a/test/features/settings/source/provider_summary_card_semantics_test.dart
+++ b/test/features/settings/source/provider_summary_card_semantics_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/features/settings/source/provider_summary_cards.dart';
+
+/// A music-source card is a single choice — "manage this source" — described by
+/// the block of text inside it. It should therefore arrive as one announcement
+/// carrying the source, its connection state and its detail line, with its
+/// actions as separate buttons after it. And because these are the surfaces
+/// that hold server addresses and credentials, the card must never say more
+/// than what is already on screen.
+Future<void> _pumpCard(
+  WidgetTester tester, {
+  required String statusLabel,
+  String? detail,
+  List<Widget> actions = const <Widget>[],
+  VoidCallback? onManage,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: ProviderSummaryCard(
+          icon: Icons.cloud_outlined,
+          title: 'Jellyfin',
+          statusLabel: statusLabel,
+          statusTone: ProviderStatusTone.positive,
+          detail: detail,
+          actions: actions,
+          onManage: onManage ?? () {},
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+/// The card's own node — the one a screen reader lands on for the card body.
+SemanticsNode _card(WidgetTester tester) =>
+    tester.getSemantics(find.text('Jellyfin'));
+
+void main() {
+  group('ProviderSummaryCard semantics', () {
+    testWidgets('reads as one button: source, state, detail', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pumpCard(
+        tester,
+        statusLabel: 'Connected',
+        detail: 'Signed in as amelia',
+      );
+
+      final SemanticsNode node = _card(tester);
+      expect(node.flagsCollection.isButton, isTrue);
+      expect(node.label, contains('Jellyfin'));
+      expect(node.label, contains('Connected'));
+      expect(node.label, contains('Signed in as amelia'));
+      // One node, not four fragments in a row.
+      expect(node.label, 'Jellyfin\nConnected\nSigned in as amelia');
+      handle.dispose();
+    });
+
+    testWidgets('a disconnected source says so', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pumpCard(
+        tester,
+        statusLabel: 'Not connected',
+        detail: 'Sign in to stream your Jellyfin library.',
+      );
+
+      expect(_card(tester).label, contains('Not connected'));
+      handle.dispose();
+    });
+
+    testWidgets('the card says nothing that is not on screen', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      // A detail line is the only place a card ever shows an address, and it
+      // is shown, not synthesised: the announcement must match it exactly and
+      // must not reach for anything else the provider knows.
+      await _pumpCard(
+        tester,
+        statusLabel: 'Connected',
+        detail: 'Home server',
+      );
+
+      expect(_card(tester).label, 'Jellyfin\nConnected\nHome server');
+      handle.dispose();
+    });
+
+    testWidgets('the decorative glyph and status dot add no nodes',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pumpCard(tester, statusLabel: 'Connected');
+
+      // Nothing unnamed to step through before reaching the card's own text.
+      expect(find.semantics.byFlag(SemanticsFlag.isImage), findsNothing);
+      expect(_card(tester).label, 'Jellyfin\nConnected');
+      handle.dispose();
+    });
+
+    testWidgets('actions stay separate, named buttons outside the card node',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pumpCard(
+        tester,
+        statusLabel: 'Connected',
+        detail: 'Signed in as amelia',
+        actions: <Widget>[
+          FilledButton(onPressed: () {}, child: const Text('Sync now')),
+          OutlinedButton(onPressed: () {}, child: const Text('Manage')),
+        ],
+      );
+
+      // Merging the card body must not have swallowed the buttons.
+      expect(_card(tester).label, isNot(contains('Sync now')));
+      expect(
+        tester.getSemantics(find.text('Sync now')).flagsCollection.isButton,
+        isTrue,
+      );
+      expect(
+        tester.getSemantics(find.text('Manage')).flagsCollection.isButton,
+        isTrue,
+      );
+      handle.dispose();
+    });
+
+    testWidgets('the whole card is the manage action', (tester) async {
+      int manages = 0;
+      await _pumpCard(
+        tester,
+        statusLabel: 'Connected',
+        onManage: () => manages++,
+      );
+
+      await tester.tap(find.text('Jellyfin'));
+      await tester.pump();
+      expect(manages, 1);
+    });
+  });
+}

--- a/test/features/shell/home_shell_focus_order_test.dart
+++ b/test/features/shell/home_shell_focus_order_test.dart
@@ -1,0 +1,215 @@
+import 'dart:ui' show Tristate;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/shell/home_shell.dart';
+
+import '../player/fake_playback_controller.dart';
+
+/// Keyboard focus has to move through the frame the way it reads: everything in
+/// the active tab first — pane by pane, in visual order — and only then the
+/// persistent bar under it, with Shift+Tab retracing exactly that path.
+///
+/// That is what the shell's layout already gives (the tab fills the body, the
+/// mini-player and destinations sit below it, and nothing overlaps), so this
+/// pins it down against a future layout change that would quietly interleave
+/// the two — the failure a keyboard user notices immediately and a mouse user
+/// never sees. The two-pane tab below stands in for the wide desktop window,
+/// where the order matters most.
+
+/// A stand-in tab laid out as two side-by-side panes, the shape a desktop
+/// window puts content in.
+class _TwoPaneTab extends StatelessWidget {
+  const _TwoPaneTab();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Expanded(
+            child: Column(
+              children: <Widget>[
+                TextButton(onPressed: () {}, child: const Text('left top')),
+                TextButton(onPressed: () {}, child: const Text('left bottom')),
+              ],
+            ),
+          ),
+          Expanded(
+            child: Column(
+              children: <Widget>[
+                // Offset so the two panes occupy distinct bands and the
+                // expected order is unambiguous.
+                const SizedBox(height: 200),
+                TextButton(onPressed: () {}, child: const Text('right top')),
+                TextButton(onPressed: () {}, child: const Text('right bottom')),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+GoRouter _router(GlobalKey<NavigatorState> rootKey,
+    List<GlobalKey<NavigatorState>> branchKeys) {
+  return GoRouter(
+    navigatorKey: rootKey,
+    initialLocation: '/one',
+    routes: <RouteBase>[
+      StatefulShellRoute.indexedStack(
+        builder: (_, __, StatefulNavigationShell shell) => HomeShell(
+          navigationShell: shell,
+          rootNavigatorKey: rootKey,
+          branchNavigatorKeys: branchKeys,
+        ),
+        branches: <StatefulShellBranch>[
+          for (final (int i, String path) in <String>[
+            '/one',
+            '/two',
+            '/three',
+            '/four',
+          ].indexed)
+            StatefulShellBranch(
+              navigatorKey: branchKeys[i],
+              routes: <RouteBase>[
+                GoRoute(
+                  path: path,
+                  builder: (_, __) =>
+                      i == 0 ? const _TwoPaneTab() : const Scaffold(),
+                ),
+              ],
+            ),
+        ],
+      ),
+    ],
+  );
+}
+
+/// The label of whatever currently holds focus, or the navigation destination
+/// it sits in — enough to describe the traversal order in one list.
+String? _focusedLabel(WidgetTester tester) {
+  final BuildContext? context = FocusManager.instance.primaryFocus?.context;
+  if (context == null) return null;
+  final Finder text = find.descendant(
+    of: find.byWidget(context.widget),
+    matching: find.byType(Text),
+  );
+  if (text.evaluate().isEmpty) return null;
+  return tester.widget<Text>(text.first).data;
+}
+
+void main() {
+  testWidgets('Tab walks the whole tab before reaching the navigation bar',
+      (tester) async {
+    final GlobalKey<NavigatorState> rootKey = GlobalKey<NavigatorState>();
+    final List<GlobalKey<NavigatorState>> branchKeys =
+        <GlobalKey<NavigatorState>>[
+      for (int i = 0; i < 4; i++) GlobalKey<NavigatorState>(),
+    ];
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          // Nothing is playing, so the mini-player collapses and the bottom
+          // group is the destinations alone.
+          playbackControllerProvider
+              .overrideWithValue(FakePlaybackController()),
+        ],
+        child: MaterialApp.router(routerConfig: _router(rootKey, branchKeys)),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    Focus.of(tester.element(find.text('left top'))).requestFocus();
+    await tester.pump();
+
+    final List<String?> order = <String?>[_focusedLabel(tester)];
+    for (int i = 0; i < 7; i++) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      order.add(_focusedLabel(tester));
+    }
+
+    // The tab's four controls first, in visual order, and only then the
+    // destinations under it — never a pane interleaved with the bar.
+    expect(
+      order.take(4),
+      <String>['left top', 'left bottom', 'right top', 'right bottom'],
+    );
+    expect(order.skip(4), <String>[
+      'Library',
+      'Playlists',
+      'Downloads',
+      'Settings',
+    ]);
+  });
+
+  testWidgets('Shift+Tab comes back the same way', (tester) async {
+    final GlobalKey<NavigatorState> rootKey = GlobalKey<NavigatorState>();
+    final List<GlobalKey<NavigatorState>> branchKeys =
+        <GlobalKey<NavigatorState>>[
+      for (int i = 0; i < 4; i++) GlobalKey<NavigatorState>(),
+    ];
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          // Nothing is playing, so the mini-player collapses and the bottom
+          // group is the destinations alone.
+          playbackControllerProvider
+              .overrideWithValue(FakePlaybackController()),
+        ],
+        child: MaterialApp.router(routerConfig: _router(rootKey, branchKeys)),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    Focus.of(tester.element(find.text('Library'))).requestFocus();
+    await tester.pump();
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+    await tester.pump();
+
+    expect(_focusedLabel(tester), 'right bottom');
+  });
+
+  testWidgets('the selected destination is exposed as selected',
+      (tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    final GlobalKey<NavigatorState> rootKey = GlobalKey<NavigatorState>();
+    final List<GlobalKey<NavigatorState>> branchKeys =
+        <GlobalKey<NavigatorState>>[
+      for (int i = 0; i < 4; i++) GlobalKey<NavigatorState>(),
+    ];
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          // Nothing is playing, so the mini-player collapses and the bottom
+          // group is the destinations alone.
+          playbackControllerProvider
+              .overrideWithValue(FakePlaybackController()),
+        ],
+        child: MaterialApp.router(routerConfig: _router(rootKey, branchKeys)),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Library is the active branch; the others must not claim to be.
+    expect(
+      tester.getSemantics(find.text('Library')).flagsCollection.isSelected,
+      Tristate.isTrue,
+    );
+    expect(
+      tester.getSemantics(find.text('Playlists')).flagsCollection.isSelected,
+      Tristate.isFalse,
+    );
+    handle.dispose();
+  });
+}

--- a/test/shared/widgets/confirm_dialog_test.dart
+++ b/test/shared/widgets/confirm_dialog_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/shared/widgets/confirm_dialog.dart';
 
@@ -61,5 +62,66 @@ void main() {
     await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
     await tester.pumpAndSettle();
     expect(result, isTrue);
+  });
+
+  testWidgets('a destructive dialog opens with the safe action focused',
+      (tester) async {
+    await pumpButton(tester, onResult: (_) {});
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    // Enter has to mean "back out", never "delete": a keyboard user who opens
+    // this dialog and presses it without reading must not lose their files.
+    expect(
+      Focus.of(tester.element(find.text('Cancel'))).hasFocus,
+      isTrue,
+    );
+    expect(
+      Focus.of(tester.element(find.text('Delete'))).hasFocus,
+      isFalse,
+    );
+  });
+
+  testWidgets('Tab moves from Cancel to the action, and back', (tester) async {
+    await pumpButton(tester, onResult: (_) {});
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    // Visual order is Cancel then the action, and focus follows it.
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+    expect(Focus.of(tester.element(find.text('Delete'))).hasFocus, isTrue);
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+    await tester.pump();
+    expect(Focus.of(tester.element(find.text('Cancel'))).hasFocus, isTrue);
+  });
+
+  testWidgets('a non-destructive dialog focuses the action instead',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (BuildContext context) => TextButton(
+              onPressed: () => showConfirmDialog(
+                context,
+                title: 'Sign in again?',
+                message: 'Your session expired.',
+                confirmLabel: 'Sign in',
+                destructive: false,
+              ),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(Focus.of(tester.element(find.text('Sign in'))).hasFocus, isTrue);
   });
 }


### PR DESCRIPTION
Refs #460.

Desktop has no touch and often no pointer, so the controls that read fine by sight — a glyph, a spinner, a wave — have to survive being heard and driven from the keyboard. This is the #460 audit applied to the controls where something was actually missing, not a semantics rewrite.

## What was already fine

Worth stating, because it shaped the size of this PR: every `IconButton` in `lib/` already has a tooltip, the transport row already exposes selected/enabled state, `WavySeekBar` already declared the slider role with a spoken `elapsed of total` value, `AlbumGridCard` already merges, and `NowPlayingIndicator` already announces playing/paused. Those are untouched.

## The substantive change

`WavySeekBar` replaces a real `Slider`. It had replaced the slider's *screen-reader* semantics but not its *keyboard* support, so on a desktop window there was no way to seek at all without a pointer. It now:

- takes Tab focus (and is skipped entirely when there is no duration to seek in, so it never eats a Tab stop for nothing),
- draws a focus ring while it holds focus,
- seeks by the existing semantic step on Left/Right, mirrored under RTL the way `Slider` does,
- takes focus on click so the arrows continue from where the pointer left off,
- offers the focus action, so assistive tech can hand it the keyboard.

This is keyboard support rather than desktop behaviour — it stays useful on an Android tablet with a keyboard case — so it needs no platform seam, and nothing here is gated on host platform.

## The rest

| Surface | Gap closed |
|---|---|
| `playback_progress_bar.dart` | The Material-slider fallback announced a bare percentage. It now gives the same name and `1:15 of 4:00` value as the wave (semantics-only: the value indicator `label` can also drive is `onlyForDiscrete`, and this slider is continuous). |
| `mini_player.dart` | The casting glyph and the buffering spinner — which stands where play/pause normally is — are named; the cover is excluded as decorative; the metadata merges into one line instead of three. |
| `track_tile.dart` | The `downloading` ring was the only download state with nothing to announce. The selection `Checkbox` is excluded: the row already carries the selected state and toggles on tap, so the box was a second, unnamed toggle. |
| `queue_sheet.dart` | The reorder drag handle is named. |
| `cast_devices_sheet.dart` | The connected device is exposed as selected (it is deliberately untappable, which without a state just reads as a row that stopped working); mute reports its toggle state; the volume slider is named and announces a percentage. |
| `provider_summary_cards.dart` | The card's text already merged into its tap target, so it only needed the button role to go with it. |
| `confirm_dialog.dart` | Destructive dialogs open focused on Cancel, so a keyboard Enter can never be the thing that deletes; non-destructive ones focus the action. Tab order was already Cancel → action. |

## Secrets

Every label added repeats something already on screen; none is built from a server address, a username or a token. `plex_settings_secrets_semantics_test.dart` walks the entire semantics tree of the Plex section with a token entered and asserts the token appears in no label, value, hint or tooltip — a regression guard on that property, not just on today's code.

## Tests

New: seek-bar keyboard/focus, mini-player semantics, track-row semantics, cast-sheet semantics, provider-card semantics, Plex secrets, and shell Tab/Shift+Tab order. Extended: the existing TalkBack, progress-bar, queue and confirm-dialog suites.

The shell test deserves a note. I first added `FocusTraversalGroup`s to `HomeShell` and then found the test passed identically without them — in a `Scaffold` the bottom bar never shares a vertical band with the body, so reading order already guarantees the order and the grouping was provably a no-op. I dropped the code and kept the test, which locks the real Tab/Shift+Tab order through a two-pane tab and the destinations under it.

Similarly, my first pass put `MergeSemantics` on the provider card; dumping the tree showed it *moved the label off* the tappable node onto a child, leaving the card unlabeled. That was replaced with the button role, which is what was actually missing.

## Checks

- `dart format --set-exit-if-changed .` — clean
- `flutter analyze` — no issues
- `flutter test` — 3763 passing

Run against the pinned SDK from `.flutter-version` (Flutter 3.44.7).

## Not in this PR

Deliberately left for follow-ups, listed in the issue thread: the A–Z scrubber rail's 26 loose letter nodes, keyboard reordering of the queue, and a real desktop/sidebar navigation pass (there is no multi-pane or sidebar layout yet — `HomeShell` renders the same `NavigationBar` everywhere).

Do not merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_015NJgCWHUKanpu75a7Dj3n3)_