### PR TITLE
test: guard local audio format parity

### DIFF
--- a/lib/core/sources/local/audio_file_types.dart
+++ b/lib/core/sources/local/audio_file_types.dart
@@ -2,9 +2,10 @@ import 'package:path/path.dart' as p;
 
 /// The audio file extensions Linthra's local scanner recognizes.
 ///
-/// Kept small and centralized on purpose: supporting a new container format
-/// later is a one-line change here that the rest of the scanner picks up for
-/// free.
+/// This is the Dart catalog's source of truth. Android's SAF scanner mirrors
+/// these values for its filename fallback because Kotlin cannot import a Dart
+/// constant; `audio_format_parity_test.dart` compares the two definitions so
+/// future additions cannot silently drift across the platform boundary.
 abstract final class AudioFileTypes {
   /// Recognized extensions, lower-case and *without* the leading dot.
   static const Set<String> supportedExtensions = <String>{

--- a/test/core/sources/local/audio_format_parity_test.dart
+++ b/test/core/sources/local/audio_format_parity_test.dart
@@ -12,7 +12,8 @@ void main() {
     expect(
       scanner.existsSync(),
       isTrue,
-      reason: 'SafDocumentScanner.kt must remain available for the parity guard',
+      reason:
+          'SafDocumentScanner.kt must remain available for the parity guard',
     );
 
     final String source = scanner.readAsStringSync();
@@ -24,7 +25,8 @@ void main() {
     expect(
       declaration,
       isNotNull,
-      reason: 'The Android SAF extension fallback declaration must stay readable',
+      reason:
+          'The Android SAF extension fallback declaration must stay readable',
     );
 
     final List<String> androidRawExtensions = RegExp(r'"([^"]+)"')

--- a/test/core/sources/local/audio_format_parity_test.dart
+++ b/test/core/sources/local/audio_format_parity_test.dart
@@ -46,8 +46,8 @@ void main() {
       expect(
         extension,
         matches(RegExp(r'^\.[^.]+$')),
-        reason: 'Android SAF extensions must start with exactly one dot: '
-            '$extension',
+        reason:
+            'Android SAF extensions must start with exactly one dot: $extension',
       );
     }
 

--- a/test/core/sources/local/audio_format_parity_test.dart
+++ b/test/core/sources/local/audio_format_parity_test.dart
@@ -27,12 +27,32 @@ void main() {
       reason: 'The Android SAF extension fallback declaration must stay readable',
     );
 
-    // Kotlin matches dotted filename suffixes (".flac"), while Dart stores the
-    // same extensions without the dot. Compare the normalized sets so any
-    // addition, removal, spelling change, or duplicate fails CI.
-    final List<String> androidExtensions = RegExp(r'"(\.[^"]+)"')
+    final List<String> androidRawExtensions = RegExp(r'"([^"]+)"')
         .allMatches(declaration!.group(1)!)
-        .map((RegExpMatch match) => match.group(1)!.substring(1))
+        .map((RegExpMatch match) => match.group(1)!)
+        .toList(growable: false);
+
+    expect(
+      androidRawExtensions,
+      isNotEmpty,
+      reason: 'The Android SAF extension fallback must declare audio formats',
+    );
+
+    // Kotlin matches dotted filename suffixes (".flac"), while Dart stores the
+    // same extensions without the dot. Validate every Kotlin entry before
+    // normalizing so a malformed value such as "webm" cannot be silently
+    // skipped by the parity guard.
+    for (final String extension in androidRawExtensions) {
+      expect(
+        extension,
+        matches(RegExp(r'^\.[^.]+$')),
+        reason: 'Android SAF extensions must start with exactly one dot: '
+            '$extension',
+      );
+    }
+
+    final List<String> androidExtensions = androidRawExtensions
+        .map((String extension) => extension.substring(1))
         .toList(growable: false);
 
     expect(

--- a/test/core/sources/local/audio_format_parity_test.dart
+++ b/test/core/sources/local/audio_format_parity_test.dart
@@ -1,0 +1,49 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/local/audio_file_types.dart';
+
+void main() {
+  test('Android SAF filename fallback matches Dart local audio formats', () {
+    final File scanner = File(
+      'android/app/src/main/kotlin/io/github/thezupzup/linthra/'
+      'SafDocumentScanner.kt',
+    );
+    expect(
+      scanner.existsSync(),
+      isTrue,
+      reason: 'SafDocumentScanner.kt must remain available for the parity guard',
+    );
+
+    final String source = scanner.readAsStringSync();
+    final RegExpMatch? declaration = RegExp(
+      r'private val AUDIO_EXTENSIONS\s*=\s*listOf\(([^)]*)\)',
+      dotAll: true,
+    ).firstMatch(source);
+
+    expect(
+      declaration,
+      isNotNull,
+      reason: 'The Android SAF extension fallback declaration must stay readable',
+    );
+
+    // Kotlin matches dotted filename suffixes (".flac"), while Dart stores the
+    // same extensions without the dot. Compare the normalized sets so any
+    // addition, removal, spelling change, or duplicate fails CI.
+    final List<String> androidExtensions = RegExp(r'"(\.[^"]+)"')
+        .allMatches(declaration!.group(1)!)
+        .map((RegExpMatch match) => match.group(1)!.substring(1))
+        .toList(growable: false);
+
+    expect(
+      androidExtensions.toSet(),
+      hasLength(androidExtensions.length),
+      reason: 'The Android SAF extension fallback must not contain duplicates',
+    );
+    expect(
+      androidExtensions,
+      unorderedEquals(AudioFileTypes.supportedExtensions),
+      reason: 'Android SAF and Dart local-audio formats must stay in sync',
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #352.

- Treats `AudioFileTypes.supportedExtensions` as the Dart catalog source of truth.
- Adds a focused cross-language regression test that reads the Android SAF scanner's filename-extension fallback and compares it with the Dart set.
- Normalizes Kotlin's leading-dot representation before comparison.
- Fails on additions, removals, spelling drift, or duplicate Android entries.
- Does not add formats or change runtime scanning behavior.

This is a fresh maintainer-side follow-up after the earlier #509 attempt was closed by its author when the Android boundary hit the owner-approval security gate.

## Validation

CI should run the normal Flutter, Android, Linux, security, and repository-integrity checks on this branch.