### PR TITLE
feat(flatpak): install the scalable Linthra application icon

### DIFF
--- a/docs/app-icon-branding.md
+++ b/docs/app-icon-branding.md
@@ -234,6 +234,23 @@ After regenerating, the classic `ic_launcher.*` and store assets stay
 byte-for-byte identical (verify with `sha256sum`); only the
 `ic_launcher_<id>.*` variant assets change.
 
+### Linux / Flatpak icon
+
+Linux packaging does not rasterise anything. The Flatpak installs the
+**canonical vector source itself** —
+[`tool/branding/linthra_icon.svg`](../tool/branding/linthra_icon.svg), the
+classic mark that `generate_icons.py` renders the Android assets from — as
+`share/icons/hicolor/scalable/apps/io.github.thezupzup.linthra.svg`, the
+icon-theme name the desktop entry's `Icon=` looks up
+(see [`flatpak/README.md`](../flatpak/README.md) §"Application icon").
+
+So there is one brand mark and no packaging-only copy: keep the SVG and the
+`generate_icons.py` constants in step, as the file's own header already says,
+and Linux follows Android automatically. The variant switching above is
+**Android-only** — the desktop icon is always Classic, matching the desktop's
+"one icon per installed app" model, and nothing on this page changes when the
+Linux icon does.
+
 ### F-Droid reproducibility
 
 The added assets are PNGs written deterministically by the stdlib-only generator

--- a/docs/flatpak-development.md
+++ b/docs/flatpak-development.md
@@ -19,9 +19,10 @@ Three docs, three jobs:
 
 > Flatpak packaging is in progress ([issue #376](https://github.com/TheZupZup/Linthra/issues/376)).
 > The committed manifest builds, installs and launches the real app with
-> working audio, and installs a desktop entry so Linthra appears in the
-> application menu, but it is not the Flathub submission: there is no icon or
-> AppStream metadata yet, and no network, filesystem or Secret Service access.
+> working audio, and installs a desktop entry and Linthra's own icon so the app
+> appears properly in the application menu, but it is not the Flathub
+> submission: there is no AppStream metadata yet, and no network, filesystem or
+> Secret Service access.
 > See [What the sandbox allows today](#what-the-sandbox-allows-today).
 
 All commands are relative to the repository. Run them from the repository root
@@ -305,12 +306,25 @@ So these are **expected**, not bugs, and not worth debugging:
   ([#441](https://github.com/TheZupZup/Linthra/issues/441)). Linthra treats
   that as signed-out and keeps running; it never falls back to plaintext.
 * Linthra is in the application menu now
-  ([#434](https://github.com/TheZupZup/Linthra/issues/434)) — but with the
-  desktop's fallback icon, because the icon files are still to come
-  ([#436](https://github.com/TheZupZup/Linthra/issues/436)), and with no
+  ([#434](https://github.com/TheZupZup/Linthra/issues/434)) with its own icon
+  ([#436](https://github.com/TheZupZup/Linthra/issues/436)) — but with no
   software-centre listing
   ([#435](https://github.com/TheZupZup/Linthra/issues/435)). `flatpak run`
   still works and is what these debugging commands assume.
+
+  To check the icon in an installed build, list what the app exported and what
+  it installed:
+
+  ```bash
+  ls ~/.local/share/flatpak/exports/share/icons/hicolor/scalable/apps/
+  flatpak run --command=ls io.github.thezupzup.linthra \
+    /app/share/icons/hicolor/scalable/apps
+  ```
+
+  Both should show `io.github.thezupzup.linthra.svg` — the same name the
+  desktop entry's `Icon=` looks up. A launcher that still draws the generic
+  icon after that is usually caching: log out and back in, or run
+  `gtk4-update-icon-cache -f ~/.local/share/flatpak/exports/share/icons/hicolor`.
 
 To exercise those paths anyway, pass the permission to `flatpak run` for a
 single launch — it applies to that invocation only, so there is nothing to

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -360,9 +360,10 @@ workflow for building, installing and debugging it on Fedora Atomic is
 [flatpak-development.md](./flatpak-development.md). It builds, installs and
 launches with working audio, and installs the desktop entry
 (`linux/packaging/io.github.thezupzup.linthra.desktop`, shared with any future
-native package rather than Flatpak-only); icons, AppStream metadata and the
-network/filesystem/Secret Service permissions are still open sub-issues. None
-of it changes the native build on this page.
+native package rather than Flatpak-only) together with Linthra's scalable icon
+under `share/icons/hicolor/scalable/apps/io.github.thezupzup.linthra.svg`;
+AppStream metadata and the network/filesystem/Secret Service permissions are
+still open sub-issues. None of it changes the native build on this page.
 
 Decisions already taken with that destination in mind:
 

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -4,10 +4,10 @@ This is the packaging **foundation**: enough to build Linthra's native Flutter
 Linux bundle inside `flatpak-builder`, install it, launch the real
 `io.github.thezupzup.linthra` app from the application menu, and get real,
 audible local and remote playback through a fully self-contained audio
-runtime. It is deliberately not the Flathub submission — the icon and
-AppStream metadata that go with the desktop entry are still open, and so are
-the sandbox permissions; see "What's deferred" below and the comments in
-`io.github.thezupzup.linthra.yml` itself.
+runtime, with Linthra's own icon on the launcher entry. It is deliberately not
+the Flathub submission — the AppStream metadata that goes with the desktop
+entry is still open, and so are the sandbox permissions; see "What's deferred"
+below and the comments in `io.github.thezupzup.linthra.yml` itself.
 
 ## Audio runtime
 
@@ -68,6 +68,42 @@ the same sources of truth the Linux runner is held to (`AppInfo.name`,
 this directory's manifests — the hand-authored template and the generated
 manifest — actually install it, so a regeneration that was never run shows up
 as a failure rather than as a Flatpak with no menu entry.
+
+## Application icon
+
+`Icon=io.github.thezupzup.linthra` in that entry is an icon-theme **name**, not
+a path. It resolves because the `linthra` module installs a file of exactly that
+name into the icon theme:
+
+```
+install -Dm644 tool/branding/linthra_icon.svg \
+  /app/share/icons/hicolor/scalable/apps/io.github.thezupzup.linthra.svg
+```
+
+Three decisions worth stating:
+
+* **The source is Linthra's canonical vector mark, installed as-is.**
+  `tool/branding/linthra_icon.svg` is the design
+  `tool/branding/generate_icons.py` rasterises into the Android launcher
+  mipmaps and the store graphics — same squircle, same four bars, same
+  violet→orange gradient. Nothing here redraws or re-exports it, so there is no
+  packaging-only copy that can drift from the brand, exactly as with the
+  desktop entry above. Android's icon pipeline is untouched by this.
+* **One scalable SVG and no rasters.** A vector is sharp at every launcher size
+  and every HiDPI scale factor by construction, so a set of PNG fallbacks could
+  only be larger and worse. `hicolor` is the theme every icon theme inherits
+  from, and `scalable/apps` is where an application's own icon belongs.
+* **No `rename-icon`.** flatpak-builder exports `/app/share/icons/hicolor/**`
+  by the same rule it exports desktop files — the basename must start with the
+  app id — and this basename *is* the app id.
+
+`scripts/check_linux_runner.py` covers this too, offline and with no extra
+packages to install: it holds the installed basename to the entry's `Icon=`,
+requires **both** manifests to install it, and checks the SVG itself — that it
+is well-formed, that it carries a `viewBox` (a file in `scalable/` that cannot
+scale is resampled by every launcher), and that it has no absolute host path
+and no reference to anything it does not carry (an external image, stylesheet
+or font would render differently, or not at all, inside the sandbox).
 
 ## Files here
 
@@ -165,13 +201,13 @@ and the current `pubspec.lock`. Diff the result before committing.
 
 Not in this manifest — each has its own issue:
 
-* **AppStream metainfo** (#435), **scalable icon packaging** (#436) — no
-  `<app-id>.metainfo.xml` and no icon is installed, so the desktop entry's
-  `Icon=io.github.thezupzup.linthra` currently resolves to nothing and the
-  launcher falls back to a generic icon. The entry deliberately names the icon
-  anyway: #436 installs the files under exactly that name and nothing here has
-  to change when it lands. `rename-desktop-file`/`rename-icon` are not used and
-  are not needed — everything is installed under the app id already.
+* **AppStream metainfo** (#435) — no `<app-id>.metainfo.xml`, so Linthra has no
+  software-centre listing (name, summary, description, screenshots, releases).
+  The desktop entry and the icon it needs are already in place, so #435 is
+  additive: its `<launchable type="desktop-id">` and `<icon type="stock">` both
+  point at names that already resolve. `rename-desktop-file`/`rename-icon` are
+  not used and are not needed — everything is installed under the app id
+  already.
 * **Provider network access** (#440) — no permanent `--share=network`.
   #433 proved the bundled ffmpeg/libmpv can decode HTTP(S) audio using only a
   temporary, non-committed grant for that validation (see

--- a/flatpak/flatpak-flutter.yml
+++ b/flatpak/flatpak-flutter.yml
@@ -264,9 +264,28 @@ modules:
       # into the `flatpak run io.github.thezupzup.linthra` form the host
       # launcher needs, and it only exports files whose name starts with the
       # app id — this one *is* the app id, so no `rename-desktop-file`. `Icon=`
-      # names the icon #436 will install; until then the entry appears with the
-      # desktop's fallback icon rather than a wrong one.
+      # names the icon installed immediately below.
       - install -Dm644 linux/packaging/io.github.thezupzup.linthra.desktop /app/share/applications/io.github.thezupzup.linthra.desktop
+      # Application icon (#436), installed from Linthra's canonical vector
+      # source — `tool/branding/linthra_icon.svg`, the same design
+      # `tool/branding/generate_icons.py` rasterises into the Android launcher
+      # mipmaps and the store graphics. It is copied, not redrawn: nothing here
+      # may fork the brand mark, and installing the source directly means there
+      # is no packaging-only duplicate to drift, exactly like the desktop entry
+      # above.
+      #
+      # One scalable SVG and nothing else. `hicolor` is the fallback theme every
+      # icon theme inherits from, `scalable/apps` is where an app's own
+      # resolution-independent icon belongs, and the basename *is* the icon-theme
+      # name the entry's `Icon=` looks up. A vector is sharp at every launcher
+      # size and every HiDPI scale factor by construction, so raster fallbacks
+      # would be dozens of files that can only be worse. scripts/check_linux_runner.py
+      # asserts this path, this basename and `Icon=` agree, in both manifests.
+      #
+      # flatpak-builder exports `/app/share/icons/hicolor/**` whose basename
+      # starts with the app id at `finish` time, the same rule as the desktop
+      # entry — so this needs no `rename-icon` either.
+      - install -Dm644 tool/branding/linthra_icon.svg /app/share/icons/hicolor/scalable/apps/io.github.thezupzup.linthra.svg
     sources:
       # The app's own source. flatpak-flutter's pre-processing step cannot
       # read a `dir` source (it only fetches `git` sources to inspect

--- a/flatpak/io.github.thezupzup.linthra.yml
+++ b/flatpak/io.github.thezupzup.linthra.yml
@@ -114,6 +114,7 @@ modules:
       - install -d /app/bin
       - ln -s ../lib/linthra/linthra /app/bin/linthra
       - install -Dm644 linux/packaging/io.github.thezupzup.linthra.desktop /app/share/applications/io.github.thezupzup.linthra.desktop
+      - install -Dm644 tool/branding/linthra_icon.svg /app/share/icons/hicolor/scalable/apps/io.github.thezupzup.linthra.svg
     sources:
       - type: dir
         path: ..

--- a/linux/packaging/io.github.thezupzup.linthra.desktop
+++ b/linux/packaging/io.github.thezupzup.linthra.desktop
@@ -4,16 +4,19 @@
 # that is what every desktop-integration lookup keys off: flatpak-builder only
 # exports a desktop file whose name starts with the app id, AppStream (#435)
 # will point its `<launchable type="desktop-id">` at this exact filename, and
-# the icon (#436) is installed as `<app-id>.png/.svg`, which is what makes
-# `Icon=` below resolve.
+# the icon (#436) is installed as `<app-id>.svg` in the hicolor icon theme,
+# which is what makes `Icon=` below resolve.
 # The same id is already `APPLICATION_ID` in linux/CMakeLists.txt, Android's
 # `applicationId`, and the Flatpak `app-id`; scripts/check_linux_runner.py
 # holds all of those together.
 #
 # Nothing here may name a build machine: `Exec=` is a bare command, resolved
 # from PATH (`/app/bin/linthra` inside the Flatpak, wherever a native package
-# puts it otherwise), and `Icon=` is an icon-theme name rather than a path.
-# check_linux_runner.py's absolute-path scan covers this file too.
+# puts it otherwise), and `Icon=` is an icon-theme name rather than a path — it
+# resolves to `.../icons/hicolor/scalable/apps/io.github.thezupzup.linthra.svg`,
+# installed from Linthra's canonical vector source, `tool/branding/linthra_icon.svg`.
+# check_linux_runner.py holds that filename and this `Icon=` together, and its
+# absolute-path scan covers this file too.
 #
 # The window this launches identifies itself with the same id — the runner
 # calls `g_set_prgname(APPLICATION_ID)` and registers its GtkApplication under

--- a/scripts/check_linux_runner.py
+++ b/scripts/check_linux_runner.py
@@ -31,6 +31,16 @@ never gets exported by flatpak-builder at all. The Flatpak manifests are
 checked for the install step that puts it in `/app/share/applications`, since
 an entry nothing installs is the same silence.
 
+The application icon (#436) is that same silence one step further out. `Icon=`
+is an icon-theme *name*, not a path, so it only resolves if a file of exactly
+that basename lands in the icon theme; install it one directory too high, or
+rename either side, and every launcher quietly falls back to a generic icon
+with nothing logged anywhere. So the manifests are checked for the install step
+that puts Linthra's canonical vector source into `hicolor/scalable/apps` under
+precisely the name `Icon=` asks for, and that source is itself checked for the
+two things that would make it unusable inside a sandbox: an absolute host path,
+or a reference to a file it does not carry.
+
 It also checks two things that are about *how* the runner builds rather than
 what it is called:
 
@@ -58,6 +68,7 @@ import argparse
 import re
 import sys
 from pathlib import Path
+from xml.etree import ElementTree
 
 # Paths this script reads, all relative to the repository root.
 CMAKELISTS = Path("linux") / "CMakeLists.txt"
@@ -75,6 +86,35 @@ FLATPAK_TEMPLATE = FLATPAK_DIR / "flatpak-flutter.yml"
 # Where a Flatpak's desktop entry has to land: flatpak-builder exports what it
 # finds in this directory at `finish` time and nothing from anywhere else.
 DESKTOP_ENTRY_INSTALL_DIR = "/app/share/applications"
+
+# Linthra's canonical vector app icon: the source design that
+# tool/branding/generate_icons.py rasterises into the Android launcher mipmaps
+# and the store graphics. Linux packaging installs this file itself rather than
+# a copy of it, so there is no second brand mark that can drift from the first.
+ICON_SOURCE = Path("tool") / "branding" / "linthra_icon.svg"
+
+# `hicolor` is the fallback theme every icon theme inherits from, and
+# `scalable/apps` is where an application's own resolution-independent icon
+# belongs — one SVG covers every launcher size and every HiDPI scale, so no
+# raster fallbacks are installed. The basename, minus the extension, is the
+# icon-theme name the desktop entry's `Icon=` looks up.
+ICON_INSTALL_DIR = "/app/share/icons/hicolor/scalable/apps"
+ICON_EXTENSION = ".svg"
+
+SVG_ROOT_TAG = "{http://www.w3.org/2000/svg}svg"
+
+# An SVG that pulls in something it does not carry — an <image href=...>, an
+# external stylesheet or font, a `file://` or `https://` reference — renders
+# differently or not at all inside the sandbox, where none of that is
+# reachable. Internal fragment references (`fill="url(#bars)"`, the gradients
+# the mark is built from) are exactly what an SVG is supposed to do, so they
+# are not matched.
+EXTERNAL_REFERENCE_PATTERN = re.compile(
+    r"(?:href|src|xlink:href)\s*=\s*[\"']?(?!#)"
+    r"|url\(\s*[\"']?(?!#)"
+    r"|@import\b",
+    re.IGNORECASE,
+)
 
 # freedesktop's main categories for an audio player. `Audio` is only valid
 # alongside `AudioVideo`, and `Player` alone would leave the entry ungrouped in
@@ -302,6 +342,98 @@ def desktop_entry_install_problems(root: Path) -> list[str]:
     return problems
 
 
+def icon_install_problems(root: Path) -> list[str]:
+    """Disagreements between the desktop entry's `Icon=` and the installed icon.
+
+    `Icon=` names a theme entry, so the two halves are only connected by the
+    installed file's basename. Both Flatpak manifests are checked, for the same
+    reason the desktop entry's install step is: `flatpak-flutter.yml` is
+    hand-authored and `<app-id>.yml` is generated from it by
+    scripts/regenerate_flatpak_sources.sh, so an icon added to one and not
+    regenerated into the other leaves the built Flatpak with no icon while the
+    diff looks complete.
+    """
+    entry = desktop_entry(root)
+    icon_name = entry.get("Icon")
+    if icon_name is None:
+        # desktop_entry_problems() already reports the missing key; without it
+        # there is no name to hold the installed file to.
+        return []
+
+    destination = f"{ICON_INSTALL_DIR}/{icon_name}{ICON_EXTENSION}"
+    install = re.compile(
+        rf"install\s+-Dm644\s+{re.escape(str(ICON_SOURCE))}\s+{re.escape(destination)}"
+    )
+
+    problems: list[str] = []
+    if not (root / ICON_SOURCE).is_file():
+        problems.append(
+            f"{ICON_SOURCE} is missing — it is the canonical vector source the "
+            "Linux packaging installs as the application icon"
+        )
+
+    app_id = android_application_id(root)
+    for manifest in (FLATPAK_TEMPLATE, FLATPAK_DIR / f"{app_id}.yml"):
+        if install.search(_read(root, manifest)) is None:
+            problems.append(
+                f"{manifest} does not install {ICON_SOURCE} to {destination}, so "
+                f"{desktop_entry_file(root)}'s Icon={icon_name} resolves to "
+                "nothing and launchers fall back to a generic icon"
+            )
+    return problems
+
+
+def icon_source_problems(root: Path) -> list[str]:
+    """Things in the icon source that make it unusable as an installed icon.
+
+    Parsed with the standard library rather than shelling out to `xmllint` or
+    `rsvg-convert`: this check has to run wherever the rest of the checker does,
+    including a CI job that installs no extra packages for it.
+    """
+    path = root / ICON_SOURCE
+    if not path.is_file():
+        # icon_install_problems() reports the missing file once.
+        return []
+
+    problems: list[str] = []
+
+    # Well-formedness first: a broken SVG installs perfectly and then draws
+    # nothing. ElementTree also refuses an undefined entity, which is how a
+    # DOCTYPE pulling in an external subset shows up here.
+    try:
+        element = ElementTree.parse(path).getroot()
+    except ElementTree.ParseError as error:
+        return [f"{ICON_SOURCE}: not well-formed XML — {error}"]
+    if element.tag != SVG_ROOT_TAG:
+        problems.append(
+            f"{ICON_SOURCE}: root element is {element.tag!r}, not an SVG in the "
+            f"{SVG_ROOT_TAG} namespace"
+        )
+    elif element.get("viewBox") is None:
+        # Without a viewBox the drawing has no coordinate system to scale, so
+        # the file lands in `scalable/` without actually being scalable — it
+        # renders at its intrinsic size and every launcher resamples it.
+        problems.append(
+            f"{ICON_SOURCE}: no viewBox, so it does not scale — an icon in "
+            f"{ICON_INSTALL_DIR} has to render sharply at every size"
+        )
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        for match in ABSOLUTE_PATH_PATTERN.findall(line):
+            problems.append(
+                f"absolute host path in the application icon: "
+                f"{ICON_SOURCE}:{line_number}: {match}"
+            )
+        for match in EXTERNAL_REFERENCE_PATTERN.findall(line):
+            problems.append(
+                f"{ICON_SOURCE}:{line_number}: the application icon references "
+                f"something outside itself ({match.strip()!r}); it has to render "
+                "from its own contents inside the sandbox"
+            )
+    return problems
+
+
 def absolute_paths_under_linux(root: Path) -> list[str]:
     """Absolute host paths hardcoded in the committed Linux build files.
 
@@ -359,6 +491,11 @@ def check(root: Path) -> list[str]:
     # runner that drifts is reported once rather than twice.
     problems.extend(desktop_entry_problems(root))
     problems.extend(desktop_entry_install_problems(root))
+
+    # The application icon (#436): `Icon=` above is only a name, so this is
+    # what connects it to a file the built Flatpak actually contains.
+    problems.extend(icon_install_problems(root))
+    problems.extend(icon_source_problems(root))
 
     # Window metrics: a minimum larger than the default would open the window
     # already clamped, which reads as the app ignoring its own default.

--- a/test/tooling/check_linux_runner_test.py
+++ b/test/tooling/check_linux_runner_test.py
@@ -14,7 +14,9 @@ keeps these tests from depending on Linthra's current version or app id.
 The desktop entry (#434) is tested the same way, and for the same reason: a
 `.desktop` file that names the wrong binary, the wrong icon or the wrong app id
 is still a perfectly valid desktop file, so only a comparison against the app's
-own identity catches it.
+own identity catches it. The application icon (#436) is the other half of that
+pair: `Icon=` is a theme name, so nothing but a comparison notices when the
+installed file stops answering to it.
 
 One test does run against the real repository, because "the checker passes on
 the actual runner" is the thing the CI job cares about.
@@ -120,6 +122,23 @@ Categories=AudioVideo;Audio;Player;Music;
 StartupNotify=true
 """
 
+# A minimal but structurally real SVG: a self-contained mark whose only
+# references are internal fragments (`url(#g)`), which is what the icon check
+# has to accept while rejecting anything reaching outside the file.
+ICON_SVG = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512"
+     viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#9C84FF" />
+      <stop offset="1" stop-color="#FF9F43" />
+    </linearGradient>
+  </defs>
+  <rect x="64" y="64" width="384" height="384" rx="96" fill="url(#g)" />
+</svg>
+"""
+
 # Only the parts of a Flatpak manifest this checker reads. Both the
 # hand-authored template and the file generated from it are written from this,
 # because the check exists precisely to catch the two disagreeing.
@@ -132,7 +151,15 @@ modules:
     build-commands:
       - install -d /app/bin
       - install -Dm644 linux/packaging/{app_id}.desktop /app/share/applications/{app_id}.desktop
+      - install -Dm644 tool/branding/linthra_icon.svg /app/share/icons/hicolor/scalable/apps/{app_id}.svg
 """
+
+# The install step the icon tests remove or rewrite, kept in one place so the
+# fixture and the assertions cannot drift apart.
+ICON_INSTALL_LINE = (
+    "      - install -Dm644 tool/branding/linthra_icon.svg "
+    "/app/share/icons/hicolor/scalable/apps/{app_id}.svg\n"
+)
 
 
 def build_checkout(
@@ -146,11 +173,14 @@ def build_checkout(
     desktop_entry: str | None = None,
     desktop_entry_name: str | None = None,
     flatpak_manifest: str | None = None,
+    icon_svg: str | None = None,
+    write_icon: bool = True,
 ) -> Path:
     """Write a minimal, internally consistent checkout the checker can read."""
     (directory / "linux" / "runner").mkdir(parents=True, exist_ok=True)
     (directory / "linux" / "packaging").mkdir(parents=True, exist_ok=True)
     (directory / "flatpak").mkdir(parents=True, exist_ok=True)
+    (directory / "tool" / "branding").mkdir(parents=True, exist_ok=True)
     (directory / "android" / "app").mkdir(parents=True, exist_ok=True)
     (directory / "lib" / "core").mkdir(parents=True, exist_ok=True)
 
@@ -200,6 +230,10 @@ def build_checkout(
         FLATPAK_MANIFEST.format(app_id=APP_ID, binary=BINARY), encoding="utf-8"
     )
     (directory / "flatpak" / f"{APP_ID}.yml").write_text(manifest, encoding="utf-8")
+    if write_icon:
+        (directory / "tool" / "branding" / "linthra_icon.svg").write_text(
+            icon_svg if icon_svg is not None else ICON_SVG, encoding="utf-8"
+        )
     return directory
 
 
@@ -309,13 +343,16 @@ class DesktopEntryTest(CheckoutCase):
         self.assertIn("Exec=", problems[0])
 
     def test_the_icon_must_be_the_app_id(self) -> None:
-        # The icon files (#436) are installed under the app id; any other name
+        # The icon file (#436) is installed under the app id; any other name
         # resolves to nothing and the entry shows a fallback icon forever.
+        # Scoped to the entry's own problems: since #436 the icon check reports
+        # this same rename from the other side (IconInstallTest), and this test
+        # is about the entry disagreeing with the app's identity.
         build_checkout(
             self.root,
             desktop_entry=self.entry().replace(f"Icon={APP_ID}", "Icon=exampleapp"),
         )
-        problems = checker.check(self.root)
+        problems = checker.desktop_entry_problems(self.root)
         self.assertEqual(len(problems), 1)
         self.assertIn("Icon=", problems[0])
 
@@ -392,6 +429,165 @@ class DesktopEntryInstallTest(CheckoutCase):
         problems = checker.check(self.root)
         self.assertEqual(len(problems), 1)
         self.assertIn("no desktop entry to export", problems[0])
+
+
+class IconInstallTest(CheckoutCase):
+    """The desktop entry's `Icon=` and the installed icon file, held together.
+
+    Nothing else connects them: `Icon=` is a theme name, the install step is a
+    shell line in a manifest, and every mismatch here builds, installs and
+    launches perfectly — it just shows a generic icon.
+    """
+
+    def test_a_consistent_checkout_installs_the_icon(self) -> None:
+        build_checkout(self.root)
+        self.assertEqual(checker.check(self.root), [])
+
+    def test_a_generated_manifest_that_lost_the_icon_is_caught(self) -> None:
+        # The same drift the desktop entry has: the template gains the install
+        # step, scripts/regenerate_flatpak_sources.sh is never re-run, and the
+        # manifest flatpak-builder consumes ships no icon.
+        build_checkout(
+            self.root,
+            flatpak_manifest=FLATPAK_MANIFEST.format(
+                app_id=APP_ID, binary=BINARY
+            ).replace(ICON_INSTALL_LINE.format(app_id=APP_ID), ""),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn(f"flatpak/{APP_ID}.yml", problems[0])
+        self.assertIn("/app/share/icons/hicolor/scalable/apps", problems[0])
+
+    def test_renaming_the_installed_icon_is_caught(self) -> None:
+        # The drift this check exists for: the icon is installed under a name
+        # that is no longer the one `Icon=` looks up.
+        build_checkout(
+            self.root,
+            flatpak_manifest=FLATPAK_MANIFEST.format(
+                app_id=APP_ID, binary=BINARY
+            ).replace(f"apps/{APP_ID}.svg", "apps/exampleapp.svg"),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn(f"Icon={APP_ID}", problems[0])
+
+    def test_renaming_the_entrys_icon_is_caught_on_both_sides(self) -> None:
+        # The mirror image: `Icon=` changes and the install step does not. The
+        # entry check reports the identity break, the icon check reports that
+        # nothing installs a file answering to the new name.
+        build_checkout(
+            self.root,
+            desktop_entry=DESKTOP_ENTRY.format(
+                display_name=DISPLAY_NAME, binary=BINARY, app_id=APP_ID
+            ).replace(f"Icon={APP_ID}", "Icon=exampleapp"),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 3)
+        self.assertTrue(any("Icon=" in problem for problem in problems))
+        self.assertEqual(
+            2,
+            sum("apps/exampleapp.svg" in problem for problem in problems),
+        )
+
+    def test_installing_outside_the_icon_theme_is_caught(self) -> None:
+        # /app/share/icons/<app-id>.svg is not in any theme, so no launcher
+        # ever looks there — the same shape of mistake as installing the
+        # desktop entry outside /app/share/applications.
+        build_checkout(
+            self.root,
+            flatpak_manifest=FLATPAK_MANIFEST.format(
+                app_id=APP_ID, binary=BINARY
+            ).replace("/app/share/icons/hicolor/scalable/apps/", "/app/share/icons/"),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("hicolor/scalable/apps", problems[0])
+
+    def test_a_missing_icon_source_is_caught(self) -> None:
+        build_checkout(self.root, write_icon=False)
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("linthra_icon.svg is missing", problems[0])
+
+
+class IconSourceTest(CheckoutCase):
+    """What the icon file itself may contain.
+
+    Both failures are invisible until the icon is rendered from inside the
+    sandbox, where the developer's filesystem and the network are not there.
+    """
+
+    def test_internal_fragment_references_are_allowed(self) -> None:
+        # `fill="url(#g)"` is how an SVG uses its own gradient. Flagging it
+        # would make the check useless on Linthra's actual mark.
+        build_checkout(self.root)
+        self.assertEqual(checker.check(self.root), [])
+
+    def test_an_external_image_reference_is_caught(self) -> None:
+        build_checkout(
+            self.root,
+            icon_svg=ICON_SVG.replace(
+                "</svg>",
+                '  <image href="https://example.invalid/mark.png" />\n</svg>',
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("references something outside itself", problems[0])
+
+    def test_an_imported_stylesheet_is_caught(self) -> None:
+        build_checkout(
+            self.root,
+            icon_svg=ICON_SVG.replace(
+                "<defs>", '<style>@import url("theme.css");</style>\n  <defs>'
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertTrue(problems)
+        self.assertTrue(
+            all("references something outside itself" in p for p in problems)
+        )
+
+    def test_a_malformed_svg_is_caught(self) -> None:
+        # A broken SVG installs perfectly and then draws nothing.
+        build_checkout(self.root, icon_svg=ICON_SVG.replace("</svg>", ""))
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("not well-formed XML", problems[0])
+
+    def test_a_non_svg_root_element_is_caught(self) -> None:
+        build_checkout(
+            self.root, icon_svg='<?xml version="1.0"?>\n<html><body /></html>\n'
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("not an SVG", problems[0])
+
+    def test_an_svg_without_a_viewbox_is_caught(self) -> None:
+        # It would sit in scalable/ without actually being scalable: it renders
+        # at its intrinsic size and every launcher resamples it.
+        build_checkout(
+            self.root, icon_svg=ICON_SVG.replace('\n     viewBox="0 0 512 512"', "")
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("no viewBox", problems[0])
+
+    def test_a_developer_machine_path_is_caught(self) -> None:
+        # An editor that saved a linked bitmap leaves exactly this behind: the
+        # icon renders on the machine it was exported from and nowhere else.
+        build_checkout(
+            self.root,
+            icon_svg=ICON_SVG.replace(
+                "</svg>",
+                '  <image href="/home/dev/art/mark.png" />\n</svg>',
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertTrue(any("absolute host path" in problem for problem in problems))
+        self.assertTrue(
+            any("/home/dev/art/mark.png" in problem for problem in problems)
+        )
 
 
 class WindowMetricsTest(CheckoutCase):
@@ -545,6 +741,35 @@ class RealRepositoryTest(unittest.TestCase):
 
     def test_the_window_title_is_the_product_name(self) -> None:
         self.assertEqual(checker.window_title(ROOT), checker.app_display_name(ROOT))
+
+    def test_the_installed_icon_is_named_for_the_desktop_entrys_icon_key(self) -> None:
+        # Stated explicitly because it is the whole point of #436: the file
+        # the Flatpak installs answers to the name the launcher looks up.
+        icon_name = checker.desktop_entry(ROOT)["Icon"]
+        installed = (
+            f"{checker.ICON_INSTALL_DIR}/{icon_name}{checker.ICON_EXTENSION}"
+        )
+        self.assertEqual(
+            installed,
+            "/app/share/icons/hicolor/scalable/apps/"
+            f"{checker.android_application_id(ROOT)}.svg",
+        )
+        for manifest in (
+            checker.FLATPAK_TEMPLATE,
+            checker.FLATPAK_DIR / f"{checker.android_application_id(ROOT)}.yml",
+        ):
+            self.assertIn(installed, (ROOT / manifest).read_text(encoding="utf-8"))
+
+    def test_the_icon_source_is_the_canonical_brand_mark(self) -> None:
+        # Not a copy and not a redraw: the file Linux packaging installs is the
+        # same vector source tool/branding/generate_icons.py renders from.
+        self.assertTrue((ROOT / checker.ICON_SOURCE).is_file())
+        self.assertIn(
+            checker.ICON_SOURCE.name,
+            (ROOT / "tool" / "branding" / "generate_icons.py").read_text(
+                encoding="utf-8"
+            ),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #436

`Icon=io.github.thezupzup.linthra` in the desktop entry (#434 / #506) named an icon that nothing installed, so GNOME/KDE fell back to a generic icon. This installs one, under exactly that name.

## Canonical source

`tool/branding/linthra_icon.svg` — the vector source `tool/branding/generate_icons.py` rasterises into the Android launcher mipmaps and the store graphics, and its own header calls "Canonical Linthra app-icon source".

It is **installed as-is**, not copied, re-exported or redrawn, so there is no packaging-only mark that can drift from the brand — the same reasoning the desktop entry already uses ("no packaging-only copy to drift"). Verified to be a faithful, non-stale source: its squircle, four bar widths/heights/baseline and all four palette hexes reproduce `generate_icons.py`'s constants exactly.

## Install path

```
install -Dm644 tool/branding/linthra_icon.svg \
  /app/share/icons/hicolor/scalable/apps/io.github.thezupzup.linthra.svg
```

* **One scalable SVG, no rasters.** A vector is sharp at every launcher size and every HiDPI scale by construction, so PNG fallbacks could only be more files and worse output. No raster fallback is needed and none is added.
* `hicolor` is the theme every icon theme inherits from; `scalable/apps` is where an application's own icon belongs.
* No `rename-icon`: flatpak-builder exports `/app/share/icons/hicolor/**` by the same "basename starts with the app id" rule it uses for desktop files, and this basename *is* the app id.

## Changed files

| File | Change |
| --- | --- |
| `flatpak/flatpak-flutter.yml` | hand-authored: the icon install command + rationale |
| `flatpak/io.github.thezupzup.linthra.yml` | generated by `./scripts/regenerate_flatpak_sources.sh` (one added line) |
| `scripts/check_linux_runner.py` | `icon_install_problems()` / `icon_source_problems()` drift guard |
| `test/tooling/check_linux_runner_test.py` | 14 new tests + icon in the synthetic checkout |
| `linux/packaging/io.github.thezupzup.linthra.desktop` | comments only — `Icon=` now resolves; no key changed |
| `flatpak/README.md`, `docs/flatpak-development.md`, `docs/linux-desktop.md`, `docs/app-icon-branding.md` | docs that said "no icon is installed" |

No new asset files: the icon already existed in the repo.

## Regression check (no new framework)

Added to the existing packaging validation, which already runs in `linux-desktop-build.yml` and `scripts/verify_linux.sh`. `scripts/check_linux_runner.py` now:

* holds the installed icon's basename to the desktop entry's `Icon=` value, so the two cannot silently drift apart;
* requires **both** manifests to install it — a template change that was never regenerated is the realistic failure;
* checks the SVG itself: well-formed, has a `viewBox` (a file in `scalable/` that cannot scale is resampled by every launcher), and carries no absolute host path and no reference to anything outside itself (an external image, stylesheet or font renders differently, or not at all, in the sandbox).

Standard library only — no new CI package, no new workflow step.

## Validation

**Actually run:**

* `python3 scripts/check_linux_runner.py` → OK.
* `python3 test/tooling/check_linux_runner_test.py` → 48 tests, all pass (34 before).
* Mutation-tested against the real repo, not only fixtures: deleting the icon install line from the generated manifest, and renaming the entry's `Icon=`, each fail the checker with the expected message; restoring passes.
* `./scripts/regenerate_flatpak_sources.sh` run three times — identical single-line diff each time, `flatpak/generated/` untouched. Reproducible.
* `xmllint --noout tool/branding/linthra_icon.svg` → well-formed. No DOCTYPE, entity, `file://`, `http(s)://`, `<image>`, `<script>` or `@import`; the only URI is the SVG namespace declaration. No developer-machine paths.
* `python3 tool/branding/generate_icons.py` → every Android/F-Droid/Play output byte-identical (clean `git status`), so the Android icon pipeline is provably unaffected.
* Icon filename ⇄ `Icon=` compared directly in both manifests: match.
* All repository Python tooling tests pass.

**Verified by inspection only:**

* The install path and flatpak-builder's icon-export rule (basename must start with the app id).
* `flutter analyze` / `flutter test` / `dart format` were not run — no Flutter SDK in this environment. This diff changes no Dart code and no Dart test references any changed file.

**Not tested — stated plainly:** `flatpak-builder` and `flatpak` are unavailable here, so the Flatpak was **not built or installed**, and **launcher rendering was not observed**. That the icon exists under `/app/share/icons/hicolor/` and that GNOME/KDE resolve it instead of the generic fallback follow from the install command and the freedesktop icon-theme lookup, but were not empirically confirmed. `docs/flatpak-development.md` now carries the two commands a reviewer with flatpak-builder can use to check it.

## Out of scope (unchanged)

No sandbox permission changes (`finish-args` untouched), no AppStream metainfo (#435), no Android/Play Store asset changes, no desktop UI work.

## What remains for #435

Everything: there is still no `io.github.thezupzup.linthra.metainfo.xml` and nothing installs one, so Linthra has no software-centre listing. #435 needs the component id, name, summary, description, categories, screenshots, release entries, content rating and project/metadata licences, an install into `/app/share/metainfo/`, and `appstreamcli validate` in CI. This PR needed **no** compatibility adjustment for it and makes it purely additive: its `<launchable type="desktop-id">` and `<icon type="stock">` will both point at names that already resolve.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwGtxXGLGQc98pLG2cyPug)_