### PR TITLE
fix(ui): keep mini-player usable with large text

### DIFF
--- a/lib/features/player/mini_player.dart
+++ b/lib/features/player/mini_player.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -61,12 +63,17 @@ class MiniPlayer extends ConsumerWidget {
         ? PlaybackSourceLabel.of(trackUri: track.uri, source: source)
         : null;
 
+    final double miniPlayerHeight = math.max(
+      64,
+      MediaQuery.textScalerOf(context).scale(48),
+    );
+
     return Material(
       color: theme.colorScheme.surfaceContainerHigh,
       child: InkWell(
         onTap: () => context.push(AppRoutes.player),
         child: SizedBox(
-          height: 64,
+          height: miniPlayerHeight,
           child: Column(
             children: [
               const _MiniProgressBar(),

--- a/test/features/player/mini_player_test.dart
+++ b/test/features/player/mini_player_test.dart
@@ -112,9 +112,9 @@ void main() {
           overrides: [
             playbackControllerProvider.overrideWithValue(controller),
           ],
-          child: MaterialApp(
-            home: Scaffold(
-              bottomNavigationBar: MediaQuery(
+          child: const MaterialApp(
+            home: const Scaffold(
+              bottomNavigationBar: const MediaQuery(
                 data: const MediaQueryData(
                   textScaler: TextScaler.linear(2.5),
                 ),

--- a/test/features/player/mini_player_test.dart
+++ b/test/features/player/mini_player_test.dart
@@ -113,12 +113,12 @@ void main() {
             playbackControllerProvider.overrideWithValue(controller),
           ],
           child: const MaterialApp(
-            home: const Scaffold(
-              bottomNavigationBar: const MediaQuery(
-                data: const MediaQueryData(
+            home: Scaffold(
+              bottomNavigationBar: MediaQuery(
+                data: MediaQueryData(
                   textScaler: TextScaler.linear(2.5),
                 ),
-                child: const MiniPlayer(),
+                child: MiniPlayer(),
               ),
             ),
           ),

--- a/test/features/player/mini_player_test.dart
+++ b/test/features/player/mini_player_test.dart
@@ -98,7 +98,38 @@ void main() {
       // not the active/default provider.
       expect(find.text('Navidrome'), findsOneWidget);
     });
+    testWidgets('keeps text and controls usable at large text sizes', (
+      tester,
+    ) async {
+      final controller = FakePlaybackController(
+        initial: const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: _track,
+        ),
+      );
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            playbackControllerProvider.overrideWithValue(controller),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              bottomNavigationBar: MediaQuery(
+                data: const MediaQueryData(
+                  textScaler: TextScaler.linear(2.5),
+                ),
+                child: const MiniPlayer(),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
 
+      expect(tester.takeException(), isNull);
+      expect(find.text('Song One'), findsOneWidget);
+      expect(find.byTooltip('Pause'), findsOneWidget);
+    });
     testWidgets('play/pause delegates to the controller', (tester) async {
       final controller = FakePlaybackController(
         initial: const PlaybackState(


### PR DESCRIPTION
## What this fixes

Fixes #340.

The mini-player has a fixed 64dp height. With Android's larger text settings, the title and metadata can outgrow that bar and make the transport control unreachable or produce a layout overflow.

The bar now keeps its compact 64dp height at normal text size, but grows proportionally when the user's text scaler requires more vertical room. The existing ellipsis behavior and controls remain unchanged.

## Verification

- `dart format lib/features/player/mini_player.dart test/features/player/mini_player_test.dart`
- Added widget coverage at `TextScaler.linear(2.5)` checking that no exception occurs and the Pause control remains present.
- `flutter test test/features/player/mini_player_test.dart` was attempted locally but could not compile because the Windows Pub cache is missing `file_picker-8.3.7/lib/file_picker.dart`; this is an environment dependency-cache issue unrelated to the changed files.
- `git diff --check` — passed