### PR TITLE
docs(about): refresh what's new for v0.2.4

### DIFF
--- a/lib/features/settings/about/whats_new_section.dart
+++ b/lib/features/settings/about/whats_new_section.dart
@@ -20,10 +20,10 @@ class WhatsNewSection extends StatelessWidget {
   /// handful of concise bullets and updated when cutting a new build; exposed so
   /// the widget test can assert each line renders without duplicating the copy.
   static const List<String> releaseNotes = <String>[
-    'Linux playback now recovers more reliably from network/server drops and suspend/resume.',
-    'Linux can restore the previous queue and position safely after an unexpected restart, without autoplay.',
-    'Audiobookshelf connection, authentication, and library support has started with the first integration milestone.',
-    'Self-hosted server URLs, IPv6 handling, source re-sync performance, and desktop defaults are improved.',
+    'Linux Flatpak packaging has advanced with a self-contained audio runtime, launcher entry, and scalable icon.',
+    'Desktop shutdown now waits for app-owned resources to close cleanly instead of leaving teardown in flight.',
+    'Keyboard and assistive-technology support is improved across playback, queue, cast, and source controls.',
+    'The mini-player stays usable with larger text, and repository release/security safeguards are substantially stronger.',
   ];
 
   @override


### PR DESCRIPTION
Refresh the in-app Settings → About → What's new copy for the changes already merged since v0.2.3.

This is intentionally separate from the `release/v0.2.4` version-bump PR because release branches are restricted to version/release metadata files.

No runtime behavior changes.