### PR TITLE
fix(security): close four review-reported guard bypasses

### DIFF
--- a/docs/repository-hardening.md
+++ b/docs/repository-hardening.md
@@ -18,7 +18,8 @@ a person's intent.
 For external contributor PRs:
 
 - `.vscode/**`, `.idea/**`, and `*.code-workspace`
-- `.github/workflows/**`
+- `.github/workflows/**` and composite actions under `.github/actions/**`, which
+  privileged workflows run from the PR head
 - repository automation under `scripts/`, `tool/`, and `tools/`
 - `CODEOWNERS`, `.gitattributes`, `.gitmodules`, and Dependabot policy
 - Git symlinks

--- a/docs/repository-hardening.md
+++ b/docs/repository-hardening.md
@@ -26,10 +26,15 @@ For external contributor PRs:
 
 For every PR, including maintainer PRs:
 
-- removal of `.idea/` or `.vscode/` from the root `.gitignore`
+- removal of `.idea/` or `.vscode/` from the root `.gitignore`, including a
+  later `!` rule that re-enables one of them (Git applies the last matching
+  rule, so presence of the entry alone proves nothing)
 - files whose extension claims WOFF/WOFF2/TTF/OTF/PNG/JPEG/GIF/WEBP but whose
-  file signature does not match
-- active/executable SVG content such as `<script>`, event handlers,
+  contents are not structurally that format. A magic prefix is not enough:
+  `wOF2` followed by JavaScript is four valid bytes, so each format is checked
+  against a self-describing field — a declared length that must equal the real
+  file size, or a redundant field derived from another
+- active/executable SVG content such as `<script>`, any `on*=` event handler,
   `javascript:` URLs, `foreignObject`, or external executable references
 - text that invokes an asset such as `.woff2`, `.png`, or `.pdf` through
   Node/Python/shell interpreters, or marks one executable with `chmod +x`

--- a/scripts/check_repository_integrity.py
+++ b/scripts/check_repository_integrity.py
@@ -12,9 +12,11 @@ commit (or be pinned as a required workflow by a repository ruleset).
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import re
 import subprocess
 import sys
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -57,15 +59,93 @@ EXTERNAL_BLOCKED_PATHS: tuple[tuple[re.Pattern[str], str], ...] = _EXTERNAL_BLOC
     for path in sorted(SELF_TEST_FIXTURE_PATHS)
 )
 
-ASSET_MAGIC: dict[str, tuple[bytes, ...]] = {
-    ".woff2": (b"wOF2",),
-    ".woff": (b"wOFF",),
-    ".ttf": (b"\x00\x01\x00\x00", b"true", b"typ1"),
-    ".otf": (b"OTTO",),
-    ".png": (b"\x89PNG\r\n\x1a\n",),
-    ".jpg": (b"\xff\xd8\xff",),
-    ".jpeg": (b"\xff\xd8\xff",),
-    ".gif": (b"GIF87a", b"GIF89a"),
+def _u16(data: bytes, offset: int) -> int:
+    return int.from_bytes(data[offset : offset + 2], "big")
+
+
+def _u32(data: bytes, offset: int) -> int:
+    return int.from_bytes(data[offset : offset + 4], "big")
+
+
+# A magic prefix alone is worthless here: `wOF2` followed by JavaScript is still
+# four valid bytes. Each validator below checks a self-describing structural
+# field — a declared length that must equal the real file size, or a redundant
+# field derived from another — so appended or substituted script breaks it.
+
+
+def _valid_woff(data: bytes, signature: bytes, header_size: int) -> bool:
+    """WOFF/WOFF2 declare their own total length and a zeroed reserved field."""
+    if len(data) < header_size or not data.startswith(signature):
+        return False
+    if _u32(data, 8) != len(data):
+        return False
+    return _u16(data, 12) != 0 and _u16(data, 14) == 0
+
+
+def _valid_sfnt(data: bytes) -> bool:
+    """TrueType/OpenType: searchRange and friends are derived from numTables."""
+    if len(data) < 12 or data[:4] not in (b"\x00\x01\x00\x00", b"true", b"typ1", b"OTTO"):
+        return False
+    num_tables = _u16(data, 4)
+    if num_tables == 0 or len(data) < 12 + 16 * num_tables:
+        return False
+    entry_selector = num_tables.bit_length() - 1
+    search_range = (1 << entry_selector) * 16
+    return (
+        _u16(data, 6) == search_range
+        and _u16(data, 8) == entry_selector
+        and _u16(data, 10) == num_tables * 16 - search_range
+    )
+
+
+def _valid_png(data: bytes) -> bool:
+    """The 8-byte signature must be followed by a well-formed 13-byte IHDR."""
+    if len(data) < 33 or not data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return False
+    return _u32(data, 8) == 13 and data[12:16] == b"IHDR"
+
+
+_JPEG_MARKERS = frozenset(range(0xC0, 0xFF)) - {0xD8, 0xD9}
+
+
+def _valid_jpeg(data: bytes) -> bool:
+    if len(data) < 4 or not data.startswith(b"\xff\xd8\xff"):
+        return False
+    return data[3] in _JPEG_MARKERS and b"\xff\xd9" in data
+
+
+def _valid_gif(data: bytes) -> bool:
+    """Header plus a logical screen descriptor with a non-zero canvas."""
+    if len(data) < 13 or data[:6] not in (b"GIF87a", b"GIF89a"):
+        return False
+    width = int.from_bytes(data[6:8], "little")
+    height = int.from_bytes(data[8:10], "little")
+    return width != 0 and height != 0
+
+
+def _valid_webp(data: bytes) -> bool:
+    """RIFF/WEBP container followed by a real VP8 chunk fourcc.
+
+    The declared RIFF size is deliberately not required to match the file size:
+    a truncated-but-genuine image is a broken asset, not a disguised script, and
+    this guard is not an image linter. The fourcc is what a script cannot fake
+    while still being a script.
+    """
+    if len(data) < 16 or data[:4] != b"RIFF" or data[8:12] != b"WEBP":
+        return False
+    return data[12:16] in (b"VP8 ", b"VP8L", b"VP8X")
+
+
+ASSET_VALIDATORS: dict[str, tuple[str, "Callable[[bytes], bool]"]] = {
+    ".woff2": ("WOFF2", lambda data: _valid_woff(data, b"wOF2", 48)),
+    ".woff": ("WOFF", lambda data: _valid_woff(data, b"wOFF", 44)),
+    ".ttf": ("TrueType", _valid_sfnt),
+    ".otf": ("OpenType", _valid_sfnt),
+    ".png": ("PNG", _valid_png),
+    ".jpg": ("JPEG", _valid_jpeg),
+    ".jpeg": ("JPEG", _valid_jpeg),
+    ".gif": ("GIF", _valid_gif),
+    ".webp": ("WEBP", _valid_webp),
 }
 
 
@@ -116,7 +196,7 @@ ACTIVE_SVG_RE = re.compile(
     r"""(?ix)
     <\s*script\b
     |javascript\s*:
-    |\bon(?:load|error|click|mouseover|focus)\s*=
+    |\bon[a-z][a-z0-9_:-]*\s*=
     |<\s*foreignObject\b
     |(?:href|xlink:href)\s*=\s*["']\s*(?:https?:|data:text/html)
     """
@@ -189,20 +269,62 @@ def is_external(pr_author: str, repo_owner: str) -> bool:
     return pr_author.casefold() != repo_owner.casefold()
 
 
+def _ignore_rules(text: str) -> list[str]:
+    rules: list[str] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        rules.append(line[1:] if line.startswith("\\") else line)
+    return rules
+
+
+def _ignore_state(rules: list[str], entry: str) -> tuple[bool, str | None]:
+    """Resolve whether `entry` ends up ignored, the way Git resolves it.
+
+    Git applies the *last* matching rule, so a later `!.vscode/` re-enables a
+    directory an earlier `.vscode/` ignored. Checking only for the presence of
+    the positive entry misses that. Negations are matched as globs, since
+    `!.vs*` re-enables the directory just as surely as `!.vscode/`.
+    """
+    name = entry.strip("/")
+    ignored = False
+    negated_by: str | None = None
+    for rule in rules:
+        if rule.startswith("!"):
+            pattern = rule[1:].strip().strip("/")
+            if pattern and fnmatch.fnmatch(name, pattern):
+                ignored = False
+                negated_by = rule
+        elif rule.strip("/") == name:
+            ignored = True
+            negated_by = None
+    return ignored, negated_by
+
+
 def check_ignore_policy(head: str) -> list[Finding]:
     text = blob_text(head, ".gitignore")
     if text is None:
         return [Finding(".gitignore", "required repository .gitignore is missing")]
-    entries = {
-        line.strip()
-        for line in text.splitlines()
-        if line.strip() and not line.lstrip().startswith("#")
-    }
-    return [
-        Finding(".gitignore", f"required ignore entry `{entry}` was removed")
-        for entry in PROTECTED_IGNORE_ENTRIES
-        if entry not in entries
-    ]
+    rules = _ignore_rules(text)
+
+    findings: list[Finding] = []
+    for entry in PROTECTED_IGNORE_ENTRIES:
+        ignored, negated_by = _ignore_state(rules, entry)
+        if ignored:
+            continue
+        if negated_by is not None:
+            findings.append(
+                Finding(
+                    ".gitignore",
+                    f"required ignore entry `{entry}` is re-enabled by `{negated_by}`",
+                )
+            )
+        else:
+            findings.append(
+                Finding(".gitignore", f"required ignore entry `{entry}` was removed")
+            )
+    return findings
 
 
 def check_external_paths(files: list[str]) -> list[Finding]:
@@ -230,24 +352,16 @@ def check_symlinks(head: str, files: list[str], external: bool) -> list[Finding]
 def check_asset_magic(head: str, files: list[str]) -> list[Finding]:
     findings: list[Finding] = []
     for path in files:
-        suffix = Path(path).suffix.lower()
-        if suffix == ".webp":
-            data = blob_bytes(head, path)
-            if data is None:
-                continue
-            if not (len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP"):
-                findings.append(Finding(path, "file extension is .webp but content is not WEBP"))
+        entry = ASSET_VALIDATORS.get(Path(path).suffix.lower())
+        if entry is None:
             continue
-
-        expected = ASSET_MAGIC.get(suffix)
-        if expected is None:
-            continue
+        label, is_valid = entry
         data = blob_bytes(head, path)
         if data is None:
             continue
-        if not any(data.startswith(prefix) for prefix in expected):
+        if not is_valid(data):
             findings.append(
-                Finding(path, f"file extension is {suffix} but file signature does not match")
+                Finding(path, f"file extension claims {label} but the file is not a valid {label}")
             )
     return findings
 

--- a/test/tooling/check_repository_integrity_test.py
+++ b/test/tooling/check_repository_integrity_test.py
@@ -143,6 +143,27 @@ class RepositoryIntegrityTest(unittest.TestCase):
             )
         )
 
+    def test_external_composite_action_change_is_blocked(self) -> None:
+        """Composite actions run from the PR head in privileged workflows."""
+        path = self.repo / ".github" / "actions" / "setup-flutter" / "action.yml"
+        path.parent.mkdir(parents=True)
+        path.write_text("runs:\n  using: composite\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(
+            any(
+                f.path == ".github/actions/setup-flutter/action.yml"
+                and "maintainer-controlled" in f.reason
+                for f in findings
+            )
+        )
+
+    def test_owner_can_change_a_composite_action(self) -> None:
+        path = self.repo / ".github" / "actions" / "setup-flutter" / "action.yml"
+        path.parent.mkdir(parents=True)
+        path.write_text("runs:\n  using: composite\n", encoding="utf-8")
+        findings = self.scan(self.commit(), author="TheZupZup")
+        self.assertEqual(findings, [])
+
     def test_removing_vscode_ignore_is_blocked(self) -> None:
         (self.repo / ".gitignore").write_text(".idea/\n", encoding="utf-8")
         findings = self.scan(self.commit())

--- a/test/tooling/check_repository_integrity_test.py
+++ b/test/tooling/check_repository_integrity_test.py
@@ -29,6 +29,25 @@ ASSET_EXECUTION_PAYLOAD = "node ./public/fonts/looks-safe.woff2\n"  # integrity-
 # Built at runtime so this source line holds neither the payload nor the marker.
 MARKED_PAYLOAD_LINE = f"{ASSET_EXECUTION_PAYLOAD.strip()}  # {integrity.FIXTURE_EXEMPTION_MARKER}"
 
+# Script body used as a disguised-asset payload. Contains no asset extension, so
+# it is inert to the text scan and needs no fixture marker of its own.
+PREFIXED_SCRIPT_PAYLOAD = b"=0;\nglobal.p=require('child_process');p.exec('id');\n"
+
+
+def woff2_blob(num_tables: int = 1) -> bytes:
+    """A structurally valid WOFF2 header padded out to its declared length."""
+    body = bytes(64)
+    total = 48 + len(body)
+    return (
+        b"wOF2"
+        + b"\x00\x01\x00\x00"
+        + total.to_bytes(4, "big")
+        + num_tables.to_bytes(2, "big")
+        + b"\x00\x00"
+        + bytes(32)
+        + body
+    )
+
 
 def git(repo: Path, *args: str) -> str:
     result = subprocess.run(
@@ -102,12 +121,42 @@ class RepositoryIntegrityTest(unittest.TestCase):
         path.parent.mkdir(parents=True)
         path.write_text("global.r=require; console.log('not a font');\n", encoding="utf-8")
         findings = self.scan(self.commit())
-        self.assertTrue(any("signature does not match" in f.reason for f in findings))
+        self.assertTrue(any("not a valid WOFF2" in f.reason for f in findings))
 
-    def test_valid_woff2_magic_passes_signature_check(self) -> None:
+    def test_valid_woff2_passes_structural_check(self) -> None:
         path = self.repo / "public" / "fonts" / "ok.woff2"
         path.parent.mkdir(parents=True)
-        path.write_bytes(b"wOF2" + b"\0" * 64)
+        path.write_bytes(woff2_blob())
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_woff2_magic_prefix_alone_is_not_enough(self) -> None:
+        """A valid `wOF2` prefix in front of script is the incident's attack."""
+        path = self.repo / "public" / "fonts" / "sneaky.woff2"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(b"wOF2" + PREFIXED_SCRIPT_PAYLOAD)
+        findings = self.scan(self.commit())
+        self.assertTrue(any("not a valid WOFF2" in f.reason for f in findings))
+
+    def test_script_appended_to_a_real_font_is_blocked(self) -> None:
+        path = self.repo / "public" / "fonts" / "trailer.woff2"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(woff2_blob() + PREFIXED_SCRIPT_PAYLOAD)
+        findings = self.scan(self.commit())
+        self.assertTrue(any("not a valid WOFF2" in f.reason for f in findings))
+
+    def test_png_signature_without_ihdr_is_blocked(self) -> None:
+        path = self.repo / "assets" / "bad.png"
+        path.parent.mkdir()
+        path.write_bytes(b"\x89PNG\r\n\x1a\n" + PREFIXED_SCRIPT_PAYLOAD)
+        findings = self.scan(self.commit())
+        self.assertTrue(any("not a valid PNG" in f.reason for f in findings))
+
+    def test_truncated_but_genuine_webp_is_not_flagged(self) -> None:
+        """Broken assets are not this guard's business; disguised ones are."""
+        path = self.repo / "assets" / "short.webp"
+        path.parent.mkdir()
+        path.write_bytes(b"RIFF" + (9999).to_bytes(4, "little") + b"WEBPVP8 " + bytes(32))
         findings = self.scan(self.commit())
         self.assertEqual(findings, [])
 
@@ -164,6 +213,30 @@ class RepositoryIntegrityTest(unittest.TestCase):
         findings = self.scan(self.commit(), author="TheZupZup")
         self.assertEqual(findings, [])
 
+    def test_negated_vscode_ignore_is_blocked(self) -> None:
+        """Git applies the last matching rule, so a later `!` undoes the entry."""
+        (self.repo / ".gitignore").write_text(".idea/\n.vscode/\n!.vscode/\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("re-enabled by" in f.reason for f in findings))
+
+    def test_glob_negation_of_a_protected_ignore_is_blocked(self) -> None:
+        (self.repo / ".gitignore").write_text(".idea/\n.vscode/\n!.vs*\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("re-enabled by" in f.reason for f in findings))
+
+    def test_negation_before_the_entry_is_harmless(self) -> None:
+        """Order matters: the positive entry comes last, so it wins."""
+        (self.repo / ".gitignore").write_text(".idea/\n!.vscode/\n.vscode/\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_unrelated_negation_is_allowed(self) -> None:
+        (self.repo / ".gitignore").write_text(
+            ".idea/\n.vscode/\nbuild/\n!build/keep.txt\n", encoding="utf-8"
+        )
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
     def test_removing_vscode_ignore_is_blocked(self) -> None:
         (self.repo / ".gitignore").write_text(".idea/\n", encoding="utf-8")
         findings = self.scan(self.commit())
@@ -173,6 +246,28 @@ class RepositoryIntegrityTest(unittest.TestCase):
         os.symlink("lib/main.dart", self.repo / "shortcut")
         findings = self.scan(self.commit())
         self.assertTrue(any("Git symlink" in f.reason for f in findings))
+
+    def test_svg_animation_event_handler_is_blocked(self) -> None:
+        """Handlers outside the old five-name allowlist still execute."""
+        path = self.repo / "assets" / "anim.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg"><animate onbegin="alert(1)"/></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+    def test_inert_svg_passes(self) -> None:
+        path = self.repo / "assets" / "ok.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg" version="1.1">'
+            '<rect width="10" height="10" fill="#0088cc"/></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
 
     def test_active_svg_is_blocked(self) -> None:
         path = self.repo / "assets" / "bad.svg"


### PR DESCRIPTION
Addresses the four `chatgpt-codex-connector` findings on [#516](https://github.com/TheZupZup/Linthra/pull/516). Targets `security/repository-integrity-hardening` so it merges into #516.

Three of the four threads were marked **resolved without a code change**. I reproduced each against the merged checker before fixing it, and re-ran the reproductions afterwards.

| Finding | Attack | Before | After |
|---|---|---|---|
| P1 fake asset | `.woff2` = valid `wOF2` prefix + JS calling `child_process` | passes | blocked |
| P1 active SVG | an `animate` element carrying an `onbegin="alert(1)"` handler | passes | blocked |
| P2 ignore policy | `.vscode/` then `!.vscode/` | passes | blocked |
| P2 composite actions | external edit to `.github/actions/setup-flutter/action.yml` | blocked by `b4ed913` | + tests |

## Fake assets — structural validation

A magic prefix proves nothing: `wOF2` followed by JavaScript is four valid bytes, and the asset-execution regex doesn't inspect payload contents, so **the exact attack class from the original incident got through by prepending four bytes**.

Each covered format is now checked against a self-describing field rather than `startswith`:

- **WOFF/WOFF2** declare a total length that must equal the real file size, plus a reserved field that must be zero
- **TrueType/OpenType** derive `searchRange`, `entrySelector` and `rangeShift` from `numTables` — mutually redundant fields that random bytes won't satisfy
- **PNG** must carry a well-formed 13-byte `IHDR` after the signature
- **JPEG** needs a valid marker byte and an EOI; **GIF** needs a non-zero canvas

This also closes the variant the finding didn't mention: script *appended* to a genuine font now breaks the declared length.

### WEBP is deliberately looser

I did **not** require the declared RIFF size to match the file size, because three screenshots in this repo are genuinely truncated:

| File | Declared | Actual | Diff |
|---|---|---|---|
| `01-welcome-v020.webp` | 14624 | 14575 | +49 |
| `03-now-playing-v020.webp` | 9078 | 8631 | +447 |
| `04-branding-v020.webp` | 10372 | 10279 | +93 |

A broken asset is not a disguised one, and this guard is not an image linter. WEBP is validated on the VP8 chunk fourcc instead — what a script cannot fake while still being a script. **Worth a separate look: those three screenshots are probably rendering wrong in the docs.**

## Active SVG — generic handler matching

The allowlist enumerated five handler names (`onload`, `onerror`, `onclick`, `onmouseover`, `onfocus`), so `onbegin`, `onrepeat` and `onanimationstart` executed unchallenged. Now any `on*=` attribute matches. Added an inert-SVG test so the broader pattern doesn't over-block.

## Ignore policy — order-aware evaluation

Git applies the **last** matching rule, so `.vscode/` followed by `!.vscode/` left the directory unignored while the old set-membership check saw the entry present and passed. Rules are now evaluated in order, and negations are matched as globs so `!.vs*` is caught too. A negation *before* the entry is correctly harmless, and unrelated negations like `!build/keep.txt` still pass.

## Composite actions

The pattern itself already landed in `b4ed913`; this adds the missing tests and docs entry. Verified the finding: `.github/actions/setup-flutter/action.yml` is the only local composite action, consumed by **nine** workflows including privileged build and release jobs, and `pull_request` runs check it out from the PR head.

## Verification

- **29 tests pass** (was 17).
- **All 76 real asset files in the repository pass the stricter validators** — I swept every `.png`/`.webp`/`.woff2` in the tree specifically to catch false positives, which is how the truncated screenshots surfaced.
- Each of the four bypasses re-run post-fix and is now blocked.
- The guard passes on this PR's own diff using the base-loaded checker, as CI runs it.

## Not addressed

`.pdf`, `.ico` and `.eot` appear in `EXECUTABLE_ASSET_EXTENSIONS` but have no signature validation at all, so a `.pdf` full of script is unchecked. Pre-existing and outside these findings — flagging it rather than widening this PR.