### PR TITLE
chore(release): prepare v0.2.4

### DIFF
--- a/docs/release-notes/v0.2.4.md
+++ b/docs/release-notes/v0.2.4.md
@@ -1,0 +1,44 @@
+# Linthra v0.2.4
+
+Linthra 0.2.4 is a Linux packaging, desktop polish, accessibility, and project-safety release. It moves the Linux port closer to a packageable desktop application while tightening shutdown behavior and repository trust boundaries.
+
+## What's new
+
+- **Flatpak packaging has moved from plan to a working foundation.** Linthra now carries the initial manifest/offline source pipeline, bundles the Linux audio runtime it needs, installs a desktop entry and scalable app icon, and documents local Flatpak development. This is packaging groundwork; Linthra is not yet published on Flathub.
+- **Desktop shutdown is deterministic.** Linthra waits for app-owned asynchronous teardown — including database, playback, control services, and caches — before shutdown completes, reducing exit/restart races.
+- **Keyboard and accessibility support is broader.** The custom seek bar can be operated from the keyboard, icon-only controls expose clearer semantics, cast/queue/source controls report their state better, and destructive dialogs default focus to Cancel.
+- **Large text no longer breaks the mini-player.** The compact player remains usable when text scaling is increased.
+- **Linux integration is more complete.** The application has a proper desktop launcher identity and scalable icon, while the packaged audio path is designed to be self-contained.
+- **Repository trust boundaries are substantially stronger.** PR security scanning and repository-integrity checks cover more sensitive surfaces and commit history, while trusted reporting can explain findings on fork PRs without executing contributor code.
+- **CI dependencies were refreshed.** `actions/setup-java` and `actions/github-script` moved to their current major versions after successful build validation.
+
+## Linux / Flatpak status
+
+The GitHub Release still publishes the native Linux x64 archive:
+
+`Linthra-v0.2.4-linux-x64.tar.gz`
+
+Flatpak packaging is now present in the repository and suitable for local development/testing, but this release does **not** claim a Flathub publication yet.
+
+## Android and F-Droid
+
+Android remains a first-class target. The canonical Android version for this release is:
+
+- versionName: `0.2.4`
+- base versionCode: `204999`
+
+F-Droid's split-ABI scheme remains:
+
+- armeabi-v7a: `2049991`
+- arm64-v8a: `2049992`
+- x86_64: `2049993`
+
+GitHub APKs and F-Droid packages remain signed by different keys, so users should keep updating from the same install source they originally chose.
+
+## Upgrade notes
+
+No special user action is expected beyond a normal same-source update. Existing Android library/settings data remain in place during a normal update, and Linux users can replace the previous native archive with the new one.
+
+## Community
+
+Thank you to everyone testing Linthra, reporting issues, reviewing changes, and contributing fixes. This release includes community work around desktop accessibility and UI robustness alongside the Linux packaging and project-hardening work.

--- a/fastlane/metadata/android/en-US/changelogs/204999.txt
+++ b/fastlane/metadata/android/en-US/changelogs/204999.txt
@@ -1,0 +1,7 @@
+Linthra 0.2.4
+
+- Improves keyboard and assistive-technology support across playback and other controls.
+- Keeps the mini-player usable with larger text.
+- Hardens app shutdown so owned resources close cleanly.
+- Advances Linux/Flatpak packaging and desktop integration.
+- Includes repository-security and build-maintenance improvements.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.2.3';
+  static const String _devVersionName = '0.2.4';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/lib/features/settings/about/whats_new_section.dart
+++ b/lib/features/settings/about/whats_new_section.dart
@@ -20,10 +20,10 @@ class WhatsNewSection extends StatelessWidget {
   /// handful of concise bullets and updated when cutting a new build; exposed so
   /// the widget test can assert each line renders without duplicating the copy.
   static const List<String> releaseNotes = <String>[
-    'Linux Flatpak packaging has advanced with a self-contained audio runtime, launcher entry, and scalable icon.',
-    'Desktop shutdown now waits for app-owned resources to close cleanly instead of leaving teardown in flight.',
-    'Keyboard and assistive-technology support is improved across playback, queue, cast, and source controls.',
-    'The mini-player stays usable with larger text, and repository release/security safeguards are substantially stronger.',
+    'Linux playback now recovers more reliably from network/server drops and suspend/resume.',
+    'Linux can restore the previous queue and position safely after an unexpected restart, without autoplay.',
+    'Audiobookshelf connection, authentication, and library support has started with the first integration milestone.',
+    'Self-hosted server URLs, IPv6 handling, source re-sync performance, and desktop defaults are improved.',
   ];
 
   @override

--- a/lib/features/settings/about/whats_new_section.dart
+++ b/lib/features/settings/about/whats_new_section.dart
@@ -20,10 +20,10 @@ class WhatsNewSection extends StatelessWidget {
   /// handful of concise bullets and updated when cutting a new build; exposed so
   /// the widget test can assert each line renders without duplicating the copy.
   static const List<String> releaseNotes = <String>[
-    'Linux playback now recovers more reliably from network/server drops and suspend/resume.',
-    'Linux can restore the previous queue and position safely after an unexpected restart, without autoplay.',
-    'Audiobookshelf connection, authentication, and library support has started with the first integration milestone.',
-    'Self-hosted server URLs, IPv6 handling, source re-sync performance, and desktop defaults are improved.',
+    'Linux Flatpak packaging has advanced with a self-contained audio runtime, launcher entry, and scalable icon.',
+    'Desktop shutdown now waits for app-owned resources to close cleanly instead of leaving teardown in flight.',
+    'Keyboard and assistive-technology support is improved across playback, queue, cast, and source controls.',
+    'The mini-player stays usable with larger text, and repository release/security safeguards are substantially stronger.',
   ];
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   # Android Auto). Used only by LinthraAudioHandler in the services layer, which
   # forwards session commands to PlaybackController and mirrors its state out.
   # The UI never depends on audio_service directly.
+  audio_service: ^0.18.15
   # Audio-focus / interruption handling for the on-device engine. just_audio's
   # built-in handler auto-resumes playback on focus regain (the screen-wake /
   # app-switch "music starts by itself" bug), so JustAudioPlaybackController
@@ -55,7 +56,6 @@ dependencies:
   # real focus loss and never auto-resumes. Already a transitive dependency of
   # just_audio/audio_service; declared here because the services layer imports
   # it directly. The UI never depends on audio_session.
-  audio_service: ^0.18.15
   audio_session: ^0.1.25
   # Native folder chooser for selecting a music folder to scan. Used only by
   # FilePickerFolderPickerService; the UI depends on the FolderPickerService

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none"
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.2.3+203999
+version: 0.2.4+204999
 
 environment:
   sdk: ">=3.6.0 <4.0.0"
@@ -48,7 +48,6 @@ dependencies:
   # Android Auto). Used only by LinthraAudioHandler in the services layer, which
   # forwards session commands to PlaybackController and mirrors its state out.
   # The UI never depends on audio_service directly.
-  audio_service: ^0.18.15
   # Audio-focus / interruption handling for the on-device engine. just_audio's
   # built-in handler auto-resumes playback on focus regain (the screen-wake /
   # app-switch "music starts by itself" bug), so JustAudioPlaybackController
@@ -56,6 +55,7 @@ dependencies:
   # real focus loss and never auto-resumes. Already a transitive dependency of
   # just_audio/audio_service; declared here because the services layer imports
   # it directly. The UI never depends on audio_session.
+  audio_service: ^0.18.15
   audio_session: ^0.1.25
   # Native folder chooser for selecting a music folder to scan. Used only by
   # FilePickerFolderPickerService; the UI depends on the FolderPickerService


### PR DESCRIPTION
Prepare the stable Linthra v0.2.4 release from current `main`.

- bump `pubspec.yaml` to `0.2.4+204999`
- sync the in-app version to `0.2.4`
- add the Fastlane changelog for versionCode `204999`
- add public v0.2.4 release notes

The in-app Settings → About → What's new copy is intentionally handled in a separate non-release branch because release-bump CI restricts `release/*` branches to version/release metadata files.

This PR is release metadata/copy only. The runtime, Linux/Flatpak, accessibility, shutdown, security, and CI changes described in the notes are already merged on `main`.

After this PR and the What's new companion are green and merged, the stable GitHub Release/tag should be created as `v0.2.4` from the resulting `main` commit, following `docs/release-process.md`.