### PR TITLE
Repository-integrity: emit structured findings and add trusted PR reporter

### DIFF
--- a/.github/workflows/repository-integrity-reporter.yml
+++ b/.github/workflows/repository-integrity-reporter.yml
@@ -1,0 +1,69 @@
+name: Repository integrity reporter
+
+on:
+  workflow_run:
+    workflows: [Repository integrity]
+    types: [completed]
+
+# This trusted workflow never checks out the PR head. Its sole write permission
+# is posting an issue-style comment on the PR identified by workflow_run.
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  report:
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests[0] != null }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout trusted default branch reporter
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Download scanner report only
+        uses: actions/download-artifact@v7
+        with:
+          name: repository-integrity-findings
+          path: ${{ runner.temp }}/repository-integrity
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Validate and render report as inert data
+        run: |
+          python3 scripts/render_repository_integrity_comment.py \
+            --report "$RUNNER_TEMP/repository-integrity/report.json" \
+            --event "$GITHUB_EVENT_PATH" \
+            --output "$RUNNER_TEMP/repository-integrity/comment.md"
+
+      - name: Create or update the sticky PR comment
+        uses: actions/github-script@v8
+        env:
+          COMMENT_PATH: ${{ runner.temp }}/repository-integrity/comment.md
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- linthra-repository-integrity-v1 -->';
+            const body = fs.readFileSync(process.env.COMMENT_PATH, 'utf8');
+            const issue_number = Number.parseInt(process.env.PR_NUMBER, 10);
+            if (!Number.isSafeInteger(issue_number) || issue_number < 1 || !body.startsWith(marker)) {
+              throw new Error('validated comment binding is invalid');
+            }
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner, repo: context.repo.repo, issue_number, per_page: 100
+            });
+            const prior = comments.find(comment =>
+              comment.user?.login === 'github-actions[bot]' && comment.body?.startsWith(marker));
+            if (prior) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                comment_id: prior.id, body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number, body
+              });
+            }

--- a/.github/workflows/repository-integrity.yml
+++ b/.github/workflows/repository-integrity.yml
@@ -23,7 +23,9 @@ jobs:
           python-version: "3.11"
 
       - name: Run guard tests
-        run: python3 test/tooling/check_repository_integrity_test.py
+        run: |
+          python3 test/tooling/check_repository_integrity_test.py
+          python3 test/tooling/render_repository_integrity_comment_test.py
 
   integrity:
     name: Repository integrity guard
@@ -34,6 +36,7 @@ jobs:
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       PR_AUTHOR: ${{ github.event.pull_request.user.login }}
       HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
       REPO_OWNER: ${{ github.repository_owner }}
       CHECKER_PATH: scripts/check_repository_integrity.py
 
@@ -72,6 +75,8 @@ jobs:
           fi
 
       - name: Run repository integrity guard
+        id: scan
+        continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail
@@ -80,7 +85,19 @@ jobs:
             --head "$HEAD_SHA" \
             --pr-author "$PR_AUTHOR" \
             --repo-owner "$REPO_OWNER" \
-            --report "$RUNNER_TEMP/repository-integrity.md"
+            --report "$RUNNER_TEMP/repository-integrity.md" \
+            --json-report "$RUNNER_TEMP/repository-integrity/report.json" \
+            --pr-number "$PR_NUMBER" \
+            --head-repository "$HEAD_REPO"
+
+      - name: Upload repository integrity findings
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: repository-integrity-findings
+          path: ${{ runner.temp }}/repository-integrity/report.json
+          if-no-files-found: warn
+          retention-days: 2
 
       - name: Publish repository integrity report
         if: ${{ always() }}
@@ -89,3 +106,7 @@ jobs:
           if [ -f "$RUNNER_TEMP/repository-integrity.md" ]; then
             cat "$RUNNER_TEMP/repository-integrity.md" >> "$GITHUB_STEP_SUMMARY"
           fi
+
+      - name: Enforce repository integrity result
+        if: ${{ steps.scan.outcome != 'success' }}
+        run: exit 1

--- a/scripts/check_repository_integrity.py
+++ b/scripts/check_repository_integrity.py
@@ -14,11 +14,12 @@ from __future__ import annotations
 import argparse
 import fnmatch
 import html
+import json
 import re
 import subprocess
 import sys
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 
@@ -26,6 +27,20 @@ from pathlib import Path
 class Finding:
     path: str
     reason: str
+    severity: str = "blocked"
+    commit: str | None = None
+    rule: str = "repository-integrity"
+    remediation: str = "Remove the prohibited change and rebuild the feature from the current clean main branch."
+
+    def as_dict(self) -> dict[str, str | None]:
+        return {
+            "severity": self.severity,
+            "commit": self.commit,
+            "path": self.path,
+            "rule": self.rule,
+            "reason": self.reason,
+            "remediation": self.remediation,
+        }
 
 
 PROTECTED_IGNORE_ENTRIES = (".idea/", ".vscode/")
@@ -405,6 +420,40 @@ def changed_files(base: str, head: str) -> list[str]:
     return [item for item in raw.split("\0") if item]
 
 
+def commits_touching_paths(base: str, head: str) -> list[tuple[str, str]]:
+    """Return every path touched by every commit the PR would introduce."""
+    raw = run_git(
+        "-c", "core.quotePath=false", "log", "--reverse", "--format=%x1e%H",
+        "--name-only", "-z", f"{base}..{head}", "--",
+    )
+    assert isinstance(raw, str)
+    result: list[tuple[str, str]] = []
+    for record in raw.split("\x1e"):
+        fields = [field for field in record.strip("\0\n").split("\0") if field]
+        if not fields:
+            continue
+        commit = fields[0].strip()
+        result.extend((commit, path.strip()) for path in fields[1:] if path.strip())
+    return result
+
+
+def historical_external_findings(base: str, head: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for commit, path in commits_touching_paths(base, head):
+        for pattern, reason in EXTERNAL_BLOCKED_PATHS:
+            if pattern.search(path):
+                findings.append(Finding(
+                    path=path,
+                    reason=(f"Commit {commit[:12]} modifies a maintainer-controlled surface. "
+                            f"{reason}. The commit remains in the PR history even if a later commit removes the path."),
+                    commit=commit,
+                    rule="external-maintainer-controlled-path",
+                    remediation="Recreate or rebase the legitimate feature work onto a clean main history, or move this repository-control change to a maintainer-owned PR.",
+                ))
+                break
+    return findings
+
+
 def blob_bytes(head: str, path: str) -> bytes | None:
     try:
         value = run_git("show", f"{head}:{path}", text=False)
@@ -678,20 +727,44 @@ def dedupe(findings: list[Finding]) -> list[Finding]:
     return result
 
 
+def actionable(finding: Finding, commits_by_path: dict[str, str]) -> Finding:
+    reason = finding.reason.lower()
+    if "executable bit" in reason:
+        rule, remediation = "asset-executable-mode", "Remove the executable permission from the asset and recommit the mode change."
+    elif "file extension claims" in reason:
+        rule, remediation = "invalid-disguised-asset", "Replace the invalid asset with a real file of the declared asset type."
+    elif "svg contains" in reason:
+        rule, remediation = "active-svg-content", "Remove scripts, event handlers, foreign objects, and external active references from the SVG."
+    elif "invokes or marks an asset" in reason:
+        rule, remediation = "asset-execution-command", "Remove commands that execute the asset or grant it executable permission."
+    elif "gitignore" in reason or "ignore entry" in reason:
+        rule, remediation = "protected-ignore-policy", "Restore the required .idea/ and .vscode/ ignore rules without later negations."
+    elif "symlink" in reason:
+        rule, remediation = "external-symlink", "Remove the Git symlink or move the repository-control change to a maintainer-owned PR."
+    else:
+        rule, remediation = finding.rule, finding.remediation
+    return replace(finding, commit=finding.commit or commits_by_path.get(finding.path),
+                   rule=rule, remediation=remediation)
+
+
 def scan(base: str, head: str, pr_author: str, repo_owner: str) -> list[Finding]:
     files = changed_files(base, head)
+    history = commits_touching_paths(base, head)
+    commits_by_path: dict[str, str] = {}
+    for commit, path in history:
+        commits_by_path.setdefault(path, commit)
     external = is_external(pr_author, repo_owner)
 
     findings: list[Finding] = []
     findings.extend(check_ignore_policy(head))
     if external:
-        findings.extend(check_external_paths(files))
+        findings.extend(historical_external_findings(base, head))
     findings.extend(check_symlinks(head, files, external))
     findings.extend(check_asset_modes(head, files))
     findings.extend(check_asset_magic(head, files))
     findings.extend(check_active_svg(head, files))
     findings.extend(check_asset_execution(head, files))
-    return dedupe(findings)
+    return dedupe([actionable(finding, commits_by_path) for finding in findings])
 
 
 def write_report(path: Path, findings: list[Finding]) -> None:
@@ -703,11 +776,25 @@ def write_report(path: Path, findings: list[Finding]) -> None:
             return
         out.write("### Blocked findings\n\n")
         for finding in findings:
-            out.write(f"- `{finding.path}` — {finding.reason}\n")
+            commit = f" (commit `{finding.commit}`)" if finding.commit else ""
+            out.write(f"- `{finding.path}`{commit} — {finding.reason}\n")
         out.write(
             "\nThese checks fail closed. Repository-control changes must be "
             "performed from a trusted maintainer-controlled branch.\n"
         )
+
+
+def write_json_report(path: Path, findings: list[Finding], *, pr_number: int,
+                      head: str, head_repository: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": 1,
+        "pr_number": pr_number,
+        "head_sha": head,
+        "head_repository": head_repository,
+        "findings": [finding.as_dict() for finding in findings],
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=True, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -717,6 +804,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--pr-author", required=True)
     parser.add_argument("--repo-owner", required=True)
     parser.add_argument("--report", required=True)
+    parser.add_argument("--json-report", required=True)
+    parser.add_argument("--pr-number", required=True, type=int)
+    parser.add_argument("--head-repository", required=True)
     args = parser.parse_args(argv)
 
     for stream in (sys.stdout, sys.stderr):
@@ -729,6 +819,8 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     write_report(Path(args.report), findings)
+    write_json_report(Path(args.json_report), findings, pr_number=args.pr_number,
+                      head=args.head, head_repository=args.head_repository)
 
     if findings:
         print("Repository integrity guard blocked the PR:")

--- a/scripts/render_repository_integrity_comment.py
+++ b/scripts/render_repository_integrity_comment.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Validate a scanner artifact and render the one sticky PR comment.
+
+This program runs only from the trusted default branch. Report fields are data:
+they are strictly bounded, escaped, and never evaluated as shell or program text.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+MARKER = "<!-- linthra-repository-integrity-v1 -->"
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+SEVERITIES = {"blocked", "review_required"}
+FIELDS = ("path", "rule", "reason", "remediation")
+MAX_FINDINGS = 100
+MAX_FIELD_LENGTH = 2000
+
+
+def safe_text(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value or len(value) > MAX_FIELD_LENGTH:
+        raise ValueError(f"invalid {field}")
+    # Numeric entities prevent Markdown, raw HTML, mentions, and links while
+    # preserving an exact, readable representation of repository data.
+    return "".join(ch if ch.isalnum() or ch in " .,_/-:" else f"&#{ord(ch)};" for ch in value)
+
+
+def validate(payload: object, event: object) -> list[dict[str, str | None]]:
+    if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+        raise ValueError("unsupported report schema")
+    if not isinstance(event, dict):
+        raise ValueError("invalid workflow event")
+    run = event.get("workflow_run")
+    if not isinstance(run, dict):
+        raise ValueError("missing workflow run")
+    prs = run.get("pull_requests")
+    if not isinstance(prs, list) or len(prs) != 1 or not isinstance(prs[0], dict):
+        raise ValueError("workflow run must identify exactly one PR")
+    expected_pr = prs[0].get("number")
+    expected_sha = run.get("head_sha")
+    head_repo = run.get("head_repository")
+    expected_repo = head_repo.get("full_name") if isinstance(head_repo, dict) else None
+    if payload.get("pr_number") != expected_pr or payload.get("head_sha") != expected_sha or payload.get("head_repository") != expected_repo:
+        raise ValueError("report does not match the triggering PR")
+    if not isinstance(expected_sha, str) or not SHA_RE.fullmatch(expected_sha):
+        raise ValueError("invalid head SHA")
+    findings = payload.get("findings")
+    if not isinstance(findings, list) or len(findings) > MAX_FINDINGS:
+        raise ValueError("invalid findings list")
+    validated: list[dict[str, str | None]] = []
+    for raw in findings:
+        if not isinstance(raw, dict) or set(raw) != {"severity", "commit", *FIELDS}:
+            raise ValueError("invalid finding shape")
+        if raw["severity"] not in SEVERITIES:
+            raise ValueError("invalid severity")
+        commit = raw["commit"]
+        if commit is not None and (not isinstance(commit, str) or not SHA_RE.fullmatch(commit)):
+            raise ValueError("invalid commit SHA")
+        item = {field: safe_text(raw[field], field) for field in FIELDS}
+        item.update(severity=raw["severity"], commit=commit)
+        validated.append(item)
+    return validated
+
+
+def render(findings: list[dict[str, str | None]]) -> str:
+    lines = [MARKER, "## Repository integrity review", ""]
+    if not findings:
+        return "\n".join(lines + ["**CLEAN**", "", "Previously reported repository-integrity findings are resolved."])
+    blocked = any(item["severity"] == "blocked" for item in findings)
+    lines += [f"**{'BLOCKED' if blocked else 'REVIEW REQUIRED'}**", "", "Repository integrity blocked this PR." if blocked else "Repository integrity requires explicit maintainer review.", ""]
+    for number, item in enumerate(findings, 1):
+        lines += [f"### Finding {number}"]
+        if item["commit"]:
+            lines.append(f"- **Commit:** `{item['commit']}`")
+        lines += [
+            f"- **Path:** `{item['path']}`",
+            f"- **Rule:** `{item['rule']}`",
+            f"- **Explanation:** {item['reason']}",
+            f"- **How to fix:** {item['remediation']}", "",
+        ]
+    lines.append("This report describes observable repository state and history; it does not infer contributor intent.")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--report", required=True, type=Path)
+    parser.add_argument("--event", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    if args.report.stat().st_size > 1_000_000:
+        raise ValueError("report exceeds size limit")
+    payload = json.loads(args.report.read_text(encoding="utf-8"))
+    event = json.loads(args.event.read_text(encoding="utf-8"))
+    args.output.write_text(render(validate(payload, event)), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/tooling/check_repository_integrity_test.py
+++ b/test/tooling/check_repository_integrity_test.py
@@ -181,6 +181,19 @@ class RepositoryIntegrityTest(unittest.TestCase):
         findings = self.scan(head)
         self.assertTrue(any(f.path == ".vscode/tasks.json" for f in findings))
 
+    def test_removed_prohibited_path_still_reports_historical_commit(self) -> None:
+        path = self.repo / ".vscode" / "tasks.json"
+        path.parent.mkdir()
+        path.write_text('{}\n', encoding="utf-8")
+        git(self.repo, "add", "-f", ".vscode/tasks.json")
+        introduced = self.commit("introduce prohibited path")
+        path.unlink()
+        head = self.commit("remove prohibited path")
+        findings = self.scan(head)
+        match = next(f for f in findings if f.path == ".vscode/tasks.json")
+        self.assertEqual(match.commit, introduced)
+        self.assertIn("remains in the PR history", match.reason)
+
     def test_case_variant_ide_paths_are_blocked(self) -> None:
         for relative in (".VSCODE/tasks.json", ".Idea/workspace.xml"):
             with self.subTest(relative):

--- a/test/tooling/render_repository_integrity_comment_test.py
+++ b/test/tooling/render_repository_integrity_comment_test.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "render_repository_integrity_comment.py"
+spec = importlib.util.spec_from_file_location("reporter", SCRIPT)
+reporter = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = reporter
+spec.loader.exec_module(reporter)
+
+SHA = "a" * 40
+
+
+def finding(path: str = ".vscode/tasks.json") -> dict:
+    return {
+        "severity": "blocked", "commit": SHA, "path": path,
+        "rule": "external-maintainer-controlled-path", "reason": "observable change",
+        "remediation": "remove the prohibited path",
+    }
+
+
+def payload(findings: list[dict]) -> dict:
+    return {"schema_version": 1, "pr_number": 7, "head_sha": SHA,
+            "head_repository": "fork/repo", "findings": findings}
+
+
+EVENT = {"workflow_run": {"head_sha": SHA, "head_repository": {"full_name": "fork/repo"},
+                          "pull_requests": [{"number": 7}]}}
+
+
+class ReporterTest(unittest.TestCase):
+    def test_one_violation_is_actionable(self) -> None:
+        body = reporter.render(reporter.validate(payload([finding()]), EVENT))
+        self.assertIn("**BLOCKED**", body)
+        self.assertIn("**How to fix:** remove the prohibited path", body)
+        self.assertIn(SHA, body)
+
+    def test_multiple_findings_are_one_comment(self) -> None:
+        body = reporter.render(reporter.validate(payload([finding("one"), finding("two")]), EVENT))
+        self.assertEqual(body.count(reporter.MARKER), 1)
+        self.assertIn("Finding 1", body)
+        self.assertIn("Finding 2", body)
+
+    def test_resolved_is_clean_with_same_marker(self) -> None:
+        body = reporter.render(reporter.validate(payload([]), EVENT))
+        self.assertTrue(body.startswith(reporter.MARKER))
+        self.assertIn("**CLEAN**", body)
+
+    def test_markup_and_html_are_inert(self) -> None:
+        hostile = finding("</details> @everyone [click](javascript:alert(1)) `x`")
+        body = reporter.render(reporter.validate(payload([hostile]), EVENT))
+        self.assertNotIn("</details>", body)
+        self.assertNotIn("@everyone", body)
+        self.assertNotIn("(javascript:alert", body)
+        self.assertIn("&#60;", body)
+
+    def test_report_binding_and_shape_are_fail_closed(self) -> None:
+        bad = payload([finding()])
+        bad["pr_number"] = 8
+        with self.assertRaises(ValueError):
+            reporter.validate(bad, EVENT)
+        injected = finding()
+        injected["command"] = "echo owned"
+        with self.assertRaises(ValueError):
+            reporter.validate(payload([injected]), EVENT)
+
+    def test_workflows_separate_untrusted_scan_from_sticky_writer(self) -> None:
+        scanner = (ROOT / ".github/workflows/repository-integrity.yml").read_text()
+        writer = (ROOT / ".github/workflows/repository-integrity-reporter.yml").read_text()
+        self.assertIn("permissions:\n  contents: read", scanner)
+        self.assertNotIn("pull-requests: write", scanner)
+        self.assertNotIn("issues: write", scanner)
+        self.assertIn("workflow_run:", writer)
+        self.assertIn("pull-requests: write", writer)
+        self.assertIn("updateComment", writer)
+        self.assertIn("createComment", writer)
+        self.assertIn("github-actions[bot]", writer)
+        self.assertIn("comment.body?.startsWith(marker)", writer)
+        self.assertIn("ref: ${{ github.event.repository.default_branch }}", writer)
+        self.assertNotIn("pull_request_target", writer)
+
+    def test_untrusted_fields_are_never_inserted_into_commands(self) -> None:
+        writer = (ROOT / ".github/workflows/repository-integrity-reporter.yml").read_text()
+        self.assertNotIn("${{ github.event.workflow_run.head", writer)
+        self.assertIn("fs.readFileSync(process.env.COMMENT_PATH", writer)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Make the repository-integrity guard act like an active, deterministic security maintainer by explaining violations directly on the PR instead of only failing CI.
- Ensure untrusted scanner jobs never get write tokens and that any PR comment is created only by trusted default-branch code that consumes a validated scanner artifact.
- Provide machine-readable findings so a trusted reporter can author safe, repeatable PR comments and avoid comment spam by updating a single sticky comment.

### Description

- Extend `scripts/check_repository_integrity.py` to emit structured findings including `severity`, `commit`, `path`, `rule`, `reason`, and `remediation` and to write a JSON artifact via a new `--json-report` argument and `write_json_report` function.
- Add historical-commit scanning (`commits_touching_paths`, `historical_external_findings`) so violations introduced by an earlier commit remain actionable even if later commits remove the path, and include the offending SHA in findings.
- Enrich `Finding` objects and map low-level reasons to actionable `rule` and `remediation` text so the reporter can render concise, technical, and actionable guidance.
- Change the scanner workflow `/.github/workflows/repository-integrity.yml` to keep the scanner read-only, produce both the human-readable step summary and a JSON artifact, upload that artifact, and still fail the check on blocked findings while not holding write privileges.
- Add a trusted reporter workflow `/.github/workflows/repository-integrity-reporter.yml` that runs from the default branch on `workflow_run`, downloads and validates the scanner JSON, renders a single sticky comment using `scripts/render_repository_integrity_comment.py`, and updates or creates the bot comment using a stable hidden marker so findings are updated rather than duplicated.
- Implement `scripts/render_repository_integrity_comment.py` to strictly validate the scanner artifact (schema, PR binding, SHA, sizes, field lengths), escape all untrusted fields into numeric entities to neutralize Markdown/HTML/mentions/links, and render `BLOCKED` / `REVIEW REQUIRED` / `CLEAN` outputs with a hidden marker.
- Add regression tests `test/tooling/check_repository_integrity_test.py` and new `test/tooling/render_repository_integrity_comment_test.py` covering: single actionable finding, grouped findings in one comment, sticky-update behavior, resolved -> CLEAN state, historical-commit reporting, hostile markup escape, and workflow separation so the scanner has no write permissions.

### Testing

- Ran `python3 test/tooling/check_repository_integrity_test.py` and all integrator unit tests passed (OK).
- Ran `python3 test/tooling/render_repository_integrity_comment_test.py` and all reporter unit tests passed (OK).
- Verified `python3 -m py_compile scripts/check_repository_integrity.py scripts/render_repository_integrity_comment.py` succeeded, YAML workflow parsing succeeded, and `git diff --check` returned clean results.
- The repository-integrity scanner still fails closed on blocked findings and the reporter validates and renders only the trusted JSON artifact, with tests asserting that untrusted scanner runs never receive write-capable tokens and that the reporter updates a single sticky bot comment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8dcb3b6dfc832dad3106699c7ddd49)