### PR TITLE
test: keep Android audio formats in sync

### DIFF
--- a/test/core/sources/local/audio_file_types_test.dart
+++ b/test/core/sources/local/audio_file_types_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/sources/local/audio_file_types.dart';
 
@@ -65,6 +67,28 @@ void main() {
           'wav',
         ]),
       );
+    });
+    test('matches the Android SAF scanner formats', () {
+      final File scanner = File(
+        'android/app/src/main/kotlin/io/github/thezupzup/linthra/'
+        'SafDocumentScanner.kt',
+      );
+      expect(scanner.existsSync(), isTrue);
+
+      final String source = scanner.readAsStringSync();
+      final RegExp listPattern = RegExp(
+        r'private val AUDIO_EXTENSIONS\s*=\s*listOf\((.*?)\)',
+        dotAll: true,
+      );
+      final RegExpMatch? listMatch = listPattern.firstMatch(source);
+      expect(listMatch, isNotNull);
+
+      final Set<String> androidExtensions = RegExp(r'"\.([^"]+)"')
+          .allMatches(listMatch!.group(1)!)
+          .map((RegExpMatch match) => match.group(1)!)
+          .toSet();
+
+      expect(androidExtensions, AudioFileTypes.supportedExtensions);
     });
   });
 


### PR DESCRIPTION
## What this fixes

Fixes #352.

The local audio formats are defined in both Dart (`AudioFileTypes`) and the Android SAF scanner (`SafDocumentScanner`). Those lists currently match, but a future format addition could update one side and silently make Android folder scans disagree with the rest of the app.

This adds a focused regression test that reads the Android scanner's extension list and asserts exact set equality with the Dart source of truth. It catches additions, removals, and spelling drift without changing the currently supported formats or runtime behavior.

## Verification

- `dart format test/core/sources/local/audio_file_types_test.dart`
- `flutter test test/core/sources/local/audio_file_types_test.dart` — 13 tests passed
- `git diff --check` — passed