### PR TITLE
fix(security): close four polyglot and glob bypasses in the guard

### DIFF
--- a/scripts/check_repository_integrity.py
+++ b/scripts/check_repository_integrity.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import fnmatch
+import html
 import re
 import subprocess
 import sys
@@ -114,26 +115,84 @@ def _valid_jpeg(data: bytes) -> bool:
     return data[3] in _JPEG_MARKERS and b"\xff\xd9" in data
 
 
+def _skip_gif_sub_blocks(data: bytes, pos: int) -> int:
+    """Walk a chain of length-prefixed sub-blocks; -1 if it runs off the end."""
+    while pos < len(data):
+        size = data[pos]
+        pos += 1
+        if size == 0:
+            return pos
+        pos += size
+    return -1
+
+
 def _valid_gif(data: bytes) -> bool:
-    """Header plus a logical screen descriptor with a non-zero canvas."""
-    if len(data) < 13 or data[:6] not in (b"GIF87a", b"GIF89a"):
+    """Walk the whole block structure through to the trailer.
+
+    A header check is not enough: `GIF89a=0;` parses as a header with non-zero
+    canvas dimensions *and* as JavaScript. Requiring the block chain to resolve
+    exactly onto the trailer leaves no room for a trailing script.
+    """
+    if len(data) < 14 or data[:6] not in (b"GIF87a", b"GIF89a"):
         return False
-    width = int.from_bytes(data[6:8], "little")
-    height = int.from_bytes(data[8:10], "little")
-    return width != 0 and height != 0
+    if int.from_bytes(data[6:8], "little") == 0 or int.from_bytes(data[8:10], "little") == 0:
+        return False
+
+    flags = data[10]
+    pos = 13
+    if flags & 0x80:
+        pos += 3 * (1 << ((flags & 0x07) + 1))
+
+    while 0 <= pos < len(data):
+        block = data[pos]
+        pos += 1
+        if block == 0x3B:
+            return pos == len(data)
+        if block == 0x21:
+            if pos >= len(data):
+                return False
+            pos = _skip_gif_sub_blocks(data, pos + 1)
+        elif block == 0x2C:
+            if pos + 9 > len(data):
+                return False
+            local = data[pos + 8]
+            pos += 9
+            if local & 0x80:
+                pos += 3 * (1 << ((local & 0x07) + 1))
+            if pos >= len(data):
+                return False
+            pos = _skip_gif_sub_blocks(data, pos + 1)
+        else:
+            return False
+    return False
 
 
 def _valid_webp(data: bytes) -> bool:
-    """RIFF/WEBP container followed by a real VP8 chunk fourcc.
+    """Declared RIFF length plus a chunk chain that lands exactly on the end.
 
-    The declared RIFF size is deliberately not required to match the file size:
-    a truncated-but-genuine image is a broken asset, not a disguised script, and
-    this guard is not an image linter. The fourcc is what a script cannot fake
-    while still being a script.
+    Checking only the fourcc is not enough: the required bytes can be parked
+    inside a JavaScript comment (`RIFF/*xxWEBPVP8 */=0;...`). Requiring the
+    declared length to match and the chunk walk to consume the file exactly
+    removes the space such a payload needs.
     """
     if len(data) < 16 or data[:4] != b"RIFF" or data[8:12] != b"WEBP":
         return False
-    return data[12:16] in (b"VP8 ", b"VP8L", b"VP8X")
+    if int.from_bytes(data[4:8], "little") != len(data) - 8:
+        return False
+
+    pos = 12
+    saw_image = False
+    while pos + 8 <= len(data):
+        fourcc = data[pos : pos + 4]
+        if not all(0x20 <= byte <= 0x7E for byte in fourcc):
+            return False
+        size = int.from_bytes(data[pos + 4 : pos + 8], "little")
+        pos += 8 + size + (size & 1)
+        if pos > len(data):
+            return False
+        if fourcc in (b"VP8 ", b"VP8L", b"VP8X"):
+            saw_image = True
+    return saw_image and pos == len(data)
 
 
 ASSET_VALIDATORS: dict[str, tuple[str, "Callable[[bytes], bool]"]] = {
@@ -279,6 +338,22 @@ def _ignore_rules(text: str) -> list[str]:
     return rules
 
 
+def _negation_reenables(pattern: str, name: str) -> bool:
+    """Whether a `!` rule re-enables `name`, using Git's matching semantics.
+
+    Python's fnmatch has no notion of `**/`, so `!**/.vscode/` — which Git
+    applies at every depth including the root — would otherwise slip through.
+    """
+    pattern = pattern.strip().strip("/")
+    if not pattern:
+        return False
+    candidates = {pattern}
+    while pattern.startswith("**/"):
+        pattern = pattern[3:]
+        candidates.add(pattern)
+    return any(fnmatch.fnmatch(name, candidate) for candidate in candidates)
+
+
 def _ignore_state(rules: list[str], entry: str) -> tuple[bool, str | None]:
     """Resolve whether `entry` ends up ignored, the way Git resolves it.
 
@@ -292,8 +367,7 @@ def _ignore_state(rules: list[str], entry: str) -> tuple[bool, str | None]:
     negated_by: str | None = None
     for rule in rules:
         if rule.startswith("!"):
-            pattern = rule[1:].strip().strip("/")
-            if pattern and fnmatch.fnmatch(name, pattern):
+            if _negation_reenables(rule[1:], name):
                 ignored = False
                 negated_by = rule
         elif rule.strip("/") == name:
@@ -359,11 +433,33 @@ def check_asset_magic(head: str, files: list[str]) -> list[Finding]:
         data = blob_bytes(head, path)
         if data is None:
             continue
+        if data and b"\x00" not in data:
+            # Every real asset in these formats carries binary content. A file
+            # that is pure text is a polyglot candidate regardless of how well
+            # it fakes a header, so reject it before the format check.
+            findings.append(
+                Finding(path, f"file extension claims {label} but the file is entirely text")
+            )
+            continue
         if not is_valid(data):
             findings.append(
                 Finding(path, f"file extension claims {label} but the file is not a valid {label}")
             )
     return findings
+
+
+def svg_is_active(text: str) -> bool:
+    """Match active content on the raw source and on its decoded form.
+
+    An XML parser resolves character references before acting on an attribute,
+    so `java&#x73;cript:` becomes `javascript:` at the point it matters. Scanning
+    only raw bytes misses that; scanning both catches the encoded form without
+    losing anything the raw scan already caught.
+    """
+    if ACTIVE_SVG_RE.search(text):
+        return True
+    decoded = html.unescape(text)
+    return decoded != text and bool(ACTIVE_SVG_RE.search(decoded))
 
 
 def check_active_svg(head: str, files: list[str]) -> list[Finding]:
@@ -372,7 +468,7 @@ def check_active_svg(head: str, files: list[str]) -> list[Finding]:
         if Path(path).suffix.lower() != ".svg":
             continue
         text = blob_text(head, path)
-        if text is not None and ACTIVE_SVG_RE.search(text):
+        if text is not None and svg_is_active(text):
             findings.append(Finding(path, "SVG contains active/external executable content"))
     return findings
 

--- a/test/tooling/check_repository_integrity_test.py
+++ b/test/tooling/check_repository_integrity_test.py
@@ -34,6 +34,22 @@ MARKED_PAYLOAD_LINE = f"{ASSET_EXECUTION_PAYLOAD.strip()}  # {integrity.FIXTURE_
 PREFIXED_SCRIPT_PAYLOAD = b"=0;\nglobal.p=require('child_process');p.exec('id');\n"
 
 
+def gif_blob() -> bytes:
+    """A minimal but structurally complete 1x1 GIF, trailer included."""
+    header = b"GIF89a" + (1).to_bytes(2, "little") + (1).to_bytes(2, "little") + bytes([0x80, 0, 0])
+    global_color_table = b"\x00\x00\x00\xff\xff\xff"
+    descriptor = b"\x2c" + bytes(8) + b"\x00"
+    image = b"\x02" + b"\x02\x4c\x01" + b"\x00"
+    return header + global_color_table + descriptor + image + b"\x3b"
+
+
+def webp_blob() -> bytes:
+    """A minimal RIFF/WEBP container whose declared length matches exactly."""
+    payload = bytes(16)
+    body = b"WEBP" + b"VP8 " + len(payload).to_bytes(4, "little") + payload
+    return b"RIFF" + len(body).to_bytes(4, "little") + body
+
+
 def woff2_blob(num_tables: int = 1) -> bytes:
     """A structurally valid WOFF2 header padded out to its declared length."""
     body = bytes(64)
@@ -121,7 +137,7 @@ class RepositoryIntegrityTest(unittest.TestCase):
         path.parent.mkdir(parents=True)
         path.write_text("global.r=require; console.log('not a font');\n", encoding="utf-8")
         findings = self.scan(self.commit())
-        self.assertTrue(any("not a valid WOFF2" in f.reason for f in findings))
+        self.assertTrue(any(f.path.endswith("bad.woff2") for f in findings))
 
     def test_valid_woff2_passes_structural_check(self) -> None:
         path = self.repo / "public" / "fonts" / "ok.woff2"
@@ -136,7 +152,7 @@ class RepositoryIntegrityTest(unittest.TestCase):
         path.parent.mkdir(parents=True)
         path.write_bytes(b"wOF2" + PREFIXED_SCRIPT_PAYLOAD)
         findings = self.scan(self.commit())
-        self.assertTrue(any("not a valid WOFF2" in f.reason for f in findings))
+        self.assertTrue(any(f.path.endswith("sneaky.woff2") for f in findings))
 
     def test_script_appended_to_a_real_font_is_blocked(self) -> None:
         path = self.repo / "public" / "fonts" / "trailer.woff2"
@@ -150,15 +166,45 @@ class RepositoryIntegrityTest(unittest.TestCase):
         path.parent.mkdir()
         path.write_bytes(b"\x89PNG\r\n\x1a\n" + PREFIXED_SCRIPT_PAYLOAD)
         findings = self.scan(self.commit())
-        self.assertTrue(any("not a valid PNG" in f.reason for f in findings))
+        self.assertTrue(any(f.path.endswith("bad.png") for f in findings))
 
-    def test_truncated_but_genuine_webp_is_not_flagged(self) -> None:
-        """Broken assets are not this guard's business; disguised ones are."""
+    def test_valid_gif_and_webp_pass(self) -> None:
+        (self.repo / "assets").mkdir()
+        (self.repo / "assets" / "ok.gif").write_bytes(gif_blob())
+        (self.repo / "assets" / "ok.webp").write_bytes(webp_blob())
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_gif_javascript_polyglot_is_blocked(self) -> None:
+        """`GIF89a=0;` is both a plausible header and executable JavaScript."""
+        path = self.repo / "assets" / "poly.gif"
+        path.parent.mkdir()
+        path.write_bytes(b"GIF89a=0;console.log('EXEC')")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("poly.gif" in f.path for f in findings))
+
+    def test_webp_javascript_polyglot_is_blocked(self) -> None:
+        """The fourcc can be parked inside a JavaScript comment."""
+        path = self.repo / "assets" / "poly.webp"
+        path.parent.mkdir()
+        path.write_bytes(b"RIFF/*xxWEBPVP8 */=0;console.log('EXEC')")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("poly.webp" in f.path for f in findings))
+
+    def test_text_only_asset_is_blocked(self) -> None:
+        """Backstop: real assets in these formats always carry binary content."""
+        path = self.repo / "assets" / "text.png"
+        path.parent.mkdir()
+        path.write_bytes(b"just plain text pretending to be an image\n")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("entirely text" in f.reason for f in findings))
+
+    def test_truncated_webp_is_blocked(self) -> None:
         path = self.repo / "assets" / "short.webp"
         path.parent.mkdir()
         path.write_bytes(b"RIFF" + (9999).to_bytes(4, "little") + b"WEBPVP8 " + bytes(32))
         findings = self.scan(self.commit())
-        self.assertEqual(findings, [])
+        self.assertTrue(any("short.webp" in f.path for f in findings))
 
     def test_asset_execution_command_is_blocked(self) -> None:
         path = self.repo / "docs" / "note.txt"
@@ -224,6 +270,17 @@ class RepositoryIntegrityTest(unittest.TestCase):
         findings = self.scan(self.commit())
         self.assertTrue(any("re-enabled by" in f.reason for f in findings))
 
+    def test_recursive_glob_negation_is_blocked(self) -> None:
+        """Git applies `**/` at every depth, including the repository root."""
+        (self.repo / ".gitignore").write_text(".idea/\n.vscode/\n!**/.vscode/\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("re-enabled by" in f.reason for f in findings))
+
+    def test_catch_all_negation_is_blocked(self) -> None:
+        (self.repo / ".gitignore").write_text(".idea/\n.vscode/\n!*\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("re-enabled by" in f.reason for f in findings))
+
     def test_negation_before_the_entry_is_harmless(self) -> None:
         """Order matters: the positive entry comes last, so it wins."""
         (self.repo / ".gitignore").write_text(".idea/\n!.vscode/\n.vscode/\n", encoding="utf-8")
@@ -257,6 +314,41 @@ class RepositoryIntegrityTest(unittest.TestCase):
         )
         findings = self.scan(self.commit())
         self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+    def test_entity_encoded_javascript_url_is_blocked(self) -> None:
+        """An XML parser resolves `java&#x73;cript:` before the link is used."""
+        path = self.repo / "assets" / "entity.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg">'
+            '<a href="java&#x73;cript:alert(1)"><rect width="1" height="1"/></a></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+    def test_decimal_entity_encoded_javascript_url_is_blocked(self) -> None:
+        path = self.repo / "assets" / "decimal.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg">'
+            '<a href="java&#115;cript:alert(1)"><rect width="1" height="1"/></a></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+    def test_svg_with_harmless_entities_passes(self) -> None:
+        """Decoding must not turn ordinary escaped text into a false positive."""
+        path = self.repo / "assets" / "amp.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg">'
+            '<title>Tools &amp; Settings &#8212; v1</title><rect width="1" height="1"/></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
 
     def test_inert_svg_passes(self) -> None:
         path = self.repo / "assets" / "ok.svg"


### PR DESCRIPTION
Fixes the four findings the codex bot raised against the merged result `5cf0b844ab`. **All four are defects in validation I added earlier in this branch**, not pre-existing gaps — each was reproduced before being fixed.

| Finding | Bypass | Before | After |
|---|---|---|---|
| P1 GIF | `GIF89a=0;console.log('EXEC')` | accepted | blocked |
| P1 WEBP | `RIFF/*xxWEBPVP8 */=0;console.log('EXEC')` | accepted | blocked |
| P1 SVG | `<a href="java&#x73;cript:alert(1)">` | accepted | blocked |
| P2 gitignore | `!**/.vscode/` | accepted | blocked |

## Why these got through

GIF and WEBP have ASCII-friendly headers, so both double as valid JavaScript. `GIF89a=0;` parses as a header whose canvas bytes (`=0`, `;c`) are non-zero, and a WEBP fourcc can be parked inside a `/* comment */`. Header-shaped checks were never going to hold for these two formats.

Both are now walked in full: GIF through its block chain to the trailer, WEBP through its chunk chain with the declared RIFF length required to match the file. Neither leaves room for a trailing payload.

### The WEBP concession was a mistake

I previously dropped WEBP's length check because three screenshots in this repo are truncated. That was the wrong trade — it is exactly the slack the polyglot exploited. The check is restored, because **the guard only scans files a PR changes**, and those screenshots are not touched by ordinary PRs. Anyone editing them would be regenerating them anyway.

They do still need regenerating (`01-welcome`, `03-now-playing`, `04-branding` under `docs/images/screenshots/`) — tracked separately, not in this PR.

### Binary backstop

Rather than fix polyglots one format at a time, any file with a covered extension that contains **no NUL byte at all** is now rejected up front. All 76 real assets in the repository carry binary content and none decode as UTF-8, so this costs nothing and closes the class generally.

Three earlier tests now trip this backstop before reaching the format check, so their assertions were relaxed from a specific message to the security property (the file is blocked). The reason string changes; the outcome does not.

### SVG and gitignore

SVG scanning now also runs over the entity-decoded text, since an XML parser resolves `java&#x73;cript:` before the link is used. Both hex and decimal references are covered.

Gitignore negations understand Git's `**/` semantics, which Python's `fnmatch` has no notion of.

## Tests

**38 pass** (was 29). Every negative test has a positive counterpart, per the audit requirements:

- valid minimal GIF and WEBP fixtures pass, proving the full structural walks don't reject real files
- an SVG carrying harmless entities (`&amp;`, `&#8212;`) is **not** flagged, proving entity decoding doesn't create false positives
- all previously-fixed bypasses re-verified as still blocked
- all 76 real repository assets re-checked: only the three known-truncated screenshots are rejected

The guard passes on this PR's own diff using the base-loaded checker, as CI runs it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3zunXpbRCjdiQ6zJwjEjy)_