### PR TITLE
fix(library): track real Jellyfin availability, not just configuration

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,6 +87,20 @@ lib/
 - **`MusicLibraryRepository`** (`core/repositories/`) — the local SQLite cache
   the UI reads from. Sources *sync into* it; the UI never talks to a source
   directly. This is what keeps the app fast and fully offline.
+- **Source availability layer** (`core/sources/source_availability.dart`,
+  `core/catalog/available_tracks.dart`) — separates *configured* from
+  *reachable*. A saved server session is not a promise that the server can be
+  reached: a LAN-only address is unreachable the moment the device leaves the
+  network. Each source carries a `SourceAvailability`
+  (`notConfigured` / `checking` / `available` / `unreachable` /
+  `authenticationError`), established by a cheap session probe on startup, on app
+  resume, on a background poll, and from what the playback path already
+  discovered. `selectAvailableTracks` then narrows the stored catalog to the
+  *active library* before de-duplication, so an unreachable server's streamed
+  tracks drop out of every browse surface at once — while its downloaded copies
+  stay playable and local music is untouched. It is a **view, never a removal**:
+  no catalog row, playlist, favourite, download, or session is touched, so the
+  full library returns on its own when the server answers again.
 - **Unified library layer** (`core/catalog/track_unifier.dart`) — a pure,
   display-time transform that collapses the per-provider rows the repository
   stores (*source tracks*) into one *logical track* per song, keeping every copy

--- a/lib/app/application_container.dart
+++ b/lib/app/application_container.dart
@@ -31,6 +31,7 @@ import '../features/player/cast/cast_providers.dart';
 import '../features/player/favorites_providers.dart';
 import '../features/player/lyrics_providers.dart';
 import '../features/player/player_providers.dart';
+import '../features/settings/jellyfin/jellyfin_availability_controller.dart';
 
 /// Production [ProviderContainer] overrides — the same list `main()` applies
 /// before bootstrap. Tests build their own override list and may include these
@@ -60,6 +61,7 @@ List<Override> productionApplicationOverrides({
     currentlyPlayingTrackOverride,
     nowPlayingOverride,
     secureJellyfinSessionStoreOverride,
+    jellyfinAvailabilityPollOverride,
     sharedPreferencesJellyfinAutoSyncStoreOverride,
     secureSubsonicSessionStoreOverride,
     sharedPreferencesSubsonicAutoSyncStoreOverride,

--- a/lib/app/linthra_app.dart
+++ b/lib/app/linthra_app.dart
@@ -18,6 +18,7 @@ import '../features/appearance/theme_mode_controller.dart';
 import '../features/library/remote_library_refresher.dart';
 import '../features/onboarding/onboarding_controller.dart';
 import '../features/player/player_providers.dart';
+import '../features/settings/jellyfin/jellyfin_availability_controller.dart';
 import '../features/support/support_actions_provider.dart';
 import '../features/support/supporter_entitlement.dart';
 import 'application_lifecycle.dart';
@@ -121,6 +122,11 @@ class _LinthraAppState extends ConsumerState<LinthraApp>
         controller.onAppResumed();
       }
       ref.read(remoteLibraryRefresherProvider).refresh();
+      // Re-probe the configured music server: coming back to the app is the
+      // moment a LAN server the user walked away from is most likely reachable
+      // again. Requirement of #536 — the library restores itself, with no
+      // reconnect and no rescan, because nothing was removed to begin with.
+      unawaited(ref.read(jellyfinAvailabilityProvider.notifier).refresh());
     }
     if (state == AppLifecycleState.detached) {
       // Desktop only. On Android `detached` also fires when the Activity is

--- a/lib/core/catalog/available_tracks.dart
+++ b/lib/core/catalog/available_tracks.dart
@@ -1,0 +1,61 @@
+import '../models/track.dart';
+import 'track_identity.dart';
+
+/// Narrows the stored catalog to the tracks that are actually usable right now,
+/// by holding back the rows that belong to a source Linthra currently cannot
+/// reach.
+///
+/// This is the *source-availability layer* the rest of the app filters at — one
+/// pure function over the catalog, applied once before de-duplication, so every
+/// browse surface (Songs, Albums, Artists, search, the detail screens, the
+/// playback-candidate map) agrees without any of them knowing what a "Jellyfin"
+/// is. It is deliberately not a UI concern: filtering in a widget would leave
+/// the grouping, search index, and fallback candidates disagreeing with what is
+/// on screen.
+///
+/// Three properties matter, and are what the tests pin down:
+///
+///  * **Nothing is deleted.** This returns a view. The repository still holds
+///    every row, and the moment [unavailableSourceIds] empties the full catalog
+///    is back — no re-sync, no re-scan, no reconnect.
+///  * **Local music is untouched.** Only the named sources are held back, so a
+///    device library stays complete while a server is away.
+///  * **A downloaded copy still counts.** A track from an unreachable source
+///    that has been made available offline plays fine without the server, so
+///    [isAvailableOffline] keeps it — hiding it would take away music the user
+///    downloaded precisely for this situation.
+///
+/// When [unavailableSourceIds] is empty the input list is returned as-is, so the
+/// everyday path costs nothing.
+List<Track> selectAvailableTracks(
+  List<Track> tracks, {
+  required Set<String> unavailableSourceIds,
+  required bool Function(Track track) isAvailableOffline,
+}) {
+  if (unavailableSourceIds.isEmpty) return tracks;
+  return <Track>[
+    for (final Track track in tracks)
+      if (!unavailableSourceIds.contains(trackSourceId(track)) ||
+          isAvailableOffline(track))
+        track,
+  ];
+}
+
+/// How many of [tracks] [selectAvailableTracks] would hold back — the count
+/// diagnostics reports so a bug report shows *why* a library looks short,
+/// instead of leaving the user to guess.
+int countUnavailableTracks(
+  List<Track> tracks, {
+  required Set<String> unavailableSourceIds,
+  required bool Function(Track track) isAvailableOffline,
+}) {
+  if (unavailableSourceIds.isEmpty) return 0;
+  int hidden = 0;
+  for (final Track track in tracks) {
+    if (unavailableSourceIds.contains(trackSourceId(track)) &&
+        !isAvailableOffline(track)) {
+      hidden++;
+    }
+  }
+  return hidden;
+}

--- a/lib/core/diagnostics/app_diagnostics.dart
+++ b/lib/core/diagnostics/app_diagnostics.dart
@@ -22,6 +22,7 @@ class AppDiagnosticsData {
     this.subsonicState,
     this.subsonicHost,
     this.libraryTrackCount,
+    this.unavailableTrackCount,
     this.localFolderSelected,
     this.localPersistedPermission,
     this.localScanFilesVisited,
@@ -60,8 +61,15 @@ class AppDiagnosticsData {
   /// otherwise — never a guess.
   final String? deviceModel;
 
-  /// The Jellyfin connection state label (e.g. `connected`), when Jellyfin has
-  /// been touched at all. Null when there is nothing to report.
+  /// The Jellyfin **availability** label — what the last probe actually found
+  /// (`connected`, `configured (unreachable)`, `configured (auth error)`,
+  /// `checking`, `disconnected`) — when Jellyfin has been touched at all. Null
+  /// when there is nothing to report.
+  ///
+  /// This is deliberately not "is a session saved?". A saved session for a
+  /// LAN-only address still reads `configured (unreachable)` from a coffee shop,
+  /// because reporting `connected` there is what sent bug reports chasing a
+  /// playback bug that was really a network one.
   final String? jellyfinState;
 
   /// The Jellyfin server address. Rendered host-only; never a full URL.
@@ -74,8 +82,17 @@ class AppDiagnosticsData {
   /// The Subsonic/Navidrome server address. Rendered host-only.
   final String? subsonicHost;
 
-  /// How many tracks are in the local catalog, when known.
+  /// How many tracks are in the local catalog, when known. Counts every stored
+  /// row, including those a currently-unreachable source has temporarily hidden —
+  /// nothing is deleted when a server goes away, so the stored count doesn't
+  /// change either.
   final int? libraryTrackCount;
+
+  /// How many of those stored tracks the active library is currently holding
+  /// back because their source is unreachable, when known. `0` in the ordinary
+  /// case. Reported so a "half my library vanished" report shows at a glance
+  /// that the tracks are hidden, not lost.
+  final int? unavailableTrackCount;
 
   /// Whether a local music folder is currently selected, when known. The folder
   /// path/URI itself is never carried — only its presence.
@@ -210,6 +227,9 @@ abstract final class AppDiagnostics {
       if (subsonicHost != null) 'Subsonic host: $subsonicHost',
       if (data.libraryTrackCount != null)
         'Library tracks: ${data.libraryTrackCount}',
+      if (data.unavailableTrackCount != null && data.unavailableTrackCount! > 0)
+        'Unavailable tracks (hidden, not deleted): '
+            '${data.unavailableTrackCount}',
       if (data.localFolderSelected != null)
         'Local folder: ${data.localFolderSelected! ? 'selected' : 'not selected'}',
       if (data.localPersistedPermission != null)

--- a/lib/core/services/reachability_aware_playable_uri_resolver.dart
+++ b/lib/core/services/reachability_aware_playable_uri_resolver.dart
@@ -43,10 +43,12 @@ class ReachabilityAwarePlayableUriResolver implements PlayableUriResolver {
     required String? Function() providerKey,
     required ProviderReachability reachability,
     ConnectivityService? connectivity,
+    void Function(ReachabilityStatus status)? onReachabilityObserved,
   })  : _inner = inner,
         _providerKey = providerKey,
         _reachability = reachability,
-        _connectivity = connectivity;
+        _connectivity = connectivity,
+        _onReachabilityObserved = onReachabilityObserved;
 
   final PlayableUriResolver _inner;
 
@@ -61,6 +63,29 @@ class ReachabilityAwarePlayableUriResolver implements PlayableUriResolver {
   /// connectivity backend is wired) the offline short-circuit is simply skipped
   /// and reachability is judged purely from probe outcomes.
   final ConnectivityService? _connectivity;
+
+  /// Optional observer told what each *live* attempt learned about the server,
+  /// so the app's source-availability state can follow the truth the playback
+  /// path already discovered instead of waiting out a background poll.
+  ///
+  /// Deliberately narrow: it is handed a [ReachabilityStatus] and nothing else —
+  /// no track, no catalog handle — so an observer can update a visibility flag
+  /// and cannot be grown into something that removes library rows off the back
+  /// of a per-track resolution error. Never fired for the remembered-outage
+  /// fast-fail (step 2), which teaches nothing new. Failures are swallowed: an
+  /// observer must never be able to break playback.
+  final void Function(ReachabilityStatus status)? _onReachabilityObserved;
+
+  void _observe(ReachabilityStatus status) {
+    final void Function(ReachabilityStatus)? observer = _onReachabilityObserved;
+    if (observer == null) return;
+    try {
+      observer(status);
+    } catch (_) {
+      // An observer is a listener, not a participant; its failure is not the
+      // player's problem.
+    }
+  }
 
   @override
   bool handles(Track track) => _inner.handles(track);
@@ -80,6 +105,7 @@ class ReachabilityAwarePlayableUriResolver implements PlayableUriResolver {
     //    returns this is false again, so a reconnect is never blocked by a stale
     //    "offline" the way a cached value would be.
     if (await _isOffline()) {
+      _observe(ReachabilityStatus.networkUnavailable);
       throw _failFast(ReachabilityStatus.networkUnavailable);
     }
 
@@ -97,11 +123,15 @@ class ReachabilityAwarePlayableUriResolver implements PlayableUriResolver {
     try {
       final ResolvedPlayable resolved = await _inner.resolve(track);
       _reachability.record(key, ReachabilityStatus.reachable);
+      _observe(ReachabilityStatus.reachable);
       return resolved;
     } on PlaybackResolutionException catch (error) {
       final ReachabilityStatus? status =
           reachabilityFromPlaybackError(error.kind);
-      if (status != null) _reachability.record(key, status);
+      if (status != null) {
+        _reachability.record(key, status);
+        _observe(status);
+      }
       rethrow;
     }
   }

--- a/lib/core/sources/jellyfin/jellyfin_availability.dart
+++ b/lib/core/sources/jellyfin/jellyfin_availability.dart
@@ -1,0 +1,29 @@
+import '../source_availability.dart';
+import 'jellyfin_exception.dart';
+
+/// Classifies a [JellyfinErrorKind] from a session probe into the
+/// [SourceAvailability] it implies for the whole Jellyfin source.
+///
+/// The exhaustive switch is deliberate: adding a [JellyfinErrorKind] becomes a
+/// compile error here rather than silently defaulting a new failure mode into
+/// "unreachable" (or worse, "available"). Only [JellyfinErrorKind.unauthorized]
+/// means the server was actually *reached*; everything else — a bad address, a
+/// dead tunnel, a 5xx, a proxy error page, an unparseable answer — is a server
+/// we could not usefully talk to, which for the library's purposes is the same
+/// thing as unreachable.
+SourceAvailability jellyfinAvailabilityFromError(JellyfinErrorKind kind) {
+  switch (kind) {
+    case JellyfinErrorKind.unauthorized:
+      return SourceAvailability.authenticationError;
+    case JellyfinErrorKind.invalidUrl:
+    case JellyfinErrorKind.notReachable:
+    case JellyfinErrorKind.notJellyfin:
+    case JellyfinErrorKind.serverError:
+    case JellyfinErrorKind.webPage:
+    case JellyfinErrorKind.notAudioStream:
+    case JellyfinErrorKind.streamUnavailable:
+    case JellyfinErrorKind.unsupportedResponse:
+    case JellyfinErrorKind.unexpected:
+      return SourceAvailability.unreachable;
+  }
+}

--- a/lib/core/sources/source_availability.dart
+++ b/lib/core/sources/source_availability.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/foundation.dart';
+
+import '../services/reachability.dart';
+
+/// Whether a music source is actually usable *right now*, as opposed to merely
+/// being configured.
+///
+/// Linthra used to conflate the two: a saved Jellyfin session meant "connected",
+/// forever, even when the server lived on a LAN address the device had long
+/// since left. That made diagnostics lie ("Jellyfin: connected" next to a
+/// playback error), and left the user with no way to get a usable library short
+/// of signing out — which throws away the catalog, playlists, favourites and
+/// downloads they want back the moment they're home again.
+///
+/// So configuration and availability are two separate facts. The session store
+/// answers "is a server configured?"; this answers "did it answer just now?".
+/// Only the *second* question gates what the active library shows, and nothing
+/// about it is destructive: an unavailable source is hidden, never forgotten.
+enum SourceAvailability {
+  /// No server is configured for this source, so there is nothing to reach.
+  /// Distinct from [unreachable]: nothing is hidden, because nothing was synced
+  /// under a connection the user still has.
+  notConfigured,
+
+  /// A server is configured and a probe is in flight; we do not know yet.
+  ///
+  /// Deliberately *optimistic* — see [hidesTracks]. A momentary "we haven't
+  /// checked yet" must never blank a library, so tracks stay visible until a
+  /// probe actually comes back negative.
+  checking,
+
+  /// The configured server answered and accepted the session.
+  available,
+
+  /// A server is configured, but it could not be reached (no network, a LAN-only
+  /// address from off the LAN, a down tunnel, a sleeping box, a 5xx, a timeout).
+  /// Its tracks are *temporarily* excluded from the active library; every record
+  /// — catalog rows, playlists, favourites, downloads, and the saved session —
+  /// is kept exactly as it was.
+  unreachable,
+
+  /// The server was reached but rejected the saved session. Its tracks are
+  /// excluded the same way, but the fix is signing in again, not moving closer
+  /// to the server — kept distinct so diagnostics and the UI can say so.
+  authenticationError,
+}
+
+/// Convenience predicates. Kept on the enum so every call site branches on the
+/// same rules rather than re-deriving them.
+extension SourceAvailabilityStatus on SourceAvailability {
+  /// A server is configured for this source, whatever its current reachability.
+  bool get isConfigured => this != SourceAvailability.notConfigured;
+
+  /// The server answered and accepted the session on the last probe.
+  bool get isAvailable => this == SourceAvailability.available;
+
+  /// A probe is in flight and nothing is known yet.
+  bool get isChecking => this == SourceAvailability.checking;
+
+  /// The server is configured but not usable right now.
+  bool get isUnavailable =>
+      this == SourceAvailability.unreachable ||
+      this == SourceAvailability.authenticationError;
+
+  /// Whether this source's streamed tracks should be held out of the active
+  /// library.
+  ///
+  /// Only a *proven* failure hides anything. [checking] and [notConfigured] both
+  /// return false, so the library is never blanked by a state that merely means
+  /// "we don't know" — under-hiding (a track that turns out not to play) is a far
+  /// smaller harm than a library that empties itself on a slow probe.
+  bool get hidesTracks => isUnavailable;
+}
+
+/// The current availability of one source, plus when it was last established.
+///
+/// A value type so it can be compared in tests and so a Riverpod rebuild only
+/// fires on a real change. It carries no session, token, address, or error text —
+/// only the state and a timestamp — so it is safe to surface in diagnostics.
+@immutable
+class SourceAvailabilityState {
+  const SourceAvailabilityState({
+    required this.status,
+    this.lastCheckedAt,
+  });
+
+  /// No server configured — the starting point for an untouched source.
+  const SourceAvailabilityState.notConfigured()
+      : status = SourceAvailability.notConfigured,
+        lastCheckedAt = null;
+
+  /// A server is configured and the first probe hasn't answered yet.
+  const SourceAvailabilityState.checking()
+      : status = SourceAvailability.checking,
+        lastCheckedAt = null;
+
+  final SourceAvailability status;
+
+  /// When the last probe completed, or `null` when none has. Used by the UI to
+  /// say how fresh the answer is; never a source of truth on its own.
+  final DateTime? lastCheckedAt;
+
+  bool get isAvailable => status.isAvailable;
+  bool get isUnavailable => status.isUnavailable;
+  bool get hidesTracks => status.hidesTracks;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is SourceAvailabilityState &&
+          other.status == status &&
+          other.lastCheckedAt == lastCheckedAt);
+
+  @override
+  int get hashCode => Object.hash(status, lastCheckedAt);
+
+  @override
+  String toString() => 'SourceAvailabilityState(${status.name})';
+}
+
+/// The secret-free label a diagnostics report uses for a source whose server is
+/// **configured**, so a bug report says what the last probe actually found.
+///
+/// Every non-available answer still says "configured", so nobody reads the line
+/// as "signed out" — the session, catalog, playlists and downloads are all still
+/// there. This is shared by the app-wide report and the per-source Jellyfin one
+/// so the two can never drift into telling a user different stories.
+String configuredSourceAvailabilityLabel(SourceAvailability availability) {
+  switch (availability) {
+    case SourceAvailability.available:
+      return 'connected';
+    case SourceAvailability.unreachable:
+      return 'configured (server unreachable)';
+    case SourceAvailability.authenticationError:
+      return 'configured (authentication error)';
+    case SourceAvailability.checking:
+      return 'configured (checking)';
+    case SourceAvailability.notConfigured:
+      // A saved session with no availability answer yet (nothing has probed in
+      // this container). Report it as configured-but-unverified rather than
+      // claiming a connection nothing has confirmed.
+      return 'configured (not checked)';
+  }
+}
+
+/// Translates a playback-path [ReachabilityStatus] into the availability it
+/// implies for the whole source.
+///
+/// This is the *non-destructive* bridge between "a track failed to resolve" and
+/// "this server is down": the only thing it can ever do is change a visibility
+/// flag. It never removes a catalog row, a download, or a session — which is
+/// exactly the coupling that made the old behaviour dangerous.
+///
+/// Returns `null` for a status that says nothing source-wide, so the caller
+/// leaves the current availability alone rather than guessing.
+SourceAvailability? availabilityFromReachability(ReachabilityStatus status) {
+  switch (status) {
+    case ReachabilityStatus.reachable:
+      return SourceAvailability.available;
+    case ReachabilityStatus.authFailure:
+      return SourceAvailability.authenticationError;
+    case ReachabilityStatus.serverUnreachable:
+    case ReachabilityStatus.timeout:
+    case ReachabilityStatus.networkUnavailable:
+      // No network at all is still "this server can't be reached"; the next
+      // probe (on reconnect, resume, or the poll) flips it straight back.
+      return SourceAvailability.unreachable;
+  }
+}

--- a/lib/features/library/source_availability_providers.dart
+++ b/lib/features/library/source_availability_providers.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/catalog/available_tracks.dart';
+import '../../core/models/track.dart';
+import '../../core/repositories/download_store.dart';
+import '../../core/sources/music_provider.dart';
+import '../../core/sources/source_availability.dart';
+import '../downloads/download_providers.dart';
+import '../settings/jellyfin/jellyfin_availability_controller.dart';
+import 'library_controller.dart';
+
+/// Live availability per source id — the honest answer to "can Linthra reach
+/// this right now?", as opposed to "is it configured?".
+///
+/// Only Jellyfin reports a real probe today (the source this addresses); the
+/// on-device library is always available, and the other servers keep their
+/// previous behaviour until they adopt the same probe. Every source that is not
+/// listed is treated as available, so adding one is opt-in and can never
+/// accidentally hide a library.
+final sourceAvailabilityProvider =
+    Provider<Map<String, SourceAvailability>>((ref) {
+  return <String, SourceAvailability>{
+    MusicProviders.jellyfin.sourceId: ref.watch(jellyfinAvailabilityProvider).status,
+  };
+});
+
+/// The source ids whose streamed tracks are currently held out of the active
+/// library. Empty in the ordinary case, which makes the filter below a no-op.
+final unavailableSourceIdsProvider = Provider<Set<String>>((ref) {
+  final Map<String, SourceAvailability> availability =
+      ref.watch(sourceAvailabilityProvider);
+  return <String>{
+    for (final MapEntry<String, SourceAvailability> entry in availability.entries)
+      if (entry.value.hidesTracks) entry.key,
+  };
+});
+
+/// A predicate for "this track plays without its server", derived from the live
+/// offline-cache set. Keyed provider-aware so a downloaded `jellyfin:101` never
+/// makes a different provider's `101` look downloaded.
+final _offlineAvailabilityProvider =
+    Provider<bool Function(Track track)>((ref) {
+  final Set<String> keys = ref.watch(offlineAvailableTrackKeysProvider);
+  if (keys.isEmpty) return (Track _) => false;
+  return (Track track) => keys.contains(CachedTrack.cacheKeyForTrack(track));
+});
+
+/// The **active library**: every stored track except those belonging to a source
+/// that is currently unreachable and that has no offline copy.
+///
+/// This is the single seam between "what the catalog holds" and "what the app
+/// shows and plays". It sits above the repository and below de-duplication, so:
+///
+///  * the repository keeps every row, every playlist, every favourite and every
+///    download — an unreachable server hides its music, it never loses it;
+///  * grouping, search and the playback-candidate map all see the same set, so
+///    an Album can't list a track the Songs tab hides;
+///  * the moment the server answers again the full catalog is back, with no
+///    reconnect and no rescan, because nothing was ever removed to restore.
+final activeLibraryTracksProvider = Provider<List<Track>>((ref) {
+  final List<Track> tracks = ref.watch(libraryControllerProvider).tracks;
+  final Set<String> unavailable = ref.watch(unavailableSourceIdsProvider);
+  if (unavailable.isEmpty) return tracks;
+  return selectAvailableTracks(
+    tracks,
+    unavailableSourceIds: unavailable,
+    isAvailableOffline: ref.watch(_offlineAvailabilityProvider),
+  );
+});
+
+/// How many stored tracks the active library is currently holding back. Zero in
+/// the ordinary case; reported in diagnostics so a short library explains itself.
+final unavailableTrackCountProvider = Provider<int>((ref) {
+  final Set<String> unavailable = ref.watch(unavailableSourceIdsProvider);
+  if (unavailable.isEmpty) return 0;
+  return countUnavailableTracks(
+    ref.watch(libraryControllerProvider).tracks,
+    unavailableSourceIds: unavailable,
+    isAvailableOffline: ref.watch(_offlineAvailabilityProvider),
+  );
+});

--- a/lib/features/library/source_availability_providers.dart
+++ b/lib/features/library/source_availability_providers.dart
@@ -20,7 +20,8 @@ import 'library_controller.dart';
 final sourceAvailabilityProvider =
     Provider<Map<String, SourceAvailability>>((ref) {
   return <String, SourceAvailability>{
-    MusicProviders.jellyfin.sourceId: ref.watch(jellyfinAvailabilityProvider).status,
+    MusicProviders.jellyfin.sourceId:
+        ref.watch(jellyfinAvailabilityProvider).status,
   };
 });
 
@@ -30,7 +31,8 @@ final unavailableSourceIdsProvider = Provider<Set<String>>((ref) {
   final Map<String, SourceAvailability> availability =
       ref.watch(sourceAvailabilityProvider);
   return <String>{
-    for (final MapEntry<String, SourceAvailability> entry in availability.entries)
+    for (final MapEntry<String, SourceAvailability> entry
+        in availability.entries)
       if (entry.value.hidesTracks) entry.key,
   };
 });

--- a/lib/features/library/unified_library_providers.dart
+++ b/lib/features/library/unified_library_providers.dart
@@ -3,18 +3,24 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/catalog/logical_track.dart';
 import '../../core/catalog/track_unifier.dart';
 import '../../core/models/track.dart';
-import 'library_controller.dart';
+import 'source_availability_providers.dart';
 import 'source_preference_controller.dart';
 
 /// The library as unified [LogicalTrack]s: one item per song, with every
 /// provider copy retained as an ordered playback candidate.
 ///
 /// This is the single place display-level de-duplication happens. It recomputes
-/// whenever the catalog reloads (scan, sync, removal) or the source preference
-/// changes, so every browse surface that reads it stays consistent. The
-/// repository still stores all per-provider rows untouched — nothing is deleted.
+/// whenever the catalog reloads (scan, sync, removal), the source preference
+/// changes, or a source's reachability changes, so every browse surface that
+/// reads it stays consistent. The repository still stores all per-provider rows
+/// untouched — nothing is deleted.
+///
+/// It unifies the **active** library ([activeLibraryTracksProvider]) rather than
+/// the raw catalog, so a temporarily unreachable server's copies drop out of
+/// candidate lists too: a song that also exists locally keeps playing from the
+/// local copy instead of resolving to a server that isn't there.
 final libraryLogicalTracksProvider = Provider<List<LogicalTrack>>((ref) {
-  final List<Track> tracks = ref.watch(libraryControllerProvider).tracks;
+  final List<Track> tracks = ref.watch(activeLibraryTracksProvider);
   final priority = ref.watch(librarySourcePriorityProvider);
   return unifyTracks(tracks, priority);
 });

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -18,6 +18,7 @@ import '../../core/services/playback_candidate_source.dart';
 import '../../core/services/playback_controller.dart';
 import '../../core/services/playback_reporting_service.dart';
 import '../../core/services/provider_reachability.dart';
+import '../../core/services/reachability.dart';
 import '../../core/services/reachability_aware_playable_uri_resolver.dart';
 import '../../core/services/remote_cache/remote_cache_resolver.dart';
 import '../../core/services/remote_cache/remote_playback_cache.dart';
@@ -45,6 +46,7 @@ import '../../data/repositories/download_repository_provider.dart';
 import '../../data/repositories/host_platform_provider.dart';
 import '../../data/repositories/play_history_repository_provider.dart';
 import '../../data/repositories/remote_cache_index_provider.dart';
+import '../settings/jellyfin/jellyfin_availability_controller.dart';
 import '../settings/jellyfin/jellyfin_settings_controller.dart';
 import '../settings/jellyfin/jellyfin_settings_providers.dart';
 import '../settings/plex/plex_settings_controller.dart';
@@ -97,13 +99,15 @@ final providerReachabilityProvider = Provider<ProviderReachability>((ref) {
 final remoteSourceRouterProvider = Provider<RoutingPlayableUriResolver>((ref) {
   PlayableUriResolver reachabilityAware(
     PlayableUriResolver inner,
-    String? Function() providerKey,
-  ) {
+    String? Function() providerKey, {
+    void Function(ReachabilityStatus status)? onReachabilityObserved,
+  }) {
     return ReachabilityAwarePlayableUriResolver(
       inner: inner,
       providerKey: providerKey,
       reachability: ref.read(providerReachabilityProvider),
       connectivity: ref.read(connectivityServiceProvider),
+      onReachabilityObserved: onReachabilityObserved,
     );
   }
 
@@ -116,6 +120,15 @@ final remoteSourceRouterProvider = Provider<RoutingPlayableUriResolver>((ref) {
             ? null
             : 'jellyfin:${jellyfinAccountFingerprint(source.session)}';
       },
+      // Let the library learn from what the player just found out: the first
+      // track that can't reach the server flips Jellyfin to unreachable (and the
+      // first that succeeds flips it back) without waiting for the background
+      // poll. Purely a visibility signal — see
+      // [JellyfinAvailabilityController.noteReachability]; no catalog row,
+      // download, playlist or session is touched by it.
+      onReachabilityObserved: (ReachabilityStatus status) => ref
+          .read(jellyfinAvailabilityProvider.notifier)
+          .noteReachability(status),
     ),
     reachabilityAware(
       SubsonicPlayableUriResolver(() => ref.read(subsonicMusicSourceProvider)),

--- a/lib/features/settings/diagnostics/diagnostics_collector.dart
+++ b/lib/features/settings/diagnostics/diagnostics_collector.dart
@@ -15,12 +15,15 @@ import '../../../core/sources/local/audio_file_types.dart';
 import '../../../core/sources/local/folder_location.dart';
 import '../../../core/sources/local/local_scan_diagnostics.dart';
 import '../../../core/sources/local/local_scan_report.dart';
+import '../../../core/sources/source_availability.dart';
 import '../../../data/repositories/music_library_repository_provider.dart';
 import '../../../data/repositories/selected_music_folder_repository_provider.dart';
 import '../../downloads/download_providers.dart';
 import '../../library/library_providers.dart';
+import '../../library/source_availability_providers.dart';
 import '../../player/cast/cast_providers.dart';
 import '../../player/player_providers.dart';
+import '../jellyfin/jellyfin_availability_controller.dart';
 import '../jellyfin/jellyfin_settings_controller.dart';
 import '../jellyfin/jellyfin_settings_state.dart';
 import '../subsonic/subsonic_settings_controller.dart';
@@ -74,11 +77,15 @@ class DiagnosticsCollector {
       // No device-model plugin is bundled, so this stays null rather than a
       // guess; the report omits the line entirely when absent.
       deviceModel: null,
-      jellyfinState: _jellyfinStateLabel(jellyfin.phase),
+      jellyfinState: _jellyfinStateLabel(
+        jellyfin.phase,
+        _ref.read(jellyfinAvailabilityProvider).status,
+      ),
       jellyfinHost: jellyfin.baseUrl,
       subsonicState: _subsonicStateLabel(subsonic),
       subsonicHost: subsonic.baseUrl,
       libraryTrackCount: await _libraryTrackCount(),
+      unavailableTrackCount: _unavailableTrackCount(),
       localFolderSelected: folderSelected,
       localPersistedPermission: persistedPermission,
       localScanFilesVisited: scan?.filesVisited,
@@ -130,10 +137,21 @@ class DiagnosticsCollector {
 
   bool _androidAutoSupported() => Platform.isAndroid;
 
-  String _jellyfinStateLabel(JellyfinConnectionPhase phase) {
+  /// The Jellyfin line, reporting **reachability**, not just configuration.
+  ///
+  /// The old version returned `connected` for any saved session, which is how a
+  /// report could read "Jellyfin: connected" beside "Playback state: error" for a
+  /// LAN-only server the phone was nowhere near. A configured session now only
+  /// says `connected` when a probe actually reached the server and it accepted
+  /// the session; otherwise the line names what is really wrong, and says the
+  /// connection is still *configured* so nobody reads it as "signed out".
+  String _jellyfinStateLabel(
+    JellyfinConnectionPhase phase,
+    SourceAvailability availability,
+  ) {
     switch (phase) {
       case JellyfinConnectionPhase.connected:
-        return 'connected';
+        return configuredSourceAvailabilityLabel(availability);
       case JellyfinConnectionPhase.tested:
         return 'tested (not signed in)';
       case JellyfinConnectionPhase.testing:
@@ -162,6 +180,16 @@ class DiagnosticsCollector {
         return 'signing in';
       case SubsonicConnectionPhase.disconnected:
         return 'disconnected';
+    }
+  }
+
+  /// How many stored tracks are currently hidden because their source is
+  /// unreachable. Best-effort: never let it break the report.
+  int? _unavailableTrackCount() {
+    try {
+      return _ref.read(unavailableTrackCountProvider);
+    } catch (_) {
+      return null;
     }
   }
 

--- a/lib/features/settings/jellyfin/jellyfin_availability_controller.dart
+++ b/lib/features/settings/jellyfin/jellyfin_availability_controller.dart
@@ -82,7 +82,8 @@ class JellyfinAvailabilityController extends Notifier<SourceAvailabilityState> {
       return const SourceAvailabilityState.notConfigured();
     }
 
-    final Duration? interval = ref.read(jellyfinAvailabilityPollIntervalProvider);
+    final Duration? interval =
+        ref.read(jellyfinAvailabilityPollIntervalProvider);
     if (interval != null && interval > Duration.zero) {
       _poll = Timer.periodic(interval, (_) => unawaited(refresh()));
     }

--- a/lib/features/settings/jellyfin/jellyfin_availability_controller.dart
+++ b/lib/features/settings/jellyfin/jellyfin_availability_controller.dart
@@ -1,0 +1,166 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/models/jellyfin_session.dart';
+import '../../../core/services/reachability.dart';
+import '../../../core/sources/jellyfin/jellyfin_availability.dart';
+import '../../../core/sources/jellyfin/jellyfin_exception.dart';
+import '../../../core/sources/source_availability.dart';
+import 'jellyfin_settings_controller.dart';
+import 'jellyfin_settings_providers.dart';
+
+/// How often a *configured* Jellyfin server is re-probed in the background, or
+/// `null` for no polling at all.
+///
+/// Defaults to **no polling**, so a bare container (every widget and unit test)
+/// never carries a live timer and probes only when something asks. The running
+/// app applies [jellyfinAvailabilityPollOverride] — the same pattern the other
+/// production-only bindings use — to switch it on.
+final jellyfinAvailabilityPollIntervalProvider =
+    Provider<Duration?>((ref) => null);
+
+/// Production binding: re-probe a configured server periodically.
+///
+/// Short enough that walking back onto the home network restores the library on
+/// its own, with no reconnect and no rescan, and long enough that an absent
+/// server costs one cheap, already-authenticated request a minute rather than a
+/// battery drain. App resume and the playback path cover the rest, so this is a
+/// backstop, not the primary signal.
+final jellyfinAvailabilityPollOverride =
+    jellyfinAvailabilityPollIntervalProvider.overrideWithValue(
+  const Duration(seconds: 45),
+);
+
+/// Tracks whether the configured Jellyfin server can actually be reached,
+/// separately from whether one is configured at all.
+///
+/// The settings controller answers "is a session saved?" and must keep saying
+/// yes while the user is away from the server — that saved session, the synced
+/// catalog, the imported playlists, the favourites, and the downloads are
+/// exactly what the user wants back when they get home. This notifier answers
+/// the *other* question, "did the server answer just now?", and is the only
+/// thing the active library and the diagnostics report gate on.
+///
+/// It probes with [JellyfinClient.verifySession] — the same cheap,
+/// already-authenticated call the playback path uses — so a probe distinguishes
+/// "can't be reached" from "session rejected" without fetching a library.
+///
+/// Nothing it does is destructive. Its whole output is one enum; no catalog row,
+/// playlist, favourite, download, or saved session is touched by any transition
+/// it can make.
+class JellyfinAvailabilityController extends Notifier<SourceAvailabilityState> {
+  Timer? _poll;
+  bool _disposed = false;
+
+  /// Guards against a slow probe from a previous session/server landing on top
+  /// of a newer answer. Every probe takes a ticket; only the newest one may
+  /// write. Kept across `build()` re-runs (Riverpod reuses the notifier), which
+  /// is precisely what makes a sign-out cancel an in-flight probe's result.
+  int _generation = 0;
+
+  @override
+  SourceAvailabilityState build() {
+    _disposed = false;
+    // Re-runs whenever a session appears or disappears (sign-in, sign-out, a
+    // restored session at startup), which is exactly when availability has to be
+    // established from scratch.
+    final bool configured = ref.watch(
+      jellyfinSettingsControllerProvider.select((s) => s.isConnected),
+    );
+    _poll?.cancel();
+    _poll = null;
+    ref.onDispose(() {
+      _disposed = true;
+      _poll?.cancel();
+      _poll = null;
+    });
+
+    if (!configured) {
+      // Nothing configured: no probe, no timer, and nothing hidden.
+      _generation++;
+      return const SourceAvailabilityState.notConfigured();
+    }
+
+    final Duration? interval = ref.read(jellyfinAvailabilityPollIntervalProvider);
+    if (interval != null && interval > Duration.zero) {
+      _poll = Timer.periodic(interval, (_) => unawaited(refresh()));
+    }
+    // Probe off the build so the notifier never writes state while building.
+    // Until it lands the state is `checking`, which hides nothing (see
+    // [SourceAvailability.hidesTracks]) — a library must not blink out while we
+    // are still asking.
+    scheduleMicrotask(() {
+      if (!_disposed) unawaited(refresh());
+    });
+    return const SourceAvailabilityState.checking();
+  }
+
+  /// Re-probes the configured server now. Safe to call from anywhere and at any
+  /// rate: it never throws, and a stale answer can't overwrite a newer one.
+  ///
+  /// Called on app resume, on a network change, and by the background poll — the
+  /// three moments a server realistically comes back.
+  Future<void> refresh() async {
+    final int generation = ++_generation;
+    final JellyfinSession? session =
+        ref.read(jellyfinSettingsControllerProvider.notifier).session;
+    if (session == null) {
+      _apply(generation, SourceAvailability.notConfigured);
+      return;
+    }
+    _apply(generation, await _probe(session));
+  }
+
+  /// Adopts what the *playback* path just learned about the server, so the first
+  /// track that fails to resolve updates availability immediately instead of the
+  /// library waiting out a poll interval.
+  ///
+  /// This is the deliberately narrow bridge between a resolution error and the
+  /// library: it can only ever move this enum. It cannot — and must not grow to —
+  /// delete a track, a download, or the session, which is the coupling that made
+  /// the old "remove the connection to get a usable library" workaround the only
+  /// option. Ignored while no server is configured.
+  void noteReachability(ReachabilityStatus status) {
+    if (_disposed || !state.status.isConfigured) return;
+    final SourceAvailability? availability =
+        availabilityFromReachability(status);
+    if (availability == null) return;
+    _apply(++_generation, availability);
+  }
+
+  Future<SourceAvailability> _probe(JellyfinSession session) async {
+    try {
+      await ref.read(jellyfinClientProvider).verifySession(session);
+      return SourceAvailability.available;
+    } on JellyfinException catch (error) {
+      return jellyfinAvailabilityFromError(error.kind);
+    } catch (_) {
+      // A transport fault the client didn't wrap. Treat it as "couldn't reach
+      // the server" rather than letting it escape into the UI — and never as
+      // available, which would leave unplayable tracks on screen.
+      return SourceAvailability.unreachable;
+    }
+  }
+
+  /// Writes [availability] when [generation] is still the newest probe and the
+  /// notifier is alive. `notConfigured` clears the timestamp so a later
+  /// "last checked" reading can't be attributed to a server that is gone.
+  void _apply(int generation, SourceAvailability availability) {
+    if (_disposed || generation != _generation) return;
+    state = availability == SourceAvailability.notConfigured
+        ? const SourceAvailabilityState.notConfigured()
+        : SourceAvailabilityState(
+            status: availability,
+            lastCheckedAt: DateTime.now(),
+          );
+  }
+}
+
+/// The live Jellyfin availability. Watched by the active library (to hold back
+/// unreachable tracks) and by diagnostics (to report the truth instead of
+/// "configured").
+final jellyfinAvailabilityProvider =
+    NotifierProvider<JellyfinAvailabilityController, SourceAvailabilityState>(
+  JellyfinAvailabilityController.new,
+);

--- a/lib/features/settings/jellyfin/jellyfin_settings_controller.dart
+++ b/lib/features/settings/jellyfin/jellyfin_settings_controller.dart
@@ -13,6 +13,7 @@ import '../../../core/sources/jellyfin/jellyfin_music_source.dart';
 import '../../../core/sources/jellyfin/jellyfin_server_capabilities.dart';
 import '../../../core/sources/jellyfin/jellyfin_track_mapper.dart';
 import '../../../core/sources/music_provider.dart';
+import '../../../core/sources/source_availability.dart';
 import '../../../data/repositories/favorites_repository_provider.dart';
 import '../../../data/repositories/jellyfin_session_store_provider.dart';
 import '../../../data/repositories/playlist_repository_provider.dart';
@@ -261,11 +262,18 @@ class JellyfinSettingsController extends Notifier<JellyfinSettingsState> {
   /// A secret-free diagnostics report for the "Copy Jellyfin diagnostics"
   /// action, assembled from display-safe state only — never the token,
   /// password, or a full authenticated URL (the address is reduced to its host).
-  String diagnosticsReport() {
+  ///
+  /// [availability] is the live result of the last reachability probe, passed in
+  /// by the caller (the settings section) rather than read here, so this
+  /// controller keeps no dependency on the availability notifier that watches
+  /// it. When it is supplied, a configured connection reports what the server
+  /// actually answered instead of a flat "connected" — the whole point of
+  /// separating *configured* from *reachable*.
+  String diagnosticsReport({SourceAvailability? availability}) {
     final String? version = state.serverVersion;
     return JellyfinDiagnostics.describe(
       appVersion: AppInfo.version,
-      connectionState: _connectionStateLabel(),
+      connectionState: _connectionStateLabel(availability),
       serverHost: JellyfinDiagnostics.hostOnly(state.baseUrl),
       serverName: state.serverName,
       serverVersion: version,
@@ -276,10 +284,12 @@ class JellyfinSettingsController extends Notifier<JellyfinSettingsState> {
     );
   }
 
-  String _connectionStateLabel() {
+  String _connectionStateLabel(SourceAvailability? availability) {
     switch (state.phase) {
       case JellyfinConnectionPhase.connected:
-        return 'connected';
+        return availability == null
+            ? 'connected'
+            : configuredSourceAvailabilityLabel(availability);
       case JellyfinConnectionPhase.tested:
         return 'tested (not signed in)';
       case JellyfinConnectionPhase.testing:

--- a/lib/features/settings/jellyfin/jellyfin_settings_section.dart
+++ b/lib/features/settings/jellyfin/jellyfin_settings_section.dart
@@ -100,13 +100,12 @@ class _JellyfinSettingsSectionState
   /// paste it into a bug report. The report is assembled by the controller and,
   /// by construction, carries no token, password, or full authenticated URL.
   Future<void> _copyDiagnostics() async {
-    final String report = ref
-        .read(jellyfinSettingsControllerProvider.notifier)
-        .diagnosticsReport(
-          // The live probe result, so a saved session for a server the device
-          // can't currently reach reports that instead of "connected".
-          availability: ref.read(jellyfinAvailabilityProvider).status,
-        );
+    final String report =
+        ref.read(jellyfinSettingsControllerProvider.notifier).diagnosticsReport(
+              // The live probe result, so a saved session for a server the device
+              // can't currently reach reports that instead of "connected".
+              availability: ref.read(jellyfinAvailabilityProvider).status,
+            );
     await Clipboard.setData(ClipboardData(text: report));
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/settings/jellyfin/jellyfin_settings_section.dart
+++ b/lib/features/settings/jellyfin/jellyfin_settings_section.dart
@@ -4,7 +4,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../app/dimens.dart';
 import '../../../core/sources/jellyfin/jellyfin_server_capabilities.dart';
+import '../../../core/sources/source_availability.dart';
 import '../../library/remote_library_refresher.dart';
+import 'jellyfin_availability_controller.dart';
 import 'jellyfin_settings_controller.dart';
 import 'jellyfin_settings_state.dart';
 import 'jellyfin_sync_controller.dart';
@@ -100,7 +102,11 @@ class _JellyfinSettingsSectionState
   Future<void> _copyDiagnostics() async {
     final String report = ref
         .read(jellyfinSettingsControllerProvider.notifier)
-        .diagnosticsReport();
+        .diagnosticsReport(
+          // The live probe result, so a saved session for a server the device
+          // can't currently reach reports that instead of "connected".
+          availability: ref.read(jellyfinAvailabilityProvider).status,
+        );
     await Clipboard.setData(ClipboardData(text: report));
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
@@ -108,6 +114,31 @@ class _JellyfinSettingsSectionState
         content: Text('Jellyfin diagnostics copied (no password or token).'),
       ),
     );
+  }
+
+  /// The line explaining that a *configured* server can't be reached right now,
+  /// or `null` when there's nothing to explain.
+  ///
+  /// This is what closes the loop for the user in #536: without it, Jellyfin
+  /// tracks quietly leaving the library would look like data loss. It says
+  /// plainly that nothing was deleted and that the music comes back on its own,
+  /// so nobody reaches for "sign out" to get a usable library again.
+  static String? _availabilityNotice(SourceAvailability availability) {
+    switch (availability) {
+      case SourceAvailability.unreachable:
+        return "Your Jellyfin server can't be reached right now, so its tracks "
+            'are hidden from your library. Nothing was deleted — they come back '
+            'automatically when the server is reachable again. Downloaded '
+            'tracks stay playable.';
+      case SourceAvailability.authenticationError:
+        return 'Your Jellyfin server rejected this sign-in, so its tracks are '
+            'hidden from your library. Nothing was deleted — sign in again to '
+            'restore them. Downloaded tracks stay playable.';
+      case SourceAvailability.available:
+      case SourceAvailability.checking:
+      case SourceAvailability.notConfigured:
+        return null;
+    }
   }
 
   /// Show the diagnostics action once there's something worth reporting: a live
@@ -123,6 +154,10 @@ class _JellyfinSettingsSectionState
         ref.watch(jellyfinSettingsControllerProvider);
     final JellyfinSyncState syncState =
         ref.watch(jellyfinSyncControllerProvider);
+    // Why the library looks short right now. Only shown for a *proven* failure,
+    // so a connection that is merely being re-checked says nothing.
+    final String? availabilityNotice =
+        _availabilityNotice(ref.watch(jellyfinAvailabilityProvider).status);
     final ThemeData theme = Theme.of(context);
 
     return Card(
@@ -157,6 +192,10 @@ class _JellyfinSettingsSectionState
               )
             else
               _buildForm(theme, state),
+            if (state.isConnected && availabilityNotice != null) ...[
+              const SizedBox(height: AppSpacing.md),
+              _StatusLine(message: availabilityNotice, isError: true),
+            ],
             if (state.errorMessage != null) ...[
               const SizedBox(height: AppSpacing.md),
               _StatusLine(message: state.errorMessage!, isError: true),

--- a/test/core/catalog/available_tracks_test.dart
+++ b/test/core/catalog/available_tracks_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/catalog/available_tracks.dart';
+import 'package:linthra/core/models/track.dart';
+
+Track _track(String uri, {String title = 'Hello'}) => Track(
+      id: uri.split(':').last,
+      title: title,
+      uri: uri,
+      artistName: 'Adele',
+      albumName: '25',
+      duration: const Duration(minutes: 3),
+    );
+
+List<String> _uris(List<Track> tracks) =>
+    <String>[for (final Track t in tracks) t.uri];
+
+bool _never(Track _) => false;
+
+void main() {
+  final Track jellyOne = _track('jellyfin:1');
+  final Track jellyTwo = _track('jellyfin:2', title: 'Someone Like You');
+  final Track localOne = _track('file:///music/a.mp3', title: 'Hello');
+  final Track subsonicOne = _track('subsonic:9', title: 'Rolling');
+  final List<Track> catalog = <Track>[
+    jellyOne,
+    localOne,
+    jellyTwo,
+    subsonicOne,
+  ];
+
+  group('selectAvailableTracks', () {
+    test('returns the catalog untouched when everything is reachable', () {
+      final List<Track> result = selectAvailableTracks(
+        catalog,
+        unavailableSourceIds: const <String>{},
+        isAvailableOffline: _never,
+      );
+      expect(identical(result, catalog), isTrue,
+          reason: 'the common path should not copy the catalog');
+    });
+
+    test('holds back only the unreachable source, keeping local music', () {
+      final List<Track> result = selectAvailableTracks(
+        catalog,
+        unavailableSourceIds: const <String>{'jellyfin'},
+        isAvailableOffline: _never,
+      );
+      expect(_uris(result), <String>['file:///music/a.mp3', 'subsonic:9']);
+    });
+
+    test('keeps an unreachable source track that is available offline', () {
+      // Downloaded precisely for this situation: hiding it would take away
+      // music that plays perfectly well without the server.
+      final List<Track> result = selectAvailableTracks(
+        catalog,
+        unavailableSourceIds: const <String>{'jellyfin'},
+        isAvailableOffline: (Track t) => t.uri == 'jellyfin:2',
+      );
+      expect(
+        _uris(result),
+        <String>['file:///music/a.mp3', 'jellyfin:2', 'subsonic:9'],
+      );
+    });
+
+    test('never mutates the catalog it filters', () {
+      final List<Track> input = <Track>[...catalog];
+      selectAvailableTracks(
+        input,
+        unavailableSourceIds: const <String>{'jellyfin'},
+        isAvailableOffline: _never,
+      );
+      expect(_uris(input), _uris(catalog),
+          reason: 'filtering is a view, never a removal');
+    });
+
+    test('restores the full catalog the moment the source is reachable', () {
+      final List<Track> hidden = selectAvailableTracks(
+        catalog,
+        unavailableSourceIds: const <String>{'jellyfin'},
+        isAvailableOffline: _never,
+      );
+      expect(hidden, hasLength(2));
+      final List<Track> restored = selectAvailableTracks(
+        catalog,
+        unavailableSourceIds: const <String>{},
+        isAvailableOffline: _never,
+      );
+      expect(_uris(restored), _uris(catalog));
+    });
+
+    test('can hold back more than one source at once', () {
+      final List<Track> result = selectAvailableTracks(
+        catalog,
+        unavailableSourceIds: const <String>{'jellyfin', 'subsonic'},
+        isAvailableOffline: _never,
+      );
+      expect(_uris(result), <String>['file:///music/a.mp3']);
+    });
+  });
+
+  group('countUnavailableTracks', () {
+    test('is zero when nothing is held back', () {
+      expect(
+        countUnavailableTracks(
+          catalog,
+          unavailableSourceIds: const <String>{},
+          isAvailableOffline: _never,
+        ),
+        0,
+      );
+    });
+
+    test('counts the hidden rows, excluding offline-available ones', () {
+      expect(
+        countUnavailableTracks(
+          catalog,
+          unavailableSourceIds: const <String>{'jellyfin'},
+          isAvailableOffline: _never,
+        ),
+        2,
+      );
+      expect(
+        countUnavailableTracks(
+          catalog,
+          unavailableSourceIds: const <String>{'jellyfin'},
+          isAvailableOffline: (Track t) => t.uri == 'jellyfin:2',
+        ),
+        1,
+      );
+    });
+  });
+}

--- a/test/core/services/reachability_aware_playable_uri_resolver_test.dart
+++ b/test/core/services/reachability_aware_playable_uri_resolver_test.dart
@@ -55,12 +55,14 @@ ReachabilityAwarePlayableUriResolver _build({
   required ProviderReachability reachability,
   String? Function()? providerKey,
   ConnectivityService? connectivity,
+  void Function(ReachabilityStatus status)? onReachabilityObserved,
 }) {
   return ReachabilityAwarePlayableUriResolver(
     inner: inner,
     providerKey: providerKey ?? () => 'jellyfin',
     reachability: reachability,
     connectivity: connectivity,
+    onReachabilityObserved: onReachabilityObserved,
   );
 }
 
@@ -285,6 +287,126 @@ void main() {
       final ResolvedPlayable resolved = await sub.resolve(s101);
       expect(resolved.source, PlaybackSource.streamingDirect);
       expect(subInner.calls, 1);
+    });
+
+    group('reachability observer', () {
+      test('reports a successful resolve as reachable', () async {
+        final observed = <ReachabilityStatus>[];
+        final resolver = _build(
+          inner: _FakeInner(),
+          reachability: CachingProviderReachability(),
+          onReachabilityObserved: observed.add,
+        );
+
+        await resolver.resolve(_track);
+
+        expect(observed, <ReachabilityStatus>[ReachabilityStatus.reachable]);
+      });
+
+      test('reports a server-level failure so the library can hide the source',
+          () async {
+        final observed = <ReachabilityStatus>[];
+        final resolver = _build(
+          inner:
+              _FakeInner(failWith: PlaybackResolutionErrorKind.serverUnreachable),
+          reachability: CachingProviderReachability(),
+          onReachabilityObserved: observed.add,
+        );
+
+        await expectLater(
+          resolver.resolve(_track),
+          throwsA(isA<PlaybackResolutionException>()),
+        );
+
+        expect(
+            observed, <ReachabilityStatus>[ReachabilityStatus.serverUnreachable]);
+      });
+
+      test('reports an expired session as an auth failure, not an outage',
+          () async {
+        final observed = <ReachabilityStatus>[];
+        final resolver = _build(
+          inner: _FakeInner(failWith: PlaybackResolutionErrorKind.sessionExpired),
+          reachability: CachingProviderReachability(),
+          onReachabilityObserved: observed.add,
+        );
+
+        await expectLater(
+          resolver.resolve(_track),
+          throwsA(isA<PlaybackResolutionException>()),
+        );
+
+        expect(observed, <ReachabilityStatus>[ReachabilityStatus.authFailure]);
+      });
+
+      test('stays silent for a track-specific failure', () async {
+        // "This one track has no stream" says nothing about the server, so the
+        // library must not hide the whole source over it.
+        final observed = <ReachabilityStatus>[];
+        final resolver = _build(
+          inner:
+              _FakeInner(failWith: PlaybackResolutionErrorKind.streamUnavailable),
+          reachability: CachingProviderReachability(),
+          onReachabilityObserved: observed.add,
+        );
+
+        await expectLater(
+          resolver.resolve(_track),
+          throwsA(isA<PlaybackResolutionException>()),
+        );
+
+        expect(observed, isEmpty);
+      });
+
+      test('stays silent for the remembered-outage fast-fail', () async {
+        // Only live attempts teach anything; replaying a cached outage would
+        // just re-assert what the observer already knows.
+        final reachability = CachingProviderReachability()
+          ..record('jellyfin', ReachabilityStatus.serverUnreachable);
+        final observed = <ReachabilityStatus>[];
+        final resolver = _build(
+          inner: _FakeInner(),
+          reachability: reachability,
+          onReachabilityObserved: observed.add,
+        );
+
+        await expectLater(
+          resolver.resolve(_track),
+          throwsA(isA<PlaybackResolutionException>()),
+        );
+
+        expect(observed, isEmpty);
+      });
+
+      test('reports the device being offline', () async {
+        final observed = <ReachabilityStatus>[];
+        final resolver = _build(
+          inner: _FakeInner(),
+          reachability: CachingProviderReachability(),
+          connectivity: _FakeConnectivity(NetworkStatus.offline),
+          onReachabilityObserved: observed.add,
+        );
+
+        await expectLater(
+          resolver.resolve(_track),
+          throwsA(isA<PlaybackResolutionException>()),
+        );
+
+        expect(
+            observed, <ReachabilityStatus>[ReachabilityStatus.networkUnavailable]);
+      });
+
+      test('an observer that throws never breaks playback', () async {
+        final resolver = _build(
+          inner: _FakeInner(),
+          reachability: CachingProviderReachability(),
+          onReachabilityObserved: (_) => throw StateError('observer bug'),
+        );
+
+        final ResolvedPlayable resolved = await resolver.resolve(_track);
+
+        expect(resolved.source, PlaybackSource.streamingDirect);
+      });
     });
   });
 }

--- a/test/core/services/reachability_aware_playable_uri_resolver_test.dart
+++ b/test/core/services/reachability_aware_playable_uri_resolver_test.dart
@@ -307,8 +307,8 @@ void main() {
           () async {
         final observed = <ReachabilityStatus>[];
         final resolver = _build(
-          inner:
-              _FakeInner(failWith: PlaybackResolutionErrorKind.serverUnreachable),
+          inner: _FakeInner(
+              failWith: PlaybackResolutionErrorKind.serverUnreachable),
           reachability: CachingProviderReachability(),
           onReachabilityObserved: observed.add,
         );
@@ -318,15 +318,16 @@ void main() {
           throwsA(isA<PlaybackResolutionException>()),
         );
 
-        expect(
-            observed, <ReachabilityStatus>[ReachabilityStatus.serverUnreachable]);
+        expect(observed,
+            <ReachabilityStatus>[ReachabilityStatus.serverUnreachable]);
       });
 
       test('reports an expired session as an auth failure, not an outage',
           () async {
         final observed = <ReachabilityStatus>[];
         final resolver = _build(
-          inner: _FakeInner(failWith: PlaybackResolutionErrorKind.sessionExpired),
+          inner:
+              _FakeInner(failWith: PlaybackResolutionErrorKind.sessionExpired),
           reachability: CachingProviderReachability(),
           onReachabilityObserved: observed.add,
         );
@@ -344,8 +345,8 @@ void main() {
         // library must not hide the whole source over it.
         final observed = <ReachabilityStatus>[];
         final resolver = _build(
-          inner:
-              _FakeInner(failWith: PlaybackResolutionErrorKind.streamUnavailable),
+          inner: _FakeInner(
+              failWith: PlaybackResolutionErrorKind.streamUnavailable),
           reachability: CachingProviderReachability(),
           onReachabilityObserved: observed.add,
         );
@@ -392,8 +393,8 @@ void main() {
           throwsA(isA<PlaybackResolutionException>()),
         );
 
-        expect(
-            observed, <ReachabilityStatus>[ReachabilityStatus.networkUnavailable]);
+        expect(observed,
+            <ReachabilityStatus>[ReachabilityStatus.networkUnavailable]);
       });
 
       test('an observer that throws never breaks playback', () async {

--- a/test/core/sources/source_availability_test.dart
+++ b/test/core/sources/source_availability_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/services/reachability.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_availability.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_exception.dart';
+import 'package:linthra/core/sources/source_availability.dart';
+
+void main() {
+  group('SourceAvailability', () {
+    test('separates "configured" from "available"', () {
+      // The whole point of #536: a saved session is not a reachable server.
+      expect(SourceAvailability.unreachable.isConfigured, isTrue);
+      expect(SourceAvailability.unreachable.isAvailable, isFalse);
+      expect(SourceAvailability.authenticationError.isConfigured, isTrue);
+      expect(SourceAvailability.authenticationError.isAvailable, isFalse);
+      expect(SourceAvailability.checking.isConfigured, isTrue);
+      expect(SourceAvailability.notConfigured.isConfigured, isFalse);
+      expect(SourceAvailability.available.isAvailable, isTrue);
+    });
+
+    test('hides tracks only for a proven failure', () {
+      expect(SourceAvailability.unreachable.hidesTracks, isTrue);
+      expect(SourceAvailability.authenticationError.hidesTracks, isTrue);
+      // "We haven't checked yet" must never blank a library.
+      expect(SourceAvailability.checking.hidesTracks, isFalse);
+      expect(SourceAvailability.available.hidesTracks, isFalse);
+      expect(SourceAvailability.notConfigured.hidesTracks, isFalse);
+    });
+  });
+
+  group('SourceAvailabilityState', () {
+    test('compares by status and timestamp', () {
+      final DateTime at = DateTime(2026, 8, 31, 12);
+      expect(
+        const SourceAvailabilityState(status: SourceAvailability.available),
+        equals(
+          const SourceAvailabilityState(status: SourceAvailability.available),
+        ),
+      );
+      expect(
+        SourceAvailabilityState(
+            status: SourceAvailability.available, lastCheckedAt: at),
+        isNot(equals(
+          const SourceAvailabilityState(status: SourceAvailability.available),
+        )),
+      );
+      expect(
+        const SourceAvailabilityState.checking(),
+        isNot(equals(const SourceAvailabilityState.notConfigured())),
+      );
+    });
+
+    test('named constructors carry no timestamp', () {
+      expect(const SourceAvailabilityState.checking().lastCheckedAt, isNull);
+      expect(
+        const SourceAvailabilityState.notConfigured().status,
+        SourceAvailability.notConfigured,
+      );
+    });
+  });
+
+  group('configuredSourceAvailabilityLabel', () {
+    test('only an available server reads as "connected"', () {
+      expect(
+        configuredSourceAvailabilityLabel(SourceAvailability.available),
+        'connected',
+      );
+      // The bug in #536: a saved session for a LAN-only server reported
+      // "connected" from anywhere. It must now name what is really wrong.
+      expect(
+        configuredSourceAvailabilityLabel(SourceAvailability.unreachable),
+        'configured (server unreachable)',
+      );
+      expect(
+        configuredSourceAvailabilityLabel(
+            SourceAvailability.authenticationError),
+        'configured (authentication error)',
+      );
+      expect(
+        configuredSourceAvailabilityLabel(SourceAvailability.checking),
+        'configured (checking)',
+      );
+      expect(
+        configuredSourceAvailabilityLabel(SourceAvailability.notConfigured),
+        'configured (not checked)',
+      );
+    });
+
+    test('every non-available label still says the server is configured', () {
+      for (final SourceAvailability availability in SourceAvailability.values) {
+        if (availability == SourceAvailability.available) continue;
+        expect(
+          configuredSourceAvailabilityLabel(availability),
+          startsWith('configured'),
+          reason: '$availability must not read as signed out',
+        );
+      }
+    });
+  });
+
+  group('availabilityFromReachability', () {
+    test('maps every playback-path reachability signal', () {
+      expect(
+        availabilityFromReachability(ReachabilityStatus.reachable),
+        SourceAvailability.available,
+      );
+      expect(
+        availabilityFromReachability(ReachabilityStatus.authFailure),
+        SourceAvailability.authenticationError,
+      );
+      for (final ReachabilityStatus offline in <ReachabilityStatus>[
+        ReachabilityStatus.serverUnreachable,
+        ReachabilityStatus.timeout,
+        ReachabilityStatus.networkUnavailable,
+      ]) {
+        expect(
+          availabilityFromReachability(offline),
+          SourceAvailability.unreachable,
+          reason: '$offline should read as unreachable',
+        );
+      }
+    });
+  });
+
+  group('jellyfinAvailabilityFromError', () {
+    test('only a rejected session is an authentication error', () {
+      expect(
+        jellyfinAvailabilityFromError(JellyfinErrorKind.unauthorized),
+        SourceAvailability.authenticationError,
+      );
+      for (final JellyfinErrorKind kind in JellyfinErrorKind.values) {
+        if (kind == JellyfinErrorKind.unauthorized) continue;
+        expect(
+          jellyfinAvailabilityFromError(kind),
+          SourceAvailability.unreachable,
+          reason: '$kind should read as unreachable',
+        );
+      }
+    });
+
+    test('never reports a failure as available', () {
+      for (final JellyfinErrorKind kind in JellyfinErrorKind.values) {
+        expect(
+          jellyfinAvailabilityFromError(kind).isAvailable,
+          isFalse,
+          reason: '$kind must not look available',
+        );
+      }
+    });
+  });
+}

--- a/test/features/library/jellyfin_availability_test.dart
+++ b/test/features/library/jellyfin_availability_test.dart
@@ -80,8 +80,13 @@ class _FixedPreference extends SourcePreferenceController {
 /// The library repository is seeded exactly as a completed Jellyfin sync plus a
 /// local folder scan would leave it, so "what is stored" and "what is shown" can
 /// be compared directly.
-Future<({ProviderContainer container, FakeJellyfinClient client, InMemoryMusicLibraryRepository repository, InMemoryJellyfinSessionStore sessionStore})>
-    _boot({
+Future<
+    ({
+      ProviderContainer container,
+      FakeJellyfinClient client,
+      InMemoryMusicLibraryRepository repository,
+      InMemoryJellyfinSessionStore sessionStore
+    })> _boot({
   JellyfinException? verifyError,
   Set<String> offlineKeys = const <String>{},
 }) async {
@@ -145,8 +150,7 @@ void main() {
         SourceAvailability.unreachable,
       );
       // The active library holds only what can actually be played.
-      expect(_uris(c.read(libraryUnifiedTracksProvider)),
-          _uris(_localTracks));
+      expect(_uris(c.read(libraryUnifiedTracksProvider)), _uris(_localTracks));
       // Albums and artists are derived from the same set, so no browse surface
       // can offer a route back to a hidden track.
       expect(
@@ -178,8 +182,8 @@ void main() {
       // And nothing was deleted from the catalog: every stored row is still
       // there, ready to reappear.
       final List<Track> stored = await boot.repository.getAllTracks();
-      expect(_uris(stored),
-          containsAll(<String>['jellyfin:101', 'jellyfin:102']));
+      expect(
+          _uris(stored), containsAll(<String>['jellyfin:101', 'jellyfin:102']));
       expect(stored, hasLength(4));
       expect(c.read(unavailableTrackCountProvider), 2);
     });

--- a/test/features/library/jellyfin_availability_test.dart
+++ b/test/features/library/jellyfin_availability_test.dart
@@ -1,0 +1,393 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/catalog/library_grouping.dart';
+import 'package:linthra/core/catalog/source_priority.dart';
+import 'package:linthra/core/diagnostics/app_diagnostics.dart';
+import 'package:linthra/core/models/jellyfin_session.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/download_store.dart';
+import 'package:linthra/core/services/reachability.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_exception.dart';
+import 'package:linthra/core/sources/source_availability.dart';
+import 'package:linthra/data/repositories/in_memory_jellyfin_session_store.dart';
+import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
+import 'package:linthra/data/repositories/jellyfin_session_store_provider.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/downloads/download_providers.dart';
+import 'package:linthra/features/library/library_browse_providers.dart';
+import 'package:linthra/features/library/library_controller.dart';
+import 'package:linthra/features/library/source_availability_providers.dart';
+import 'package:linthra/features/library/source_preference_controller.dart';
+import 'package:linthra/features/library/unified_library_providers.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_availability_controller.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_settings_controller.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_settings_providers.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_settings_state.dart';
+
+import '../../core/sources/jellyfin/fake_jellyfin_client.dart';
+
+/// The reporter's setup, reduced to essentials: a Jellyfin server saved at a
+/// LAN-only address, plus some on-device music.
+const JellyfinSession _session = JellyfinSession(
+  baseUrl: 'http://192.168.22.1:8096',
+  userId: 'user-1',
+  accessToken: 'tok',
+  deviceId: 'device-1',
+  userName: 'alice',
+  serverName: 'Home',
+);
+
+Track _jellyfin(String id, String title) => Track(
+      id: id,
+      title: title,
+      uri: 'jellyfin:$id',
+      artistName: 'Adele',
+      albumName: '25',
+      duration: const Duration(minutes: 3),
+    );
+
+Track _local(String name, String title) => Track(
+      id: name,
+      title: title,
+      uri: 'file:///music/$name.mp3',
+      artistName: 'Portishead',
+      albumName: 'Dummy',
+      duration: const Duration(minutes: 4),
+    );
+
+final List<Track> _jellyfinTracks = <Track>[
+  _jellyfin('101', 'Hello'),
+  _jellyfin('102', 'Someone Like You'),
+];
+final List<Track> _localTracks = <Track>[
+  _local('glory-box', 'Glory Box'),
+  _local('roads', 'Roads'),
+];
+
+List<String> _uris(List<Track> tracks) =>
+    <String>[for (final Track t in tracks) t.uri];
+
+/// Pins the source preference so unification is deterministic and the async
+/// preference load can't race the assertions.
+class _FixedPreference extends SourcePreferenceController {
+  @override
+  SourcePriority build() => const SourcePriority(<String>['jellyfin']);
+}
+
+/// A container wired the way the app is, but with the network and the poll timer
+/// under the test's control.
+///
+/// The library repository is seeded exactly as a completed Jellyfin sync plus a
+/// local folder scan would leave it, so "what is stored" and "what is shown" can
+/// be compared directly.
+Future<({ProviderContainer container, FakeJellyfinClient client, InMemoryMusicLibraryRepository repository, InMemoryJellyfinSessionStore sessionStore})>
+    _boot({
+  JellyfinException? verifyError,
+  Set<String> offlineKeys = const <String>{},
+}) async {
+  final repository = InMemoryMusicLibraryRepository();
+  await repository.upsertCatalog(
+    sourceId: 'jellyfin',
+    tracks: _jellyfinTracks,
+    albums: groupAlbums(_jellyfinTracks),
+    artists: groupArtists(_jellyfinTracks),
+  );
+  await repository.upsertCatalog(
+    sourceId: 'local',
+    tracks: _localTracks,
+    albums: groupAlbums(_localTracks),
+    artists: groupArtists(_localTracks),
+  );
+  final sessionStore = InMemoryJellyfinSessionStore(initialSession: _session);
+  final client = FakeJellyfinClient(verifyError: verifyError);
+  final container = ProviderContainer(
+    overrides: <Override>[
+      musicLibraryRepositoryProvider.overrideWithValue(repository),
+      jellyfinSessionStoreProvider.overrideWithValue(sessionStore),
+      jellyfinClientProvider.overrideWithValue(client),
+      librarySourcePriorityProvider.overrideWith(_FixedPreference.new),
+      offlineAvailableTrackKeysProvider.overrideWithValue(offlineKeys),
+      // Drive probes explicitly instead of racing a background timer.
+      jellyfinAvailabilityPollIntervalProvider.overrideWithValue(null),
+    ],
+  );
+  addTearDown(container.dispose);
+  // Keep the availability notifier alive for the whole test, the way the app's
+  // library subscription does.
+  container.listen(jellyfinAvailabilityProvider, (_, __) {});
+  container.listen(libraryControllerProvider, (_, __) {});
+  // Let the persisted session load, the catalog load, and the startup probe run.
+  await _settle(container);
+  return (
+    container: container,
+    client: client,
+    repository: repository,
+    sessionStore: sessionStore,
+  );
+}
+
+/// Lets the async session load, catalog load and availability probe settle.
+Future<void> _settle(ProviderContainer container) async {
+  for (int i = 0; i < 6; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+  await container.read(libraryControllerProvider.notifier).refresh();
+}
+
+void main() {
+  group('app starts while Jellyfin is unreachable', () {
+    test('excludes Jellyfin tracks and keeps local music usable', () async {
+      final boot = await _boot(verifyError: JellyfinException.notReachable());
+      final ProviderContainer c = boot.container;
+
+      expect(
+        c.read(jellyfinAvailabilityProvider).status,
+        SourceAvailability.unreachable,
+      );
+      // The active library holds only what can actually be played.
+      expect(_uris(c.read(libraryUnifiedTracksProvider)),
+          _uris(_localTracks));
+      // Albums and artists are derived from the same set, so no browse surface
+      // can offer a route back to a hidden track.
+      expect(
+        <String>[for (final a in c.read(libraryAlbumsProvider)) a.title],
+        <String>['Dummy'],
+      );
+      expect(
+        <String>[for (final a in c.read(libraryArtistsProvider)) a.name],
+        <String>['Portishead'],
+      );
+    });
+
+    test('keeps the connection configured and every record intact', () async {
+      final boot = await _boot(verifyError: JellyfinException.notReachable());
+      final ProviderContainer c = boot.container;
+
+      // The saved server configuration is untouched — the user does not have to
+      // remove the connection to get a usable library.
+      final JellyfinSettingsState settings =
+          c.read(jellyfinSettingsControllerProvider);
+      expect(settings.phase, JellyfinConnectionPhase.connected);
+      expect(settings.baseUrl, 'http://192.168.22.1:8096');
+      expect(await boot.sessionStore.read(), isNotNull);
+      expect(
+        c.read(jellyfinSettingsControllerProvider.notifier).session,
+        isNotNull,
+      );
+
+      // And nothing was deleted from the catalog: every stored row is still
+      // there, ready to reappear.
+      final List<Track> stored = await boot.repository.getAllTracks();
+      expect(_uris(stored),
+          containsAll(<String>['jellyfin:101', 'jellyfin:102']));
+      expect(stored, hasLength(4));
+      expect(c.read(unavailableTrackCountProvider), 2);
+    });
+
+    test('a rejected session reads as an authentication error, not offline',
+        () async {
+      final boot = await _boot(verifyError: JellyfinException.unauthorized());
+      expect(
+        boot.container.read(jellyfinAvailabilityProvider).status,
+        SourceAvailability.authenticationError,
+      );
+      // Still excluded — the tracks can't be fetched either way — but the state
+      // says the fix is signing in again, not moving closer to the server.
+      expect(_uris(boot.container.read(libraryUnifiedTracksProvider)),
+          _uris(_localTracks));
+    });
+
+    test('keeps Jellyfin tracks that are available offline', () async {
+      final boot = await _boot(
+        verifyError: JellyfinException.notReachable(),
+        offlineKeys: <String>{
+          CachedTrack.cacheKeyForTrack(_jellyfinTracks.first),
+        },
+      );
+      expect(
+        _uris(boot.container.read(libraryUnifiedTracksProvider)),
+        <String>['jellyfin:101', ..._uris(_localTracks)],
+      );
+      expect(boot.container.read(unavailableTrackCountProvider), 1);
+    });
+  });
+
+  group('connected -> unreachable', () {
+    test('a reachable server shows the whole library', () async {
+      final boot = await _boot();
+      expect(
+        boot.container.read(jellyfinAvailabilityProvider).status,
+        SourceAvailability.available,
+      );
+      expect(
+        _uris(boot.container.read(libraryUnifiedTracksProvider)),
+        <String>[..._uris(_jellyfinTracks), ..._uris(_localTracks)],
+      );
+    });
+
+    test('leaving the network hides Jellyfin tracks on the next probe',
+        () async {
+      final boot = await _boot();
+      final ProviderContainer c = boot.container;
+      expect(c.read(libraryUnifiedTracksProvider), hasLength(4));
+
+      boot.client.verifyError = JellyfinException.notReachable();
+      await c.read(jellyfinAvailabilityProvider.notifier).refresh();
+
+      expect(c.read(jellyfinAvailabilityProvider).status,
+          SourceAvailability.unreachable);
+      expect(_uris(c.read(libraryUnifiedTracksProvider)), _uris(_localTracks));
+      // Nothing was removed to make that happen.
+      expect(await boot.repository.getAllTracks(), hasLength(4));
+      expect(await boot.sessionStore.read(), isNotNull);
+    });
+
+    test('a failed playback resolution hides them without deleting anything',
+        () async {
+      // The playback path's own finding is adopted immediately, so the user
+      // isn't left staring at tracks that just failed to play until the next
+      // poll. It may only move the availability flag.
+      final boot = await _boot();
+      final ProviderContainer c = boot.container;
+
+      c
+          .read(jellyfinAvailabilityProvider.notifier)
+          .noteReachability(ReachabilityStatus.serverUnreachable);
+
+      expect(c.read(jellyfinAvailabilityProvider).status,
+          SourceAvailability.unreachable);
+      expect(_uris(c.read(libraryUnifiedTracksProvider)), _uris(_localTracks));
+      expect(await boot.repository.getAllTracks(), hasLength(4));
+      expect(await boot.sessionStore.read(), isNotNull);
+      expect(c.read(jellyfinSettingsControllerProvider).phase,
+          JellyfinConnectionPhase.connected);
+    });
+
+    test('an expired session is reported as an authentication error', () async {
+      final boot = await _boot();
+      boot.container
+          .read(jellyfinAvailabilityProvider.notifier)
+          .noteReachability(ReachabilityStatus.authFailure);
+      expect(boot.container.read(jellyfinAvailabilityProvider).status,
+          SourceAvailability.authenticationError);
+    });
+  });
+
+  group('unreachable -> connected', () {
+    test('tracks reappear on their own, with no reconnect or rescan', () async {
+      final boot = await _boot(verifyError: JellyfinException.notReachable());
+      final ProviderContainer c = boot.container;
+      expect(c.read(libraryUnifiedTracksProvider), hasLength(2));
+
+      // Back on the home network. Nothing but the probe result changes — no
+      // sign-in, no upsertCatalog, no library refresh.
+      boot.client.verifyError = null;
+      await c.read(jellyfinAvailabilityProvider.notifier).refresh();
+
+      expect(c.read(jellyfinAvailabilityProvider).status,
+          SourceAvailability.available);
+      expect(
+        _uris(c.read(libraryUnifiedTracksProvider)),
+        <String>[..._uris(_jellyfinTracks), ..._uris(_localTracks)],
+      );
+      expect(c.read(unavailableTrackCountProvider), 0);
+    });
+
+    test('a successful playback resolution restores them too', () async {
+      final boot = await _boot(verifyError: JellyfinException.notReachable());
+      final ProviderContainer c = boot.container;
+      expect(c.read(libraryUnifiedTracksProvider), hasLength(2));
+
+      c
+          .read(jellyfinAvailabilityProvider.notifier)
+          .noteReachability(ReachabilityStatus.reachable);
+
+      expect(c.read(libraryUnifiedTracksProvider), hasLength(4));
+    });
+
+    test('survives a round trip out and back', () async {
+      final boot = await _boot();
+      final ProviderContainer c = boot.container;
+      final notifier = c.read(jellyfinAvailabilityProvider.notifier);
+
+      boot.client.verifyError = JellyfinException.notReachable();
+      await notifier.refresh();
+      expect(c.read(libraryUnifiedTracksProvider), hasLength(2));
+
+      boot.client.verifyError = null;
+      await notifier.refresh();
+      expect(c.read(libraryUnifiedTracksProvider), hasLength(4));
+
+      boot.client.verifyError = JellyfinException.notReachable();
+      await notifier.refresh();
+      expect(c.read(libraryUnifiedTracksProvider), hasLength(2));
+
+      // Four rows stored throughout: visibility changed, the catalog never did.
+      expect(await boot.repository.getAllTracks(), hasLength(4));
+    });
+  });
+
+  group('no server configured', () {
+    test('reports notConfigured and hides nothing', () async {
+      final repository = InMemoryMusicLibraryRepository();
+      await repository.upsertCatalog(
+        sourceId: 'local',
+        tracks: _localTracks,
+        albums: groupAlbums(_localTracks),
+        artists: groupArtists(_localTracks),
+      );
+      final container = ProviderContainer(
+        overrides: <Override>[
+          musicLibraryRepositoryProvider.overrideWithValue(repository),
+          jellyfinSessionStoreProvider
+              .overrideWithValue(InMemoryJellyfinSessionStore()),
+          jellyfinClientProvider.overrideWithValue(FakeJellyfinClient()),
+          librarySourcePriorityProvider.overrideWith(_FixedPreference.new),
+          jellyfinAvailabilityPollIntervalProvider.overrideWithValue(null),
+        ],
+      );
+      addTearDown(container.dispose);
+      container.listen(jellyfinAvailabilityProvider, (_, __) {});
+      await _settle(container);
+
+      expect(container.read(jellyfinAvailabilityProvider).status,
+          SourceAvailability.notConfigured);
+      expect(container.read(unavailableSourceIdsProvider), isEmpty);
+      expect(_uris(container.read(libraryUnifiedTracksProvider)),
+          _uris(_localTracks));
+    });
+  });
+
+  group('diagnostics report the real connection state', () {
+    test('an unreachable configured server does not read as connected', () {
+      const AppDiagnosticsData data = AppDiagnosticsData(
+        appVersion: '0.2.4',
+        jellyfinState: 'configured (server unreachable)',
+        jellyfinHost: 'http://192.168.22.1:8096',
+        libraryTrackCount: 9063,
+        unavailableTrackCount: 9000,
+      );
+      final String report = AppDiagnostics.report(data);
+      expect(report, contains('Jellyfin: configured (server unreachable)'));
+      expect(report, isNot(contains('Jellyfin: connected')));
+      expect(report, contains('Jellyfin host: 192.168.22.1:8096'));
+      expect(report, contains('Library tracks: 9063'));
+      expect(
+        report,
+        contains('Unavailable tracks (hidden, not deleted): 9000'),
+      );
+    });
+
+    test('omits the hidden-track line when nothing is hidden', () {
+      const AppDiagnosticsData data = AppDiagnosticsData(
+        appVersion: '0.2.4',
+        jellyfinState: 'connected',
+        libraryTrackCount: 9063,
+        unavailableTrackCount: 0,
+      );
+      final String report = AppDiagnostics.report(data);
+      expect(report, contains('Jellyfin: connected'));
+      expect(report, isNot(contains('Unavailable tracks')));
+    });
+  });
+}

--- a/test/features/settings/jellyfin/jellyfin_availability_controller_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_availability_controller_test.dart
@@ -1,0 +1,197 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/jellyfin_session.dart';
+import 'package:linthra/core/services/reachability.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_exception.dart';
+import 'package:linthra/core/sources/source_availability.dart';
+import 'package:linthra/data/repositories/in_memory_jellyfin_session_store.dart';
+import 'package:linthra/data/repositories/jellyfin_session_store_provider.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_availability_controller.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_settings_controller.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_settings_providers.dart';
+
+import '../../../core/sources/jellyfin/fake_jellyfin_client.dart';
+
+const JellyfinSession _session = JellyfinSession(
+  baseUrl: 'http://192.168.22.1:8096',
+  userId: 'user-1',
+  accessToken: 'tok',
+  deviceId: 'device-1',
+  userName: 'alice',
+);
+
+/// A client whose session probe is held open until the test releases it, so the
+/// `checking` window can be observed rather than raced.
+class _GatedJellyfinClient extends FakeJellyfinClient {
+  _GatedJellyfinClient();
+
+  Completer<void>? gate;
+
+  @override
+  Future<void> verifySession(JellyfinSession session) async {
+    final Completer<void>? held = gate;
+    if (held != null) await held.future;
+    return super.verifySession(session);
+  }
+}
+
+ProviderContainer _container({
+  JellyfinSession? saved,
+  required FakeJellyfinClient client,
+  Duration? poll,
+}) {
+  final container = ProviderContainer(
+    overrides: <Override>[
+      jellyfinSessionStoreProvider.overrideWithValue(
+        InMemoryJellyfinSessionStore(initialSession: saved),
+      ),
+      jellyfinClientProvider.overrideWithValue(client),
+      jellyfinAvailabilityPollIntervalProvider.overrideWithValue(poll),
+    ],
+  );
+  addTearDown(container.dispose);
+  container.listen(jellyfinAvailabilityProvider, (_, __) {});
+  return container;
+}
+
+Future<void> _settle() async {
+  for (int i = 0; i < 6; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+void main() {
+  test('reports notConfigured with no saved session, and never probes',
+      () async {
+    final client = FakeJellyfinClient();
+    final container = _container(client: client);
+    await _settle();
+    expect(container.read(jellyfinAvailabilityProvider).status,
+        SourceAvailability.notConfigured);
+    expect(client.verifyCount, 0,
+        reason: 'nothing configured means nothing to reach');
+  });
+
+  test('shows "checking" while the first probe is in flight, hiding nothing',
+      () async {
+    final client = _GatedJellyfinClient()..gate = Completer<void>();
+    final container = _container(saved: _session, client: client);
+    await _settle();
+
+    expect(container.read(jellyfinAvailabilityProvider).status,
+        SourceAvailability.checking);
+    // A library must not blink out while we are still asking.
+    expect(container.read(jellyfinAvailabilityProvider).hidesTracks, isFalse);
+
+    client.gate!.complete();
+    await _settle();
+    expect(container.read(jellyfinAvailabilityProvider).status,
+        SourceAvailability.available);
+  });
+
+  test('probes a restored session at startup and records the outcome',
+      () async {
+    final client =
+        FakeJellyfinClient(verifyError: JellyfinException.notReachable());
+    final container = _container(saved: _session, client: client);
+    await _settle();
+
+    expect(client.verifyCount, 1);
+    final state = container.read(jellyfinAvailabilityProvider);
+    expect(state.status, SourceAvailability.unreachable);
+    expect(state.lastCheckedAt, isNotNull);
+    expect(state.hidesTracks, isTrue);
+  });
+
+  test('an unwrapped transport fault is never reported as available', () async {
+    final client = _ThrowingClient();
+    final container = _container(saved: _session, client: client);
+    await _settle();
+    expect(container.read(jellyfinAvailabilityProvider).status,
+        SourceAvailability.unreachable);
+  });
+
+  test('noteReachability is ignored while nothing is configured', () async {
+    final client = FakeJellyfinClient();
+    final container = _container(client: client);
+    await _settle();
+
+    container
+        .read(jellyfinAvailabilityProvider.notifier)
+        .noteReachability(ReachabilityStatus.serverUnreachable);
+
+    expect(container.read(jellyfinAvailabilityProvider).status,
+        SourceAvailability.notConfigured);
+  });
+
+  test('a stale in-flight probe cannot overwrite a newer answer', () async {
+    final client = _GatedJellyfinClient()
+      ..gate = Completer<void>()
+      ..verifyError = JellyfinException.notReachable();
+    final container = _container(saved: _session, client: client);
+    await _settle();
+    expect(container.read(jellyfinAvailabilityProvider).status,
+        SourceAvailability.checking);
+
+    // The playback path learns the server is fine while the slow probe is still
+    // hanging; the probe's later, stale "unreachable" must not win.
+    container
+        .read(jellyfinAvailabilityProvider.notifier)
+        .noteReachability(ReachabilityStatus.reachable);
+    expect(container.read(jellyfinAvailabilityProvider).status,
+        SourceAvailability.available);
+
+    client.gate!.complete();
+    await _settle();
+    expect(container.read(jellyfinAvailabilityProvider).status,
+        SourceAvailability.available);
+  });
+
+  test('signing out returns to notConfigured without a probe', () async {
+    final client = FakeJellyfinClient();
+    final container = _container(saved: _session, client: client);
+    await _settle();
+    expect(container.read(jellyfinAvailabilityProvider).status,
+        SourceAvailability.available);
+
+    await container.read(jellyfinSettingsControllerProvider.notifier).clear();
+    await _settle();
+
+    expect(container.read(jellyfinAvailabilityProvider).status,
+        SourceAvailability.notConfigured);
+  });
+
+  test('the background poll re-probes a configured server', () async {
+    final client =
+        FakeJellyfinClient(verifyError: JellyfinException.notReachable());
+    final container = _container(
+      saved: _session,
+      client: client,
+      // The production override turns polling on; here it is compressed so the
+      // recovery can be observed without a 45 s wait.
+      poll: const Duration(milliseconds: 20),
+    );
+    await _settle();
+    expect(container.read(jellyfinAvailabilityProvider).status,
+        SourceAvailability.unreachable);
+
+    // Back on the network: the poll picks it up with no user action at all.
+    client.verifyError = null;
+    await Future<void>.delayed(const Duration(milliseconds: 60));
+    await _settle();
+
+    expect(container.read(jellyfinAvailabilityProvider).status,
+        SourceAvailability.available);
+    expect(client.verifyCount, greaterThan(1));
+  });
+}
+
+/// A client whose probe throws something the Jellyfin layer never wrapped.
+class _ThrowingClient extends FakeJellyfinClient {
+  @override
+  Future<void> verifySession(JellyfinSession session) async {
+    throw StateError('socket exploded');
+  }
+}

--- a/test/features/settings/jellyfin/jellyfin_settings_section_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_settings_section_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/jellyfin_session.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_exception.dart';
 import 'package:linthra/data/repositories/in_memory_jellyfin_session_store.dart';
 import 'package:linthra/data/repositories/jellyfin_session_store_provider.dart';
@@ -49,7 +50,72 @@ Future<void> _fillForm(
   await tester.pump();
 }
 
+/// Pumps the section with a *saved* session, so the connected view renders, and
+/// with a probe outcome the test chooses.
+Future<void> _pumpConnected(
+  WidgetTester tester, {
+  JellyfinException? verifyError,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        jellyfinAuthenticatorProvider
+            .overrideWithValue(FakeJellyfinAuthenticator()),
+        jellyfinSessionStoreProvider.overrideWithValue(
+          InMemoryJellyfinSessionStore(
+            initialSession: const JellyfinSession(
+              baseUrl: 'http://192.168.22.1:8096',
+              userId: 'user-1',
+              accessToken: 'tok',
+              deviceId: 'device-1',
+              userName: 'alice',
+            ),
+          ),
+        ),
+        jellyfinClientProvider
+            .overrideWithValue(FakeJellyfinClient(verifyError: verifyError)),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(body: JellyfinSettingsSection()),
+      ),
+    ),
+  );
+  // Let the session load and the availability probe settle.
+  for (int i = 0; i < 8; i++) {
+    await tester.pump();
+  }
+}
+
 void main() {
+  group('JellyfinSettingsSection availability notice', () {
+    testWidgets('explains an unreachable server without offering sign-out as '
+        'the fix', (tester) async {
+      await _pumpConnected(tester, verifyError: JellyfinException.notReachable());
+
+      // The user is told the tracks are hidden, not lost — the whole point of
+      // #536, where removing the connection was the only apparent way out.
+      expect(find.textContaining("can't be reached right now"), findsOneWidget);
+      expect(find.textContaining('Nothing was deleted'), findsOneWidget);
+      expect(find.textContaining('come back'), findsOneWidget);
+      // The connection itself is untouched, so signing out stays an option the
+      // user chooses rather than one they're pushed into.
+      expect(find.text('Sign out & clear'), findsOneWidget);
+    });
+
+    testWidgets('names a rejected sign-in as the reason', (tester) async {
+      await _pumpConnected(tester, verifyError: JellyfinException.unauthorized());
+
+      expect(find.textContaining('rejected this sign-in'), findsOneWidget);
+      expect(find.textContaining('Nothing was deleted'), findsOneWidget);
+    });
+
+    testWidgets('says nothing when the server answers', (tester) async {
+      await _pumpConnected(tester);
+
+      expect(find.textContaining('hidden from your library'), findsNothing);
+    });
+  });
+
   group('JellyfinSettingsSection', () {
     testWidgets('shows the connection form when disconnected', (tester) async {
       await _pumpSection(tester, authenticator: FakeJellyfinAuthenticator());

--- a/test/features/settings/jellyfin/jellyfin_settings_section_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_settings_section_test.dart
@@ -88,9 +88,11 @@ Future<void> _pumpConnected(
 
 void main() {
   group('JellyfinSettingsSection availability notice', () {
-    testWidgets('explains an unreachable server without offering sign-out as '
+    testWidgets(
+        'explains an unreachable server without offering sign-out as '
         'the fix', (tester) async {
-      await _pumpConnected(tester, verifyError: JellyfinException.notReachable());
+      await _pumpConnected(tester,
+          verifyError: JellyfinException.notReachable());
 
       // The user is told the tracks are hidden, not lost — the whole point of
       // #536, where removing the connection was the only apparent way out.
@@ -103,7 +105,8 @@ void main() {
     });
 
     testWidgets('names a rejected sign-in as the reason', (tester) async {
-      await _pumpConnected(tester, verifyError: JellyfinException.unauthorized());
+      await _pumpConnected(tester,
+          verifyError: JellyfinException.unauthorized());
 
       expect(find.textContaining('rejected this sign-in'), findsOneWidget);
       expect(find.textContaining('Nothing was deleted'), findsOneWidget);


### PR DESCRIPTION
Closes #536.

## The problem

A saved Jellyfin session was treated as a live connection forever. With a LAN-only server address (`192.168.22.1:8096` in the report), leaving the network left the app reporting `Jellyfin: connected` while every stream failed with a resolution error — and the only way to get a usable library back was to remove the connection entirely, throwing away the catalog, playlists, favourites and downloads the user wants back the moment they're home again.

## The fix

Configuration and reachability are now two separate facts, resolved at the source-availability layer rather than by filtering in the UI.

**Availability model** — `lib/core/sources/source_availability.dart`
`SourceAvailability` gives each source an explicit state: `notConfigured` / `checking` / `available` / `unreachable` / `authenticationError`. Only a *proven* failure hides tracks; `checking` is deliberately optimistic so a slow probe can never blank a library. `configuredSourceAvailabilityLabel` is the one place the diagnostics wording lives, shared by both reports so they can't drift.

**Probing** — `lib/features/settings/jellyfin/jellyfin_availability_controller.dart`
Establishes that state with the same cheap `verifySession` call the playback path already uses, so "can't be reached" is distinguished from "session rejected" without fetching a library. It probes on startup (including a session restored from storage), on app resume, on a background poll, and from what a live playback resolution just discovered. Probes are generation-guarded, so a slow answer from an old session can never overwrite a newer one. The poll is a production-only override, so no container in a test carries a live timer.

**Filtering** — `lib/core/catalog/available_tracks.dart`
`selectAvailableTracks` narrows the stored catalog to the *active library* before de-duplication, so Songs / Albums / Artists, search, the detail screens and the playback-candidate map all see the same set. A song that also exists locally keeps playing from the local copy instead of resolving to a server that isn't there.

**Nothing is destructive.** The filter returns a view. No catalog row, playlist, favourite, download, or saved session is touched, so the full library returns on its own when the server answers again — no reconnect, no rescan. Local music is untouched throughout, and Jellyfin tracks that are available offline stay in the library while the server is away.

**The playback bridge stays narrow.** `ReachabilityAwarePlayableUriResolver` gained an optional observer that is handed a `ReachabilityStatus` and nothing else — no track, no catalog handle — so a per-track resolution error can only move a visibility flag and cannot grow into something that removes library rows. It stays silent for track-specific failures (`streamUnavailable`) and for the remembered-outage fast-fail, and an observer that throws never breaks playback.

**Diagnostics tell the truth.** A configured-but-unreachable server now reads `Jellyfin: configured (server unreachable)` instead of `connected`, with a `Unavailable tracks (hidden, not deleted): N` line so a short library explains itself. The Jellyfin settings card says the same thing in place, so vanished tracks never read as data loss — and nobody reaches for "sign out" to get a usable library again.

## Files changed

| File | Why |
| --- | --- |
| `lib/core/sources/source_availability.dart` *(new)* | The availability enum, its value type, the shared diagnostics label, and the non-destructive `ReachabilityStatus` → availability bridge. |
| `lib/core/sources/jellyfin/jellyfin_availability.dart` *(new)* | Exhaustive `JellyfinErrorKind` → availability mapping; only `unauthorized` means the server was actually reached. |
| `lib/core/catalog/available_tracks.dart` *(new)* | The pure filter and hidden-count over the stored catalog. |
| `lib/features/settings/jellyfin/jellyfin_availability_controller.dart` *(new)* | Probes the configured server; owns the state the library and diagnostics gate on. |
| `lib/features/library/source_availability_providers.dart` *(new)* | Per-source availability map, the unavailable-source set, the offline-availability predicate, and the active-library provider. |
| `lib/features/library/unified_library_providers.dart` | Unifies the active library instead of the raw catalog, so unreachable copies drop out of candidate lists too. |
| `lib/core/services/reachability_aware_playable_uri_resolver.dart` | Optional, failure-tolerant reachability observer. |
| `lib/features/player/player_providers.dart` | Wires that observer, for Jellyfin only, to the availability controller. |
| `lib/core/diagnostics/app_diagnostics.dart` | `unavailableTrackCount` field and line; `jellyfinState` re-documented as availability. |
| `lib/features/settings/diagnostics/diagnostics_collector.dart` | Reports live availability and the hidden-track count. |
| `lib/features/settings/jellyfin/jellyfin_settings_controller.dart` | `diagnosticsReport({availability})` — passed in by the caller so this controller keeps no dependency on the notifier that watches it. |
| `lib/features/settings/jellyfin/jellyfin_settings_section.dart` | In-place notice explaining hidden tracks and that nothing was deleted. |
| `lib/app/linthra_app.dart` | Re-probe on app resume. |
| `lib/app/application_container.dart` | Production-only background poll override. |
| `docs/architecture.md` | Documents the new seam. |

## Tests

New: `test/core/sources/source_availability_test.dart`, `test/core/catalog/available_tracks_test.dart`, `test/features/library/jellyfin_availability_test.dart`, `test/features/settings/jellyfin/jellyfin_availability_controller_test.dart`. Extended: the reachability-resolver and Jellyfin settings-section tests.

Covering the requested scenarios and more:

- app starts while Jellyfin is unreachable → tracks excluded, local music intact, browse surfaces agree
- connected → unreachable, by probe and by a failed playback resolution
- unreachable → connected, by probe and by a successful resolution, plus a full round trip
- local library remains available throughout
- Jellyfin records and the saved configuration are preserved while unavailable (catalog rows, session store, connection phase)
- diagnostics reflect the real connection state, and no non-available label reads as signed out
- downloaded Jellyfin tracks stay in the library while the server is away
- `checking` hides nothing; a stale probe can't overwrite a newer answer; an unwrapped transport fault is never reported as available; the observer stays silent for track-specific failures

## Verification

`flutter analyze` — no issues. `flutter test` — 3821 tests, all passing (Flutter 3.44.7, the pinned SDK).

---
_Generated by [Claude Code](https://claude.ai/code/session_019S5aStLBFimroum7xj7Qvx)_