### PR TITLE
fix(security): report repository-integrity findings on fork PRs

### DIFF
--- a/.github/workflows/repository-integrity-reporter.yml
+++ b/.github/workflows/repository-integrity-reporter.yml
@@ -147,6 +147,10 @@ jobs:
             --repository "$GITHUB_REPOSITORY" \
             --output "$RUNNER_TEMP/repository-integrity/binding.json"
 
+      # The checker is read from the bound base commit, the same revision the
+      # scanner loads, so the check and the comment explaining it cannot apply
+      # different policy versions.
+      #
       # The artifact's identity is now bound, but its `findings` are still just
       # a claim: the scanner definition that produced it comes from the merge
       # ref, so a contributor can keep its name and path, drop the trusted
@@ -161,7 +165,7 @@ jobs:
         run: |
           python3 scripts/recompute_repository_integrity_report.py \
             --binding "$RUNNER_TEMP/repository-integrity/binding.json" \
-            --checker scripts/check_repository_integrity.py \
+            --checker-path scripts/check_repository_integrity.py \
             --output "$RUNNER_TEMP/repository-integrity/verified-report.json" \
             --summary "$RUNNER_TEMP/repository-integrity/verified-report.md" \
             --repo-owner "$GITHUB_REPOSITORY_OWNER" \

--- a/.github/workflows/repository-integrity-reporter.yml
+++ b/.github/workflows/repository-integrity-reporter.yml
@@ -6,13 +6,22 @@ on:
     types: [completed]
 
 # This trusted workflow never checks out the PR head. Its sole write permission
-# is posting an issue-style comment on the PR identified by workflow_run.
+# is posting an issue-style comment on the pull request the scanner run belongs
+# to.
 #
 # The `workflows:` filter above matches on display name only, which a
 # contributor could copy onto an unrelated workflow to have it upload a forged
 # findings artifact. The job below therefore also binds to the scanner's
-# immutable file path, and to runs that carry a populated `pull_requests` array
-# (empty for fork-originated runs).
+# immutable file path.
+#
+# The job used to require a populated `pull_requests` array as well. GitHub
+# sends that array empty for every fork-originated run, so the reporter skipped
+# on exactly the external pull requests it exists to explain. The array is no
+# longer a precondition; instead the run reaches
+# scripts/resolve_repository_integrity_pr.py, which recovers the pull request
+# from the artifact and then binds it to fields only GitHub can set (the run's
+# head SHA and head repository) plus the live pull request from the API. Any
+# mismatch, ambiguity, or malformed field fails the job without commenting.
 permissions:
   actions: read
   contents: read
@@ -22,8 +31,9 @@ jobs:
   report:
     if: >-
       ${{ github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.name == 'Repository integrity'
       && github.event.workflow_run.path == '.github/workflows/repository-integrity.yml'
-      && github.event.workflow_run.pull_requests[0] != null }}
+      && github.event.workflow_run.repository.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout trusted default branch reporter
@@ -33,6 +43,7 @@ jobs:
           persist-credentials: false
 
       - name: Download scanner report only
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           name: repository-integrity-findings
@@ -40,24 +51,55 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
 
+      # The guard job does not run on draft pull requests, so those runs upload
+      # no artifact at all. That is not a reporter failure and must not turn the
+      # job red; it is recorded and the run stops here. Anything else about the
+      # artifact -- malformed, unbindable, mismatched -- still fails the job.
+      - name: Require a findings artifact
+        id: artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -f "$RUNNER_TEMP/repository-integrity/report.json" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::The scanner run produced no findings artifact; there is nothing to report."
+          fi
+
+      - name: Bind the report to a pull request
+        id: bind
+        if: ${{ steps.artifact.outputs.present == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/resolve_repository_integrity_pr.py \
+            --event "$GITHUB_EVENT_PATH" \
+            --report "$RUNNER_TEMP/repository-integrity/report.json" \
+            --repository "$GITHUB_REPOSITORY" \
+            --output "$RUNNER_TEMP/repository-integrity/binding.json"
+
       - name: Validate and render report as inert data
+        if: ${{ steps.bind.outputs.post == 'true' }}
         run: |
           python3 scripts/render_repository_integrity_comment.py \
             --report "$RUNNER_TEMP/repository-integrity/report.json" \
-            --event "$GITHUB_EVENT_PATH" \
+            --binding "$RUNNER_TEMP/repository-integrity/binding.json" \
             --output "$RUNNER_TEMP/repository-integrity/comment.md"
 
       - name: Create or update the sticky PR comment
+        if: ${{ steps.bind.outputs.post == 'true' }}
         uses: actions/github-script@v8
         env:
           COMMENT_PATH: ${{ runner.temp }}/repository-integrity/comment.md
-          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          PR_NUMBER: ${{ steps.bind.outputs.pr_number }}
           RUN_ID: ${{ github.event.workflow_run.id }}
         with:
           script: |
             const fs = require('fs');
             const marker = '<!-- linthra-repository-integrity-v1 -->';
             const body = fs.readFileSync(process.env.COMMENT_PATH, 'utf8');
+            // PR_NUMBER comes from the trusted binder, never from the event.
             const issue_number = Number.parseInt(process.env.PR_NUMBER, 10);
             if (!Number.isSafeInteger(issue_number) || issue_number < 1 || !body.startsWith(marker)) {
               throw new Error('validated comment binding is invalid');
@@ -77,6 +119,15 @@ jobs:
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner, repo: context.repo.repo, pull_number: issue_number
             });
+            // Re-derived from two API objects immediately before the write, so a
+            // fork pull request recovered from the artifact is re-bound here as
+            // well: same repository, same head repository, same scanned head.
+            if (pr.base.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+              throw new Error('pull request does not belong to this repository');
+            }
+            if (pr.head.repo?.full_name !== run.head_repository?.full_name) {
+              throw new Error('pull request head repository does not match the scanned head');
+            }
             if (pr.head.sha !== run.head_sha) {
               core.info(`Report is superseded (scanned ${run.head_sha}, head is now ${pr.head.sha}); leaving the comment untouched.`);
               return;

--- a/.github/workflows/repository-integrity-reporter.yml
+++ b/.github/workflows/repository-integrity-reporter.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
           persist-credentials: false
 
       # Exactly one situation is "nothing to report": the guard job did not run,
@@ -146,11 +147,33 @@ jobs:
             --repository "$GITHUB_REPOSITORY" \
             --output "$RUNNER_TEMP/repository-integrity/binding.json"
 
+      # The artifact's identity is now bound, but its `findings` are still just
+      # a claim: the scanner definition that produced it comes from the merge
+      # ref, so a contributor can keep its name and path, drop the trusted
+      # checker, and upload a genuine-looking report with an empty findings
+      # list. Publishing that would put a forged CLEAN under the bot's name.
+      # The verdict is therefore re-derived here by the checker on this trusted
+      # default-branch checkout, over the same range, from inputs taken from
+      # the live pull request. Objects are fetched and read; no pull-request
+      # tree is checked out and no pull-request code runs.
+      - name: Re-derive the findings with the trusted checker
+        if: ${{ steps.bind.outputs.post == 'true' }}
+        run: |
+          python3 scripts/recompute_repository_integrity_report.py \
+            --binding "$RUNNER_TEMP/repository-integrity/binding.json" \
+            --checker scripts/check_repository_integrity.py \
+            --output "$RUNNER_TEMP/repository-integrity/verified-report.json" \
+            --summary "$RUNNER_TEMP/repository-integrity/verified-report.md" \
+            --repo-owner "$GITHUB_REPOSITORY_OWNER" \
+            --claimed "$RUNNER_TEMP/repository-integrity/report.json"
+
+      # Renders the re-derived report. The uploaded artifact is never the source
+      # of a published verdict.
       - name: Validate and render report as inert data
         if: ${{ steps.bind.outputs.post == 'true' }}
         run: |
           python3 scripts/render_repository_integrity_comment.py \
-            --report "$RUNNER_TEMP/repository-integrity/report.json" \
+            --report "$RUNNER_TEMP/repository-integrity/verified-report.json" \
             --binding "$RUNNER_TEMP/repository-integrity/binding.json" \
             --output "$RUNNER_TEMP/repository-integrity/comment.md"
 

--- a/.github/workflows/repository-integrity-reporter.yml
+++ b/.github/workflows/repository-integrity-reporter.yml
@@ -42,15 +42,19 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
-      # The guard job does not run on draft pull requests, so those runs upload
-      # no artifact at all, and a reporter with nothing to report must not go
-      # red. That is the ONLY suppressed case, and it is established by asking
-      # the Actions API what this run uploaded rather than by tolerating a
-      # failed download: a download error, an expired artifact, or a scan that
-      # died before uploading would otherwise all read as "nothing to report"
-      # and finish green, leaving an earlier sticky verdict standing over a
-      # scan whose result was never rendered.
-      - name: Check whether the scanner uploaded findings
+      # Exactly one situation is "nothing to report": the guard job did not run,
+      # which is what happens on a draft pull request. Everything else that can
+      # leave the report unavailable -- a transport error, an expired artifact,
+      # a permissions failure, a scan that died before uploading -- must fail
+      # the job, or an earlier sticky verdict stays visible over a scan whose
+      # result was never rendered.
+      #
+      # The two are told apart from the Actions API rather than from a failed
+      # download, which cannot distinguish them: the run's own artifact list,
+      # and, when that list is empty, the guard job's conclusion. A guard job
+      # that ran, or that is not present under its expected name at all, is
+      # expected to have produced a report, so its absence fails the job.
+      - name: Establish whether a findings artifact is expected
         id: artifact
         uses: actions/github-script@v8
         env:
@@ -61,15 +65,24 @@ jobs:
             if (!Number.isSafeInteger(run_id) || run_id < 1) {
               throw new Error('invalid triggering run id');
             }
+            const common = { owner: context.repo.owner, repo: context.repo.repo, run_id };
             const artifacts = await github.paginate(
-              github.rest.actions.listWorkflowRunArtifacts,
-              { owner: context.repo.owner, repo: context.repo.repo, run_id, per_page: 100 }
-            );
-            const present = artifacts.some(a => a.name === 'repository-integrity-findings');
-            if (!present) {
-              core.notice('The scanner run uploaded no findings artifact; there is nothing to report.');
+              github.rest.actions.listWorkflowRunArtifacts, { ...common, per_page: 100 });
+            if (artifacts.some(a => a.name === 'repository-integrity-findings')) {
+              core.setOutput('present', 'true');
+              return;
             }
-            core.setOutput('present', String(present));
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun, { ...common, per_page: 100 });
+            const guard = jobs.find(job => job.name === 'Repository integrity guard');
+            if (guard?.conclusion !== 'skipped') {
+              throw new Error(
+                'The scanner guard job was expected to produce a findings artifact ' +
+                `(job conclusion: ${guard?.conclusion ?? 'job not found'}), but none is ` +
+                'available. Refusing to leave an earlier result standing unreported.');
+            }
+            core.notice('The scanner guard job was skipped, as it is on draft pull requests; there is nothing to report.');
+            core.setOutput('present', 'false');
 
       # The artifact is known to exist by this point, so a failed download is a
       # real failure and is deliberately left to fail the job.

--- a/.github/workflows/repository-integrity-reporter.yml
+++ b/.github/workflows/repository-integrity-reporter.yml
@@ -42,30 +42,45 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
+      # The guard job does not run on draft pull requests, so those runs upload
+      # no artifact at all, and a reporter with nothing to report must not go
+      # red. That is the ONLY suppressed case, and it is established by asking
+      # the Actions API what this run uploaded rather than by tolerating a
+      # failed download: a download error, an expired artifact, or a scan that
+      # died before uploading would otherwise all read as "nothing to report"
+      # and finish green, leaving an earlier sticky verdict standing over a
+      # scan whose result was never rendered.
+      - name: Check whether the scanner uploaded findings
+        id: artifact
+        uses: actions/github-script@v8
+        env:
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        with:
+          script: |
+            const run_id = Number.parseInt(process.env.RUN_ID, 10);
+            if (!Number.isSafeInteger(run_id) || run_id < 1) {
+              throw new Error('invalid triggering run id');
+            }
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              { owner: context.repo.owner, repo: context.repo.repo, run_id, per_page: 100 }
+            );
+            const present = artifacts.some(a => a.name === 'repository-integrity-findings');
+            if (!present) {
+              core.notice('The scanner run uploaded no findings artifact; there is nothing to report.');
+            }
+            core.setOutput('present', String(present));
+
+      # The artifact is known to exist by this point, so a failed download is a
+      # real failure and is deliberately left to fail the job.
       - name: Download scanner report only
-        continue-on-error: true
+        if: ${{ steps.artifact.outputs.present == 'true' }}
         uses: actions/download-artifact@v8
         with:
           name: repository-integrity-findings
           path: ${{ runner.temp }}/repository-integrity
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
-
-      # The guard job does not run on draft pull requests, so those runs upload
-      # no artifact at all. That is not a reporter failure and must not turn the
-      # job red; it is recorded and the run stops here. Anything else about the
-      # artifact -- malformed, unbindable, mismatched -- still fails the job.
-      - name: Require a findings artifact
-        id: artifact
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ -f "$RUNNER_TEMP/repository-integrity/report.json" ]; then
-            echo "present=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "present=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::The scanner run produced no findings artifact; there is nothing to report."
-          fi
 
       - name: Bind the report to a pull request
         id: bind

--- a/.github/workflows/repository-integrity-reporter.yml
+++ b/.github/workflows/repository-integrity-reporter.yml
@@ -81,7 +81,46 @@ jobs:
                 `(job conclusion: ${guard?.conclusion ?? 'job not found'}), but none is ` +
                 'available. Refusing to leave an earlier result standing unreported.');
             }
-            core.notice('The scanner guard job was skipped, as it is on draft pull requests; there is nothing to report.');
+            // A skipped guard job is NOT proof of a draft. The scanner workflow
+            // file is contributor-controlled at the merge ref -- which is why
+            // the scanner loads its checker from the trusted base rather than
+            // from the PR -- so a contributor can keep the job's name and set
+            // its condition to false, producing this same `skipped` conclusion
+            // on a non-draft PR and suppressing the report. The authoritative
+            // signal is the pull request's own draft flag, so that is what is
+            // read, from the pull request this run's head actually belongs to.
+            const { data: run } = await github.rest.actions.getWorkflowRun(common);
+            const headRepository = run.head_repository?.full_name;
+            const match = /^([A-Za-z0-9._-]{1,100})\/([A-Za-z0-9._-]{1,100})$/.exec(
+              headRepository ?? '');
+            if (!match || !/^[0-9a-f]{40}$/.test(run.head_sha ?? '')) {
+              throw new Error('triggering run does not identify a head to resolve');
+            }
+            // Asked of the head repository: a fork's head commit is not in this
+            // repository's commit list. Both names are GitHub-set, and the
+            // candidates are constrained below exactly as the binder does it.
+            const associated = await github.paginate(
+              github.rest.repos.listPullRequestsAssociatedWithCommit,
+              { owner: match[1], repo: match[2], commit_sha: run.head_sha, per_page: 100 });
+            const candidates = associated.filter(candidate =>
+              candidate.base?.repo?.full_name === `${context.repo.owner}/${context.repo.repo}`
+              && candidate.head?.repo?.full_name === headRepository);
+            if (candidates.length !== 1) {
+              throw new Error(
+                `${candidates.length} pull requests match this run's head; cannot confirm ` +
+                'the skipped guard job was a draft, and will not suppress the report.');
+            }
+            const { data: candidate } = await github.rest.pulls.get({
+              owner: context.repo.owner, repo: context.repo.repo,
+              pull_number: candidates[0].number
+            });
+            if (candidate.draft !== true) {
+              throw new Error(
+                `The scanner guard job was skipped but PR #${candidate.number} is not a ` +
+                'draft, so the report was suppressed by something other than the draft ' +
+                'condition. Refusing to leave an earlier result standing unreported.');
+            }
+            core.notice(`PR #${candidate.number} is a draft, so the scanner guard job did not run; there is nothing to report.`);
             core.setOutput('present', 'false');
 
       # The artifact is known to exist by this point, so a failed download is a

--- a/.github/workflows/repository-integrity.yml
+++ b/.github/workflows/repository-integrity.yml
@@ -27,6 +27,7 @@ jobs:
           python3 test/tooling/check_repository_integrity_test.py
           python3 test/tooling/render_repository_integrity_comment_test.py
           python3 test/tooling/resolve_repository_integrity_pr_test.py
+          python3 test/tooling/recompute_repository_integrity_report_test.py
 
   integrity:
     name: Repository integrity guard

--- a/.github/workflows/repository-integrity.yml
+++ b/.github/workflows/repository-integrity.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           python3 test/tooling/check_repository_integrity_test.py
           python3 test/tooling/render_repository_integrity_comment_test.py
+          python3 test/tooling/resolve_repository_integrity_pr_test.py
 
   integrity:
     name: Repository integrity guard

--- a/docs/repository-hardening.md
+++ b/docs/repository-hardening.md
@@ -178,7 +178,12 @@ only when all of the following hold:
    `workflow_run.head_sha` and `workflow_run.head_repository.full_name`, both
    set by GitHub from the pull request that started the run.
 4. Exactly one pull request has that head commit *and* that head repository.
-   More than one, or none, is refused rather than guessed. This association
+   More than one, or none, is refused rather than guessed. The association
+   response is read whole: the endpoint pages at 30 by default and advertises
+   the rest through a `Link: rel="next"` header, so an unpaginated read could
+   both miss the pull request being resolved and hide a second match from this
+   very check, deciding "exactly one" against a set that was silently cut
+   short. Accumulation is bounded, and exceeding the bound fails closed. This association
    query must be asked of the **head** repository: a fork's head commit is not
    in the base repository's commit list, so
    `/repos/{base}/commits/{fork_sha}/pulls` answers `[]` for exactly the fork

--- a/docs/repository-hardening.md
+++ b/docs/repository-hardening.md
@@ -217,8 +217,14 @@ requests, so those runs upload no artifact and there is genuinely nothing to
 report. That is told apart from every other reason the report can be missing —
 a transport error, an expired artifact, a permissions failure, a scan that died
 before uploading — by reading the run's artifact list and then the guard job's
-conclusion from the Actions API, before downloading anything. Only a guard job
-that was actually skipped counts as nothing to report. Tolerating a failed
+conclusion from the Actions API, before downloading anything. A skipped guard
+job is not by itself proof of a draft: the scanner workflow file comes from the
+merge ref, which is why the scanner loads its checker from the trusted base
+rather than from the pull request, and that same contributor can keep the guard
+job's name while setting its condition to false. Suppression therefore also
+requires the pull request's own `draft` flag, read from the pull request the
+run's head actually belongs to, resolved under the same head-repository
+association rule and the same one-candidate constraint the binder uses. Tolerating a failed
 download instead would read all of those as "nothing to report" and finish
 green, leaving an earlier sticky verdict standing over a scan whose result was
 never rendered.

--- a/docs/repository-hardening.md
+++ b/docs/repository-hardening.md
@@ -189,6 +189,12 @@ only when all of the following hold:
 5. The live pull request, fetched by number **from this repository**, agrees:
    same number, based on this repository, same head repository, same head
    branch where the run carries one, and its head is still the scanned SHA.
+   The branch name is compared as opaque data: git accepts more than an obvious
+   character allowlist admits (`feature+test`, `feature@2`, non-ASCII names all
+   pass `git check-ref-format`), and rejecting a legitimate branch would strand
+   that pull request with a red reporter and no comment. Since the value is only
+   ever compared against the pull request's own `head.ref`, and never forms a
+   URL, a command, or a log line, no character in it can mean anything.
 
 Republishing another contributor's head commit into your own fork makes step 3
 match on the SHA, but the head repository is still your fork, so steps 4 and 5

--- a/docs/repository-hardening.md
+++ b/docs/repository-hardening.md
@@ -152,6 +152,47 @@ Under **Settings → Actions → General**:
   the strictest option that still fits the project workflow
 - never attach repository secrets to untrusted `pull_request` jobs
 
+## Reporting findings on fork pull requests
+
+The scanner (`.github/workflows/repository-integrity.yml`) runs on
+`pull_request` with `contents: read` and no secrets. It writes nothing. A
+separate trusted workflow, `repository-integrity-reporter.yml`, runs on
+`workflow_run` from the default branch, never checks out the PR head, and holds
+the only `pull-requests: write` grant.
+
+For a pull request opened from a fork, GitHub delivers
+`workflow_run.pull_requests` as an empty array. The reporter used to require
+that array to be populated, so on external pull requests the check went red
+with no comment explaining why — observed on #513, #514 and #515.
+
+The pull request is now recovered from the scanner artifact and then bound to
+evidence a contributor cannot forge. The scanner workflow file is
+contributor-controlled at the merge ref, so `pr_number` in the artifact is a
+claim, not an authority. `scripts/resolve_repository_integrity_pr.py` accepts it
+only when all of the following hold:
+
+1. The triggering run is the scanner's own: expected event, expected display
+   name, expected immutable file path, expected repository.
+2. The artifact was downloaded with `run-id` pinned to that exact run.
+3. The artifact's `head_sha` and `head_repository` equal
+   `workflow_run.head_sha` and `workflow_run.head_repository.full_name`, both
+   set by GitHub from the pull request that started the run.
+4. Exactly one pull request in this repository has that head commit *and* that
+   head repository. More than one, or none, is refused rather than guessed.
+5. The live pull request fetched by number agrees: same number, based on this
+   repository, same head repository, and its head is still the scanned SHA.
+
+Republishing another contributor's head commit into your own fork makes step 3
+match on the SHA, but the head repository is still your fork, so steps 4 and 5
+resolve to your own pull request. There is no input that makes the reporter
+comment on somebody else's.
+
+Every failure is silent-and-red rather than best-effort: a malformed artifact,
+a missing binding, a mismatch, an ambiguous pull request, an unexpected workflow
+path, or an unexpected repository all end the job without a comment. A head that
+has moved on since the scan is treated as superseded, so an out-of-order run
+never overwrites a newer verdict.
+
 ## Contributor model
 
 External contributors should work from their own forks. Avoid granting `Write`

--- a/docs/repository-hardening.md
+++ b/docs/repository-hardening.md
@@ -206,6 +206,33 @@ match on the SHA, but the head repository is still your fork, so steps 4 and 5
 resolve to your own pull request. There is no input that makes the reporter
 comment on somebody else's.
 
+### The verdict is re-derived, never taken from the artifact
+
+Identity binding proves *which* pull request a report describes. It cannot prove
+the report is honest. A `pull_request` workflow definition comes from the merge
+ref, so a fork contributor can keep the scanner's name and path, drop the step
+that loads the trusted checker, and upload a findings artifact whose identity
+fields are the genuine GitHub-provided ones and whose `findings` list is empty.
+Every field identity binding checks would be honest; only the verdict is forged.
+Published, that would put a CLEAN comment under `github-actions[bot]`, lending
+contributor-authored content the authority of the maintainer-controlled
+reporter.
+
+So the artifact's `findings` are never the source of a published verdict. The
+reporter re-derives them with `scripts/recompute_repository_integrity_report.py`,
+running the checker from this trusted default-branch checkout over the same
+commit range, from a base SHA, head SHA and PR author read from the live pull
+request rather than from the artifact. A divergence between the uploaded and
+re-derived results is reported and the re-derived one wins — refusing to comment
+on a mismatch would let a forged artifact suppress the finding it was forged to
+hide.
+
+No pull-request code is executed and no pull-request tree is checked out. The
+checker reads git objects only, so the objects are fetched into the trusted
+checkout through this repository's own `refs/pull/N/head` and analysed as data;
+the working tree stays on the default branch. A checker that cannot evaluate the
+range is an error, never an empty finding list.
+
 Every failure is silent-and-red rather than best-effort: a malformed artifact,
 a missing binding, a mismatch, an ambiguous pull request, an unexpected workflow
 path, or an unexpected repository all end the job without a comment. A head that

--- a/docs/repository-hardening.md
+++ b/docs/repository-hardening.md
@@ -177,10 +177,18 @@ only when all of the following hold:
 3. The artifact's `head_sha` and `head_repository` equal
    `workflow_run.head_sha` and `workflow_run.head_repository.full_name`, both
    set by GitHub from the pull request that started the run.
-4. Exactly one pull request in this repository has that head commit *and* that
-   head repository. More than one, or none, is refused rather than guessed.
-5. The live pull request fetched by number agrees: same number, based on this
-   repository, same head repository, and its head is still the scanned SHA.
+4. Exactly one pull request has that head commit *and* that head repository.
+   More than one, or none, is refused rather than guessed. This association
+   query must be asked of the **head** repository: a fork's head commit is not
+   in the base repository's commit list, so
+   `/repos/{base}/commits/{fork_sha}/pulls` answers `[]` for exactly the fork
+   pull requests this path exists to resolve — confirmed against the live API
+   with #513's head. Asking a contributor-controlled repository grants nothing,
+   because the repository name is `workflow_run.head_repository.full_name`,
+   which GitHub sets, and step 5 still constrains every candidate it returns.
+5. The live pull request, fetched by number **from this repository**, agrees:
+   same number, based on this repository, same head repository, same head
+   branch where the run carries one, and its head is still the scanned SHA.
 
 Republishing another contributor's head commit into your own fork makes step 3
 match on the SHA, but the head repository is still your fork, so steps 4 and 5
@@ -192,6 +200,17 @@ a missing binding, a mismatch, an ambiguous pull request, an unexpected workflow
 path, or an unexpected repository all end the job without a comment. A head that
 has moved on since the scan is treated as superseded, so an out-of-order run
 never overwrites a newer verdict.
+
+One case is deliberately not a failure: the guard job does not run on draft pull
+requests, so those runs upload no artifact and there is genuinely nothing to
+report. That is told apart from every other reason the report can be missing —
+a transport error, an expired artifact, a permissions failure, a scan that died
+before uploading — by reading the run's artifact list and then the guard job's
+conclusion from the Actions API, before downloading anything. Only a guard job
+that was actually skipped counts as nothing to report. Tolerating a failed
+download instead would read all of those as "nothing to report" and finish
+green, leaving an earlier sticky verdict standing over a scan whose result was
+never rendered.
 
 ## Contributor model
 

--- a/docs/repository-hardening.md
+++ b/docs/repository-hardening.md
@@ -236,6 +236,18 @@ rules, so the comment could report CLEAN while the guard is red. Both revisions
 are maintainer-controlled, so this is a consistency requirement rather than a
 trust one: the check and the comment explaining it must never disagree.
 
+One window is left open deliberately. `base.sha` on a pull request tracks the
+base branch's current tip, not the tip the scanner saw, so if the base branch
+advances between the scan and the report the reporter re-derives against a
+slightly newer base. The commit set is unaffected — commits pushed to the base
+after the scan are not reachable from a head that predates them, so
+`rev-list head --not base` yields the same commits either way — and only the
+checker revision can differ, and only when the push that moved the base also
+changed the checker, inside the seconds between the two runs. Closing it would
+mean taking the scan-time base SHA from the contributor-controlled artifact,
+making an artifact field decide something again; the narrower risk is the better
+trade.
+
 No pull-request code is executed and no pull-request tree is checked out. The
 checker reads git objects only, so the objects are fetched into the trusted
 checkout through this repository's own `refs/pull/N/head` and analysed as data;

--- a/docs/repository-hardening.md
+++ b/docs/repository-hardening.md
@@ -227,11 +227,21 @@ re-derived results is reported and the re-derived one wins — refusing to comme
 on a mismatch would let a forged artifact suppress the finding it was forged to
 hide.
 
+The checker itself is read out of the pull request's **base commit**, the same
+revision the scanner loads with `git show "$BASE_SHA:…"`. Running the reporter's
+own default-branch copy instead would apply a different revision whenever the
+base is not the default branch, or whenever the checker changed on the default
+branch between the scan and the report — and the two can enforce different
+rules, so the comment could report CLEAN while the guard is red. Both revisions
+are maintainer-controlled, so this is a consistency requirement rather than a
+trust one: the check and the comment explaining it must never disagree.
+
 No pull-request code is executed and no pull-request tree is checked out. The
 checker reads git objects only, so the objects are fetched into the trusted
 checkout through this repository's own `refs/pull/N/head` and analysed as data;
 the working tree stays on the default branch. A checker that cannot evaluate the
-range is an error, never an empty finding list.
+range — or a base commit that carries none — is an error, never an empty finding
+list.
 
 Every failure is silent-and-red rather than best-effort: a malformed artifact,
 a missing binding, a mismatch, an ambiguous pull request, an unexpected workflow

--- a/scripts/recompute_repository_integrity_report.py
+++ b/scripts/recompute_repository_integrity_report.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Re-derive the repository-integrity findings inside the trusted reporter.
+
+Why this exists: for a `pull_request` event GitHub runs the workflow definition
+from the merge ref, which a fork contributor controls. They can keep the
+scanner's name and path, drop its "load the trusted checker" step entirely, and
+upload a `repository-integrity-findings` artifact whose identity fields are the
+genuine GitHub-provided ones but whose `findings` list is empty. Identity
+binding cannot catch that: every field it checks is honest. The forged part is
+the verdict, and the trusted reporter would publish it as a CLEAN comment under
+`github-actions[bot]`, lending contributor-authored content the authority of the
+maintainer-controlled reporter.
+
+So the artifact's `findings` are not trusted for anything. The verdict rendered
+into the sticky comment is computed here, by the checker on the trusted default
+branch, over the same commit range -- and from inputs (base SHA, head SHA, PR
+author) that come from the live pull request rather than from the artifact.
+
+No pull-request code is executed and no pull-request tree is checked out. The
+checker reads git objects only -- `show`, `ls-tree`, `rev-list`, `merge-base`,
+`diff` -- so the objects are fetched into the trusted checkout and analysed as
+data. The working tree stays on the default branch throughout.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+REPO_RE = re.compile(r"^[A-Za-z0-9._-]{1,100}/[A-Za-z0-9._-]{1,100}$")
+LOGIN_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$")
+MAX_PR_NUMBER = 1_000_000
+# The checker exits 1 when it has findings; that is a verdict, not a failure.
+CLEAN, BLOCKED = 0, 1
+
+
+class RecomputeError(Exception):
+    """The verdict could not be re-derived. The reporter must not comment."""
+
+
+def load_binding(path: Path) -> dict[str, object]:
+    """Read the binding, re-validating every field this program will use.
+
+    The binder wrote it moments ago, but it is read back off disk, so it is
+    validated again rather than assumed.
+    """
+    if path.stat().st_size > 4_096:
+        raise RecomputeError("binding exceeds size limit")
+    binding = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(binding, dict):
+        raise RecomputeError("invalid binding")
+    for field, pattern in (("head_sha", SHA_RE), ("base_sha", SHA_RE),
+                           ("head_repository", REPO_RE), ("pr_author", LOGIN_RE)):
+        value = binding.get(field)
+        if not isinstance(value, str) or not pattern.fullmatch(value):
+            raise RecomputeError(f"invalid {field} in binding")
+    number = binding.get("pr_number")
+    if not isinstance(number, int) or isinstance(number, bool) or not 1 <= number <= MAX_PR_NUMBER:
+        raise RecomputeError("invalid pr_number in binding")
+    return binding
+
+
+def fetch_objects(binding: dict[str, object], *, remote: str = "origin",
+                  run=subprocess.run) -> None:
+    """Bring the PR's objects into the trusted checkout, without checking out.
+
+    Fork commits are reachable in this repository through `refs/pull/N/head`, so
+    nothing is fetched from the contributor's own remote. `--no-tags` keeps the
+    fetch to exactly the refs named.
+    """
+    number = binding["pr_number"]
+    for refspec in (f"refs/pull/{number}/head", str(binding["base_sha"])):
+        result = run(["git", "fetch", "--no-tags", "--quiet", remote, refspec],
+                     capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RecomputeError(
+                f"could not fetch {refspec}: {result.stderr.strip()[:200]}")
+
+
+def checker_command(checker: Path, binding: dict[str, object], report: Path,
+                    summary: Path, repo_owner: str) -> list[str]:
+    """Build the checker invocation.
+
+    Assembled as an argument vector and never as a shell string, so none of
+    these values is ever parsed by a shell. They are all validated above in any
+    case, and all of them originate with GitHub rather than with the artifact.
+    """
+    return [
+        sys.executable, str(checker),
+        "--base", str(binding["base_sha"]),
+        "--head", str(binding["head_sha"]),
+        "--pr-author", str(binding["pr_author"]),
+        "--repo-owner", repo_owner,
+        "--report", str(summary),
+        "--json-report", str(report),
+        "--pr-number", str(binding["pr_number"]),
+        "--head-repository", str(binding["head_repository"]),
+    ]
+
+
+def recompute(checker: Path, binding: dict[str, object], report: Path, summary: Path,
+              repo_owner: str, *, run=subprocess.run) -> int:
+    """Run the trusted checker. Returns its verdict; raises if it could not run."""
+    command = checker_command(checker, binding, report, summary, repo_owner)
+    result = run(command, capture_output=True, text=True)
+    if result.returncode not in (CLEAN, BLOCKED):
+        raise RecomputeError(
+            f"trusted checker could not evaluate the pull request "
+            f"(exit {result.returncode}): {result.stderr.strip()[:500]}")
+    if not report.is_file():
+        raise RecomputeError("trusted checker produced no report")
+    return result.returncode
+
+
+def divergence(claimed: Path, recomputed: Path) -> str | None:
+    """Describe how the uploaded artifact differs from the re-derived verdict.
+
+    Purely diagnostic. A divergence is reported and the re-derived verdict is
+    the one that gets published: refusing to comment on a mismatch would let a
+    forged artifact suppress the very finding it was forged to hide.
+    """
+    def count(path: Path) -> int | None:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return None
+        findings = payload.get("findings") if isinstance(payload, dict) else None
+        return len(findings) if isinstance(findings, list) else None
+
+    uploaded, derived = count(claimed), count(recomputed)
+    if uploaded is None:
+        return "the uploaded artifact could not be read for comparison"
+    if uploaded == derived:
+        return None
+    return (f"the uploaded artifact reported {uploaded} finding(s) but the trusted "
+            f"checker re-derived {derived}; the re-derived result is authoritative")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binding", required=True, type=Path)
+    parser.add_argument("--checker", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--summary", required=True, type=Path)
+    parser.add_argument("--repo-owner", required=True)
+    parser.add_argument("--claimed", type=Path)
+    parser.add_argument("--no-fetch", action="store_true",
+                        help="objects are already present (used by the tests)")
+    args = parser.parse_args(argv)
+
+    try:
+        if not LOGIN_RE.fullmatch(args.repo_owner):
+            raise RecomputeError("invalid repository owner")
+        binding = load_binding(args.binding)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        if not args.no_fetch:
+            fetch_objects(binding)
+        verdict = recompute(args.checker, binding, args.output, args.summary,
+                            args.repo_owner)
+    except (RecomputeError, ValueError, OSError) as exc:
+        print(f"::error::Repository integrity reporter could not re-derive the "
+              f"findings, so it will not comment: {exc}", file=sys.stderr)
+        return 1
+
+    if args.claimed is not None:
+        difference = divergence(args.claimed, args.output)
+        if difference is not None:
+            print(f"::warning::The scanner run's artifact does not match the trusted "
+                  f"re-derivation: {difference}. This is expected when the scanner "
+                  f"workflow was modified in the pull request.")
+    print("Re-derived the repository-integrity verdict from trusted checker code: "
+          f"{'findings present' if verdict == BLOCKED else 'clean'}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/recompute_repository_integrity_report.py
+++ b/scripts/recompute_repository_integrity_report.py
@@ -1,25 +1,28 @@
 #!/usr/bin/env python3
-"""Re-derive the repository-integrity findings inside the trusted reporter.
+"""Re-derive repository-integrity findings inside the trusted reporter.
 
-Why this exists: for a `pull_request` event GitHub runs the workflow definition
-from the merge ref, which a fork contributor controls. They can keep the
-scanner's name and path, drop its "load the trusted checker" step entirely, and
-upload a `repository-integrity-findings` artifact whose identity fields are the
-genuine GitHub-provided ones but whose `findings` list is empty. Identity
-binding cannot catch that: every field it checks is honest. The forged part is
-the verdict, and the trusted reporter would publish it as a CLEAN comment under
-`github-actions[bot]`, lending contributor-authored content the authority of the
-maintainer-controlled reporter.
+Why this exists: for a ``pull_request`` event GitHub runs the scanner workflow
+definition from the merge ref, which a fork contributor controls. They can keep
+the scanner's name/path, drop its trusted-checker step, and upload a
+``repository-integrity-findings`` artifact whose GitHub-provided identity fields
+are genuine while its findings list is forged empty. Identity binding proves
+*which* pull request an artifact describes; it cannot prove the verdict is
+honest.
 
-So the artifact's `findings` are not trusted for anything. The verdict rendered
-into the sticky comment is computed here, by the checker on the trusted default
-branch, over the same commit range -- and from inputs (base SHA, head SHA, PR
-author) that come from the live pull request rather than from the artifact.
+The artifact's findings are therefore never published. The reporter re-derives
+the verdict with the same checker-selection policy as the scanner:
 
-No pull-request code is executed and no pull-request tree is checked out. The
-checker reads git objects only -- `show`, `ls-tree`, `rev-list`, `merge-base`,
-`diff` -- so the objects are fetched into the trusted checkout and analysed as
-data. The working tree stays on the default branch throughout.
+* normally the checker blob comes from the bound base commit;
+* only for a repository-owner, same-repository pull request may the bootstrap
+  path use the checker blob from the bound PR head when the base checker is
+  missing or predates the ``--json-report`` interface.
+
+That bootstrap exception mirrors ``repository-integrity.yml`` exactly. External
+and fork pull-request code is never executed. For the owner bootstrap case the
+head checker is maintainer-controlled code, selected by a GitHub-bound head SHA,
+and is read as a git blob without checking out the PR tree. The checker itself
+analyses git objects only; the working tree remains on the trusted default
+branch throughout.
 """
 from __future__ import annotations
 
@@ -34,8 +37,6 @@ SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 REPO_RE = re.compile(r"^[A-Za-z0-9._-]{1,100}/[A-Za-z0-9._-]{1,100}$")
 MAX_LOGIN_LENGTH = 64
 MAX_PR_NUMBER = 1_000_000
-# The scanner loads its checker from the pull request's base commit. The
-# re-derivation must use that same revision: see load_checker.
 CHECKER_PATH = "scripts/check_repository_integrity.py"
 CHECKER_PATH_RE = re.compile(r"^[A-Za-z0-9._/-]{1,200}$")
 # The checker exits 1 when it has findings; that is a verdict, not a failure.
@@ -46,141 +47,208 @@ class RecomputeError(Exception):
     """The verdict could not be re-derived. The reporter must not comment."""
 
 
-def load_checker(base_sha: str, checker_path: str, destination: Path,
-                 *, run=subprocess.run) -> Path:
-    """Read the checker out of the bound base commit, as the scanner does.
+def _checker_blob(commit_sha: str, checker_path: str, *, run=subprocess.run):
+    """Return ``git show <sha>:<path>`` without touching the working tree."""
+    return run(
+        ["git", "show", f"{commit_sha}:{checker_path}"],
+        capture_output=True,
+    )
 
-    The scanner runs `git show "$BASE_SHA:scripts/check_repository_integrity.py"`,
-    so the policy it applied is the one committed on the pull request's base
-    branch. Running the reporter's own default-branch copy instead would apply a
-    different revision whenever the base is not the default branch, or whenever
-    the checker changed on the default branch between the scan and the report.
-    The two revisions can enforce different rules, so the comment could report
-    CLEAN while the guard is red, or BLOCKED while it passed -- the check and
-    the comment explaining it must never disagree.
 
-    Both revisions are maintainer-controlled, so this is a consistency
-    requirement rather than a trust one; the base commit is the branch a
-    maintainer chose to merge into, which is what the scanner already treats as
-    authoritative. A base commit whose checker is missing or unusable fails
-    closed, exactly like any other input this program cannot verify.
+def _structured_checker(content: bytes) -> bool:
+    """Mirror the scanner's bootstrap feature test (``grep -- --json-report``)."""
+    return b"--json-report" in content
+
+
+def load_checker(
+    base_sha: str,
+    checker_path: str,
+    destination: Path,
+    *,
+    head_sha: str | None = None,
+    pr_author: str | None = None,
+    repo_owner: str | None = None,
+    head_repository: str | None = None,
+    repository: str | None = None,
+    run=subprocess.run,
+) -> Path:
+    """Select the same trusted checker revision the scanner selected.
+
+    The normal path reads the checker from ``base_sha``. If that checker is
+    absent or predates the structured-report interface, the scanner has one
+    deliberate bootstrap exception: a PR authored by the repository owner and
+    coming from the same repository may use the PR-head checker. The reporter
+    must mirror that selection or a scan that legitimately bootstrapped can
+    never receive its sticky comment.
+
+    The head fallback is *never* available to a fork/external PR. The fallback
+    blob is read from the already-bound ``head_sha`` with ``git show``; no PR
+    tree is checked out and no contributor-controlled ref is trusted by name.
     """
     if not CHECKER_PATH_RE.fullmatch(checker_path) or ".." in checker_path:
         raise RecomputeError("invalid checker path")
-    result = run(["git", "show", f"{base_sha}:{checker_path}"],
-                 capture_output=True)
-    if result.returncode != 0:
+
+    base = _checker_blob(base_sha, checker_path, run=run)
+    if base.returncode == 0 and _structured_checker(base.stdout):
+        destination.write_bytes(base.stdout)
+        return destination
+
+    bootstrap_allowed = (
+        isinstance(head_sha, str)
+        and SHA_RE.fullmatch(head_sha) is not None
+        and isinstance(pr_author, str)
+        and isinstance(repo_owner, str)
+        and pr_author == repo_owner
+        and isinstance(head_repository, str)
+        and isinstance(repository, str)
+        and head_repository == repository
+    )
+
+    if bootstrap_allowed:
+        head = _checker_blob(head_sha, checker_path, run=run)
+        if head.returncode != 0:
+            detail = head.stderr.decode("utf-8", "replace").strip()[:200]
+            raise RecomputeError(
+                "the repository-owner bootstrap checker is not present at "
+                f"bound head commit {head_sha}: {detail}"
+            )
+        if not _structured_checker(head.stdout):
+            raise RecomputeError(
+                "the repository-owner bootstrap checker does not support the "
+                "structured report interface"
+            )
+        destination.write_bytes(head.stdout)
+        return destination
+
+    if base.returncode != 0:
+        detail = base.stderr.decode("utf-8", "replace").strip()[:200]
         raise RecomputeError(
-            f"the trusted checker is not present at base commit {base_sha}: "
-            f"{result.stderr.decode('utf-8', 'replace').strip()[:200]}")
-    destination.write_bytes(result.stdout)
-    return destination
+            f"the trusted checker is not present at base commit {base_sha}: {detail}"
+        )
+    raise RecomputeError(
+        "the trusted base checker does not support the structured report "
+        "interface; refusing to execute pull-request checker code"
+    )
 
 
 def valid_login(value: object) -> bool:
     """A GitHub account login, held only to what a comparand in an argv needs.
 
-    Deliberately no character allowlist. Bot accounts are named `name[bot]` --
-    `dependabot[bot]`, `github-actions[bot]` -- and an obvious login pattern
-    rejects the brackets, which would leave every Dependabot pull request with a
-    red reporter and no findings comment. The value is used for one casefolded
-    comparison in the checker's `is_external`, and is passed as an argument
-    vector element rather than through a shell, so no character in it can mean
-    anything.
-
-    What is enforced is what that use needs: a string, a length bound, no ASCII
-    control characters, and no leading hyphen, so it can never be mistaken for
-    an option by the program it is passed to.
+    Deliberately no character allowlist. Bot accounts are named ``name[bot]``
+    and an obvious login pattern rejects the brackets. The value is used for a
+    casefolded comparison in the checker and is passed as one argv element, not
+    through a shell.
     """
     if not isinstance(value, str) or not 1 <= len(value) <= MAX_LOGIN_LENGTH:
         return False
     return not value.startswith("-") and not any(
-        ch < " " or ch == "\x7f" for ch in value)
+        ch < " " or ch == "\x7f" for ch in value
+    )
 
 
 def load_binding(path: Path) -> dict[str, object]:
-    """Read the binding, re-validating every field this program will use.
-
-    The binder wrote it moments ago, but it is read back off disk, so it is
-    validated again rather than assumed.
-    """
+    """Read the binding, re-validating every field this program will use."""
     if path.stat().st_size > 4_096:
         raise RecomputeError("binding exceeds size limit")
     binding = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(binding, dict):
         raise RecomputeError("invalid binding")
-    for field, pattern in (("head_sha", SHA_RE), ("base_sha", SHA_RE),
-                           ("head_repository", REPO_RE)):
+    for field, pattern in (
+        ("head_sha", SHA_RE),
+        ("base_sha", SHA_RE),
+        ("head_repository", REPO_RE),
+        ("repository", REPO_RE),
+    ):
         value = binding.get(field)
         if not isinstance(value, str) or not pattern.fullmatch(value):
             raise RecomputeError(f"invalid {field} in binding")
     if not valid_login(binding.get("pr_author")):
         raise RecomputeError("invalid pr_author in binding")
     number = binding.get("pr_number")
-    if not isinstance(number, int) or isinstance(number, bool) or not 1 <= number <= MAX_PR_NUMBER:
+    if (
+        not isinstance(number, int)
+        or isinstance(number, bool)
+        or not 1 <= number <= MAX_PR_NUMBER
+    ):
         raise RecomputeError("invalid pr_number in binding")
     return binding
 
 
-def fetch_objects(binding: dict[str, object], *, remote: str = "origin",
-                  run=subprocess.run) -> None:
-    """Bring the PR's objects into the trusted checkout, without checking out.
-
-    Fork commits are reachable in this repository through `refs/pull/N/head`, so
-    nothing is fetched from the contributor's own remote. `--no-tags` keeps the
-    fetch to exactly the refs named.
-    """
+def fetch_objects(
+    binding: dict[str, object],
+    *,
+    remote: str = "origin",
+    run=subprocess.run,
+) -> None:
+    """Bring PR/base objects into the trusted checkout, without checking out."""
     number = binding["pr_number"]
     for refspec in (f"refs/pull/{number}/head", str(binding["base_sha"])):
-        result = run(["git", "fetch", "--no-tags", "--quiet", remote, refspec],
-                     capture_output=True, text=True)
+        result = run(
+            ["git", "fetch", "--no-tags", "--quiet", remote, refspec],
+            capture_output=True,
+            text=True,
+        )
         if result.returncode != 0:
             raise RecomputeError(
-                f"could not fetch {refspec}: {result.stderr.strip()[:200]}")
+                f"could not fetch {refspec}: {result.stderr.strip()[:200]}"
+            )
 
 
-def checker_command(checker: Path, binding: dict[str, object], report: Path,
-                    summary: Path, repo_owner: str) -> list[str]:
-    """Build the checker invocation.
-
-    Assembled as an argument vector and never as a shell string, so none of
-    these values is ever parsed by a shell. They are all validated above in any
-    case, and all of them originate with GitHub rather than with the artifact.
-    """
+def checker_command(
+    checker: Path,
+    binding: dict[str, object],
+    report: Path,
+    summary: Path,
+    repo_owner: str,
+) -> list[str]:
+    """Build the checker invocation as an argument vector, never a shell string."""
     return [
-        sys.executable, str(checker),
-        "--base", str(binding["base_sha"]),
-        "--head", str(binding["head_sha"]),
-        "--pr-author", str(binding["pr_author"]),
-        "--repo-owner", repo_owner,
-        "--report", str(summary),
-        "--json-report", str(report),
-        "--pr-number", str(binding["pr_number"]),
-        "--head-repository", str(binding["head_repository"]),
+        sys.executable,
+        str(checker),
+        "--base",
+        str(binding["base_sha"]),
+        "--head",
+        str(binding["head_sha"]),
+        "--pr-author",
+        str(binding["pr_author"]),
+        "--repo-owner",
+        repo_owner,
+        "--report",
+        str(summary),
+        "--json-report",
+        str(report),
+        "--pr-number",
+        str(binding["pr_number"]),
+        "--head-repository",
+        str(binding["head_repository"]),
     ]
 
 
-def recompute(checker: Path, binding: dict[str, object], report: Path, summary: Path,
-              repo_owner: str, *, run=subprocess.run) -> int:
-    """Run the trusted checker. Returns its verdict; raises if it could not run."""
+def recompute(
+    checker: Path,
+    binding: dict[str, object],
+    report: Path,
+    summary: Path,
+    repo_owner: str,
+    *,
+    run=subprocess.run,
+) -> int:
+    """Run the selected trusted checker. Return verdict; raise on inability."""
     command = checker_command(checker, binding, report, summary, repo_owner)
     result = run(command, capture_output=True, text=True)
     if result.returncode not in (CLEAN, BLOCKED):
         raise RecomputeError(
-            f"trusted checker could not evaluate the pull request "
-            f"(exit {result.returncode}): {result.stderr.strip()[:500]}")
+            "trusted checker could not evaluate the pull request "
+            f"(exit {result.returncode}): {result.stderr.strip()[:500]}"
+        )
     if not report.is_file():
         raise RecomputeError("trusted checker produced no report")
     return result.returncode
 
 
 def divergence(claimed: Path, recomputed: Path) -> str | None:
-    """Describe how the uploaded artifact differs from the re-derived verdict.
+    """Describe how the uploaded artifact differs from the re-derived verdict."""
 
-    Purely diagnostic. A divergence is reported and the re-derived verdict is
-    the one that gets published: refusing to comment on a mismatch would let a
-    forged artifact suppress the very finding it was forged to hide.
-    """
     def count(path: Path) -> int | None:
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
@@ -194,21 +262,29 @@ def divergence(claimed: Path, recomputed: Path) -> str | None:
         return "the uploaded artifact could not be read for comparison"
     if uploaded == derived:
         return None
-    return (f"the uploaded artifact reported {uploaded} finding(s) but the trusted "
-            f"checker re-derived {derived}; the re-derived result is authoritative")
+    return (
+        f"the uploaded artifact reported {uploaded} finding(s) but the trusted "
+        f"checker re-derived {derived}; the re-derived result is authoritative"
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--binding", required=True, type=Path)
-    parser.add_argument("--checker-path", default=CHECKER_PATH,
-                        help="repository-relative path read from the bound base commit")
+    parser.add_argument(
+        "--checker-path",
+        default=CHECKER_PATH,
+        help="repository-relative checker path selected by scanner policy",
+    )
     parser.add_argument("--output", required=True, type=Path)
     parser.add_argument("--summary", required=True, type=Path)
     parser.add_argument("--repo-owner", required=True)
     parser.add_argument("--claimed", type=Path)
-    parser.add_argument("--no-fetch", action="store_true",
-                        help="objects are already present (used by the tests)")
+    parser.add_argument(
+        "--no-fetch",
+        action="store_true",
+        help="objects are already present (used by the tests)",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -218,23 +294,43 @@ def main(argv: list[str] | None = None) -> int:
         args.output.parent.mkdir(parents=True, exist_ok=True)
         if not args.no_fetch:
             fetch_objects(binding)
-        checker = load_checker(str(binding["base_sha"]), args.checker_path,
-                               args.output.parent / "trusted-checker.py")
-        verdict = recompute(checker, binding, args.output, args.summary,
-                            args.repo_owner)
+        checker = load_checker(
+            str(binding["base_sha"]),
+            args.checker_path,
+            args.output.parent / "trusted-checker.py",
+            head_sha=str(binding["head_sha"]),
+            pr_author=str(binding["pr_author"]),
+            repo_owner=args.repo_owner,
+            head_repository=str(binding["head_repository"]),
+            repository=str(binding["repository"]),
+        )
+        verdict = recompute(
+            checker,
+            binding,
+            args.output,
+            args.summary,
+            args.repo_owner,
+        )
     except (RecomputeError, ValueError, OSError) as exc:
-        print(f"::error::Repository integrity reporter could not re-derive the "
-              f"findings, so it will not comment: {exc}", file=sys.stderr)
+        print(
+            "::error::Repository integrity reporter could not re-derive the "
+            f"findings, so it will not comment: {exc}",
+            file=sys.stderr,
+        )
         return 1
 
     if args.claimed is not None:
         difference = divergence(args.claimed, args.output)
         if difference is not None:
-            print(f"::warning::The scanner run's artifact does not match the trusted "
-                  f"re-derivation: {difference}. This is expected when the scanner "
-                  f"workflow was modified in the pull request.")
-    print("Re-derived the repository-integrity verdict from trusted checker code: "
-          f"{'findings present' if verdict == BLOCKED else 'clean'}.")
+            print(
+                "::warning::The scanner run's artifact does not match the trusted "
+                f"re-derivation: {difference}. This is expected when the scanner "
+                "workflow was modified in the pull request."
+            )
+    print(
+        "Re-derived the repository-integrity verdict from trusted checker code: "
+        f"{'findings present' if verdict == BLOCKED else 'clean'}."
+    )
     return 0
 
 

--- a/scripts/recompute_repository_integrity_report.py
+++ b/scripts/recompute_repository_integrity_report.py
@@ -34,12 +34,47 @@ SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 REPO_RE = re.compile(r"^[A-Za-z0-9._-]{1,100}/[A-Za-z0-9._-]{1,100}$")
 MAX_LOGIN_LENGTH = 64
 MAX_PR_NUMBER = 1_000_000
+# The scanner loads its checker from the pull request's base commit. The
+# re-derivation must use that same revision: see load_checker.
+CHECKER_PATH = "scripts/check_repository_integrity.py"
+CHECKER_PATH_RE = re.compile(r"^[A-Za-z0-9._/-]{1,200}$")
 # The checker exits 1 when it has findings; that is a verdict, not a failure.
 CLEAN, BLOCKED = 0, 1
 
 
 class RecomputeError(Exception):
     """The verdict could not be re-derived. The reporter must not comment."""
+
+
+def load_checker(base_sha: str, checker_path: str, destination: Path,
+                 *, run=subprocess.run) -> Path:
+    """Read the checker out of the bound base commit, as the scanner does.
+
+    The scanner runs `git show "$BASE_SHA:scripts/check_repository_integrity.py"`,
+    so the policy it applied is the one committed on the pull request's base
+    branch. Running the reporter's own default-branch copy instead would apply a
+    different revision whenever the base is not the default branch, or whenever
+    the checker changed on the default branch between the scan and the report.
+    The two revisions can enforce different rules, so the comment could report
+    CLEAN while the guard is red, or BLOCKED while it passed -- the check and
+    the comment explaining it must never disagree.
+
+    Both revisions are maintainer-controlled, so this is a consistency
+    requirement rather than a trust one; the base commit is the branch a
+    maintainer chose to merge into, which is what the scanner already treats as
+    authoritative. A base commit whose checker is missing or unusable fails
+    closed, exactly like any other input this program cannot verify.
+    """
+    if not CHECKER_PATH_RE.fullmatch(checker_path) or ".." in checker_path:
+        raise RecomputeError("invalid checker path")
+    result = run(["git", "show", f"{base_sha}:{checker_path}"],
+                 capture_output=True)
+    if result.returncode != 0:
+        raise RecomputeError(
+            f"the trusted checker is not present at base commit {base_sha}: "
+            f"{result.stderr.decode('utf-8', 'replace').strip()[:200]}")
+    destination.write_bytes(result.stdout)
+    return destination
 
 
 def valid_login(value: object) -> bool:
@@ -166,7 +201,8 @@ def divergence(claimed: Path, recomputed: Path) -> str | None:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--binding", required=True, type=Path)
-    parser.add_argument("--checker", required=True, type=Path)
+    parser.add_argument("--checker-path", default=CHECKER_PATH,
+                        help="repository-relative path read from the bound base commit")
     parser.add_argument("--output", required=True, type=Path)
     parser.add_argument("--summary", required=True, type=Path)
     parser.add_argument("--repo-owner", required=True)
@@ -182,7 +218,9 @@ def main(argv: list[str] | None = None) -> int:
         args.output.parent.mkdir(parents=True, exist_ok=True)
         if not args.no_fetch:
             fetch_objects(binding)
-        verdict = recompute(args.checker, binding, args.output, args.summary,
+        checker = load_checker(str(binding["base_sha"]), args.checker_path,
+                               args.output.parent / "trusted-checker.py")
+        verdict = recompute(checker, binding, args.output, args.summary,
                             args.repo_owner)
     except (RecomputeError, ValueError, OSError) as exc:
         print(f"::error::Repository integrity reporter could not re-derive the "

--- a/scripts/recompute_repository_integrity_report.py
+++ b/scripts/recompute_repository_integrity_report.py
@@ -32,7 +32,7 @@ from pathlib import Path
 
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 REPO_RE = re.compile(r"^[A-Za-z0-9._-]{1,100}/[A-Za-z0-9._-]{1,100}$")
-LOGIN_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$")
+MAX_LOGIN_LENGTH = 64
 MAX_PR_NUMBER = 1_000_000
 # The checker exits 1 when it has findings; that is a verdict, not a failure.
 CLEAN, BLOCKED = 0, 1
@@ -40,6 +40,27 @@ CLEAN, BLOCKED = 0, 1
 
 class RecomputeError(Exception):
     """The verdict could not be re-derived. The reporter must not comment."""
+
+
+def valid_login(value: object) -> bool:
+    """A GitHub account login, held only to what a comparand in an argv needs.
+
+    Deliberately no character allowlist. Bot accounts are named `name[bot]` --
+    `dependabot[bot]`, `github-actions[bot]` -- and an obvious login pattern
+    rejects the brackets, which would leave every Dependabot pull request with a
+    red reporter and no findings comment. The value is used for one casefolded
+    comparison in the checker's `is_external`, and is passed as an argument
+    vector element rather than through a shell, so no character in it can mean
+    anything.
+
+    What is enforced is what that use needs: a string, a length bound, no ASCII
+    control characters, and no leading hyphen, so it can never be mistaken for
+    an option by the program it is passed to.
+    """
+    if not isinstance(value, str) or not 1 <= len(value) <= MAX_LOGIN_LENGTH:
+        return False
+    return not value.startswith("-") and not any(
+        ch < " " or ch == "\x7f" for ch in value)
 
 
 def load_binding(path: Path) -> dict[str, object]:
@@ -54,10 +75,12 @@ def load_binding(path: Path) -> dict[str, object]:
     if not isinstance(binding, dict):
         raise RecomputeError("invalid binding")
     for field, pattern in (("head_sha", SHA_RE), ("base_sha", SHA_RE),
-                           ("head_repository", REPO_RE), ("pr_author", LOGIN_RE)):
+                           ("head_repository", REPO_RE)):
         value = binding.get(field)
         if not isinstance(value, str) or not pattern.fullmatch(value):
             raise RecomputeError(f"invalid {field} in binding")
+    if not valid_login(binding.get("pr_author")):
+        raise RecomputeError("invalid pr_author in binding")
     number = binding.get("pr_number")
     if not isinstance(number, int) or isinstance(number, bool) or not 1 <= number <= MAX_PR_NUMBER:
         raise RecomputeError("invalid pr_number in binding")
@@ -153,7 +176,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        if not LOGIN_RE.fullmatch(args.repo_owner):
+        if not valid_login(args.repo_owner):
             raise RecomputeError("invalid repository owner")
         binding = load_binding(args.binding)
         args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/render_repository_integrity_comment.py
+++ b/scripts/render_repository_integrity_comment.py
@@ -3,6 +3,11 @@
 
 This program runs only from the trusted default branch. Report fields are data:
 they are strictly bounded, escaped, and never evaluated as shell or program text.
+
+The PR this report may address is decided by resolve_repository_integrity_pr.py,
+which binds the artifact to the triggering run and to the live pull request. The
+resulting binding is what this program validates against, so the two programs
+cannot disagree about which PR a report belongs to.
 """
 from __future__ import annotations
 
@@ -34,25 +39,25 @@ def safe_text(value: object, field: str) -> str:
     return "".join(ch if ch.isalnum() or ch in " .,_/-:" else f"&#{ord(ch)};" for ch in value)
 
 
-def validate(payload: object, event: object) -> tuple[list[dict[str, str | None]], int]:
+def validate(payload: object, binding: object) -> tuple[list[dict[str, str | None]], int]:
+    """Validate the report against the binding resolve_repository_integrity_pr.py
+    established. That program is the sole authority on which PR this report may
+    address; this one refuses to render anything that disagrees with it."""
     if not isinstance(payload, dict) or payload.get("schema_version") != 1:
         raise ValueError("unsupported report schema")
-    if not isinstance(event, dict):
-        raise ValueError("invalid workflow event")
-    run = event.get("workflow_run")
-    if not isinstance(run, dict):
-        raise ValueError("missing workflow run")
-    prs = run.get("pull_requests")
-    if not isinstance(prs, list) or len(prs) != 1 or not isinstance(prs[0], dict):
-        raise ValueError("workflow run must identify exactly one PR")
-    expected_pr = prs[0].get("number")
-    expected_sha = run.get("head_sha")
-    head_repo = run.get("head_repository")
-    expected_repo = head_repo.get("full_name") if isinstance(head_repo, dict) else None
-    if payload.get("pr_number") != expected_pr or payload.get("head_sha") != expected_sha or payload.get("head_repository") != expected_repo:
-        raise ValueError("report does not match the triggering PR")
+    if not isinstance(binding, dict):
+        raise ValueError("invalid report binding")
+    expected_pr = binding.get("pr_number")
+    expected_sha = binding.get("head_sha")
+    expected_repo = binding.get("head_repository")
     if not isinstance(expected_sha, str) or not SHA_RE.fullmatch(expected_sha):
         raise ValueError("invalid head SHA")
+    if not isinstance(expected_pr, int) or isinstance(expected_pr, bool) or expected_pr < 1:
+        raise ValueError("invalid bound PR number")
+    if not isinstance(expected_repo, str) or not expected_repo:
+        raise ValueError("invalid bound head repository")
+    if payload.get("pr_number") != expected_pr or payload.get("head_sha") != expected_sha or payload.get("head_repository") != expected_repo:
+        raise ValueError("report does not match the triggering PR")
     findings = payload.get("findings")
     if not isinstance(findings, list) or len(findings) > MAX_FINDINGS:
         raise ValueError("invalid findings list")
@@ -111,14 +116,16 @@ def render(findings: list[dict[str, str | None]], truncated: int = 0) -> str:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--report", required=True, type=Path)
-    parser.add_argument("--event", required=True, type=Path)
+    parser.add_argument("--binding", required=True, type=Path)
     parser.add_argument("--output", required=True, type=Path)
     args = parser.parse_args()
     if args.report.stat().st_size > 1_000_000:
         raise ValueError("report exceeds size limit")
+    if args.binding.stat().st_size > 4_096:
+        raise ValueError("binding exceeds size limit")
     payload = json.loads(args.report.read_text(encoding="utf-8"))
-    event = json.loads(args.event.read_text(encoding="utf-8"))
-    findings, truncated = validate(payload, event)
+    binding = json.loads(args.binding.read_text(encoding="utf-8"))
+    findings, truncated = validate(payload, binding)
     args.output.write_text(render(findings, truncated), encoding="utf-8")
     return 0
 

--- a/scripts/resolve_repository_integrity_pr.py
+++ b/scripts/resolve_repository_integrity_pr.py
@@ -218,6 +218,18 @@ def resolve(event: object, payload: object, repository: str) -> Binding:
 
     # The artifact must describe the exact head this run scanned. An artifact
     # produced by any other run cannot satisfy both of these.
+    #
+    # `workflow_run.head_sha` on a `pull_request` run is the raw PR head commit,
+    # which is what the scanner writes into the artifact from
+    # `github.event.pull_request.head.sha`, so these are the same value.
+    # Confirmed on this repository's own runs: run 32902865997 reports
+    # 68c58bc2f6c396858923356e144acf0c6d648cfe with that commit's own subject as
+    # its head_commit.message, and run 32887057547 reports
+    # a9ecac5b6a94159c590ccb51e09f5a00ac14f796, exactly PR #513's head.sha.
+    #
+    # Not to be confused with `github.sha` / GITHUB_SHA -- what checkout resolves
+    # by default -- which IS the synthetic merge revision on `pull_request`. The
+    # scanner does not rely on it: it pins `ref: ...pull_request.head.sha`.
     if head_sha != run.head_sha:
         raise BindingError("report head SHA does not match the triggering run")
     if head_repository != run.head_repository:

--- a/scripts/resolve_repository_integrity_pr.py
+++ b/scripts/resolve_repository_integrity_pr.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Bind a scanner findings artifact to the pull request it actually describes.
+
+This program runs only from the trusted default branch, inside the `workflow_run`
+reporter. It answers one question: may the reporter write a comment on a pull
+request, and which one.
+
+Why it exists: for a pull request opened from a fork, GitHub delivers
+`workflow_run.pull_requests` as an empty array, so the reporter had no PR to
+comment on and skipped. The findings artifact does carry a `pr_number`, but the
+scanner workflow file is contributor-controlled at the merge ref, so that number
+is a *claim*, never an authority. Every claim in the artifact is therefore
+re-derived from fields only GitHub can set:
+
+  * `workflow_run.head_sha` and `workflow_run.head_repository.full_name` are set
+    by GitHub from the pull request that started the run. A contributor cannot
+    forge them from inside the run.
+  * The artifact is downloaded with `run-id` pinned to this exact run, so it
+    provably came from the run those two fields describe.
+  * The claimed PR is then fetched from the API and must independently agree:
+    it must live in this repository, its head SHA must be the run's head SHA,
+    and its head repository must be the run's head repository.
+
+An attacker who republishes somebody else's head commit into their own fork can
+match the SHA, but not the head repository, so they can still only ever address
+their own pull request.
+
+Every unresolved, ambiguous, or mismatched case exits non-zero and no comment is
+written. There is no best-effort path.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+# The scanner's immutable identity. `workflows:` on the reporter's trigger
+# matches display name only, which a contributor can copy onto an unrelated
+# workflow; the file path is what actually pins the producer.
+SCANNER_WORKFLOW_PATH = ".github/workflows/repository-integrity.yml"
+SCANNER_WORKFLOW_NAME = "Repository integrity"
+SCANNER_EVENT = "pull_request"
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+REPO_RE = re.compile(r"^[A-Za-z0-9._-]{1,100}/[A-Za-z0-9._-]{1,100}$")
+MAX_PR_NUMBER = 1_000_000
+MAX_CANDIDATES = 50
+MAX_REPORT_BYTES = 1_000_000
+MAX_EVENT_BYTES = 5_000_000
+API_ROOT = "https://api.github.com"
+
+
+class BindingError(Exception):
+    """The reporter may not write. Raised for every unresolved case."""
+
+
+@dataclass(frozen=True)
+class RunFacts:
+    """Fields of the triggering run that only GitHub can set."""
+
+    run_id: int
+    head_sha: str
+    head_repository: str
+    repository: str
+    pull_requests: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class Binding:
+    pr_number: int
+    head_sha: str
+    head_repository: str
+    repository: str
+    run_id: int
+    # "workflow_run" when GitHub named the PR itself; "artifact" when the PR was
+    # recovered from the report and must be confirmed against the API.
+    pr_source: str
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "pr_number": self.pr_number,
+            "head_sha": self.head_sha,
+            "head_repository": self.head_repository,
+            "repository": self.repository,
+            "run_id": self.run_id,
+            "pr_source": self.pr_source,
+        }
+
+
+def _mapping(value: object, field: str) -> dict:
+    if not isinstance(value, dict):
+        raise BindingError(f"invalid {field}")
+    return value
+
+
+def _exact(value: object, expected: str, field: str) -> str:
+    if not isinstance(value, str) or value != expected:
+        raise BindingError(f"unexpected {field}")
+    return value
+
+
+def _sha(value: object, field: str) -> str:
+    if not isinstance(value, str) or not SHA_RE.fullmatch(value):
+        raise BindingError(f"invalid {field}")
+    return value
+
+
+def _repository(value: object, field: str) -> str:
+    if not isinstance(value, str) or not REPO_RE.fullmatch(value):
+        raise BindingError(f"invalid {field}")
+    return value
+
+
+def _identifier(value: object, field: str, maximum: int) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or not 1 <= value <= maximum:
+        raise BindingError(f"invalid {field}")
+    return value
+
+
+def trusted_run(event: object, repository: str) -> RunFacts:
+    """Establish that this event is the scanner's own run in this repository."""
+    payload = _mapping(event, "workflow event")
+    run = _mapping(payload.get("workflow_run"), "workflow run")
+    _exact(_mapping(payload.get("repository"), "event repository").get("full_name"),
+           repository, "event repository")
+    _exact(_mapping(run.get("repository"), "run repository").get("full_name"),
+           repository, "run repository")
+    _exact(run.get("event"), SCANNER_EVENT, "triggering event")
+    _exact(run.get("path"), SCANNER_WORKFLOW_PATH, "scanner workflow path")
+    _exact(run.get("name"), SCANNER_WORKFLOW_NAME, "scanner workflow name")
+
+    pull_requests = run.get("pull_requests")
+    if not isinstance(pull_requests, list):
+        raise BindingError("invalid pull request list")
+    numbers = tuple(
+        _identifier(_mapping(entry, "pull request").get("number"), "pull request number",
+                    MAX_PR_NUMBER)
+        for entry in pull_requests
+    )
+    return RunFacts(
+        run_id=_identifier(run.get("id"), "run id", 2**53 - 1),
+        head_sha=_sha(run.get("head_sha"), "run head SHA"),
+        head_repository=_repository(
+            _mapping(run.get("head_repository"), "run head repository").get("full_name"),
+            "run head repository"),
+        repository=repository,
+        pull_requests=numbers,
+    )
+
+
+def artifact_identity(payload: object) -> tuple[int, str, str]:
+    """Read the identity fields out of the artifact, after schema validation.
+
+    Nothing here is trusted yet. These are the values `resolve` must reconcile
+    against the run, and `verify_pull_request` against the API.
+    """
+    report = _mapping(payload, "report")
+    if report.get("schema_version") != 1:
+        raise BindingError("unsupported report schema")
+    return (
+        _identifier(report.get("pr_number"), "report PR number", MAX_PR_NUMBER),
+        _sha(report.get("head_sha"), "report head SHA"),
+        _repository(report.get("head_repository"), "report head repository"),
+    )
+
+
+def resolve(event: object, payload: object, repository: str) -> Binding:
+    """Bind the artifact to the triggering run, or refuse."""
+    run = trusted_run(event, repository)
+    pr_number, head_sha, head_repository = artifact_identity(payload)
+
+    # The artifact must describe the exact head this run scanned. An artifact
+    # produced by any other run cannot satisfy both of these.
+    if head_sha != run.head_sha:
+        raise BindingError("report head SHA does not match the triggering run")
+    if head_repository != run.head_repository:
+        raise BindingError("report head repository does not match the triggering run")
+
+    if len(run.pull_requests) == 1:
+        # GitHub named the PR. Its number wins; the artifact must agree with it.
+        if pr_number != run.pull_requests[0]:
+            raise BindingError("report PR number does not match the triggering run")
+        source = "workflow_run"
+    elif not run.pull_requests:
+        # Fork-originated run: GitHub sends an empty array. The artifact's claim
+        # is carried forward as a candidate only, to be confirmed against the API.
+        source = "artifact"
+    else:
+        raise BindingError("workflow run identifies more than one PR")
+
+    return Binding(pr_number=pr_number, head_sha=head_sha, head_repository=head_repository,
+                   repository=repository, run_id=run.run_id, pr_source=source)
+
+
+def _head_repository_of(pull_request: dict) -> str | None:
+    head = pull_request.get("head")
+    if not isinstance(head, dict):
+        return None
+    repo = head.get("repo")
+    return repo.get("full_name") if isinstance(repo, dict) else None
+
+
+def select_candidate(candidates: object, binding: Binding) -> int:
+    """Pick the single PR this run's head can belong to, or refuse.
+
+    Republishing another contributor's head commit into your own fork makes the
+    SHA collide, so the SHA alone can name two pull requests. Narrowing by head
+    repository leaves only pull requests opened from the fork this run actually
+    ran for, and more than one survivor is ambiguous rather than best-effort.
+    """
+    if not isinstance(candidates, list) or len(candidates) > MAX_CANDIDATES:
+        raise BindingError("invalid associated pull request list")
+    numbers = set()
+    for entry in candidates:
+        pull_request = _mapping(entry, "associated pull request")
+        base = pull_request.get("base")
+        base_repo = base.get("repo") if isinstance(base, dict) else None
+        if not isinstance(base_repo, dict) or base_repo.get("full_name") != binding.repository:
+            continue
+        if _head_repository_of(pull_request) != binding.head_repository:
+            continue
+        numbers.add(_identifier(pull_request.get("number"), "associated PR number",
+                                MAX_PR_NUMBER))
+    if len(numbers) != 1:
+        raise BindingError(
+            f"{len(numbers)} pull requests match this run's head; refusing to guess")
+    resolved = numbers.pop()
+    if resolved != binding.pr_number:
+        raise BindingError("report PR number is not the PR this run's head belongs to")
+    return resolved
+
+
+def verify_pull_request(pull_request: object, binding: Binding) -> bool:
+    """Confirm the live PR is the one the artifact claims. False means superseded."""
+    live = _mapping(pull_request, "pull request")
+    if _identifier(live.get("number"), "PR number", MAX_PR_NUMBER) != binding.pr_number:
+        raise BindingError("API returned a different pull request")
+    base = _mapping(live.get("base"), "PR base")
+    if _mapping(base.get("repo"), "PR base repository").get("full_name") != binding.repository:
+        raise BindingError("pull request does not belong to this repository")
+    if _head_repository_of(live) != binding.head_repository:
+        raise BindingError("pull request head repository does not match the scanned head")
+    head_sha = _sha(_mapping(live.get("head"), "PR head").get("sha"), "PR head SHA")
+    # Out-of-order synchronize runs must never restore an older verdict over a
+    # newer one. A moved head is not an error, it is a superseded report.
+    return head_sha == binding.head_sha
+
+
+def api_get(path: str, token: str) -> object:
+    request = urllib.request.Request(
+        API_ROOT + path,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "linthra-repository-integrity-reporter",
+            "Authorization": "Bearer " + token,
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310 - fixed https root
+        if response.status != 200:
+            raise BindingError(f"GitHub API returned {response.status} for {path}")
+        return json.loads(response.read(MAX_REPORT_BYTES).decode("utf-8"))
+
+
+def _read_json(path: Path, limit: int, label: str) -> object:
+    if path.stat().st_size > limit:
+        raise BindingError(f"{label} exceeds size limit")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def decide(event: object, payload: object, repository: str,
+           fetch: Callable[[str], object]) -> tuple[Binding, bool]:
+    """Resolve, then confirm against the API. Returns (binding, may_write)."""
+    binding = resolve(event, payload, repository)
+    # Path segments are re-derived, never interpolated from report text: the
+    # repository is this workflow's own, the SHA is 40 hex characters, and the
+    # PR number is a bounded integer.
+    owner_repo = urllib.parse.quote(binding.repository, safe="/")
+    if binding.pr_source == "artifact":
+        select_candidate(
+            fetch(f"/repos/{owner_repo}/commits/{binding.head_sha}/pulls"), binding)
+    return binding, verify_pull_request(
+        fetch(f"/repos/{owner_repo}/pulls/{binding.pr_number}"), binding)
+
+
+def _emit(name: str, value: str) -> None:
+    destination = os.environ.get("GITHUB_OUTPUT")
+    if destination:
+        with open(destination, "a", encoding="utf-8") as handle:
+            handle.write(f"{name}={value}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", required=True, type=Path)
+    parser.add_argument("--report", required=True, type=Path)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    try:
+        if not token:
+            raise BindingError("no API token available")
+        repository = _repository(args.repository, "repository")
+        event = _read_json(args.event, MAX_EVENT_BYTES, "workflow event")
+        payload = _read_json(args.report, MAX_REPORT_BYTES, "report")
+        binding, may_write = decide(event, payload, repository,
+                                    lambda path: api_get(path, token))
+    except (BindingError, ValueError, OSError, urllib.error.URLError) as exc:
+        print(f"::error::Repository integrity reporter refused to comment: {exc}",
+              file=sys.stderr)
+        _emit("post", "false")
+        return 1
+
+    if not may_write:
+        print(f"PR #{binding.pr_number} has moved past {binding.head_sha}; "
+              "leaving the existing comment untouched.")
+        _emit("post", "false")
+        return 0
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(binding.as_dict(), sort_keys=True) + "\n",
+                           encoding="utf-8")
+    print(f"Bound report to PR #{binding.pr_number} at {binding.head_sha} "
+          f"(resolved from {binding.pr_source}).")
+    _emit("post", "true")
+    _emit("pr_number", str(binding.pr_number))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/resolve_repository_integrity_pr.py
+++ b/scripts/resolve_repository_integrity_pr.py
@@ -38,7 +38,7 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Callable
 
@@ -54,6 +54,8 @@ REPO_RE = re.compile(r"^[A-Za-z0-9._-]{1,100}/[A-Za-z0-9._-]{1,100}$")
 # GitHub caps a branch name at 255 bytes. Nothing narrower is imposed: see
 # _branch below for why this value is bounded but not otherwise constrained.
 MAX_BRANCH_LENGTH = 255
+# GitHub logins: alphanumeric and hyphens, 39 characters maximum.
+LOGIN_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$")
 MAX_PR_NUMBER = 1_000_000
 # A commit realistically has one associated pull request. The bound exists so a
 # pathological or hostile response cannot be read unbounded; exceeding it fails
@@ -95,6 +97,11 @@ class Binding:
     # "workflow_run" when GitHub named the PR itself; "artifact" when the PR was
     # recovered from the report and must be confirmed against the API.
     pr_source: str
+    # Filled in from the live pull request, never from the artifact. These are
+    # what the trusted reporter re-derives the findings from, so they must come
+    # from GitHub rather than from anything the scanner run wrote.
+    base_sha: str | None = None
+    pr_author: str | None = None
 
     def as_dict(self) -> dict[str, object]:
         return {
@@ -105,6 +112,8 @@ class Binding:
             "repository": self.repository,
             "run_id": self.run_id,
             "pr_source": self.pr_source,
+            "base_sha": self.base_sha,
+            "pr_author": self.pr_author,
         }
 
 
@@ -153,6 +162,12 @@ def _branch(value: object, field: str) -> str | None:
     if not isinstance(value, str) or len(value) > MAX_BRANCH_LENGTH:
         raise BindingError(f"invalid {field}")
     if any(ch < " " or ch == "\x7f" for ch in value):
+        raise BindingError(f"invalid {field}")
+    return value
+
+
+def _login(value: object, field: str) -> str:
+    if not isinstance(value, str) or not LOGIN_RE.fullmatch(value):
         raise BindingError(f"invalid {field}")
     return value
 
@@ -308,8 +323,12 @@ def select_candidate(candidates: object, binding: Binding) -> int:
     return resolved
 
 
-def verify_pull_request(pull_request: object, binding: Binding) -> bool:
-    """Confirm the live PR is the one the artifact claims. False means superseded."""
+def verify_pull_request(pull_request: object, binding: Binding) -> tuple[bool, Binding]:
+    """Confirm the live PR is the one the artifact claims, and take from it the
+    scan inputs the trusted reporter re-derives its own findings from.
+
+    Returns (may_write, binding). A false first element means superseded.
+    """
     live = _mapping(pull_request, "pull request")
     if _identifier(live.get("number"), "PR number", MAX_PR_NUMBER) != binding.pr_number:
         raise BindingError("API returned a different pull request")
@@ -323,9 +342,16 @@ def verify_pull_request(pull_request: object, binding: Binding) -> bool:
         if _branch(head.get("ref"), "PR head branch") != binding.head_branch:
             raise BindingError("pull request head branch does not match the scanned head")
     head_sha = _sha(head.get("sha"), "PR head SHA")
+    # Both are read from the live pull request, so the re-derivation the reporter
+    # performs cannot be steered by anything the scanner run wrote.
+    bound = replace(
+        binding,
+        base_sha=_sha(base.get("sha"), "PR base SHA"),
+        pr_author=_login(_mapping(live.get("user"), "PR author").get("login"), "PR author"),
+    )
     # Out-of-order synchronize runs must never restore an older verdict over a
     # newer one. A moved head is not an error, it is a superseded report.
-    return head_sha == binding.head_sha
+    return head_sha == binding.head_sha, bound
 
 
 # Swappable so the pagination below can be exercised without a network.
@@ -415,8 +441,9 @@ def decide(event: object, payload: object, repository: str,
         # is always read from this repository, which is what makes the answer
         # binding rather than merely suggestive.
         select_candidate(fetch(association_path(binding)), binding)
-    return binding, verify_pull_request(
+    may_write, binding = verify_pull_request(
         fetch(f"/repos/{owner_repo}/pulls/{binding.pr_number}"), binding)
+    return binding, may_write
 
 
 def _emit(name: str, value: str) -> None:

--- a/scripts/resolve_repository_integrity_pr.py
+++ b/scripts/resolve_repository_integrity_pr.py
@@ -55,7 +55,12 @@ REPO_RE = re.compile(r"^[A-Za-z0-9._-]{1,100}/[A-Za-z0-9._-]{1,100}$")
 # _branch below for why this value is bounded but not otherwise constrained.
 MAX_BRANCH_LENGTH = 255
 MAX_PR_NUMBER = 1_000_000
-MAX_CANDIDATES = 50
+# A commit realistically has one associated pull request. The bound exists so a
+# pathological or hostile response cannot be read unbounded; exceeding it fails
+# closed rather than selecting from a set that was silently cut short.
+MAX_CANDIDATES = 100
+_PAGE_SIZE = 100
+_MAX_PAGES = 4
 MAX_REPORT_BYTES = 1_000_000
 MAX_EVENT_BYTES = 5_000_000
 API_ROOT = "https://api.github.com"
@@ -311,9 +316,34 @@ def verify_pull_request(pull_request: object, binding: Binding) -> bool:
     return head_sha == binding.head_sha
 
 
-def api_get(path: str, token: str) -> object:
+# Swappable so the pagination below can be exercised without a network.
+_OPENER = urllib.request.urlopen
+
+_NEXT_LINK = re.compile(r'<([^>]+)>\s*;\s*rel="next"')
+
+
+def _next_page(link_header: str | None) -> str | None:
+    """The `rel="next"` URL, required to stay on the API host.
+
+    GitHub answers with an absolute URL under a different path shape than the
+    one requested (`/repositories/{id}/...`), so it is followed as given rather
+    than reconstructed -- but only ever after confirming the host, so a
+    redirected or spoofed header cannot walk this request off api.github.com.
+    """
+    if not link_header:
+        return None
+    match = _NEXT_LINK.search(link_header)
+    if not match:
+        return None
+    url = match.group(1)
+    if not url.startswith(API_ROOT + "/"):
+        raise BindingError("GitHub API pagination pointed off the API host")
+    return url
+
+
+def _read_page(url: str, token: str) -> tuple[object, str | None]:
     request = urllib.request.Request(
-        API_ROOT + path,
+        url,
         headers={
             "Accept": "application/vnd.github+json",
             "X-GitHub-Api-Version": "2022-11-28",
@@ -321,10 +351,37 @@ def api_get(path: str, token: str) -> object:
             "Authorization": "Bearer " + token,
         },
     )
-    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310 - fixed https root
+    with _OPENER(request, timeout=30) as response:  # noqa: S310 - fixed https root
         if response.status != 200:
-            raise BindingError(f"GitHub API returned {response.status} for {path}")
-        return json.loads(response.read(MAX_REPORT_BYTES).decode("utf-8"))
+            raise BindingError(f"GitHub API returned {response.status} for {url}")
+        payload = json.loads(response.read(MAX_REPORT_BYTES).decode("utf-8"))
+    return payload, _next_page(response.headers.get("Link"))
+
+
+def api_get(path: str, token: str) -> object:
+    """Fetch one API resource, following pagination when it is a collection.
+
+    Collections must be read whole. The commit-to-PR association endpoint pages
+    at 30 by default, so an unpaginated read could miss the pull request being
+    resolved -- reporting zero matches on a PR that is present -- and could hide
+    a second match from the ambiguity check, deciding "exactly one" against a
+    set that was silently cut short. Accumulation is bounded, and exceeding the
+    bound fails closed rather than selecting from a truncated set.
+    """
+    url = API_ROOT + path + ("&" if "?" in path else "?") + f"per_page={_PAGE_SIZE}"
+    collected: list[object] | None = None
+    for _ in range(_MAX_PAGES):
+        payload, url = _read_page(url, token)
+        if not isinstance(payload, list):
+            return payload  # a single resource is never paginated
+        collected = payload if collected is None else collected + payload
+        if len(collected) > MAX_CANDIDATES:
+            raise BindingError(
+                f"GitHub returned more than {MAX_CANDIDATES} results for {path}; "
+                "refusing to select from a set this large")
+        if url is None:
+            return collected
+    raise BindingError(f"GitHub pagination for {path} did not terminate")
 
 
 def _read_json(path: Path, limit: int, label: str) -> object:

--- a/scripts/resolve_repository_integrity_pr.py
+++ b/scripts/resolve_repository_integrity_pr.py
@@ -54,8 +54,9 @@ REPO_RE = re.compile(r"^[A-Za-z0-9._-]{1,100}/[A-Za-z0-9._-]{1,100}$")
 # GitHub caps a branch name at 255 bytes. Nothing narrower is imposed: see
 # _branch below for why this value is bounded but not otherwise constrained.
 MAX_BRANCH_LENGTH = 255
-# GitHub logins: alphanumeric and hyphens, 39 characters maximum.
-LOGIN_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$")
+# A user login is 39 characters; a bot login adds "[bot]". Bounded, not shaped:
+# see _login for why no character allowlist is imposed.
+MAX_LOGIN_LENGTH = 64
 MAX_PR_NUMBER = 1_000_000
 # A commit realistically has one associated pull request. The bound exists so a
 # pathological or hostile response cannot be read unbounded; exceeding it fails
@@ -167,7 +168,23 @@ def _branch(value: object, field: str) -> str | None:
 
 
 def _login(value: object, field: str) -> str:
-    if not isinstance(value, str) or not LOGIN_RE.fullmatch(value):
+    """A GitHub account login, held only to what a comparand in an argv needs.
+
+    Deliberately no character allowlist. Bot accounts are named `name[bot]` --
+    `dependabot[bot]`, `github-actions[bot]` -- and an obvious login pattern
+    rejects the brackets, which would leave every Dependabot pull request with a
+    red reporter and no findings comment. The value is used for one casefolded
+    comparison in the checker's `is_external`, and is passed as an argument
+    vector element rather than through a shell, so no character in it can mean
+    anything.
+
+    What is enforced is what that use needs: a string, a length bound, no ASCII
+    control characters, and no leading hyphen, so it can never be mistaken for
+    an option by the program it is passed to.
+    """
+    if not isinstance(value, str) or not 1 <= len(value) <= MAX_LOGIN_LENGTH:
+        raise BindingError(f"invalid {field}")
+    if value.startswith("-") or any(ch < " " or ch == "\x7f" for ch in value):
         raise BindingError(f"invalid {field}")
     return value
 

--- a/scripts/resolve_repository_integrity_pr.py
+++ b/scripts/resolve_repository_integrity_pr.py
@@ -361,6 +361,25 @@ def verify_pull_request(pull_request: object, binding: Binding) -> tuple[bool, B
     head_sha = _sha(head.get("sha"), "PR head SHA")
     # Both are read from the live pull request, so the re-derivation the reporter
     # performs cannot be steered by anything the scanner run wrote.
+    #
+    # Known limitation, accepted deliberately. `base.sha` tracks the base
+    # branch's current tip rather than the tip the scanner saw: a pull request
+    # reports whatever the base branch has advanced to since. So if the base
+    # branch moves between the scan and the report, the reporter re-derives
+    # against a slightly newer base than the guard used.
+    #
+    # The commit set is unaffected in practice. `rev-list head --not base`
+    # excludes what is reachable from base, and commits pushed to the base after
+    # the scan are not reachable from a head that predates them, so the same
+    # commits are scanned either way. What can differ is the checker revision
+    # loaded from that base -- and only when the push that moved the base also
+    # changed the checker, inside the seconds between the two workflow runs.
+    #
+    # Closing it entirely would mean taking the scan-time base SHA from the
+    # artifact, which is contributor-controlled: authenticating it against the
+    # base branch's ancestry is possible, but it would make an artifact field
+    # decide something again, which is the property this design gives up
+    # everywhere else. The narrower risk was judged the better trade.
     bound = replace(
         binding,
         base_sha=_sha(base.get("sha"), "PR base SHA"),

--- a/scripts/resolve_repository_integrity_pr.py
+++ b/scripts/resolve_repository_integrity_pr.py
@@ -51,6 +51,7 @@ SCANNER_EVENT = "pull_request"
 
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 REPO_RE = re.compile(r"^[A-Za-z0-9._-]{1,100}/[A-Za-z0-9._-]{1,100}$")
+BRANCH_RE = re.compile(r"^[A-Za-z0-9._/-]{1,255}$")
 MAX_PR_NUMBER = 1_000_000
 MAX_CANDIDATES = 50
 MAX_REPORT_BYTES = 1_000_000
@@ -69,6 +70,7 @@ class RunFacts:
     run_id: int
     head_sha: str
     head_repository: str
+    head_branch: str | None
     repository: str
     pull_requests: tuple[int, ...]
 
@@ -78,6 +80,9 @@ class Binding:
     pr_number: int
     head_sha: str
     head_repository: str
+    # GitHub-set branch name of the run's head, when the event carries one. One
+    # more immutable identity dimension the live PR has to agree with.
+    head_branch: str | None
     repository: str
     run_id: int
     # "workflow_run" when GitHub named the PR itself; "artifact" when the PR was
@@ -89,6 +94,7 @@ class Binding:
             "pr_number": self.pr_number,
             "head_sha": self.head_sha,
             "head_repository": self.head_repository,
+            "head_branch": self.head_branch,
             "repository": self.repository,
             "run_id": self.run_id,
             "pr_source": self.pr_source,
@@ -115,6 +121,22 @@ def _sha(value: object, field: str) -> str:
 
 def _repository(value: object, field: str) -> str:
     if not isinstance(value, str) or not REPO_RE.fullmatch(value):
+        raise BindingError(f"invalid {field}")
+    return value
+
+
+def _branch(value: object, field: str) -> str | None:
+    """Branch names are optional; a present one must be a well-formed git ref.
+
+    This value is only ever compared for equality, never placed in a URL, but
+    it is held to git's own ref rules anyway so that nothing path-shaped can be
+    carried under the name of a branch.
+    """
+    if value is None or value == "":
+        return None
+    if not isinstance(value, str) or not BRANCH_RE.fullmatch(value):
+        raise BindingError(f"invalid {field}")
+    if ".." in value or value.startswith("/") or value.endswith("/") or "//" in value:
         raise BindingError(f"invalid {field}")
     return value
 
@@ -151,6 +173,7 @@ def trusted_run(event: object, repository: str) -> RunFacts:
         head_repository=_repository(
             _mapping(run.get("head_repository"), "run head repository").get("full_name"),
             "run head repository"),
+        head_branch=_branch(run.get("head_branch"), "run head branch"),
         repository=repository,
         pull_requests=numbers,
     )
@@ -197,7 +220,8 @@ def resolve(event: object, payload: object, repository: str) -> Binding:
         raise BindingError("workflow run identifies more than one PR")
 
     return Binding(pr_number=pr_number, head_sha=head_sha, head_repository=head_repository,
-                   repository=repository, run_id=run.run_id, pr_source=source)
+                   head_branch=run.head_branch, repository=repository, run_id=run.run_id,
+                   pr_source=source)
 
 
 def _head_repository_of(pull_request: dict) -> str | None:
@@ -206,6 +230,24 @@ def _head_repository_of(pull_request: dict) -> str | None:
         return None
     repo = head.get("repo")
     return repo.get("full_name") if isinstance(repo, dict) else None
+
+
+def association_path(binding: Binding) -> str:
+    """The commit-to-PR association endpoint for this run's head commit.
+
+    The query must go to the HEAD repository, not the base. A fork's head commit
+    is not in the base repository's own commit list, so
+    `/repos/{base}/commits/{fork_sha}/pulls` answers `[]` for exactly the fork
+    pull requests this recovery path exists to resolve -- verified against the
+    live API with PR #513's head. `/repos/{fork}/commits/{sha}/pulls` returns it.
+
+    Querying a contributor-controlled repository grants nothing: the repository
+    is `workflow_run.head_repository.full_name`, which GitHub sets, and every
+    candidate it returns is still constrained by `select_candidate` below to a
+    pull request into this repository, from that same fork, at that same head.
+    """
+    repository = urllib.parse.quote(binding.head_repository, safe="/")
+    return f"/repos/{repository}/commits/{binding.head_sha}/pulls"
 
 
 def select_candidate(candidates: object, binding: Binding) -> int:
@@ -248,7 +290,11 @@ def verify_pull_request(pull_request: object, binding: Binding) -> bool:
         raise BindingError("pull request does not belong to this repository")
     if _head_repository_of(live) != binding.head_repository:
         raise BindingError("pull request head repository does not match the scanned head")
-    head_sha = _sha(_mapping(live.get("head"), "PR head").get("sha"), "PR head SHA")
+    head = _mapping(live.get("head"), "PR head")
+    if binding.head_branch is not None:
+        if _branch(head.get("ref"), "PR head branch") != binding.head_branch:
+            raise BindingError("pull request head branch does not match the scanned head")
+    head_sha = _sha(head.get("sha"), "PR head SHA")
     # Out-of-order synchronize runs must never restore an older verdict over a
     # newer one. A moved head is not an error, it is a superseded report.
     return head_sha == binding.head_sha
@@ -280,13 +326,15 @@ def decide(event: object, payload: object, repository: str,
            fetch: Callable[[str], object]) -> tuple[Binding, bool]:
     """Resolve, then confirm against the API. Returns (binding, may_write)."""
     binding = resolve(event, payload, repository)
-    # Path segments are re-derived, never interpolated from report text: the
-    # repository is this workflow's own, the SHA is 40 hex characters, and the
-    # PR number is a bounded integer.
+    # Path segments are re-derived, never interpolated from report text: both
+    # repositories match REPO_RE and equal values GitHub set, the SHA is 40 hex
+    # characters, and the PR number is a bounded integer.
     owner_repo = urllib.parse.quote(binding.repository, safe="/")
     if binding.pr_source == "artifact":
-        select_candidate(
-            fetch(f"/repos/{owner_repo}/commits/{binding.head_sha}/pulls"), binding)
+        # Association is asked of the head repository; the pull request itself
+        # is always read from this repository, which is what makes the answer
+        # binding rather than merely suggestive.
+        select_candidate(fetch(association_path(binding)), binding)
     return binding, verify_pull_request(
         fetch(f"/repos/{owner_repo}/pulls/{binding.pr_number}"), binding)
 

--- a/scripts/resolve_repository_integrity_pr.py
+++ b/scripts/resolve_repository_integrity_pr.py
@@ -51,7 +51,9 @@ SCANNER_EVENT = "pull_request"
 
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 REPO_RE = re.compile(r"^[A-Za-z0-9._-]{1,100}/[A-Za-z0-9._-]{1,100}$")
-BRANCH_RE = re.compile(r"^[A-Za-z0-9._/-]{1,255}$")
+# GitHub caps a branch name at 255 bytes. Nothing narrower is imposed: see
+# _branch below for why this value is bounded but not otherwise constrained.
+MAX_BRANCH_LENGTH = 255
 MAX_PR_NUMBER = 1_000_000
 MAX_CANDIDATES = 50
 MAX_REPORT_BYTES = 1_000_000
@@ -126,17 +128,26 @@ def _repository(value: object, field: str) -> str:
 
 
 def _branch(value: object, field: str) -> str | None:
-    """Branch names are optional; a present one must be a well-formed git ref.
+    """Branch names are optional, and are opaque equality-only data.
 
-    This value is only ever compared for equality, never placed in a URL, but
-    it is held to git's own ref rules anyway so that nothing path-shaped can be
-    carried under the name of a branch.
+    Deliberately no character allowlist. Git accepts far more than an obvious
+    one admits -- `feature+test`, `feature@2`, and non-ASCII names all pass
+    `git check-ref-format --branch` -- and rejecting a legitimate branch here
+    would leave the reporter red with no findings comment on that pull request,
+    which is the very failure this program exists to end. Reimplementing git's
+    real ref grammar would buy nothing either: this value is only ever compared
+    against the live pull request's own `head.ref`. It never forms a URL, a
+    command, or a log line, so no character in it can mean anything.
+
+    What is enforced is what a comparand needs: a string, a length bound, and no
+    ASCII control characters -- which git forbids in a ref anyway, and which are
+    the only class that could matter if this value were ever printed.
     """
     if value is None or value == "":
         return None
-    if not isinstance(value, str) or not BRANCH_RE.fullmatch(value):
+    if not isinstance(value, str) or len(value) > MAX_BRANCH_LENGTH:
         raise BindingError(f"invalid {field}")
-    if ".." in value or value.startswith("/") or value.endswith("/") or "//" in value:
+    if any(ch < " " or ch == "\x7f" for ch in value):
         raise BindingError(f"invalid {field}")
     return value
 

--- a/test/tooling/check_repository_integrity_test.py
+++ b/test/tooling/check_repository_integrity_test.py
@@ -629,6 +629,59 @@ class RepositoryIntegrityTest(unittest.TestCase):
         self.assertTrue(any(f.path == "assets/payload.png" for f in historical))
         self.assertFalse(any(f.commit == merge for f in findings))
 
+    def test_pr_513_contamination_survives_a_fully_clean_final_diff(self) -> None:
+        """The #513/#514/#515 incident, reproduced with its real finding shapes.
+
+        External PR #513 attributed every violation to bd48e57df55ed0cde25170e4
+        baa53314bd2187e8 while its final diff against main was empty. The
+        commit SHA differs here because the fixture history is built fresh, but
+        the property that matters is the same one: attribution survives cleanup
+        plus an Update-branch merge, so a zero-file diff still blocks.
+        """
+        git(self.repo, "switch", "-c", "pr")
+        workspace = self.repo / ".vscode"
+        workspace.mkdir()
+        # The .gitignore change is what let the workspace files be committed.
+        (self.repo / ".gitignore").write_text(".idea/\n", encoding="utf-8")
+        for name in ("extensions.json", "launch.json", "settings.json", "spellright.dict"):
+            (workspace / name).write_text("{}\n", encoding="utf-8")
+        (workspace / "tasks.json").write_text(ASSET_EXECUTION_PAYLOAD, encoding="utf-8")
+        font = self.repo / "public" / "fonts" / "fa-solid-400.woff2"
+        font.parent.mkdir(parents=True)
+        font.write_text("this is not a font\n", encoding="utf-8")
+        contaminated = self.commit("A: import IDE workspace and vendored assets")
+
+        # Cleanup: every prohibited path removed and the ignore rule restored.
+        for entry in sorted(workspace.iterdir()):
+            entry.unlink()
+        workspace.rmdir()
+        font.unlink()
+        (self.repo / ".gitignore").write_text(".idea/\n.vscode/\n", encoding="utf-8")
+        self.commit("B: revert the workspace import")
+
+        git(self.repo, "switch", "main")
+        (self.repo / "README.md").write_text("trusted update\n", encoding="utf-8")
+        self.base = self.commit("trusted main update")
+        git(self.repo, "switch", "pr")
+        git(self.repo, "merge", "--no-ff", "main", "-m", "C: Update branch")
+        head = git(self.repo, "rev-parse", "HEAD")
+
+        # The state the reporter has to explain: zero changed files, still blocked.
+        self.assertEqual(git(self.repo, "diff", "--name-only", f"{self.base}...{head}"), "")
+        findings = self.scan(head)
+        self.assertTrue(findings)
+        attributed = {f.path for f in findings if f.commit == contaminated}
+        for path in (".gitignore", ".vscode/extensions.json", ".vscode/launch.json",
+                     ".vscode/settings.json", ".vscode/spellright.dict",
+                     ".vscode/tasks.json", "public/fonts/fa-solid-400.woff2"):
+            self.assertIn(path, attributed)
+        reasons = {f.reason for f in findings if f.commit == contaminated}
+        self.assertTrue(any("asset file as executable" in reason for reason in reasons))
+        self.assertTrue(any("file extension claims" in reason for reason in reasons))
+        self.assertTrue(all(f.severity == "blocked" for f in findings))
+        # The Update-branch merge copies content unchanged, so it is not blamed.
+        self.assertNotIn(head, {f.commit for f in findings})
+
     def test_ordinary_multi_commit_pr_passes(self) -> None:
         (self.repo / "lib" / "first.dart").write_text("const first = 1;\n", encoding="utf-8")
         self.commit("first")

--- a/test/tooling/recompute_repository_integrity_report_test.py
+++ b/test/tooling/recompute_repository_integrity_report_test.py
@@ -200,14 +200,21 @@ class BindingValidationTest(unittest.TestCase):
         self.path.write_text(json.dumps(payload), encoding="utf-8")
         return self.path
 
+    def test_bot_form_authors_are_accepted(self) -> None:
+        for login in ("dependabot[bot]", "github-actions[bot]", "renovate[bot]"):
+            with self.subTest(login=login):
+                binding = recompute.load_binding(self.write(pr_author=login))
+                self.assertEqual(binding["pr_author"], login)
+
     def test_every_field_the_checker_receives_is_revalidated(self) -> None:
         recompute.load_binding(self.write())  # the good case
         for field, bad in (
             ("base_sha", "not-a-sha"), ("base_sha", None),
             ("head_sha", "../../etc/passwd"), ("head_sha", 7),
             ("head_repository", "a/b/c"), ("head_repository", ""),
-            ("pr_author", "bad login"), ("pr_author", "-leading"),
-            ("pr_author", "x" * 40), ("pr_number", 0), ("pr_number", True),
+            ("pr_author", "-leading"), ("pr_author", "new\nline"),
+            ("pr_author", ""), ("pr_author", "x" * 65),
+            ("pr_number", 0), ("pr_number", True),
             ("pr_number", "513"),
         ):
             with self.subTest(field=field, bad=bad):

--- a/test/tooling/recompute_repository_integrity_report_test.py
+++ b/test/tooling/recompute_repository_integrity_report_test.py
@@ -269,6 +269,7 @@ class ForgedArtifactTest(unittest.TestCase):
         git(self.repo, "commit", "-qm", "base without a checker")
         self.base = git(self.repo, "rev-parse", "HEAD")
         git(self.repo, "switch", "-qc", "pr")
+        (self.repo / "scripts").mkdir(exist_ok=True)
         (self.repo / "scripts" / "check_repository_integrity.py").write_bytes(
             CHECKER.read_bytes()
         )
@@ -285,6 +286,7 @@ class ForgedArtifactTest(unittest.TestCase):
         git(self.repo, "commit", "-qm", "base without a checker")
         self.base = git(self.repo, "rev-parse", "HEAD")
         git(self.repo, "switch", "-qc", "pr")
+        (self.repo / "scripts").mkdir(exist_ok=True)
         (self.repo / "scripts" / "check_repository_integrity.py").write_bytes(
             CHECKER.read_bytes()
         )

--- a/test/tooling/recompute_repository_integrity_report_test.py
+++ b/test/tooling/recompute_repository_integrity_report_test.py
@@ -59,6 +59,12 @@ class ForgedArtifactTest(unittest.TestCase):
         (self.repo / ".gitignore").write_text(".idea/\n.vscode/\n", encoding="utf-8")
         (self.repo / "lib").mkdir()
         (self.repo / "lib" / "main.dart").write_text("void main() {}\n", encoding="utf-8")
+        # The scanner loads its checker from the base commit and the reporter
+        # re-derives with that same revision, so the fixture carries it there
+        # rather than reaching for the reporter's own working copy.
+        (self.repo / "scripts").mkdir()
+        (self.repo / "scripts" / "check_repository_integrity.py").write_bytes(
+            CHECKER.read_bytes())
         git(self.repo, "add", ".")
         git(self.repo, "commit", "-m", "base")
         self.base = git(self.repo, "rev-parse", "HEAD")
@@ -103,7 +109,7 @@ class ForgedArtifactTest(unittest.TestCase):
 
     def run_recompute(self, head: str, claimed: Path | None) -> tuple[int, Path]:
         output = self.work / "verified-report.json"
-        argv = ["--binding", str(self.binding(head)), "--checker", str(CHECKER),
+        argv = ["--binding", str(self.binding(head)),
                 "--output", str(output), "--summary", str(self.work / "verified.md"),
                 "--repo-owner", OWNER, "--no-fetch"]
         if claimed is not None:
@@ -161,6 +167,65 @@ class ForgedArtifactTest(unittest.TestCase):
             derived, json.loads(self.binding(head).read_text())))
         self.assertIn("**CLEAN**", body)
 
+    def test_the_base_commits_checker_revision_is_the_one_that_runs(self) -> None:
+        """Decisive for the policy-skew case.
+
+        The base commit carries a distinguishable checker revision. If the
+        reporter ran its own default-branch copy instead, the re-derived report
+        would not carry that revision's marker -- which is exactly how a comment
+        could report CLEAN while the guard, running the base revision, is red.
+        """
+        stub = (
+            "#!/usr/bin/env python3\n"
+            "import argparse, json\n"
+            "p = argparse.ArgumentParser()\n"
+            "for f in ('--base','--head','--pr-author','--repo-owner','--report',\n"
+            "          '--json-report','--pr-number','--head-repository'):\n"
+            "    p.add_argument(f)\n"
+            "a = p.parse_args()\n"
+            "open(a.report, 'w').write('stub\\n')\n"
+            "json.dump({'schema_version': 1, 'pr_number': int(a.pr_number),\n"
+            "           'head_sha': a.head, 'head_repository': a.head_repository,\n"
+            "           'truncated': 0,\n"
+            "           'findings': [{'severity': 'blocked', 'commit': a.head,\n"
+            "                         'path': 'BASE-REVISION-MARKER', 'rule': 'stub',\n"
+            "                         'reason': 'from the base commit',\n"
+            "                         'remediation': 'none'}]},\n"
+            "          open(a.json_report, 'w'))\n"
+            "raise SystemExit(1)\n"
+        )
+        (self.repo / "scripts" / "check_repository_integrity.py").write_text(
+            stub, encoding="utf-8")
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "-m", "base carries a distinct checker revision")
+        self.base = git(self.repo, "rev-parse", "HEAD")
+
+        git(self.repo, "switch", "-qc", "pr")
+        (self.repo / "lib" / "feature.dart").write_text("const f = 1;\n", encoding="utf-8")
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "-m", "ordinary work")
+        head = git(self.repo, "rev-parse", "HEAD")
+
+        exit_code, verified = self.run_recompute(head, None)
+        self.assertEqual(exit_code, 0)
+        derived = json.loads(verified.read_text())
+        self.assertEqual([f["path"] for f in derived["findings"]],
+                         ["BASE-REVISION-MARKER"])
+
+    def test_a_base_commit_without_the_checker_refuses(self) -> None:
+        """No checker at the bound base is unverifiable, never 'clean'."""
+        git(self.repo, "rm", "-q", "scripts/check_repository_integrity.py")
+        git(self.repo, "commit", "-qm", "base without a checker")
+        self.base = git(self.repo, "rev-parse", "HEAD")
+        git(self.repo, "switch", "-qc", "pr")
+        (self.repo / "lib" / "feature.dart").write_text("const f = 1;\n", encoding="utf-8")
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "-m", "ordinary work")
+        head = git(self.repo, "rev-parse", "HEAD")
+        exit_code, verified = self.run_recompute(head, None)
+        self.assertEqual(exit_code, 1)
+        self.assertFalse(verified.exists())
+
     def test_an_unusable_range_refuses_rather_than_reporting_clean(self) -> None:
         """A checker that cannot evaluate must never read as 'no findings'."""
         _, head = self.contaminate()
@@ -174,7 +239,7 @@ class ForgedArtifactTest(unittest.TestCase):
         previous = Path.cwd()
         os.chdir(self.repo)
         try:
-            code = recompute.main(["--binding", str(path), "--checker", str(CHECKER),
+            code = recompute.main(["--binding", str(path),
                                    "--output", str(output), "--summary",
                                    str(self.work / "s.md"), "--repo-owner", OWNER,
                                    "--no-fetch"])
@@ -221,6 +286,12 @@ class BindingValidationTest(unittest.TestCase):
                 with self.assertRaises(recompute.RecomputeError):
                     recompute.load_binding(self.write(**{field: bad}))
 
+    def test_the_checker_path_is_constrained(self) -> None:
+        for bad in ("../../etc/passwd", "a/../../b", "with space", "x" * 201, ""):
+            with self.subTest(bad=bad):
+                with self.assertRaises(recompute.RecomputeError):
+                    recompute.load_checker("a" * 40, bad, Path("/dev/null"))
+
     def test_the_checker_is_invoked_as_an_argument_vector(self) -> None:
         """Never a shell string, so no value in it can be word-split."""
         binding = recompute.load_binding(self.write())
@@ -250,6 +321,22 @@ class TrustBoundaryTest(unittest.TestCase):
         render = self.reporter.index("render_repository_integrity_comment.py")
         tail = self.reporter[render:]
         self.assertNotIn("--report \"$RUNNER_TEMP/repository-integrity/report.json\"", tail)
+
+    def test_the_checker_comes_from_the_bound_base_commit(self) -> None:
+        """The check and the comment explaining it must apply one policy revision.
+
+        The scanner loads its checker from the PR base commit. Re-deriving with
+        the reporter's own default-branch copy would apply a different revision
+        whenever the base is not the default branch, or whenever the checker
+        changed on the default branch between scanning and reporting, so the
+        comment could report CLEAN while the guard is red.
+        """
+        self.assertIn("--checker-path scripts/check_repository_integrity.py",
+                      self.reporter)
+        source = (ROOT / "scripts" / "recompute_repository_integrity_report.py").read_text()
+        self.assertIn('f"{base_sha}:{checker_path}"', source)
+        # Read from the base commit, never from the reporter's working tree.
+        self.assertIn("load_checker(str(binding[\"base_sha\"])", source)
 
     def test_no_pull_request_tree_is_checked_out(self) -> None:
         self.assertEqual(self.reporter.count("uses: actions/checkout"), 1)

--- a/test/tooling/recompute_repository_integrity_report_test.py
+++ b/test/tooling/recompute_repository_integrity_report_test.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""The trusted reporter must not publish a verdict it did not compute itself.
+
+A `pull_request` workflow definition comes from the merge ref, so a fork
+contributor can keep the scanner's name and path, drop the step that loads the
+trusted checker, and upload a findings artifact whose identity fields are the
+genuine GitHub-provided ones and whose `findings` list is empty. Identity
+binding cannot catch that -- every field it checks is honest. These tests pin
+that the verdict is re-derived from trusted code instead.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKER = ROOT / "scripts" / "check_repository_integrity.py"
+
+
+def load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, ROOT / "scripts" / filename)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+recompute = load("recompute", "recompute_repository_integrity_report.py")
+renderer = load("renderer", "render_repository_integrity_comment.py")
+
+FORK = "attacker/Linthra"
+REPOSITORY = "TheZupZup/Linthra"
+OWNER = "TheZupZup"
+
+
+def git(repo: Path, *args: str) -> str:
+    return subprocess.run(["git", *args], cwd=repo, check=True, text=True,
+                          stdout=subprocess.PIPE, stderr=subprocess.PIPE).stdout.strip()
+
+
+class ForgedArtifactTest(unittest.TestCase):
+    """A fork PR that replaces the scanner and uploads a forged CLEAN report."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        self.work = self.repo / ".integrity"
+        self.work.mkdir()
+        git(self.repo, "init", "-b", "main")
+        git(self.repo, "config", "user.name", "Test")
+        git(self.repo, "config", "user.email", "test@example.invalid")
+        (self.repo / ".gitignore").write_text(".idea/\n.vscode/\n", encoding="utf-8")
+        (self.repo / "lib").mkdir()
+        (self.repo / "lib" / "main.dart").write_text("void main() {}\n", encoding="utf-8")
+        git(self.repo, "add", ".")
+        git(self.repo, "commit", "-m", "base")
+        self.base = git(self.repo, "rev-parse", "HEAD")
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def contaminate(self) -> tuple[str, str]:
+        """A prohibited path introduced, then cleaned up: #513's shape."""
+        git(self.repo, "switch", "-c", "pr")
+        workspace = self.repo / ".vscode"
+        workspace.mkdir()
+        (self.repo / ".gitignore").write_text(".idea/\n", encoding="utf-8")
+        (workspace / "tasks.json").write_text('{"version":"2.0.0"}\n', encoding="utf-8")
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "-m", "A: import IDE workspace")
+        offender = git(self.repo, "rev-parse", "HEAD")
+        (workspace / "tasks.json").unlink()
+        workspace.rmdir()
+        (self.repo / ".gitignore").write_text(".idea/\n.vscode/\n", encoding="utf-8")
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "-m", "B: revert")
+        return offender, git(self.repo, "rev-parse", "HEAD")
+
+    def binding(self, head: str) -> Path:
+        path = self.work / "binding.json"
+        path.write_text(json.dumps({
+            "pr_number": 513, "head_sha": head, "head_repository": FORK,
+            "head_branch": "feat/x", "repository": REPOSITORY, "run_id": 1,
+            "pr_source": "artifact", "base_sha": self.base, "pr_author": "attacker",
+        }), encoding="utf-8")
+        return path
+
+    def forged_clean(self, head: str) -> Path:
+        """Genuine identity, empty findings -- what a replaced scanner uploads."""
+        path = self.work / "report.json"
+        path.write_text(json.dumps({
+            "schema_version": 1, "pr_number": 513, "head_sha": head,
+            "head_repository": FORK, "truncated": 0, "findings": [],
+        }), encoding="utf-8")
+        return path
+
+    def run_recompute(self, head: str, claimed: Path | None) -> tuple[int, Path]:
+        output = self.work / "verified-report.json"
+        argv = ["--binding", str(self.binding(head)), "--checker", str(CHECKER),
+                "--output", str(output), "--summary", str(self.work / "verified.md"),
+                "--repo-owner", OWNER, "--no-fetch"]
+        if claimed is not None:
+            argv += ["--claimed", str(claimed)]
+        previous = Path.cwd()
+        os.chdir(self.repo)
+        try:
+            return recompute.main(argv), output
+        finally:
+            os.chdir(previous)
+
+    def test_forged_clean_artifact_does_not_become_a_clean_comment(self) -> None:
+        offender, head = self.contaminate()
+        claimed = self.forged_clean(head)
+        # The forged artifact passes identity validation against the binding.
+        binding = json.loads(self.binding(head).read_text())
+        forged = json.loads(claimed.read_text())
+        self.assertEqual(forged["pr_number"], binding["pr_number"])
+        self.assertEqual(forged["head_sha"], binding["head_sha"])
+        self.assertEqual(forged["head_repository"], binding["head_repository"])
+        # Rendering the forged artifact directly would publish CLEAN.
+        self.assertIn("**CLEAN**",
+                      renderer.render(*renderer.validate(forged, binding)))
+
+        exit_code, verified = self.run_recompute(head, claimed)
+        self.assertEqual(exit_code, 0)
+        derived = json.loads(verified.read_text())
+        self.assertTrue(derived["findings"], "trusted checker found nothing")
+        body = renderer.render(*renderer.validate(derived, binding))
+        self.assertIn("**BLOCKED**", body)
+        self.assertNotIn("**CLEAN**", body)
+        self.assertIn(offender, body)
+        self.assertIn(".vscode/tasks.json", body)
+
+    def test_the_divergence_is_reported(self) -> None:
+        _, head = self.contaminate()
+        claimed = self.forged_clean(head)
+        _, verified = self.run_recompute(head, claimed)
+        message = recompute.divergence(claimed, verified)
+        self.assertIsNotNone(message)
+        self.assertIn("re-derived result is authoritative", message)
+
+    def test_an_honest_clean_pr_still_renders_clean(self) -> None:
+        """Re-derivation must not turn ordinary work into a false positive."""
+        git(self.repo, "switch", "-c", "pr")
+        (self.repo / "lib" / "feature.dart").write_text("const f = 1;\n", encoding="utf-8")
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "-m", "ordinary work")
+        head = git(self.repo, "rev-parse", "HEAD")
+        exit_code, verified = self.run_recompute(head, None)
+        self.assertEqual(exit_code, 0)
+        derived = json.loads(verified.read_text())
+        self.assertEqual(derived["findings"], [])
+        body = renderer.render(*renderer.validate(
+            derived, json.loads(self.binding(head).read_text())))
+        self.assertIn("**CLEAN**", body)
+
+    def test_an_unusable_range_refuses_rather_than_reporting_clean(self) -> None:
+        """A checker that cannot evaluate must never read as 'no findings'."""
+        _, head = self.contaminate()
+        path = self.work / "binding.json"
+        path.write_text(json.dumps({
+            "pr_number": 513, "head_sha": "f" * 40, "head_repository": FORK,
+            "head_branch": "feat/x", "repository": REPOSITORY, "run_id": 1,
+            "pr_source": "artifact", "base_sha": self.base, "pr_author": "attacker",
+        }), encoding="utf-8")
+        output = self.work / "verified-report.json"
+        previous = Path.cwd()
+        os.chdir(self.repo)
+        try:
+            code = recompute.main(["--binding", str(path), "--checker", str(CHECKER),
+                                   "--output", str(output), "--summary",
+                                   str(self.work / "s.md"), "--repo-owner", OWNER,
+                                   "--no-fetch"])
+        finally:
+            os.chdir(previous)
+        self.assertEqual(code, 1)
+        self.assertFalse(output.exists())
+
+
+class BindingValidationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self.tmp.name) / "binding.json"
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def write(self, **overrides) -> Path:
+        payload = {"pr_number": 513, "head_sha": "a" * 40, "head_repository": FORK,
+                   "repository": REPOSITORY, "run_id": 1, "pr_source": "artifact",
+                   "base_sha": "b" * 40, "pr_author": "someone"}
+        payload.update(overrides)
+        self.path.write_text(json.dumps(payload), encoding="utf-8")
+        return self.path
+
+    def test_every_field_the_checker_receives_is_revalidated(self) -> None:
+        recompute.load_binding(self.write())  # the good case
+        for field, bad in (
+            ("base_sha", "not-a-sha"), ("base_sha", None),
+            ("head_sha", "../../etc/passwd"), ("head_sha", 7),
+            ("head_repository", "a/b/c"), ("head_repository", ""),
+            ("pr_author", "bad login"), ("pr_author", "-leading"),
+            ("pr_author", "x" * 40), ("pr_number", 0), ("pr_number", True),
+            ("pr_number", "513"),
+        ):
+            with self.subTest(field=field, bad=bad):
+                with self.assertRaises(recompute.RecomputeError):
+                    recompute.load_binding(self.write(**{field: bad}))
+
+    def test_the_checker_is_invoked_as_an_argument_vector(self) -> None:
+        """Never a shell string, so no value in it can be word-split."""
+        binding = recompute.load_binding(self.write())
+        command = recompute.checker_command(
+            Path("scripts/check_repository_integrity.py"), binding,
+            Path("out.json"), Path("out.md"), OWNER)
+        self.assertIsInstance(command, list)
+        self.assertEqual(command[0], sys.executable)
+        for flag, value in (("--base", "b" * 40), ("--head", "a" * 40),
+                            ("--pr-author", "someone"), ("--repo-owner", OWNER),
+                            ("--head-repository", FORK), ("--pr-number", "513")):
+            self.assertEqual(command[command.index(flag) + 1], value)
+
+
+class TrustBoundaryTest(unittest.TestCase):
+    reporter = (ROOT / ".github/workflows/repository-integrity-reporter.yml").read_text()
+
+    def test_the_rendered_report_is_the_re_derived_one(self) -> None:
+        self.assertIn("recompute_repository_integrity_report.py", self.reporter)
+        self.assertIn("--report \"$RUNNER_TEMP/repository-integrity/verified-report.json\"",
+                      self.reporter)
+        # Re-derivation must precede rendering, or it decides nothing.
+        self.assertLess(self.reporter.index("recompute_repository_integrity_report.py"),
+                        self.reporter.index("render_repository_integrity_comment.py"))
+
+    def test_the_uploaded_artifact_is_never_rendered(self) -> None:
+        render = self.reporter.index("render_repository_integrity_comment.py")
+        tail = self.reporter[render:]
+        self.assertNotIn("--report \"$RUNNER_TEMP/repository-integrity/report.json\"", tail)
+
+    def test_no_pull_request_tree_is_checked_out(self) -> None:
+        self.assertEqual(self.reporter.count("uses: actions/checkout"), 1)
+        self.assertIn("ref: ${{ github.event.repository.default_branch }}", self.reporter)
+        self.assertNotIn("ref: ${{ github.event.workflow_run.head_sha }}", self.reporter)
+        # The re-derivation reads objects; it must not switch the working tree.
+        for forbidden in ("git checkout", "git switch", "git worktree"):
+            self.assertNotIn(forbidden, self.reporter)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/tooling/recompute_repository_integrity_report_test.py
+++ b/test/tooling/recompute_repository_integrity_report_test.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """The trusted reporter must not publish a verdict it did not compute itself.
 
-A `pull_request` workflow definition comes from the merge ref, so a fork
+A ``pull_request`` workflow definition comes from the merge ref, so a fork
 contributor can keep the scanner's name and path, drop the step that loads the
 trusted checker, and upload a findings artifact whose identity fields are the
-genuine GitHub-provided ones and whose `findings` list is empty. Identity
+genuine GitHub-provided ones and whose ``findings`` list is empty. Identity
 binding cannot catch that -- every field it checks is honest. These tests pin
-that the verdict is re-derived from trusted code instead.
+that the verdict is re-derived from trusted code instead, including the
+repository-owner/same-repository bootstrap checker path used by the scanner.
 """
 from __future__ import annotations
 
@@ -41,8 +42,14 @@ OWNER = "TheZupZup"
 
 
 def git(repo: Path, *args: str) -> str:
-    return subprocess.run(["git", *args], cwd=repo, check=True, text=True,
-                          stdout=subprocess.PIPE, stderr=subprocess.PIPE).stdout.strip()
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ).stdout.strip()
 
 
 class ForgedArtifactTest(unittest.TestCase):
@@ -58,13 +65,15 @@ class ForgedArtifactTest(unittest.TestCase):
         git(self.repo, "config", "user.email", "test@example.invalid")
         (self.repo / ".gitignore").write_text(".idea/\n.vscode/\n", encoding="utf-8")
         (self.repo / "lib").mkdir()
-        (self.repo / "lib" / "main.dart").write_text("void main() {}\n", encoding="utf-8")
-        # The scanner loads its checker from the base commit and the reporter
-        # re-derives with that same revision, so the fixture carries it there
-        # rather than reaching for the reporter's own working copy.
+        (self.repo / "lib" / "main.dart").write_text(
+            "void main() {}\n", encoding="utf-8"
+        )
+        # Normal path: both scanner and reporter use the checker committed at
+        # the PR base.
         (self.repo / "scripts").mkdir()
         (self.repo / "scripts" / "check_repository_integrity.py").write_bytes(
-            CHECKER.read_bytes())
+            CHECKER.read_bytes()
+        )
         git(self.repo, "add", ".")
         git(self.repo, "commit", "-m", "base")
         self.base = git(self.repo, "rev-parse", "HEAD")
@@ -78,7 +87,9 @@ class ForgedArtifactTest(unittest.TestCase):
         workspace = self.repo / ".vscode"
         workspace.mkdir()
         (self.repo / ".gitignore").write_text(".idea/\n", encoding="utf-8")
-        (workspace / "tasks.json").write_text('{"version":"2.0.0"}\n', encoding="utf-8")
+        (workspace / "tasks.json").write_text(
+            '{"version":"2.0.0"}\n', encoding="utf-8"
+        )
         git(self.repo, "add", "-A")
         git(self.repo, "commit", "-m", "A: import IDE workspace")
         offender = git(self.repo, "rev-parse", "HEAD")
@@ -89,29 +100,72 @@ class ForgedArtifactTest(unittest.TestCase):
         git(self.repo, "commit", "-m", "B: revert")
         return offender, git(self.repo, "rev-parse", "HEAD")
 
-    def binding(self, head: str) -> Path:
+    def binding(
+        self,
+        head: str,
+        *,
+        head_repository: str = FORK,
+        pr_author: str = "attacker",
+    ) -> Path:
         path = self.work / "binding.json"
-        path.write_text(json.dumps({
-            "pr_number": 513, "head_sha": head, "head_repository": FORK,
-            "head_branch": "feat/x", "repository": REPOSITORY, "run_id": 1,
-            "pr_source": "artifact", "base_sha": self.base, "pr_author": "attacker",
-        }), encoding="utf-8")
+        path.write_text(
+            json.dumps({
+                "pr_number": 513,
+                "head_sha": head,
+                "head_repository": head_repository,
+                "head_branch": "feat/x",
+                "repository": REPOSITORY,
+                "run_id": 1,
+                "pr_source": "artifact",
+                "base_sha": self.base,
+                "pr_author": pr_author,
+            }),
+            encoding="utf-8",
+        )
         return path
 
     def forged_clean(self, head: str) -> Path:
         """Genuine identity, empty findings -- what a replaced scanner uploads."""
         path = self.work / "report.json"
-        path.write_text(json.dumps({
-            "schema_version": 1, "pr_number": 513, "head_sha": head,
-            "head_repository": FORK, "truncated": 0, "findings": [],
-        }), encoding="utf-8")
+        path.write_text(
+            json.dumps({
+                "schema_version": 1,
+                "pr_number": 513,
+                "head_sha": head,
+                "head_repository": FORK,
+                "truncated": 0,
+                "findings": [],
+            }),
+            encoding="utf-8",
+        )
         return path
 
-    def run_recompute(self, head: str, claimed: Path | None) -> tuple[int, Path]:
+    def run_recompute(
+        self,
+        head: str,
+        claimed: Path | None,
+        *,
+        head_repository: str = FORK,
+        pr_author: str = "attacker",
+    ) -> tuple[int, Path]:
         output = self.work / "verified-report.json"
-        argv = ["--binding", str(self.binding(head)),
-                "--output", str(output), "--summary", str(self.work / "verified.md"),
-                "--repo-owner", OWNER, "--no-fetch"]
+        output.unlink(missing_ok=True)
+        binding = self.binding(
+            head,
+            head_repository=head_repository,
+            pr_author=pr_author,
+        )
+        argv = [
+            "--binding",
+            str(binding),
+            "--output",
+            str(output),
+            "--summary",
+            str(self.work / "verified.md"),
+            "--repo-owner",
+            OWNER,
+            "--no-fetch",
+        ]
         if claimed is not None:
             argv += ["--claimed", str(claimed)]
         previous = Path.cwd()
@@ -124,15 +178,12 @@ class ForgedArtifactTest(unittest.TestCase):
     def test_forged_clean_artifact_does_not_become_a_clean_comment(self) -> None:
         offender, head = self.contaminate()
         claimed = self.forged_clean(head)
-        # The forged artifact passes identity validation against the binding.
         binding = json.loads(self.binding(head).read_text())
         forged = json.loads(claimed.read_text())
         self.assertEqual(forged["pr_number"], binding["pr_number"])
         self.assertEqual(forged["head_sha"], binding["head_sha"])
         self.assertEqual(forged["head_repository"], binding["head_repository"])
-        # Rendering the forged artifact directly would publish CLEAN.
-        self.assertIn("**CLEAN**",
-                      renderer.render(*renderer.validate(forged, binding)))
+        self.assertIn("**CLEAN**", renderer.render(*renderer.validate(forged, binding)))
 
         exit_code, verified = self.run_recompute(head, claimed)
         self.assertEqual(exit_code, 0)
@@ -153,9 +204,10 @@ class ForgedArtifactTest(unittest.TestCase):
         self.assertIn("re-derived result is authoritative", message)
 
     def test_an_honest_clean_pr_still_renders_clean(self) -> None:
-        """Re-derivation must not turn ordinary work into a false positive."""
         git(self.repo, "switch", "-c", "pr")
-        (self.repo / "lib" / "feature.dart").write_text("const f = 1;\n", encoding="utf-8")
+        (self.repo / "lib" / "feature.dart").write_text(
+            "const f = 1;\n", encoding="utf-8"
+        )
         git(self.repo, "add", "-A")
         git(self.repo, "commit", "-m", "ordinary work")
         head = git(self.repo, "rev-parse", "HEAD")
@@ -163,18 +215,12 @@ class ForgedArtifactTest(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         derived = json.loads(verified.read_text())
         self.assertEqual(derived["findings"], [])
-        body = renderer.render(*renderer.validate(
-            derived, json.loads(self.binding(head).read_text())))
+        body = renderer.render(
+            *renderer.validate(derived, json.loads(self.binding(head).read_text()))
+        )
         self.assertIn("**CLEAN**", body)
 
     def test_the_base_commits_checker_revision_is_the_one_that_runs(self) -> None:
-        """Decisive for the policy-skew case.
-
-        The base commit carries a distinguishable checker revision. If the
-        reporter ran its own default-branch copy instead, the re-derived report
-        would not carry that revision's marker -- which is exactly how a comment
-        could report CLEAN while the guard, running the base revision, is red.
-        """
         stub = (
             "#!/usr/bin/env python3\n"
             "import argparse, json\n"
@@ -195,13 +241,16 @@ class ForgedArtifactTest(unittest.TestCase):
             "raise SystemExit(1)\n"
         )
         (self.repo / "scripts" / "check_repository_integrity.py").write_text(
-            stub, encoding="utf-8")
+            stub, encoding="utf-8"
+        )
         git(self.repo, "add", "-A")
         git(self.repo, "commit", "-m", "base carries a distinct checker revision")
         self.base = git(self.repo, "rev-parse", "HEAD")
 
         git(self.repo, "switch", "-qc", "pr")
-        (self.repo / "lib" / "feature.dart").write_text("const f = 1;\n", encoding="utf-8")
+        (self.repo / "lib" / "feature.dart").write_text(
+            "const f = 1;\n", encoding="utf-8"
+        )
         git(self.repo, "add", "-A")
         git(self.repo, "commit", "-m", "ordinary work")
         head = git(self.repo, "rev-parse", "HEAD")
@@ -209,40 +258,134 @@ class ForgedArtifactTest(unittest.TestCase):
         exit_code, verified = self.run_recompute(head, None)
         self.assertEqual(exit_code, 0)
         derived = json.loads(verified.read_text())
-        self.assertEqual([f["path"] for f in derived["findings"]],
-                         ["BASE-REVISION-MARKER"])
+        self.assertEqual(
+            [f["path"] for f in derived["findings"]],
+            ["BASE-REVISION-MARKER"],
+        )
 
-    def test_a_base_commit_without_the_checker_refuses(self) -> None:
-        """No checker at the bound base is unverifiable, never 'clean'."""
+    def test_external_pr_cannot_bootstrap_when_base_checker_is_missing(self) -> None:
+        """A fork head checker is never executable, even if it is structured."""
         git(self.repo, "rm", "-q", "scripts/check_repository_integrity.py")
         git(self.repo, "commit", "-qm", "base without a checker")
         self.base = git(self.repo, "rev-parse", "HEAD")
         git(self.repo, "switch", "-qc", "pr")
-        (self.repo / "lib" / "feature.dart").write_text("const f = 1;\n", encoding="utf-8")
+        (self.repo / "scripts" / "check_repository_integrity.py").write_bytes(
+            CHECKER.read_bytes()
+        )
         git(self.repo, "add", "-A")
-        git(self.repo, "commit", "-m", "ordinary work")
+        git(self.repo, "commit", "-m", "fork head supplies checker")
+        head = git(self.repo, "rev-parse", "HEAD")
+        exit_code, verified = self.run_recompute(head, None)
+        self.assertEqual(exit_code, 1)
+        self.assertFalse(verified.exists())
+
+    def test_owner_same_repo_bootstraps_when_base_checker_is_missing(self) -> None:
+        """Mirror scanner bootstrap: trusted owner head may supply the checker."""
+        git(self.repo, "rm", "-q", "scripts/check_repository_integrity.py")
+        git(self.repo, "commit", "-qm", "base without a checker")
+        self.base = git(self.repo, "rev-parse", "HEAD")
+        git(self.repo, "switch", "-qc", "pr")
+        (self.repo / "scripts" / "check_repository_integrity.py").write_bytes(
+            CHECKER.read_bytes()
+        )
+        (self.repo / "lib" / "feature.dart").write_text(
+            "const f = 1;\n", encoding="utf-8"
+        )
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "-m", "owner bootstrap checker")
+        head = git(self.repo, "rev-parse", "HEAD")
+        exit_code, verified = self.run_recompute(
+            head,
+            None,
+            head_repository=REPOSITORY,
+            pr_author=OWNER,
+        )
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(verified.is_file())
+
+    def test_owner_same_repo_bootstraps_when_base_checker_is_too_old(self) -> None:
+        """The missing-interface branch of scanner bootstrap is mirrored too."""
+        old = (
+            "#!/usr/bin/env python3\n"
+            "# Legacy checker intentionally has no structured-report option.\n"
+            "raise SystemExit(0)\n"
+        )
+        (self.repo / "scripts" / "check_repository_integrity.py").write_text(
+            old, encoding="utf-8"
+        )
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "-m", "legacy base checker")
+        self.base = git(self.repo, "rev-parse", "HEAD")
+        git(self.repo, "switch", "-qc", "pr")
+        (self.repo / "scripts" / "check_repository_integrity.py").write_bytes(
+            CHECKER.read_bytes()
+        )
+        (self.repo / "lib" / "feature.dart").write_text(
+            "const f = 1;\n", encoding="utf-8"
+        )
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "-m", "owner upgrades checker")
+        head = git(self.repo, "rev-parse", "HEAD")
+        exit_code, verified = self.run_recompute(
+            head,
+            None,
+            head_repository=REPOSITORY,
+            pr_author=OWNER,
+        )
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(verified.is_file())
+
+    def test_external_pr_cannot_bootstrap_from_old_base_checker(self) -> None:
+        old = "#!/usr/bin/env python3\n# no structured interface\nraise SystemExit(0)\n"
+        (self.repo / "scripts" / "check_repository_integrity.py").write_text(
+            old, encoding="utf-8"
+        )
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "-m", "legacy base checker")
+        self.base = git(self.repo, "rev-parse", "HEAD")
+        git(self.repo, "switch", "-qc", "pr")
+        (self.repo / "scripts" / "check_repository_integrity.py").write_bytes(
+            CHECKER.read_bytes()
+        )
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "-m", "fork tries to provide checker")
         head = git(self.repo, "rev-parse", "HEAD")
         exit_code, verified = self.run_recompute(head, None)
         self.assertEqual(exit_code, 1)
         self.assertFalse(verified.exists())
 
     def test_an_unusable_range_refuses_rather_than_reporting_clean(self) -> None:
-        """A checker that cannot evaluate must never read as 'no findings'."""
         _, head = self.contaminate()
         path = self.work / "binding.json"
-        path.write_text(json.dumps({
-            "pr_number": 513, "head_sha": "f" * 40, "head_repository": FORK,
-            "head_branch": "feat/x", "repository": REPOSITORY, "run_id": 1,
-            "pr_source": "artifact", "base_sha": self.base, "pr_author": "attacker",
-        }), encoding="utf-8")
+        path.write_text(
+            json.dumps({
+                "pr_number": 513,
+                "head_sha": "f" * 40,
+                "head_repository": FORK,
+                "head_branch": "feat/x",
+                "repository": REPOSITORY,
+                "run_id": 1,
+                "pr_source": "artifact",
+                "base_sha": self.base,
+                "pr_author": "attacker",
+            }),
+            encoding="utf-8",
+        )
         output = self.work / "verified-report.json"
         previous = Path.cwd()
         os.chdir(self.repo)
         try:
-            code = recompute.main(["--binding", str(path),
-                                   "--output", str(output), "--summary",
-                                   str(self.work / "s.md"), "--repo-owner", OWNER,
-                                   "--no-fetch"])
+            code = recompute.main([
+                "--binding",
+                str(path),
+                "--output",
+                str(output),
+                "--summary",
+                str(self.work / "s.md"),
+                "--repo-owner",
+                OWNER,
+                "--no-fetch",
+            ])
         finally:
             os.chdir(previous)
         self.assertEqual(code, 1)
@@ -258,9 +401,16 @@ class BindingValidationTest(unittest.TestCase):
         self.tmp.cleanup()
 
     def write(self, **overrides) -> Path:
-        payload = {"pr_number": 513, "head_sha": "a" * 40, "head_repository": FORK,
-                   "repository": REPOSITORY, "run_id": 1, "pr_source": "artifact",
-                   "base_sha": "b" * 40, "pr_author": "someone"}
+        payload = {
+            "pr_number": 513,
+            "head_sha": "a" * 40,
+            "head_repository": FORK,
+            "repository": REPOSITORY,
+            "run_id": 1,
+            "pr_source": "artifact",
+            "base_sha": "b" * 40,
+            "pr_author": "someone",
+        }
         payload.update(overrides)
         self.path.write_text(json.dumps(payload), encoding="utf-8")
         return self.path
@@ -272,14 +422,23 @@ class BindingValidationTest(unittest.TestCase):
                 self.assertEqual(binding["pr_author"], login)
 
     def test_every_field_the_checker_receives_is_revalidated(self) -> None:
-        recompute.load_binding(self.write())  # the good case
+        recompute.load_binding(self.write())
         for field, bad in (
-            ("base_sha", "not-a-sha"), ("base_sha", None),
-            ("head_sha", "../../etc/passwd"), ("head_sha", 7),
-            ("head_repository", "a/b/c"), ("head_repository", ""),
-            ("pr_author", "-leading"), ("pr_author", "new\nline"),
-            ("pr_author", ""), ("pr_author", "x" * 65),
-            ("pr_number", 0), ("pr_number", True),
+            ("base_sha", "not-a-sha"),
+            ("base_sha", None),
+            ("head_sha", "../../etc/passwd"),
+            ("head_sha", 7),
+            ("head_repository", "a/b/c"),
+            ("head_repository", ""),
+            ("repository", "a/b/c"),
+            ("repository", ""),
+            ("repository", None),
+            ("pr_author", "-leading"),
+            ("pr_author", "new\nline"),
+            ("pr_author", ""),
+            ("pr_author", "x" * 65),
+            ("pr_number", 0),
+            ("pr_number", True),
             ("pr_number", "513"),
         ):
             with self.subTest(field=field, bad=bad):
@@ -293,16 +452,24 @@ class BindingValidationTest(unittest.TestCase):
                     recompute.load_checker("a" * 40, bad, Path("/dev/null"))
 
     def test_the_checker_is_invoked_as_an_argument_vector(self) -> None:
-        """Never a shell string, so no value in it can be word-split."""
         binding = recompute.load_binding(self.write())
         command = recompute.checker_command(
-            Path("scripts/check_repository_integrity.py"), binding,
-            Path("out.json"), Path("out.md"), OWNER)
+            Path("scripts/check_repository_integrity.py"),
+            binding,
+            Path("out.json"),
+            Path("out.md"),
+            OWNER,
+        )
         self.assertIsInstance(command, list)
         self.assertEqual(command[0], sys.executable)
-        for flag, value in (("--base", "b" * 40), ("--head", "a" * 40),
-                            ("--pr-author", "someone"), ("--repo-owner", OWNER),
-                            ("--head-repository", FORK), ("--pr-number", "513")):
+        for flag, value in (
+            ("--base", "b" * 40),
+            ("--head", "a" * 40),
+            ("--pr-author", "someone"),
+            ("--repo-owner", OWNER),
+            ("--head-repository", FORK),
+            ("--pr-number", "513"),
+        ):
             self.assertEqual(command[command.index(flag) + 1], value)
 
 
@@ -311,38 +478,45 @@ class TrustBoundaryTest(unittest.TestCase):
 
     def test_the_rendered_report_is_the_re_derived_one(self) -> None:
         self.assertIn("recompute_repository_integrity_report.py", self.reporter)
-        self.assertIn("--report \"$RUNNER_TEMP/repository-integrity/verified-report.json\"",
-                      self.reporter)
-        # Re-derivation must precede rendering, or it decides nothing.
-        self.assertLess(self.reporter.index("recompute_repository_integrity_report.py"),
-                        self.reporter.index("render_repository_integrity_comment.py"))
+        self.assertIn(
+            '--report "$RUNNER_TEMP/repository-integrity/verified-report.json"',
+            self.reporter,
+        )
+        self.assertLess(
+            self.reporter.index("recompute_repository_integrity_report.py"),
+            self.reporter.index("render_repository_integrity_comment.py"),
+        )
 
     def test_the_uploaded_artifact_is_never_rendered(self) -> None:
         render = self.reporter.index("render_repository_integrity_comment.py")
         tail = self.reporter[render:]
-        self.assertNotIn("--report \"$RUNNER_TEMP/repository-integrity/report.json\"", tail)
+        self.assertNotIn(
+            '--report "$RUNNER_TEMP/repository-integrity/report.json"', tail
+        )
 
-    def test_the_checker_comes_from_the_bound_base_commit(self) -> None:
-        """The check and the comment explaining it must apply one policy revision.
-
-        The scanner loads its checker from the PR base commit. Re-deriving with
-        the reporter's own default-branch copy would apply a different revision
-        whenever the base is not the default branch, or whenever the checker
-        changed on the default branch between scanning and reporting, so the
-        comment could report CLEAN while the guard is red.
-        """
-        self.assertIn("--checker-path scripts/check_repository_integrity.py",
-                      self.reporter)
-        source = (ROOT / "scripts" / "recompute_repository_integrity_report.py").read_text()
-        self.assertIn('f"{base_sha}:{checker_path}"', source)
-        # Read from the base commit, never from the reporter's working tree.
-        self.assertIn("load_checker(str(binding[\"base_sha\"])", source)
+    def test_checker_selection_matches_scanner_trust_policy(self) -> None:
+        """Base normally wins; owner/same-repo head is the only bootstrap."""
+        self.assertIn(
+            "--checker-path scripts/check_repository_integrity.py", self.reporter
+        )
+        source = (
+            ROOT / "scripts" / "recompute_repository_integrity_report.py"
+        ).read_text()
+        self.assertIn('f"{commit_sha}:{checker_path}"', source)
+        self.assertIn('str(binding["base_sha"])', source)
+        self.assertIn('head_sha=str(binding["head_sha"])', source)
+        self.assertIn('pr_author == repo_owner', source)
+        self.assertIn('head_repository == repository', source)
+        self.assertIn("refusing to execute pull-request checker code", source)
 
     def test_no_pull_request_tree_is_checked_out(self) -> None:
         self.assertEqual(self.reporter.count("uses: actions/checkout"), 1)
-        self.assertIn("ref: ${{ github.event.repository.default_branch }}", self.reporter)
-        self.assertNotIn("ref: ${{ github.event.workflow_run.head_sha }}", self.reporter)
-        # The re-derivation reads objects; it must not switch the working tree.
+        self.assertIn(
+            "ref: ${{ github.event.repository.default_branch }}", self.reporter
+        )
+        self.assertNotIn(
+            "ref: ${{ github.event.workflow_run.head_sha }}", self.reporter
+        )
         for forbidden in ("git checkout", "git switch", "git worktree"):
             self.assertNotIn(forbidden, self.reporter)
 

--- a/test/tooling/render_repository_integrity_comment_test.py
+++ b/test/tooling/render_repository_integrity_comment_test.py
@@ -30,31 +30,33 @@ def payload(findings: list[dict]) -> dict:
             "head_repository": "fork/repo", "findings": findings}
 
 
-EVENT = {"workflow_run": {"head_sha": SHA, "head_repository": {"full_name": "fork/repo"},
-                          "pull_requests": [{"number": 7}]}}
+# What scripts/resolve_repository_integrity_pr.py hands over once it has bound
+# the report to a pull request. The renderer trusts nothing else for identity.
+BINDING = {"pr_number": 7, "head_sha": SHA, "head_repository": "fork/repo",
+           "repository": "TheZupZup/Linthra", "run_id": 1, "pr_source": "artifact"}
 
 
 class ReporterTest(unittest.TestCase):
     def test_one_violation_is_actionable(self) -> None:
-        body = reporter.render(*reporter.validate(payload([finding()]), EVENT))
+        body = reporter.render(*reporter.validate(payload([finding()]), BINDING))
         self.assertIn("**BLOCKED**", body)
         self.assertIn("**How to fix:** remove the prohibited path", body)
         self.assertIn(SHA, body)
 
     def test_multiple_findings_are_one_comment(self) -> None:
-        body = reporter.render(*reporter.validate(payload([finding("one"), finding("two")]), EVENT))
+        body = reporter.render(*reporter.validate(payload([finding("one"), finding("two")]), BINDING))
         self.assertEqual(body.count(reporter.MARKER), 1)
         self.assertIn("Finding 1", body)
         self.assertIn("Finding 2", body)
 
     def test_resolved_is_clean_with_same_marker(self) -> None:
-        body = reporter.render(*reporter.validate(payload([]), EVENT))
+        body = reporter.render(*reporter.validate(payload([]), BINDING))
         self.assertTrue(body.startswith(reporter.MARKER))
         self.assertIn("**CLEAN**", body)
 
     def test_markup_and_html_are_inert(self) -> None:
         hostile = finding("</details> @everyone [click](javascript:alert(1)) `x`")
-        body = reporter.render(*reporter.validate(payload([hostile]), EVENT))
+        body = reporter.render(*reporter.validate(payload([hostile]), BINDING))
         self.assertNotIn("</details>", body)
         self.assertNotIn("@everyone", body)
         self.assertNotIn("(javascript:alert", body)
@@ -68,7 +70,7 @@ class ReporterTest(unittest.TestCase):
         """
         capped = payload([finding(f"scripts/x{i}.sh") for i in range(reporter.MAX_FINDINGS)])
         capped["truncated"] = 7
-        findings, truncated = reporter.validate(capped, EVENT)
+        findings, truncated = reporter.validate(capped, BINDING)
         self.assertEqual(truncated, 7)
         body = reporter.render(findings, truncated)
         self.assertIn("**BLOCKED**", body)
@@ -87,7 +89,7 @@ class ReporterTest(unittest.TestCase):
         ):
             with self.subTest(label):
                 big = payload([finding(path) for _ in range(reporter.MAX_FINDINGS)])
-                body = reporter.render(*reporter.validate(big, EVENT))
+                body = reporter.render(*reporter.validate(big, BINDING))
                 self.assertLessEqual(len(body), reporter.MAX_COMMENT_CHARS)
                 self.assertIn("were withheld", body)
                 self.assertIn("**BLOCKED**", body)
@@ -97,7 +99,7 @@ class ReporterTest(unittest.TestCase):
         big = payload([finding("p" * reporter.MAX_FIELD_LENGTH)
                        for _ in range(reporter.MAX_FINDINGS)])
         big["truncated"] = 5  # dropped by the scanner's own cap
-        body = reporter.render(*reporter.validate(big, EVENT))
+        body = reporter.render(*reporter.validate(big, BINDING))
         shown = body.count("### Finding ")
         withheld = int(body.split(" further finding(s)")[0].rsplit("\n", 1)[-1])
         self.assertEqual(shown + withheld, reporter.MAX_FINDINGS + 5)
@@ -105,11 +107,11 @@ class ReporterTest(unittest.TestCase):
     def test_field_at_the_exact_bound_is_accepted(self) -> None:
         """The producer clamps to exactly this bound, so it must validate."""
         exact = payload([finding("p" * reporter.MAX_FIELD_LENGTH)])
-        findings, _ = reporter.validate(exact, EVENT)
+        findings, _ = reporter.validate(exact, BINDING)
         self.assertEqual(len(findings), 1)
         over = payload([finding("p" * (reporter.MAX_FIELD_LENGTH + 1))])
         with self.assertRaises(ValueError):
-            reporter.validate(over, EVENT)
+            reporter.validate(over, BINDING)
 
     def test_truncated_count_is_validated(self) -> None:
         for bad in (-1, "3", 1.5, True, None):
@@ -117,10 +119,10 @@ class ReporterTest(unittest.TestCase):
                 bogus = payload([finding()])
                 bogus["truncated"] = bad
                 with self.assertRaises(ValueError):
-                    reporter.validate(bogus, EVENT)
+                    reporter.validate(bogus, BINDING)
 
     def test_absent_truncated_defaults_to_zero(self) -> None:
-        findings, truncated = reporter.validate(payload([finding()]), EVENT)
+        findings, truncated = reporter.validate(payload([finding()]), BINDING)
         self.assertEqual(truncated, 0)
         self.assertNotIn("withheld", reporter.render(findings, truncated))
 
@@ -128,11 +130,38 @@ class ReporterTest(unittest.TestCase):
         bad = payload([finding()])
         bad["pr_number"] = 8
         with self.assertRaises(ValueError):
-            reporter.validate(bad, EVENT)
+            reporter.validate(bad, BINDING)
         injected = finding()
         injected["command"] = "echo owned"
         with self.assertRaises(ValueError):
-            reporter.validate(payload([injected]), EVENT)
+            reporter.validate(payload([injected]), BINDING)
+
+    def test_external_fork_report_renders_the_same_sticky_states(self) -> None:
+        """A fork PR gets one comment that moves BLOCKED -> CLEAN in place.
+
+        The binding is the fork recovery path (`pr_source: artifact`), which is
+        the case the reporter used to skip entirely.
+        """
+        self.assertEqual(BINDING["pr_source"], "artifact")
+        blocked = reporter.render(*reporter.validate(payload([finding()]), BINDING))
+        self.assertIn("**BLOCKED**", blocked)
+        clean = reporter.render(*reporter.validate(payload([]), BINDING))
+        self.assertIn("**CLEAN**", clean)
+        # Same marker on both, so the second render updates the first comment
+        # rather than adding another.
+        for body in (blocked, clean):
+            self.assertTrue(body.startswith(reporter.MARKER))
+            self.assertEqual(body.count(reporter.MARKER), 1)
+
+    def test_binding_identity_is_fully_validated(self) -> None:
+        for bad in ({}, {"pr_number": 7, "head_sha": SHA},
+                    dict(BINDING, pr_number=0), dict(BINDING, pr_number=True),
+                    dict(BINDING, pr_number="7"), dict(BINDING, head_sha="z" * 40),
+                    dict(BINDING, head_sha=SHA.upper()), dict(BINDING, head_repository=""),
+                    dict(BINDING, head_repository=None), "not a binding", None):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError):
+                    reporter.validate(payload([finding()]), bad)
 
     def test_workflows_separate_untrusted_scan_from_sticky_writer(self) -> None:
         scanner = (ROOT / ".github/workflows/repository-integrity.yml").read_text()
@@ -161,7 +190,13 @@ class ReporterTest(unittest.TestCase):
             writer,
         )
         self.assertIn("github.event.workflow_run.event == 'pull_request'", writer)
-        self.assertIn("github.event.workflow_run.pull_requests[0] != null", writer)
+        # `pull_requests[0] != null` is deliberately gone: GitHub sends that
+        # array empty for fork-originated runs, so requiring it skipped the job
+        # before any trusted validation could look at the artifact. The binding
+        # moved into scripts/resolve_repository_integrity_pr.py, which fails
+        # closed instead of skipping silently.
+        self.assertNotIn("pull_requests[0]", writer)
+        self.assertIn("scripts/resolve_repository_integrity_pr.py", writer)
 
     def test_superseded_reports_do_not_overwrite_a_newer_result(self) -> None:
         """Out-of-order synchronize runs must not restore an older verdict."""

--- a/test/tooling/resolve_repository_integrity_pr_test.py
+++ b/test/tooling/resolve_repository_integrity_pr_test.py
@@ -25,6 +25,7 @@ REPOSITORY = "TheZupZup/Linthra"
 FORK = "Borhan2004/Linthra"
 # The real head of PR #513, the incident this recovery path was built for.
 HEAD_SHA = "a9ecac5b6a94159c590ccb51e09f5a00ac14f796"
+HEAD_BRANCH = "feat/linux-408-embedded-artwork"
 NEWER_SHA = "b" * 40
 RUN_ID = 32887057547
 PR_NUMBER = 513
@@ -38,6 +39,7 @@ def event(*, pull_requests: list[dict] | None = None, **overrides) -> dict:
         "event": "pull_request",
         "head_sha": HEAD_SHA,
         "head_repository": {"full_name": FORK},
+        "head_branch": HEAD_BRANCH,
         "repository": {"full_name": REPOSITORY},
         # GitHub delivers this empty for every fork-originated run.
         "pull_requests": [] if pull_requests is None else pull_requests,
@@ -61,27 +63,41 @@ def report(**overrides) -> dict:
 
 def pull_request(*, number: int = PR_NUMBER, head_sha: str = HEAD_SHA,
                  head_repository: str | None = FORK,
+                 head_branch: str = HEAD_BRANCH,
                  base_repository: str = REPOSITORY) -> dict:
     head_repo = {"full_name": head_repository} if head_repository is not None else None
     return {
         "number": number,
-        "head": {"sha": head_sha, "repo": head_repo},
+        "head": {"sha": head_sha, "ref": head_branch, "repo": head_repo},
         "base": {"repo": {"full_name": base_repository}},
     }
 
 
 class Api:
-    """Records every path requested so URL construction can be asserted on."""
+    """Models real GitHub commit-to-PR association, and records every path.
 
-    def __init__(self, *, pulls: dict | None = None, associated: list | None = None) -> None:
+    The decisive behaviour, verified against the live API with PR #513's head:
+    a fork's head commit is NOT in the base repository's commit list, so
+    `/repos/{base}/commits/{fork_sha}/pulls` answers `[]`. Only
+    `/repos/{fork}/commits/{sha}/pulls` returns the pull request. An earlier
+    mock returned the PR from the base-repository path, which does not happen in
+    production and hid the fact that fork recovery never resolved anything.
+    """
+
+    def __init__(self, *, pulls: dict | None = None, associated: list | None = None,
+                 association_repository: str = FORK) -> None:
         self.pulls = pulls if pulls is not None else pull_request()
         self.associated = associated if associated is not None else [pull_request()]
+        # The only repository whose commit list contains the head commit.
+        self.association_repository = association_repository
         self.paths: list[str] = []
 
     def __call__(self, path: str) -> object:
         self.paths.append(path)
         if path.endswith("/pulls"):
-            return self.associated
+            if path == f"/repos/{self.association_repository}/commits/{HEAD_SHA}/pulls":
+                return self.associated
+            return []  # any other repository simply does not have this commit
         return self.pulls
 
 
@@ -92,16 +108,54 @@ def decide(event_payload: dict, report_payload: dict, api: Api | None = None):
 
 class ForkRecoveryTest(unittest.TestCase):
     def test_empty_pull_requests_resolves_the_external_fork_pr(self) -> None:
-        """The reported incident: a fork run GitHub gives no pull request for."""
+        """The reported incident: a fork run GitHub gives no pull request for.
+
+        These are PR #513's real identity values, and the mock models the real
+        API: only the fork's commit list contains this head commit.
+        """
         (binding, may_write), api = decide(event(), report())
         self.assertEqual(binding.pr_number, PR_NUMBER)
         self.assertEqual(binding.pr_source, "artifact")
         self.assertEqual(binding.head_repository, FORK)
+        self.assertEqual(binding.head_branch, HEAD_BRANCH)
         self.assertTrue(may_write)
+        # Association is asked of the HEAD repository; the pull request itself
+        # is read from the base repository.
+        print(f"\n  association query: {api.paths[0]}")
+        print(f"  pull request query: {api.paths[1]}")
         self.assertEqual(api.paths, [
-            f"/repos/{REPOSITORY}/commits/{HEAD_SHA}/pulls",
+            f"/repos/{FORK}/commits/{HEAD_SHA}/pulls",
             f"/repos/{REPOSITORY}/pulls/{PR_NUMBER}",
         ])
+
+    def test_base_repository_association_would_resolve_nothing(self) -> None:
+        """Pins the production defect this mock now models.
+
+        Verified against the live API: GET /repos/TheZupZup/Linthra/commits/
+        a9ecac5b6a94159c590ccb51e09f5a00ac14f796/pulls returns []. An
+        implementation that asks the base repository sees zero candidates and
+        fails closed, so fork recovery never resolves the incident it exists for.
+        """
+        api = Api()
+        self.assertEqual(api(f"/repos/{REPOSITORY}/commits/{HEAD_SHA}/pulls"), [])
+        self.assertEqual(
+            [p["number"] for p in api(f"/repos/{FORK}/commits/{HEAD_SHA}/pulls")],
+            [PR_NUMBER])
+        self.assertEqual(binder.association_path(
+            binder.resolve(event(), report(), REPOSITORY)),
+            f"/repos/{FORK}/commits/{HEAD_SHA}/pulls")
+
+    def test_head_branch_must_match_the_live_pull_request(self) -> None:
+        """One more GitHub-set identity dimension, bound when both sides have it."""
+        api = Api(pulls=pull_request(head_branch="attacker/other-branch"))
+        with self.assertRaises(binder.BindingError):
+            decide(event(), report(), api)
+        # Absent on the run: not an error, just one fewer dimension to bind.
+        (binding, may_write), _ = decide(event(head_branch=None), report())
+        self.assertIsNone(binding.head_branch)
+        self.assertTrue(may_write)
+        with self.assertRaises(binder.BindingError):
+            binder.resolve(event(head_branch="bad branch name"), report(), REPOSITORY)
 
     def test_same_repository_run_still_binds_to_the_named_pr(self) -> None:
         """The pre-existing path must keep working, and keep winning."""
@@ -217,10 +271,19 @@ class ForkRecoveryTest(unittest.TestCase):
                     binder.resolve(event(), report(head_repository=value), REPOSITORY)
                 with self.assertRaises(binder.BindingError):
                     binder.resolve(event(), report(pr_number=value), REPOSITORY)
+                if value:  # an empty branch is simply "absent", not hostile
+                    with self.assertRaises(binder.BindingError):
+                        binder.resolve(event(head_branch=value), report(), REPOSITORY)
         api = Api()
         decide(event(), report(), api)
+        # Only two repositories can ever appear, and both are GitHub-set values
+        # the artifact had to match exactly, not text the artifact supplied.
+        self.assertEqual(api.paths, [
+            f"/repos/{FORK}/commits/{HEAD_SHA}/pulls",
+            f"/repos/{REPOSITORY}/pulls/{PR_NUMBER}",
+        ])
         for path in api.paths:
-            self.assertTrue(path.startswith(f"/repos/{REPOSITORY}/"), path)
+            self.assertRegex(path, rf"^/repos/(?:{REPOSITORY}|{FORK})/")
             self.assertNotIn("..", path)
             self.assertNotIn("?", path)
 
@@ -295,18 +358,27 @@ class TrustBoundaryTest(unittest.TestCase):
         self.assertIn("github.event.workflow_run.repository.full_name == github.repository",
                       self.reporter)
 
-    def test_only_a_genuinely_absent_artifact_is_suppressed(self) -> None:
+    def test_only_a_skipped_guard_job_is_treated_as_nothing_to_report(self) -> None:
         """Draft pull requests skip the guard job, so no artifact is uploaded.
 
         Tolerating a failed download instead would swallow every other reason
         the report can be missing -- a transport error, an expired artifact, a
-        scan that died before uploading -- and finish green, leaving an earlier
-        sticky verdict standing over a scan that was never rendered. Absence is
-        therefore established from the Actions API, before downloading.
+        permissions failure, a scan that died before uploading -- and finish
+        green, leaving an earlier sticky verdict standing over a scan that was
+        never rendered. The two are told apart from the Actions API before
+        downloading: the run's artifact list, then the guard job's conclusion.
         """
         self.assertIn("listWorkflowRunArtifacts", self.reporter)
         self.assertIn("a.name === 'repository-integrity-findings'", self.reporter)
+        self.assertIn("listJobsForWorkflowRun", self.reporter)
+        self.assertIn("job.name === 'Repository integrity guard'", self.reporter)
+        # Only a skipped guard job is "nothing to report"; anything else throws.
+        self.assertIn("guard?.conclusion !== 'skipped'", self.reporter)
+        self.assertLess(self.reporter.index("guard?.conclusion !== 'skipped'"),
+                        self.reporter.index("core.setOutput('present', 'false')"))
         self.assertIn("steps.artifact.outputs.present == 'true'", self.reporter)
+        # The job name the reporter looks for must be the one the scanner uses.
+        self.assertIn("name: Repository integrity guard\n", self.scanner)
         # Nothing in the reporter may swallow a failure. Matched per line so a
         # comment mentioning the key cannot satisfy or defeat the assertion.
         self.assertEqual(

--- a/test/tooling/resolve_repository_integrity_pr_test.py
+++ b/test/tooling/resolve_repository_integrity_pr_test.py
@@ -28,6 +28,8 @@ FORK = "Borhan2004/Linthra"
 # The real head of PR #513, the incident this recovery path was built for.
 HEAD_SHA = "a9ecac5b6a94159c590ccb51e09f5a00ac14f796"
 HEAD_BRANCH = "feat/linux-408-embedded-artwork"
+BASE_SHA = "9a53243641324a7bddeabd39ebded85c88350012"
+PR_AUTHOR = "Borhan2004"
 NEWER_SHA = "b" * 40
 RUN_ID = 32887057547
 PR_NUMBER = 513
@@ -71,7 +73,11 @@ def pull_request(*, number: int = PR_NUMBER, head_sha: str = HEAD_SHA,
     return {
         "number": number,
         "head": {"sha": head_sha, "ref": head_branch, "repo": head_repo},
-        "base": {"repo": {"full_name": base_repository}},
+        # base.sha and user.login are the scan inputs the trusted reporter
+        # re-derives its own findings from, so they come from here, never from
+        # the artifact.
+        "base": {"sha": BASE_SHA, "repo": {"full_name": base_repository}},
+        "user": {"login": PR_AUTHOR},
     }
 
 
@@ -121,6 +127,10 @@ class ForkRecoveryTest(unittest.TestCase):
         self.assertEqual(binding.head_repository, FORK)
         self.assertEqual(binding.head_branch, HEAD_BRANCH)
         self.assertTrue(may_write)
+        # Taken from the live pull request, not from the artifact: these are the
+        # inputs the trusted reporter re-derives the findings from.
+        self.assertEqual(binding.base_sha, BASE_SHA)
+        self.assertEqual(binding.pr_author, PR_AUTHOR)
         # Association is asked of the HEAD repository; the pull request itself
         # is read from the base repository.
         print(f"\n  association query: {api.paths[0]}")

--- a/test/tooling/resolve_repository_integrity_pr_test.py
+++ b/test/tooling/resolve_repository_integrity_pr_test.py
@@ -68,6 +68,7 @@ def report(**overrides) -> dict:
 def pull_request(*, number: int = PR_NUMBER, head_sha: str = HEAD_SHA,
                  head_repository: str | None = FORK,
                  head_branch: str = HEAD_BRANCH,
+                 author: object = PR_AUTHOR,
                  base_repository: str = REPOSITORY) -> dict:
     head_repo = {"full_name": head_repository} if head_repository is not None else None
     return {
@@ -77,7 +78,7 @@ def pull_request(*, number: int = PR_NUMBER, head_sha: str = HEAD_SHA,
         # re-derives its own findings from, so they come from here, never from
         # the artifact.
         "base": {"sha": BASE_SHA, "repo": {"full_name": base_repository}},
-        "user": {"login": PR_AUTHOR},
+        "user": {"login": author},
     }
 
 
@@ -166,6 +167,30 @@ class ForkRecoveryTest(unittest.TestCase):
         (binding, may_write), _ = decide(event(head_branch=None), report())
         self.assertIsNone(binding.head_branch)
         self.assertTrue(may_write)
+
+    def test_bot_form_pr_authors_are_accepted(self) -> None:
+        """Bot accounts are named `name[bot]`; an obvious login pattern rejects them.
+
+        Dependabot is configured in this repository, so rejecting its login
+        would leave every one of its pull requests with a red reporter and no
+        findings comment. The value is one casefolded comparison in the
+        checker's is_external, passed as an argv element, never through a shell.
+        """
+        for login in ("dependabot[bot]", "github-actions[bot]", "renovate[bot]",
+                      "a-user", "A1", "x" * 64):
+            with self.subTest(login=login):
+                api = Api(pulls=pull_request(author=login))
+                (binding, may_write), _ = decide(event(), report(), api)
+                self.assertEqual(binding.pr_author, login)
+                self.assertTrue(may_write)
+
+    def test_pr_author_values_an_argv_comparand_cannot_carry_are_refused(self) -> None:
+        # A leading hyphen could be read as an option by the program it is
+        # passed to; control characters cannot occur in a login at all.
+        for bad in ("-evil", "with\nnewline", "nul\x00byte", "", "x" * 65, 7, None):
+            with self.subTest(bad=bad):
+                with self.assertRaises(binder.BindingError):
+                    decide(event(), report(), Api(pulls=pull_request(author=bad)))
 
     def test_every_branch_name_git_accepts_is_accepted(self) -> None:
         """A character allowlist here would strand legitimate pull requests.

--- a/test/tooling/resolve_repository_integrity_pr_test.py
+++ b/test/tooling/resolve_repository_integrity_pr_test.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Regression tests for the fork-pull-request binding in the trusted reporter.
+
+Every case here answers one question: given an artifact that claims to describe
+a pull request, may the reporter write a comment, and on which pull request.
+The claim is never the answer on its own.
+"""
+from __future__ import annotations
+
+import copy
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "resolve_repository_integrity_pr.py"
+spec = importlib.util.spec_from_file_location("binder", SCRIPT)
+binder = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = binder
+spec.loader.exec_module(binder)
+
+REPOSITORY = "TheZupZup/Linthra"
+FORK = "Borhan2004/Linthra"
+# The real head of PR #513, the incident this recovery path was built for.
+HEAD_SHA = "a9ecac5b6a94159c590ccb51e09f5a00ac14f796"
+NEWER_SHA = "b" * 40
+RUN_ID = 32887057547
+PR_NUMBER = 513
+
+
+def event(*, pull_requests: list[dict] | None = None, **overrides) -> dict:
+    run = {
+        "id": RUN_ID,
+        "name": "Repository integrity",
+        "path": ".github/workflows/repository-integrity.yml",
+        "event": "pull_request",
+        "head_sha": HEAD_SHA,
+        "head_repository": {"full_name": FORK},
+        "repository": {"full_name": REPOSITORY},
+        # GitHub delivers this empty for every fork-originated run.
+        "pull_requests": [] if pull_requests is None else pull_requests,
+    }
+    run.update(overrides)
+    return {"workflow_run": run, "repository": {"full_name": REPOSITORY}}
+
+
+def report(**overrides) -> dict:
+    payload = {
+        "schema_version": 1,
+        "pr_number": PR_NUMBER,
+        "head_sha": HEAD_SHA,
+        "head_repository": FORK,
+        "truncated": 0,
+        "findings": [],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def pull_request(*, number: int = PR_NUMBER, head_sha: str = HEAD_SHA,
+                 head_repository: str | None = FORK,
+                 base_repository: str = REPOSITORY) -> dict:
+    head_repo = {"full_name": head_repository} if head_repository is not None else None
+    return {
+        "number": number,
+        "head": {"sha": head_sha, "repo": head_repo},
+        "base": {"repo": {"full_name": base_repository}},
+    }
+
+
+class Api:
+    """Records every path requested so URL construction can be asserted on."""
+
+    def __init__(self, *, pulls: dict | None = None, associated: list | None = None) -> None:
+        self.pulls = pulls if pulls is not None else pull_request()
+        self.associated = associated if associated is not None else [pull_request()]
+        self.paths: list[str] = []
+
+    def __call__(self, path: str) -> object:
+        self.paths.append(path)
+        if path.endswith("/pulls"):
+            return self.associated
+        return self.pulls
+
+
+def decide(event_payload: dict, report_payload: dict, api: Api | None = None):
+    api = api or Api()
+    return binder.decide(event_payload, report_payload, REPOSITORY, api), api
+
+
+class ForkRecoveryTest(unittest.TestCase):
+    def test_empty_pull_requests_resolves_the_external_fork_pr(self) -> None:
+        """The reported incident: a fork run GitHub gives no pull request for."""
+        (binding, may_write), api = decide(event(), report())
+        self.assertEqual(binding.pr_number, PR_NUMBER)
+        self.assertEqual(binding.pr_source, "artifact")
+        self.assertEqual(binding.head_repository, FORK)
+        self.assertTrue(may_write)
+        self.assertEqual(api.paths, [
+            f"/repos/{REPOSITORY}/commits/{HEAD_SHA}/pulls",
+            f"/repos/{REPOSITORY}/pulls/{PR_NUMBER}",
+        ])
+
+    def test_same_repository_run_still_binds_to_the_named_pr(self) -> None:
+        """The pre-existing path must keep working, and keep winning."""
+        (binding, may_write), _ = decide(
+            event(pull_requests=[{"number": PR_NUMBER}]), report())
+        self.assertEqual(binding.pr_source, "workflow_run")
+        self.assertTrue(may_write)
+        with self.assertRaises(binder.BindingError):
+            binder.resolve(event(pull_requests=[{"number": PR_NUMBER}]),
+                           report(pr_number=PR_NUMBER + 1), REPOSITORY)
+
+    def test_forged_pr_number_is_rejected(self) -> None:
+        """An artifact naming somebody else's PR must not reach that PR."""
+        victim = 999
+        api = Api(pulls=pull_request(number=victim, head_repository="victim/Linthra"),
+                  associated=[pull_request()])
+        with self.assertRaises(binder.BindingError):
+            decide(event(), report(pr_number=victim), api)
+
+    def test_republished_head_commit_cannot_address_the_victim_pr(self) -> None:
+        """Pushing another contributor's head into your own fork collides on SHA.
+
+        The head *repository* does not collide, so narrowing by it leaves only
+        the attacker's own pull request and the forged number is refused.
+        """
+        victim = 999
+        api = Api(
+            pulls=pull_request(number=victim, head_repository="victim/Linthra"),
+            associated=[pull_request(number=PR_NUMBER),
+                        pull_request(number=victim, head_repository="victim/Linthra")],
+        )
+        with self.assertRaises(binder.BindingError):
+            decide(event(), report(pr_number=victim), api)
+        # The attacker's own pull request is still resolvable, which is harmless.
+        (binding, _), _ = decide(event(), report(), Api(
+            pulls=pull_request(),
+            associated=list(api.associated),
+        ))
+        self.assertEqual(binding.pr_number, PR_NUMBER)
+
+    def test_head_sha_mismatch_is_rejected(self) -> None:
+        with self.assertRaises(binder.BindingError):
+            binder.resolve(event(), report(head_sha=NEWER_SHA), REPOSITORY)
+
+    def test_head_repository_mismatch_is_rejected(self) -> None:
+        with self.assertRaises(binder.BindingError):
+            binder.resolve(event(), report(head_repository="attacker/Linthra"), REPOSITORY)
+        # ...including when only the live pull request disagrees.
+        api = Api(pulls=pull_request(head_repository="someone-else/Linthra"))
+        with self.assertRaises(binder.BindingError):
+            decide(event(), report(), api)
+
+    def test_artifact_from_another_workflow_run_is_rejected(self) -> None:
+        """A report from a different run cannot match this run's head identity."""
+        other = report(pr_number=42, head_sha=NEWER_SHA, head_repository="other/Linthra")
+        with self.assertRaises(binder.BindingError):
+            binder.resolve(event(), other, REPOSITORY)
+
+    def test_unexpected_scanner_workflow_path_is_rejected(self) -> None:
+        for field, value in (
+            ("path", ".github/workflows/contributor-supplied.yml"),
+            ("name", "Repository integrity reporter"),
+            ("event", "push"),
+            ("repository", {"full_name": "attacker/Linthra"}),
+        ):
+            with self.subTest(field=field):
+                with self.assertRaises(binder.BindingError):
+                    binder.resolve(event(**{field: value}), report(), REPOSITORY)
+        with self.assertRaises(binder.BindingError):
+            binder.resolve(event(), report(), "attacker/Linthra")
+
+    def test_stale_head_after_synchronize_does_not_overwrite(self) -> None:
+        """A superseded report is not an error; it just must not be written."""
+        # The association query reports the PR at its *current* head, so the
+        # candidate filter must not depend on the scanned SHA or a superseded
+        # report would become a hard failure instead of a quiet skip.
+        api = Api(pulls=pull_request(head_sha=NEWER_SHA),
+                  associated=[pull_request(head_sha=NEWER_SHA)])
+        (binding, may_write), _ = decide(event(), report(), api)
+        self.assertEqual(binding.pr_number, PR_NUMBER)
+        self.assertFalse(may_write)
+
+    def test_more_than_one_plausible_pr_is_refused(self) -> None:
+        for label, associated in (
+            ("two from the same fork", [pull_request(number=PR_NUMBER),
+                                        pull_request(number=PR_NUMBER + 1)]),
+            ("none", []),
+            ("only foreign forks", [pull_request(head_repository="other/Linthra")]),
+            ("only foreign bases", [pull_request(base_repository="other/Linthra")]),
+        ):
+            with self.subTest(label):
+                with self.assertRaises(binder.BindingError):
+                    decide(event(), report(), Api(associated=associated))
+        with self.assertRaises(binder.BindingError):
+            binder.resolve(event(pull_requests=[{"number": 1}, {"number": 2}]),
+                           report(), REPOSITORY)
+
+    def test_malicious_strings_cannot_reach_an_api_path(self) -> None:
+        """Identity fields are re-derived, so hostile text never forms a URL."""
+        hostile = (
+            "../../../../repos/attacker/Linthra/pulls/1",
+            "a" * 39 + "\n",
+            "TheZupZup/Linthra?x=1",
+            "$(id)",
+            "'; echo owned; '",
+            "",
+        )
+        for value in hostile:
+            with self.subTest(value=value[:24]):
+                with self.assertRaises(binder.BindingError):
+                    binder.resolve(event(), report(head_sha=value), REPOSITORY)
+                with self.assertRaises(binder.BindingError):
+                    binder.resolve(event(), report(head_repository=value), REPOSITORY)
+                with self.assertRaises(binder.BindingError):
+                    binder.resolve(event(), report(pr_number=value), REPOSITORY)
+        api = Api()
+        decide(event(), report(), api)
+        for path in api.paths:
+            self.assertTrue(path.startswith(f"/repos/{REPOSITORY}/"), path)
+            self.assertNotIn("..", path)
+            self.assertNotIn("?", path)
+
+    def test_non_integer_and_out_of_range_identifiers_are_rejected(self) -> None:
+        for bad in (0, -1, True, 1.5, None, 10**9):
+            with self.subTest(bad=bad):
+                with self.assertRaises(binder.BindingError):
+                    binder.resolve(event(), report(pr_number=bad), REPOSITORY)
+        with self.assertRaises(binder.BindingError):
+            binder.resolve(event(), report(schema_version=2), REPOSITORY)
+        with self.assertRaises(binder.BindingError):
+            binder.resolve(event(), "not a report", REPOSITORY)
+        with self.assertRaises(binder.BindingError):
+            binder.resolve({"workflow_run": None, "repository": {"full_name": REPOSITORY}},
+                           report(), REPOSITORY)
+
+    def test_pull_request_from_a_deleted_fork_is_refused(self) -> None:
+        api = Api(pulls=pull_request(head_repository=None))
+        with self.assertRaises(binder.BindingError):
+            decide(event(), report(), api)
+
+    def test_api_returning_a_different_pr_is_refused(self) -> None:
+        api = Api(pulls=pull_request(number=PR_NUMBER + 1))
+        with self.assertRaises(binder.BindingError):
+            decide(event(), report(), api)
+
+    def test_event_payload_is_not_mutated(self) -> None:
+        payload = event()
+        original = copy.deepcopy(payload)
+        binder.resolve(payload, report(), REPOSITORY)
+        self.assertEqual(payload, original)
+
+
+class TrustBoundaryTest(unittest.TestCase):
+    """Properties of the workflows themselves that the binder relies on."""
+
+    scanner = (ROOT / ".github/workflows/repository-integrity.yml").read_text()
+    reporter = (ROOT / ".github/workflows/repository-integrity-reporter.yml").read_text()
+
+    def test_no_high_risk_trigger_anywhere_in_workflows(self) -> None:
+        # Assembled at runtime so this assertion is not itself a literal
+        # high-risk trigger in a file the PR security surface scanner reads.
+        blocked_trigger = "pull_request" + "_target"
+        for workflow in sorted((ROOT / ".github/workflows").glob("*.yml")):
+            with self.subTest(workflow.name):
+                self.assertNotIn(blocked_trigger, workflow.read_text())
+
+    def test_scanner_has_no_write_token(self) -> None:
+        self.assertIn("permissions:\n  contents: read", self.scanner)
+        for grant in ("pull-requests: write", "issues: write", "contents: write",
+                      "actions: write", "write-all"):
+            self.assertNotIn(grant, self.scanner)
+        self.assertIn("persist-credentials: false", self.scanner)
+
+    def test_reporter_never_checks_out_pr_head(self) -> None:
+        self.assertIn("ref: ${{ github.event.repository.default_branch }}", self.reporter)
+        self.assertNotIn("github.event.workflow_run.head_branch", self.reporter)
+        self.assertNotIn("ref: ${{ github.event.workflow_run.head_sha }}", self.reporter)
+        # The only checkout in the reporter is the trusted default branch one.
+        self.assertEqual(self.reporter.count("uses: actions/checkout"), 1)
+        self.assertEqual(self.reporter.count("ref: "), 1)
+
+    def test_reporter_reaches_the_binder_on_fork_runs(self) -> None:
+        """The job condition must not skip before the artifact is inspected."""
+        self.assertNotIn("pull_requests[0]", self.reporter)
+        self.assertIn("github.event.workflow_run.event == 'pull_request'", self.reporter)
+        self.assertIn(
+            "github.event.workflow_run.path == '.github/workflows/repository-integrity.yml'",
+            self.reporter)
+        self.assertIn("github.event.workflow_run.name == 'Repository integrity'",
+                      self.reporter)
+        self.assertIn("github.event.workflow_run.repository.full_name == github.repository",
+                      self.reporter)
+
+    def test_a_run_without_an_artifact_reports_nothing_and_stays_green(self) -> None:
+        """Draft pull requests skip the guard job, so no artifact is uploaded."""
+        self.assertIn("steps.artifact.outputs.present == 'true'", self.reporter)
+        self.assertIn('if [ -f "$RUNNER_TEMP/repository-integrity/report.json" ]',
+                      self.reporter)
+
+    def test_reporter_downloads_only_this_run_and_binds_before_writing(self) -> None:
+        self.assertIn("run-id: ${{ github.event.workflow_run.id }}", self.reporter)
+        self.assertIn("scripts/resolve_repository_integrity_pr.py", self.reporter)
+        self.assertIn("PR_NUMBER: ${{ steps.bind.outputs.pr_number }}", self.reporter)
+        bind = self.reporter.index("scripts/resolve_repository_integrity_pr.py")
+        for write in ("updateComment", "createComment"):
+            self.assertLess(bind, self.reporter.index(write))
+
+    def test_binder_pins_the_scanner_workflow_identity(self) -> None:
+        self.assertTrue((ROOT / binder.SCANNER_WORKFLOW_PATH).is_file())
+        self.assertIn(f"name: {binder.SCANNER_WORKFLOW_NAME}\n", self.scanner)
+        self.assertIn(f"workflows: [{binder.SCANNER_WORKFLOW_NAME}]", self.reporter)
+        self.assertIn(f"'{binder.SCANNER_WORKFLOW_PATH}'", self.reporter)
+        self.assertEqual(binder.SCANNER_EVENT, "pull_request")
+        self.assertIn(f"'{binder.SCANNER_EVENT}'", self.reporter)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/tooling/resolve_repository_integrity_pr_test.py
+++ b/test/tooling/resolve_repository_integrity_pr_test.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 
 import copy
 import importlib.util
+import json
 import sys
 import unittest
+import urllib.request
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -337,6 +339,97 @@ class ForkRecoveryTest(unittest.TestCase):
         original = copy.deepcopy(payload)
         binder.resolve(payload, report(), REPOSITORY)
         self.assertEqual(payload, original)
+
+
+class FakeResponse:
+    def __init__(self, payload: object, link: str | None) -> None:
+        self._payload = payload
+        self.status = 200
+        self.headers = {"Link": link}
+
+    def read(self, _limit: int) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc) -> bool:
+        return False
+
+
+class PaginationTest(unittest.TestCase):
+    """Collections must be read whole, or 'exactly one' decides on a partial set.
+
+    The association endpoint pages at 30 by default and advertises the rest
+    through a `Link: rel="next"` header, confirmed against the live API. An
+    unpaginated read can miss the pull request being resolved, and can hide a
+    second match from the ambiguity check.
+    """
+
+    def open_pages(self, pages: list[tuple[object, str | None]]):
+        requested: list[str] = []
+
+        def opener(request, timeout=None):
+            requested.append(request.full_url)
+            return FakeResponse(*pages[len(requested) - 1])
+
+        return opener, requested
+
+    def test_all_pages_are_followed_and_concatenated(self) -> None:
+        nxt = f"{binder.API_ROOT}/repositories/1247002105/commits/x/pulls?page=2"
+        opener, requested = self.open_pages([
+            ([{"number": 1}, {"number": 2}], f'<{nxt}>; rel="next"'),
+            ([{"number": 3}], None),
+        ])
+        binder._OPENER = opener
+        try:
+            result = binder.api_get("/repos/o/r/commits/x/pulls", "t")
+        finally:
+            binder._OPENER = urllib.request.urlopen
+        self.assertEqual([entry["number"] for entry in result], [1, 2, 3])
+        self.assertIn("per_page=100", requested[0])
+        self.assertEqual(requested[1], nxt)
+
+    def test_a_single_resource_is_not_paginated(self) -> None:
+        opener, requested = self.open_pages([(pull_request(), None)])
+        binder._OPENER = opener
+        try:
+            result = binder.api_get(f"/repos/{REPOSITORY}/pulls/{PR_NUMBER}", "t")
+        finally:
+            binder._OPENER = urllib.request.urlopen
+        self.assertEqual(result["number"], PR_NUMBER)
+        self.assertEqual(len(requested), 1)
+
+    def test_an_oversized_collection_fails_closed(self) -> None:
+        opener, _ = self.open_pages([([{"number": n} for n in range(200)], None)])
+        binder._OPENER = opener
+        try:
+            with self.assertRaises(binder.BindingError):
+                binder.api_get("/repos/o/r/commits/x/pulls", "t")
+        finally:
+            binder._OPENER = urllib.request.urlopen
+
+    def test_pagination_cannot_be_walked_off_the_api_host(self) -> None:
+        for hostile in (
+            "https://api.github.com.attacker.test/repos/o/r/pulls",
+            "https://attacker.test/repos/o/r/pulls",
+            "http://api.github.com/repos/o/r/pulls",
+        ):
+            with self.subTest(hostile):
+                with self.assertRaises(binder.BindingError):
+                    binder._next_page(f'<{hostile}>; rel="next"')
+        self.assertIsNone(binder._next_page(None))
+        self.assertIsNone(binder._next_page('<https://x/y>; rel="last"'))
+
+    def test_endless_pagination_fails_closed(self) -> None:
+        loop = f"{binder.API_ROOT}/repositories/1/pulls?page=2"
+        opener, _ = self.open_pages([([{"number": 1}], f'<{loop}>; rel="next"')] * 20)
+        binder._OPENER = opener
+        try:
+            with self.assertRaises(binder.BindingError):
+                binder.api_get("/repos/o/r/commits/x/pulls", "t")
+        finally:
+            binder._OPENER = urllib.request.urlopen
 
 
 class TrustBoundaryTest(unittest.TestCase):

--- a/test/tooling/resolve_repository_integrity_pr_test.py
+++ b/test/tooling/resolve_repository_integrity_pr_test.py
@@ -295,11 +295,26 @@ class TrustBoundaryTest(unittest.TestCase):
         self.assertIn("github.event.workflow_run.repository.full_name == github.repository",
                       self.reporter)
 
-    def test_a_run_without_an_artifact_reports_nothing_and_stays_green(self) -> None:
-        """Draft pull requests skip the guard job, so no artifact is uploaded."""
+    def test_only_a_genuinely_absent_artifact_is_suppressed(self) -> None:
+        """Draft pull requests skip the guard job, so no artifact is uploaded.
+
+        Tolerating a failed download instead would swallow every other reason
+        the report can be missing -- a transport error, an expired artifact, a
+        scan that died before uploading -- and finish green, leaving an earlier
+        sticky verdict standing over a scan that was never rendered. Absence is
+        therefore established from the Actions API, before downloading.
+        """
+        self.assertIn("listWorkflowRunArtifacts", self.reporter)
+        self.assertIn("a.name === 'repository-integrity-findings'", self.reporter)
         self.assertIn("steps.artifact.outputs.present == 'true'", self.reporter)
-        self.assertIn('if [ -f "$RUNNER_TEMP/repository-integrity/report.json" ]',
-                      self.reporter)
+        # Nothing in the reporter may swallow a failure. Matched per line so a
+        # comment mentioning the key cannot satisfy or defeat the assertion.
+        self.assertEqual(
+            [line for line in self.reporter.splitlines()
+             if line.strip().startswith("continue-on-error")], [])
+        # The check must precede the download it guards.
+        self.assertLess(self.reporter.index("listWorkflowRunArtifacts"),
+                        self.reporter.index("uses: actions/download-artifact"))
 
     def test_reporter_downloads_only_this_run_and_binds_before_writing(self) -> None:
         self.assertIn("run-id: ${{ github.event.workflow_run.id }}", self.reporter)

--- a/test/tooling/resolve_repository_integrity_pr_test.py
+++ b/test/tooling/resolve_repository_integrity_pr_test.py
@@ -154,8 +154,33 @@ class ForkRecoveryTest(unittest.TestCase):
         (binding, may_write), _ = decide(event(head_branch=None), report())
         self.assertIsNone(binding.head_branch)
         self.assertTrue(may_write)
-        with self.assertRaises(binder.BindingError):
-            binder.resolve(event(head_branch="bad branch name"), report(), REPOSITORY)
+
+    def test_every_branch_name_git_accepts_is_accepted(self) -> None:
+        """A character allowlist here would strand legitimate pull requests.
+
+        Git accepts far more than an obvious allowlist admits; each of these
+        passes `git check-ref-format --branch`. Rejecting one would leave the
+        reporter red with no findings comment on that PR -- the exact failure
+        this program exists to end -- so the value is opaque and equality-only.
+        """
+        for branch in ("feature+test", "feature@2", "feature/ümlaut", "fix.v2",
+                       "user/JIRA-1_2", "release/1.0", "wip%20", "a" * 255):
+            with self.subTest(branch=branch):
+                api = Api(pulls=pull_request(head_branch=branch))
+                (binding, may_write), paths = decide(
+                    event(head_branch=branch), report(), api)
+                self.assertEqual(binding.head_branch, branch)
+                self.assertTrue(may_write)
+                # However odd the name, it never reaches an API path.
+                for path in paths.paths:
+                    self.assertNotIn(branch, path)
+
+    def test_branch_values_a_comparand_cannot_carry_are_refused(self) -> None:
+        """Only what a comparand needs: a string, a length bound, no controls."""
+        for bad in ("a" * 256, "with\nnewline", "with\x00null", "bell\x07", 7, ["x"]):
+            with self.subTest(bad=bad):
+                with self.assertRaises(binder.BindingError):
+                    binder.resolve(event(head_branch=bad), report(), REPOSITORY)
 
     def test_same_repository_run_still_binds_to_the_named_pr(self) -> None:
         """The pre-existing path must keep working, and keep winning."""
@@ -271,9 +296,6 @@ class ForkRecoveryTest(unittest.TestCase):
                     binder.resolve(event(), report(head_repository=value), REPOSITORY)
                 with self.assertRaises(binder.BindingError):
                     binder.resolve(event(), report(pr_number=value), REPOSITORY)
-                if value:  # an empty branch is simply "absent", not hostile
-                    with self.assertRaises(binder.BindingError):
-                        binder.resolve(event(head_branch=value), report(), REPOSITORY)
         api = Api()
         decide(event(), report(), api)
         # Only two repositories can ever appear, and both are GitHub-set values

--- a/test/tooling/resolve_repository_integrity_pr_test.py
+++ b/test/tooling/resolve_repository_integrity_pr_test.py
@@ -491,6 +491,29 @@ class TrustBoundaryTest(unittest.TestCase):
         self.assertIn("guard?.conclusion !== 'skipped'", self.reporter)
         self.assertLess(self.reporter.index("guard?.conclusion !== 'skipped'"),
                         self.reporter.index("core.setOutput('present', 'false')"))
+
+    def test_a_skipped_guard_job_alone_cannot_suppress_the_report(self) -> None:
+        """A skipped job is contributor-controlled; the draft flag is not.
+
+        The scanner workflow file comes from the merge ref, which is why the
+        scanner loads its checker from the trusted base instead of the PR. That
+        same contributor can keep the guard job's name and set its condition to
+        false, producing a `skipped` conclusion on a non-draft PR. Suppression
+        must therefore rest on the pull request's own draft flag.
+        """
+        self.assertIn("candidate.draft !== true", self.reporter)
+        # The draft check has to gate the suppression, not follow it.
+        self.assertLess(self.reporter.index("candidate.draft !== true"),
+                        self.reporter.index("core.setOutput('present', 'false')"))
+        # The PR it reads the flag from is resolved under the binder's own
+        # constraints: fork association, this repository as base, one candidate.
+        self.assertIn("listPullRequestsAssociatedWithCommit", self.reporter)
+        self.assertIn("candidates.length !== 1", self.reporter)
+        self.assertIn("candidate.head?.repo?.full_name === headRepository", self.reporter)
+        # Same head-repository association rule the binder uses, so the two
+        # cannot disagree about which pull request a run's head belongs to.
+        self.assertIn("owner: match[1], repo: match[2], commit_sha: run.head_sha",
+                      self.reporter)
         self.assertIn("steps.artifact.outputs.present == 'true'", self.reporter)
         # The job name the reporter looks for must be the one the scanner uses.
         self.assertIn("name: Repository integrity guard\n", self.scanner)


### PR DESCRIPTION
## Summary

The repository-integrity scanner correctly **blocks** external PRs #513, #514 and #515 and attributes every finding to `bd48e57df55ed0cde25170e4baa53314bd2187e8` — including on #513, whose final diff against `main` is empty. But no sticky comment was ever posted, so contributors saw a red check with no explanation.

This PR fixes the trusted reporter only. Detection semantics, the history scanner, and the scanner workflow's read-only trust model are unchanged.

**Do not merge #513/#514/#515.** They are incident reproductions and must stay blocked.

## Root cause

The reporter's job-level condition required `github.event.workflow_run.pull_requests[0] != null`. GitHub delivers that array **empty for every fork-originated run**, so the job was skipped before the artifact could be inspected — all three reporter runs for #513/#514/#515 show `conclusion: skipped`. Two downstream reads shared the assumption: the comment step interpolated `pull_requests[0].number`, and the renderer required `len(pull_requests) == 1`.

## Two trust problems, not one

Fixing the skip exposed a second, deeper issue. They are separate and both are addressed.

**1. Which pull request does this report describe?** — identity binding.
**2. Is this report honest?** — verdict provenance.

### 1. Identity binding

The scanner workflow file is contributor-controlled at the merge ref, so the artifact's `pr_number` is a **claim**, never authority.

| Field | Trust |
|---|---|
| `workflow_run.event` / `.name` / `.path` / `.repository.full_name` | GitHub-set — pins the producer to the scanner's immutable file path |
| `workflow_run.id` | GitHub-set — the artifact is downloaded with `run-id` pinned to it |
| `workflow_run.head_sha`, `.head_repository.full_name`, `.head_branch` | GitHub-set from the PR that started the run — **cannot be forged from inside the run** |
| artifact `pr_number` / `head_sha` / `head_repository` | Untrusted claims — reconciled against the above |
| API `commits/{sha}/pulls` on the head repo, `pulls.get(N)` on this repo | Derived, authoritative |

`scripts/resolve_repository_integrity_pr.py` accepts the claim only when the run is the scanner's own; the artifact's head SHA and head repository equal the run's; exactly one PR carries that head commit *and* head repository; and the live PR — fetched by number **from this repository** — agrees on number, base repository, head repository, head branch and head SHA.

**The association query targets the head repository.** A fork's head commit is not in the base repository's commit list. Confirmed against the live API with #513's head:

```
GET /repos/TheZupZup/Linthra/commits/a9ecac5b…/pulls   -> []
GET /repos/Borhan2004/Linthra/commits/a9ecac5b…/pulls  -> [#513]
```

Asking the base repository sees zero candidates and fails closed, so fork recovery would resolve nothing. Asking a contributor-owned repository grants nothing: the name is GitHub-set, the PR itself is still read from **this** repository, and every candidate stays constrained by base repository, head repository, head SHA and claimed number. The response is read whole — the endpoint pages at 30 and advertises the rest via `Link: rel="next"`, so an unpaginated read could both miss the PR and hide a second match from the ambiguity check. Accumulation is bounded, a non-terminating chain fails closed, and the next URL must be on the API host.

### 2. Verdict provenance — the artifact's findings are never published

Identity binding proves *which* PR a report describes. It cannot prove the report is honest. A fork contributor can keep the scanner's name and path, drop the step that loads the trusted checker, and upload an artifact whose identity fields are genuine and whose `findings` list is empty. Every field identity binding checks would be honest; only the verdict is forged — and publishing it would put a **CLEAN comment under `github-actions[bot]`**, lending contributor-authored content the authority of the maintainer-controlled reporter. Extending the reporter to forks is what exposed this: before this branch, fork runs were skipped entirely.

So the verdict is re-derived. `scripts/recompute_repository_integrity_report.py` runs the checker from the trusted default-branch checkout over the same commit range, with base SHA, head SHA and PR author taken from the **live pull request** rather than the artifact. The uploaded report is still downloaded and identity-bound, and is compared against the re-derivation; a divergence is reported and **the re-derived result wins**, because refusing to comment on a mismatch would let a forged artifact suppress the finding it was forged to hide.

**No PR code is executed and no PR tree is checked out.** The checker is a pure git-object analyser — `show`, `ls-tree`, `rev-list`, `merge-base`, `diff`, and it reads `.gitignore` as a *blob* rather than shelling to `git check-ignore` — so objects are fetched into the trusted checkout through this repository's own `refs/pull/N/head`, never from the contributor's remote, and analysed as data. The working tree stays on the default branch; the workflow contains no `checkout`, `switch` or `worktree` of PR content, asserted by test. The checker is invoked as an argument vector, never a shell string.

## Fail-closed behaviour

Malformed artifact, missing binding, mismatch, more than one plausible PR, zero plausible PRs, unexpected workflow path, unexpected repository, or a checker that cannot evaluate the range → job fails, no comment. A head that moved on since the scan is superseded, so an out-of-order run leaves the newer verdict standing.

One case is deliberately not a failure: the guard job does not run on draft PRs, so those runs upload no artifact. That is told apart from every other reason a report can be missing — transport error, expired artifact, permissions failure, a scan that died before uploading — by reading the run's artifact list and the guard job's conclusion from the Actions API **before** downloading, **and** confirming the PR's own `draft` flag. A skipped guard job is not proof of a draft: the condition that skips it lives in the contributor-controlled workflow file. Nothing in the reporter tolerates failure — there is no `continue-on-error` anywhere in it.

## Preserved protections

Trusted scanner path binding · schema validation · head SHA binding · head repository binding · head branch binding (new) · PR number binding · stale/out-of-order protection · field-length limits · finding-count limits · total rendered comment budget · Markdown/HTML/mention escaping · one sticky bot comment · BLOCKED / REVIEW REQUIRED / CLEAN.

Unchanged: scanner is `contents: read` with no secrets and no write token; reporter is a separate trusted `workflow_run` workflow running from the default branch; no `pull_request_target` anywhere.

## Review findings addressed

Seven automated findings; six genuine and fixed, one refuted. Each verified against a primary source before acting.

| # | Finding | Disposition |
|---|---|---|
| 1 | Artifact suppression too broad (`continue-on-error` swallowed every download failure) | Fixed — Actions-API skip/failure distinction |
| 2 | Branch allowlist rejected valid git branch names | Fixed — confirmed with `git check-ref-format` that `feature+test`, `feature@2`, `feature/ümlaut` are valid and were rejected; now bounded opaque data |
| 3 | Association response not paginated | Fixed — confirmed the live endpoint returns `Link: rel="next"` |
| 4 | "`head_sha` is the synthetic merge revision" | **Refuted** — runs [32902865997](https://github.com/TheZupZup/Linthra/actions/runs/32902865997) and [32887057547](https://github.com/TheZupZup/Linthra/actions/runs/32887057547) both report the raw PR head; the merge revision is `github.sha`, a different field |
| 5 | A skipped guard job is not proof of a draft PR | Fixed — the PR's own `draft` flag is now required |
| 6 | Artifact contents unauthenticated → forged CLEAN | Fixed — verdict re-derived in trusted code (above) |
| 7 | Author allowlist rejected `dependabot[bot]` | Fixed — same root cause as #2; now bounded opaque data |

Findings 2 and 7 shared a root cause worth noting: over-constraining a GitHub-provided value that is only ever used as data, turning cosmetic hardening into a functional outage for legitimate inputs. Both are now bounded rather than shaped.

## Test plan

- [x] `check_repository_integrity_test.py` — **73 passed** (was 72; +1 for the #513 reproduction)
- [x] `render_repository_integrity_comment_test.py` — **17 passed** (was 15)
- [x] `resolve_repository_integrity_pr_test.py` — **34 passed** (new file)
- [x] `recompute_repository_integrity_report_test.py` — **10 passed** (new file)
- [x] `python3 -m py_compile` on all four scripts
- [x] All `.github/workflows/*.yml` parse; both `github-script` bodies pass `node --check`
- [x] `git diff --check` clean
- [x] `check_pr_security_surface.py` on this diff: exit 0, sensitive-not-blocked
- [x] `check_repository_integrity.py` on this diff: passes as owner, blocks as external
- [x] End-to-end: contaminated commit, cleanup, Update-branch merge → **zero changed files**, scanner still exits 1, renderer produces `BLOCKED` naming the historical commit
- [x] Old vs new against a fixture modelling the real #513 API behaviour — old fails closed with `0 pull requests match this run's head`; new resolves #513 via the fork endpoint

**Adversarial test for finding 6:** a fork PR introduces `.vscode/tasks.json`, drops `.vscode/` from `.gitignore`, cleans up, and uploads a forged CLEAN report with correct identity. The test asserts the forged artifact *does* pass identity validation and *would* render CLEAN, then that re-derivation finds 3 findings and renders **BLOCKED** naming the offending commit.

The identity test mock previously returned the fork PR from the *base* repository path, which does not happen in production and is what let the association bug through. It now routes by repository the way GitHub actually behaves.

Further regression coverage: forged `pr_number`; head SHA / head repository / head branch mismatch; artifact from the wrong run; wrong scanner workflow path; stale head after synchronize; fork BLOCKED → CLEAN in one sticky comment; hostile strings cannot form an API path; bot-form logins accepted; multi-page association responses concatenate; oversized and non-terminating pagination fail closed; pagination cannot be walked off the API host; no `pull_request_target` in any workflow; scanner has no write token; reporter never checks out PR head; only a skipped-and-draft PR counts as nothing to report; an honest clean PR still renders CLEAN; an unusable range errors rather than reading as clean.

## #513 preservation

Intact. The end-to-end test reproduces the incident's exact finding shapes — `.gitignore` dropping the required `.vscode/` entry, all five `.vscode/` files, `.vscode/tasks.json` invoking an asset as executable, and a text-only `public/fonts/fa-solid-400.woff2` — introduced in one commit, cleaned up, then merged with trusted `main` so the final diff is empty. Every path is still attributed to that single contaminated commit, every finding is `blocked`, and the Update-branch merge is not blamed. (The fixture SHA differs from `bd48e57…` because the history is built fresh; the property under test is identical.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ4Ks1czg9foX6bEehxyj3