### PR TITLE
security: scan PR-introduced commits to prevent history-burying bypass

### DIFF
--- a/docs/pr-security-guard.md
+++ b/docs/pr-security-guard.md
@@ -1,5 +1,26 @@
 # PR security surface guard
 
+## Repository-integrity history
+
+The separate `.github/workflows/repository-integrity.yml` gate also inspects
+the commits a pull request would add to the target branch. A clean final diff
+is not sufficient: adding a prohibited asset or repository trust-surface
+change and deleting it in a later commit remains blocked because the offending
+commit would still enter history.
+
+The history boundary is deliberately narrow. The checker enumerates commits
+reachable from the PR head but not from the trusted base SHA, so commits already
+reachable from `main` are never reclassified. Each ordinary commit is checked
+against its parent. For a merge commit, only a path whose result differs from
+every parent is considered merge-introduced; this catches a novel conflict
+resolution without treating an ordinary GitHub **Update branch** merge as if
+it authored all the legitimate changes imported from `main`.
+
+Reports name the full offending commit SHA, path, and reason. The workflow uses
+a full-history checkout and loads the checker itself from the trusted base, so
+missing ancestry or an unreadable commit fails closed rather than silently
+falling back to the final tree.
+
 `.github/workflows/pr-security-review.yml` decides whether a pull request
 crosses a trust boundary that deserves an explicit maintainer security review,
 and hard-rejects a small set of unusually powerful additions. The classifier

--- a/scripts/check_repository_integrity.py
+++ b/scripts/check_repository_integrity.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 @dataclass(frozen=True)
 class Finding:
+    commit: str
     path: str
     reason: str
 
@@ -487,7 +488,7 @@ def _ignore_state(rules: list[str], entry: str) -> tuple[bool, str | None]:
 def check_ignore_policy(head: str) -> list[Finding]:
     text = blob_text(head, ".gitignore")
     if text is None:
-        return [Finding(".gitignore", "required repository .gitignore is missing")]
+        return [Finding(head, ".gitignore", "required repository .gitignore is missing")]
     rules = _ignore_rules(text)
 
     findings: list[Finding] = []
@@ -498,23 +499,24 @@ def check_ignore_policy(head: str) -> list[Finding]:
         if negated_by is not None:
             findings.append(
                 Finding(
+                    head,
                     ".gitignore",
                     f"required ignore entry `{entry}` is re-enabled by `{negated_by}`",
                 )
             )
         else:
             findings.append(
-                Finding(".gitignore", f"required ignore entry `{entry}` was removed")
+                Finding(head, ".gitignore", f"required ignore entry `{entry}` was removed")
             )
     return findings
 
 
-def check_external_paths(files: list[str]) -> list[Finding]:
+def check_external_paths(commit: str, files: list[str]) -> list[Finding]:
     findings: list[Finding] = []
     for path in files:
         for pattern, reason in EXTERNAL_BLOCKED_PATHS:
             if pattern.search(path):
-                findings.append(Finding(path, reason))
+                findings.append(Finding(commit, path, reason))
                 break
     return findings
 
@@ -526,7 +528,7 @@ def check_symlinks(head: str, files: list[str], external: bool) -> list[Finding]
     for path in files:
         if git_mode(head, path) == "120000":
             findings.append(
-                Finding(path, "external PR introduces or modifies a Git symlink")
+                Finding(head, path, "external PR introduces or modifies a Git symlink")
             )
     return findings
 
@@ -544,7 +546,7 @@ def check_asset_modes(head: str, files: list[str]) -> list[Finding]:
             continue
         if git_mode(head, path) == "100755":
             findings.append(
-                Finding(path, "asset file is committed with the executable bit set")
+                Finding(head, path, "asset file is committed with the executable bit set")
             )
     return findings
 
@@ -565,12 +567,12 @@ def check_asset_magic(head: str, files: list[str]) -> list[Finding]:
             # that is pure text is a polyglot candidate regardless of how well
             # it fakes a header, so reject it before the format check.
             findings.append(
-                Finding(path, f"file extension claims {label} but the file is entirely text")
+                Finding(head, path, f"file extension claims {label} but the file is entirely text")
             )
             continue
         if not is_valid(data):
             findings.append(
-                Finding(path, f"file extension claims {label} but the file is not a valid {label}")
+                Finding(head, path, f"file extension claims {label} but the file is not a valid {label}")
             )
     return findings
 
@@ -614,7 +616,7 @@ def check_active_svg(head: str, files: list[str]) -> list[Finding]:
             continue
         text = blob_text(head, path)
         if text is not None and svg_is_active(text):
-            findings.append(Finding(path, "SVG contains active/external executable content"))
+            findings.append(Finding(head, path, "SVG contains active/external executable content"))
     return findings
 
 
@@ -647,11 +649,11 @@ def asset_execution_finding(path: str, text: str) -> Finding | None:
     normalised = re.sub(r"\\\r?\n", "", "".join(scannable))
     for line in re.split(r"[\r\n]", normalised):
         if _EXECUTABLE_ASSET_RE.search(line):
-            return Finding(path, "text invokes or marks an asset file as executable")
+            return Finding("", path, "text invokes or marks an asset file as executable")
         for match in _NUMERIC_CHMOD_ASSET_RE.finditer(line):
             permission_digits = match.group("mode")[-3:]
             if any(int(digit) & 1 for digit in permission_digits):
-                return Finding(path, "text invokes or marks an asset file as executable")
+                return Finding("", path, "text invokes or marks an asset file as executable")
     return None
 
 
@@ -663,34 +665,104 @@ def check_asset_execution(head: str, files: list[str]) -> list[Finding]:
             continue
         finding = asset_execution_finding(path, data.decode("utf-8", "surrogateescape"))
         if finding is not None:
-            findings.append(finding)
+            findings.append(Finding(head, finding.path, finding.reason))
     return findings
 
 
 def dedupe(findings: list[Finding]) -> list[Finding]:
-    seen: set[tuple[str, str]] = set()
+    seen: set[tuple[str, str, str]] = set()
     result: list[Finding] = []
     for finding in findings:
-        key = (finding.path, finding.reason)
+        key = (finding.commit, finding.path, finding.reason)
         if key not in seen:
             seen.add(key)
             result.append(finding)
     return result
 
 
+def resolve_commit(revision: str) -> str:
+    value = run_git("rev-parse", "--verify", f"{revision}^{{commit}}")
+    assert isinstance(value, str)
+    return value.strip()
+
+
+def commit_parents(commit: str) -> list[str]:
+    value = run_git("show", "-s", "--format=%P", commit)
+    assert isinstance(value, str)
+    return value.strip().split()
+
+
+def changed_files_between(old: str, new: str) -> list[str]:
+    raw = run_git(
+        "-c", "core.quotePath=false", "diff", "--name-only", "-z",
+        "--no-renames", old, new, "--",
+    )
+    assert isinstance(raw, str)
+    return [item for item in raw.split("\0") if item]
+
+
+EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+
+def commit_introduced_files(commit: str) -> list[str]:
+    """Paths whose state was introduced by this commit rather than a parent.
+
+    For an ordinary commit this is its parent diff. For a merge, only paths
+    different from *every* parent are merge-introduced. That catches novel
+    conflict resolutions without blaming an Update-branch merge for content
+    copied unchanged from either the PR or trusted-main parent.
+    """
+    parents = commit_parents(commit)
+    if not parents:
+        return changed_files_between(EMPTY_TREE, commit)
+    changed_by_parent = [set(changed_files_between(parent, commit)) for parent in parents]
+    return sorted(set.intersection(*changed_by_parent))
+
+
+def introduced_commits(base: str, head: str) -> list[str]:
+    # A GitHub PR must share ancestry with its trusted base. Refuse unrelated
+    # histories rather than broadening the scan to an entire foreign history.
+    merge_base = run_git("merge-base", base, head)
+    assert isinstance(merge_base, str)
+    if not merge_base.strip():
+        raise IntegrityError("PR head has no merge base with the trusted base")
+    raw = run_git("rev-list", "--reverse", "--topo-order", head, "--not", base)
+    assert isinstance(raw, str)
+    return raw.split()
+
+
+def scan_tree(commit: str, files: list[str], external: bool, *, check_ignore: bool) -> list[Finding]:
+    findings: list[Finding] = []
+    if check_ignore:
+        findings.extend(check_ignore_policy(commit))
+    if external:
+        findings.extend(check_external_paths(commit, files))
+    findings.extend(check_symlinks(commit, files, external))
+    findings.extend(check_asset_modes(commit, files))
+    findings.extend(check_asset_magic(commit, files))
+    findings.extend(check_active_svg(commit, files))
+    findings.extend(check_asset_execution(commit, files))
+    return findings
+
+
 def scan(base: str, head: str, pr_author: str, repo_owner: str) -> list[Finding]:
-    files = changed_files(base, head)
+    base = resolve_commit(base)
+    head = resolve_commit(head)
     external = is_external(pr_author, repo_owner)
 
     findings: list[Finding] = []
-    findings.extend(check_ignore_policy(head))
-    if external:
-        findings.extend(check_external_paths(files))
-    findings.extend(check_symlinks(head, files, external))
-    findings.extend(check_asset_modes(head, files))
-    findings.extend(check_asset_magic(head, files))
-    findings.extend(check_active_svg(head, files))
-    findings.extend(check_asset_execution(head, files))
+    for commit in introduced_commits(base, head):
+        files = commit_introduced_files(commit)
+        findings.extend(scan_tree(commit, files, external, check_ignore=".gitignore" in files))
+
+    # Preserve the final-tree check as defense in depth, but do not attribute a
+    # historical violation to a later merge merely because it remains present
+    # there. Historical findings are the more precise explanation.
+    files = changed_files(base, head)
+    historical_keys = {(finding.path, finding.reason) for finding in findings}
+    for finding in scan_tree(head, files, external, check_ignore=".gitignore" in files):
+        if (finding.path, finding.reason) not in historical_keys:
+            findings.append(finding)
     return dedupe(findings)
 
 
@@ -703,7 +775,9 @@ def write_report(path: Path, findings: list[Finding]) -> None:
             return
         out.write("### Blocked findings\n\n")
         for finding in findings:
-            out.write(f"- `{finding.path}` — {finding.reason}\n")
+            out.write(
+                f"- commit `{finding.commit}` — `{finding.path}` — {finding.reason}\n"
+            )
         out.write(
             "\nThese checks fail closed. Repository-control changes must be "
             "performed from a trusted maintainer-controlled branch.\n"
@@ -733,7 +807,7 @@ def main(argv: list[str] | None = None) -> int:
     if findings:
         print("Repository integrity guard blocked the PR:")
         for finding in findings:
-            print(f"  {finding.path}: {finding.reason}")
+            print(f"  {finding.commit} {finding.path}: {finding.reason}")
         return 1
 
     print("Repository integrity guard passed.")

--- a/test/tooling/check_repository_integrity_test.py
+++ b/test/tooling/check_repository_integrity_test.py
@@ -567,6 +567,121 @@ class RepositoryIntegrityTest(unittest.TestCase):
         findings = self.scan(self.commit())
         self.assertTrue(any("SVG contains active" in f.reason for f in findings))
 
+    def test_prohibited_history_survives_cleanup_and_update_branch_merge(self) -> None:
+        """Regression for #513: an empty final diff must not erase PR history."""
+        git(self.repo, "switch", "-c", "pr")
+        payload = self.repo / "assets" / "payload.png"
+        payload.parent.mkdir()
+        payload.write_text("#!/bin/sh\necho payload\n", encoding="utf-8")
+        prohibited = self.commit("A: introduce prohibited payload")
+        payload.unlink()
+        self.commit("B: clean payload")
+
+        git(self.repo, "switch", "main")
+        (self.repo / "README.md").write_text("trusted update\n", encoding="utf-8")
+        self.base = self.commit("trusted main update")
+        git(self.repo, "switch", "pr")
+        git(self.repo, "merge", "--no-ff", "main", "-m", "C: Update branch")
+        merge = git(self.repo, "rev-parse", "HEAD")
+
+        self.assertEqual(git(self.repo, "diff", "--name-only", f"{self.base}...{merge}"), "")
+        findings = self.scan(merge)
+        historical = [finding for finding in findings if finding.commit == prohibited]
+        self.assertTrue(any(f.path == "assets/payload.png" for f in historical))
+        self.assertFalse(any(f.commit == merge for f in findings))
+
+    def test_ordinary_multi_commit_pr_passes(self) -> None:
+        (self.repo / "lib" / "first.dart").write_text("const first = 1;\n", encoding="utf-8")
+        self.commit("first")
+        (self.repo / "lib" / "second.dart").write_text("const second = 2;\n", encoding="utf-8")
+        self.assertEqual(self.scan(self.commit("second")), [])
+
+    def test_legitimate_commit_followed_by_cleanup_passes(self) -> None:
+        note = self.repo / "notes.txt"
+        note.write_text("temporary note\n", encoding="utf-8")
+        self.commit("add note")
+        note.unlink()
+        self.assertEqual(self.scan(self.commit("remove note")), [])
+
+    def test_update_branch_merge_from_trusted_main_passes(self) -> None:
+        git(self.repo, "switch", "-c", "pr")
+        (self.repo / "lib" / "feature.dart").write_text("const feature = true;\n", encoding="utf-8")
+        self.commit("feature")
+        git(self.repo, "switch", "main")
+        (self.repo / "README.md").write_text("trusted update\n", encoding="utf-8")
+        self.base = self.commit("trusted main update")
+        git(self.repo, "switch", "pr")
+        git(self.repo, "merge", "--no-ff", "main", "-m", "Update branch")
+        self.assertEqual(self.scan(git(self.repo, "rev-parse", "HEAD")), [])
+
+    def test_prohibited_commit_in_trusted_base_does_not_poison_pr(self) -> None:
+        payload = self.repo / "assets" / "legacy.png"
+        payload.parent.mkdir()
+        payload.write_text("legacy text payload\n", encoding="utf-8")
+        self.base = self.commit("trusted legacy state")
+        (self.repo / "lib" / "feature.dart").write_text("const feature = true;\n", encoding="utf-8")
+        self.assertEqual(self.scan(self.commit("unrelated feature")), [])
+
+    def test_linear_prohibited_then_cleaned_history_fails(self) -> None:
+        payload = self.repo / "assets" / "linear.png"
+        payload.parent.mkdir()
+        payload.write_text("not really an image\n", encoding="utf-8")
+        prohibited = self.commit("prohibited")
+        payload.unlink()
+        findings = self.scan(self.commit("cleanup"))
+        self.assertTrue(any(f.commit == prohibited and f.path == "assets/linear.png" for f in findings))
+
+    def test_squashed_clean_history_passes(self) -> None:
+        """A clean squash introduces no prohibited commit object to main."""
+        (self.repo / "lib" / "squashed.dart").write_text("const clean = true;\n", encoding="utf-8")
+        self.assertEqual(self.scan(self.commit("squashed clean feature")), [])
+
+    def test_pr_side_merge_reports_unique_offender_once_not_merge(self) -> None:
+        git(self.repo, "switch", "-c", "side")
+        payload = self.repo / "assets" / "side.png"
+        payload.parent.mkdir()
+        payload.write_text("not really an image\n", encoding="utf-8")
+        prohibited = self.commit("side payload")
+        git(self.repo, "switch", "-c", "pr", self.base)
+        (self.repo / "lib" / "feature.dart").write_text("const feature = true;\n", encoding="utf-8")
+        self.commit("feature")
+        git(self.repo, "merge", "--no-ff", "side", "-m", "merge side")
+        merge = git(self.repo, "rev-parse", "HEAD")
+        findings = self.scan(merge)
+        matches = [f for f in findings if f.path == "assets/side.png"]
+        self.assertEqual([f.commit for f in matches], [prohibited])
+        self.assertNotIn(merge, [f.commit for f in findings])
+
+    def test_novel_prohibited_merge_resolution_is_scanned(self) -> None:
+        git(self.repo, "switch", "-c", "side")
+        (self.repo / "lib" / "side.dart").write_text("const side = true;\n", encoding="utf-8")
+        self.commit("side")
+        git(self.repo, "switch", "-c", "pr", self.base)
+        (self.repo / "lib" / "feature.dart").write_text("const feature = true;\n", encoding="utf-8")
+        self.commit("feature")
+        git(self.repo, "merge", "--no-ff", "--no-commit", "side")
+        payload = self.repo / "assets" / "resolution.png"
+        payload.parent.mkdir()
+        payload.write_text("not really an image\n", encoding="utf-8")
+        merge = self.commit("merge with novel resolution")
+        findings = self.scan(merge)
+        self.assertTrue(
+            any(f.commit == merge and f.path == "assets/resolution.png" for f in findings)
+        )
+
+    def test_report_names_commit_path_and_reason(self) -> None:
+        path = self.repo / "assets" / "report.png"
+        path.parent.mkdir()
+        path.write_text("not really an image\n", encoding="utf-8")
+        commit = self.commit("report payload")
+        findings = self.scan(commit)
+        report = self.repo / "report.md"
+        integrity.write_report(report, findings)
+        text = report.read_text(encoding="utf-8")
+        self.assertIn(commit, text)
+        self.assertIn("assets/report.png", text)
+        self.assertIn("file extension claims PNG", text)
+
 
 class FixtureExemptionTest(unittest.TestCase):
     """The narrow carve-out that lets this module hold literal attack strings."""


### PR DESCRIPTION
### Motivation

- The repository-integrity guard validated only the final tree/diff and missed PRs that introduce a prohibited payload in an earlier commit then remove it before merge (the #513 topology).  
- The goal is to ensure a PR cannot hide an introduced prohibited payload by later cleaning or by an "update branch" merge from trusted main.  

### Description

- Enumerate the commits the PR would add relative to the trusted base using a head-only reachability set (`git rev-list --not base` semantics) and inspect only those commits rather than the whole repository history.  
- For each PR-introduced commit, compute the set of paths that commit introduced (`commit_introduced_files`) and run the existing checks (ignore-policy, maintainer-controlled paths, symlinks, asset modes/magic, active SVG, asset-execution text) against that commit's state.  
- Treat merge commits carefully: do not blame a merge for changes copied unchanged from any parent; only paths whose result differs from every parent are considered merge-introduced so Update-branch merges are not misattributed, while novel merge resolutions are still scanned.  
- Record the offending commit SHA in `Finding.commit` and update the report format to show `commit`, `path`, and `reason`; keep the existing final-tree scan as defense-in-depth but avoid re-attributing historical violations to a later merge.  
- Fail closed on missing/unreadable ancestry and reuse existing detection semantics to avoid broadening the scanner beyond its narrow trust-surface purpose.  

### Testing

- Added deterministic unit tests reproducing the #513 topology and a compatibility suite covering ordinary multi-commit PRs, cleanup-only sequences, Update-branch merges, prohibited content already present in the trusted base, linear vs squashed histories, PR-side merges, novel merge resolutions, and report formatting; tests are in `test/tooling/check_repository_integrity_test.py`.  
- Ran the test suite with `python3 test/tooling/check_repository_integrity_test.py` and all tests passed (69/69).  
- Verified byte-compile of guard and test files with `python3 -m py_compile` and ran `git diff --check` to ensure no leftover whitespace issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8dca785654832d91393bb6df925f1a)