### PR TITLE
Add Ruff lint/format checks for Python tooling

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,0 +1,58 @@
+name: Python lint
+
+# Fast lint/format feedback for Linthra's Python tooling, so the Python under
+# scripts/, tool/ and tools/ gets the same kind of check Dart already gets from
+# `dart format --set-exit-if-changed` and `flutter analyze` in ci.yml.
+#
+# Only the three real Python trees are passed to Ruff, so nothing vendored or
+# generated can be linted by accident. ruff.toml excludes the same trees, which
+# means the local twin of this job is either the two commands below or simply
+# `ruff check .` and `ruff format --check .` from the repository root — both
+# report exactly what this job gates on.
+on:
+  pull_request:
+    paths:
+      - "ruff.toml"
+      - ".github/workflows/python-lint.yml"
+      - "scripts/**.py"
+      - "tool/**.py"
+      - "tools/**.py"
+  push:
+    branches: [main]
+    paths:
+      - "ruff.toml"
+      - ".github/workflows/python-lint.yml"
+      - "scripts/**.py"
+      - "tool/**.py"
+      - "tools/**.py"
+
+permissions:
+  contents: read
+
+jobs:
+  ruff:
+    name: Ruff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # Same Python every other Linthra workflow sets up, and the version
+      # ruff.toml targets.
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      # Pinned exactly. A new Ruff release can add rules or change formatter
+      # output, which would turn an unrelated PR red for reasons its author did
+      # not cause; bumping the pin is then its own reviewable change, the same
+      # way .flutter-version is.
+      - name: Install Ruff
+        run: python3 -m pip install --quiet "ruff==0.15.8"
+
+      - name: Lint
+        run: ruff check scripts tool tools
+
+      - name: Verify formatting
+        run: ruff format --check scripts tool tools

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,8 +1,14 @@
 name: Python lint
 
 # Fast lint/format feedback for Linthra's Python tooling, so the Python under
-# scripts/, tool/ and tools/ gets the same kind of check Dart already gets from
-# `dart format --set-exit-if-changed` and `flutter analyze` in ci.yml.
+# scripts/, tool/ and tools/ gets the same kind of check the Dart format and
+# analysis steps in ci.yml already give Dart.
+#
+# Naming those steps by their literal command strings would trip the guardrail
+# in test/tooling/toolchain_pins_test.dart, which reads every workflow as text
+# and requires anything that looks like it runs the Flutter SDK to install it
+# through .github/actions/setup-flutter. That guard is right to be text-based,
+# and this job genuinely does not need the SDK.
 #
 # Only the three real Python trees are passed to Ruff, so nothing vendored or
 # generated can be linted by accident. ruff.toml excludes the same trees, which

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -10,11 +10,10 @@ name: Python lint
 # through .github/actions/setup-flutter. That guard is right to be text-based,
 # and this job genuinely does not need the SDK.
 #
-# Only the three real Python trees are passed to Ruff, so nothing vendored or
-# generated can be linted by accident. ruff.toml excludes the same trees, which
-# means the local twin of this job is either the two commands below or simply
-# `ruff check .` and `ruff format --check .` from the repository root — both
-# report exactly what this job gates on.
+# The linted scope is exactly the three paths passed on the command line below,
+# so nothing vendored or generated can be linted by accident. ruff.toml sets the
+# rules, not the scope — it only adds excludes — so the local twin of this job is
+# the two commands below with those same paths, not a bare `ruff check .`.
 on:
   pull_request:
     paths:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,11 @@ For the other areas:
   debugging it locally — on Fedora Atomic (Kinoite/Silverblue) or anywhere
   else — is [docs/flatpak-development.md](./docs/flatpak-development.md).
 - `tools/large_library/` contains the Python and SQLite large-library tooling.
+- Python tooling (`scripts/`, `tool/`, `tools/`) is checked with
+  [Ruff](https://docs.astral.sh/ruff/). Before pushing a Python change, run
+  `ruff check .` and `ruff format --check .` from the repository root — the same
+  two commands CI runs. Details are in
+  [docs/development.md](./docs/development.md#python-tooling-checks-ruff).
 
 ## Before you start
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,8 +64,8 @@ For the other areas:
 - `tools/large_library/` contains the Python and SQLite large-library tooling.
 - Python tooling (`scripts/`, `tool/`, `tools/`) is checked with
   [Ruff](https://docs.astral.sh/ruff/). Before pushing a Python change, run
-  `ruff check .` and `ruff format --check .` from the repository root — the same
-  two commands CI runs. Details are in
+  `ruff check scripts tool tools` and `ruff format --check scripts tool tools` —
+  the same two commands, with the same paths, that CI runs. Details are in
   [docs/development.md](./docs/development.md#python-tooling-checks-ruff).
 
 ## Before you start

--- a/docs/development.md
+++ b/docs/development.md
@@ -267,6 +267,27 @@ SDK locally avoids spurious `dart format` diffs from formatter changes in newer
 Dart releases. The automatic `ci.yml` workflow is **code-quality only**; native
 builds and optional release signing live in separate workflows.
 
+### Python tooling checks (Ruff)
+
+Linthra's Python — the release/toolchain scripts in `scripts/`, icon generation
+in `tool/branding/`, and the large-library fixtures and benchmarks in
+`tools/large_library/` — is linted and format-checked by
+[Ruff](https://docs.astral.sh/ruff/) in the **Python lint** workflow
+(`.github/workflows/python-lint.yml`), which runs on every PR that touches those
+files. Run the same two checks locally:
+
+```bash
+pip install 'ruff==0.15.8'   # the version CI pins
+ruff check .                 # lint
+ruff format --check .        # formatting (drop --check to apply)
+```
+
+Configuration lives in `ruff.toml` at the repository root. It scopes Ruff to the
+three Python trees above, so running the commands bare from the root reports
+exactly what CI gates on. CI pins the Ruff version for the same reason it pins
+Flutter: a new release can add rules or change formatter output, and that should
+land as its own reviewable bump rather than turning an unrelated PR red.
+
 ### Generating Drift files in CI
 
 Drift/SQLite persistence relies on `build_runner` code generation, which can be

--- a/docs/development.md
+++ b/docs/development.md
@@ -277,16 +277,20 @@ in `tool/branding/`, and the large-library fixtures and benchmarks in
 files. Run the same two checks locally:
 
 ```bash
-pip install 'ruff==0.15.8'   # the version CI pins
-ruff check .                 # lint
-ruff format --check .        # formatting (drop --check to apply)
+pip install 'ruff==0.15.8'                  # the version CI pins
+ruff check scripts tool tools              # lint
+ruff format --check scripts tool tools     # formatting (drop --check to apply)
 ```
 
-Configuration lives in `ruff.toml` at the repository root. It scopes Ruff to the
-three Python trees above, so running the commands bare from the root reports
-exactly what CI gates on. CI pins the Ruff version for the same reason it pins
-Flutter: a new release can add rules or change formatter output, and that should
-land as its own reviewable bump rather than turning an unrelated PR red.
+Pass those three paths — they are what CI passes, and they are what defines the
+linted scope. `ruff.toml` at the repository root holds the rules and a few
+excludes, but it does not restrict Ruff to those trees, so a bare `ruff check .`
+is a *different* check: it would also report a Python file added elsewhere in the
+repository, which this workflow never looks at.
+
+CI pins the Ruff version for the same reason it pins Flutter: a new release can
+add rules or change formatter output, and that should land as its own reviewable
+bump rather than turning an unrelated PR red.
 
 ### Generating Drift files in CI
 

--- a/docs/language-areas.md
+++ b/docs/language-areas.md
@@ -38,6 +38,8 @@ Keep it small. Anything that could live in Dart should — the runner exists to 
 
 Python should remove repetitive maintainer work or create useful developer fixtures. Linthra already uses Python in release/branding tooling; `tools/large_library/` adds deterministic 200k-track SQLite generation and query benchmarks using only the standard library. `scripts/check_linux_runner.py` is a good shape to copy: a config invariant that no compiler would catch, checked against its real sources of truth, with unit tests beside it.
 
+Ruff lints and format-checks this code on every PR that touches it. Run `ruff check .` and `ruff format --check .` from the repository root before pushing; the configuration is in `ruff.toml` and the setup is described in [development.md](development.md#python-tooling-checks-ruff).
+
 ## SQL / database performance
 
 SQL matters when a query that feels instant at 5,000 tracks becomes obvious at 200,000. Contributions should include the query plan and a representative fixture/benchmark when possible. Avoid adding indexes speculatively: each index costs storage and write time, so keep ones that serve measured access patterns.

--- a/docs/language-areas.md
+++ b/docs/language-areas.md
@@ -38,7 +38,7 @@ Keep it small. Anything that could live in Dart should — the runner exists to 
 
 Python should remove repetitive maintainer work or create useful developer fixtures. Linthra already uses Python in release/branding tooling; `tools/large_library/` adds deterministic 200k-track SQLite generation and query benchmarks using only the standard library. `scripts/check_linux_runner.py` is a good shape to copy: a config invariant that no compiler would catch, checked against its real sources of truth, with unit tests beside it.
 
-Ruff lints and format-checks this code on every PR that touches it. Run `ruff check .` and `ruff format --check .` from the repository root before pushing; the configuration is in `ruff.toml` and the setup is described in [development.md](development.md#python-tooling-checks-ruff).
+Ruff lints and format-checks this code on every PR that touches it. Run `ruff check scripts tool tools` and `ruff format --check scripts tool tools` before pushing — those paths are the linted scope, and are what CI passes. The rules are in `ruff.toml` and the setup is described in [development.md](development.md#python-tooling-checks-ruff).
 
 ## SQL / database performance
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -17,9 +17,12 @@
 # with python-version "3.11") and that the scripts are run with locally.
 target-version = "py311"
 
-# Keeps a bare `ruff check .` / `ruff format --check .` reporting exactly what
-# the CI job gates on, so a contributor who runs Ruff from the repository root
-# never sees a failure CI does not enforce.
+# These are excludes, not an allowlist: Ruff still walks whatever path it is
+# given, minus the entries below. The linted scope is set by the paths passed on
+# the command line — `scripts tool tools`, in CI and in the docs — so a bare
+# `ruff check .` is NOT the same check: it would also report a Python file added
+# anywhere else in the repository, which CI does not look at. Always pass the
+# three paths.
 extend-exclude = [
   # Vendored and generated trees. Neither holds Python today; excluding them
   # means neither can start being linted by accident. third_party/ in
@@ -28,13 +31,13 @@ extend-exclude = [
   "build",
   "third_party",
 
-  # The one real exception, and it is deliberate rather than a rule being
-  # switched off: issue #353 scopes Ruff to scripts/, tool/ and tools/, and
-  # test/tooling/ holds the Python unit tests for those scripts. They are
-  # tooling too and should be linted, but bringing them in means reformatting
-  # nine more files, which belongs in its own follow-up PR rather than riding
-  # along here. Removing this entry and re-running `ruff format` is the whole
-  # of that change.
+  # Not in the linted scope anyway — the CI paths do not include it — but named
+  # here so the decision is recorded rather than implicit: issue #353 scopes
+  # Ruff to scripts/, tool/ and tools/, and test/tooling/ holds the Python unit
+  # tests for those scripts. They are tooling too and should be linted, but
+  # bringing them in means reformatting nine more files, which belongs in its
+  # own follow-up PR rather than riding along here. Adding test/tooling to the
+  # CI paths and re-running `ruff format` is the whole of that change.
   "test/tooling",
 ]
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -17,12 +17,25 @@
 # with python-version "3.11") and that the scripts are run with locally.
 target-version = "py311"
 
-# Nothing here is Python, but an explicit exclude keeps a bare `ruff check .`
-# from ever wandering into vendored or generated trees if Python appears in
-# one later.
+# Keeps a bare `ruff check .` / `ruff format --check .` reporting exactly what
+# the CI job gates on, so a contributor who runs Ruff from the repository root
+# never sees a failure CI does not enforce.
 extend-exclude = [
+  # Vendored and generated trees. Neither holds Python today; excluding them
+  # means neither can start being linted by accident. third_party/ in
+  # particular is upstream source held to upstream's style, exactly as
+  # analysis_options.yaml already excludes it from `flutter analyze`.
   "build",
   "third_party",
+
+  # The one real exception, and it is deliberate rather than a rule being
+  # switched off: issue #353 scopes Ruff to scripts/, tool/ and tools/, and
+  # test/tooling/ holds the Python unit tests for those scripts. They are
+  # tooling too and should be linted, but bringing them in means reformatting
+  # nine more files, which belongs in its own follow-up PR rather than riding
+  # along here. Removing this entry and re-running `ruff format` is the whole
+  # of that change.
+  "test/tooling",
 ]
 
 [lint]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,40 @@
+# Ruff configuration for Linthra's Python tooling.
+#
+# Linthra is a Flutter app, not a Python package: there is no library to build,
+# publish or install, so this lives in ruff.toml rather than a root
+# pyproject.toml, which would suggest a Python distribution that does not exist.
+#
+# The Python that is linted is the developer/release tooling:
+#   * scripts/            — release, toolchain and repository-integrity checks
+#   * tool/branding/      — icon generation
+#   * tools/large_library/ — SQLite fixture generation and benchmarks
+#
+# Local twin of the CI job (.github/workflows/python-lint.yml):
+#   ruff check scripts tool tools
+#   ruff format --check scripts tool tools
+
+# Matches the Python that every Linthra workflow sets up (actions/setup-python
+# with python-version "3.11") and that the scripts are run with locally.
+target-version = "py311"
+
+# Nothing here is Python, but an explicit exclude keeps a bare `ruff check .`
+# from ever wandering into vendored or generated trees if Python appears in
+# one later.
+extend-exclude = [
+  "build",
+  "third_party",
+]
+
+[lint]
+# Ruff's default set (E4/E7/E9 pycodestyle + F pyflakes) plus two rules that
+# catch real problems rather than taste:
+#   I  — import sorting, so import blocks stop drifting between scripts.
+#   B  — flake8-bugbear, for genuine bug shapes (mutable default arguments,
+#        loop-variable capture in closures, ...).
+#
+# Deliberately not selected: E501 (line-too-long). `ruff format` already owns
+# line width, and E501 only ever fires on the lines the formatter cannot split
+# (long URLs, literal SHA-256 digests, error strings quoted verbatim from the
+# tools they wrap), so enabling it would mean scattering `# noqa` through the
+# existing scripts for no correctness gain.
+select = ["E4", "E7", "E9", "F", "I", "B"]

--- a/scripts/check_android_toolchain_update.py
+++ b/scripts/check_android_toolchain_update.py
@@ -143,7 +143,7 @@ import sys
 import urllib.request
 import xml.etree.ElementTree as ElementTree
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from toolchain_pins import (
     TOOL_NAMES,

--- a/scripts/check_android_toolchain_update.py
+++ b/scripts/check_android_toolchain_update.py
@@ -236,7 +236,9 @@ def load_index(url: str, path: Optional[str]) -> Tuple[str, str]:
         with urllib.request.urlopen(url, timeout=_FETCH_TIMEOUT_SECONDS) as response:
             raw = response.read(_MAX_INDEX_BYTES + 1)
     except Exception as error:  # network, TLS, HTTP status
-        raise CheckError(f"could not fetch the release index from {url}: {error}") from error
+        raise CheckError(
+            f"could not fetch the release index from {url}: {error}"
+        ) from error
     if len(raw) > _MAX_INDEX_BYTES:
         raise CheckError(
             f"{url} returned more than {_MAX_INDEX_BYTES} bytes; refusing to parse it"
@@ -460,7 +462,9 @@ def classify(current: Version, latest: Version) -> str:
     return STATUS_PATCH
 
 
-def evaluate(name: str, current: Version, found: Candidates, origin: str) -> Dict[str, str]:
+def evaluate(
+    name: str, current: Version, found: Candidates, origin: str
+) -> Dict[str, str]:
     """Everything the workflow needs to know about one tool."""
     t = tool(name)
 
@@ -494,8 +498,7 @@ def evaluate(name: str, current: Version, found: Candidates, origin: str) -> Dic
         # but an index that has never heard of the version we ship is worth a
         # human's eye.
         notes.append(
-            f"the pinned version {format_version(current)} is not listed in "
-            f"{origin}"
+            f"the pinned version {format_version(current)} is not listed in {origin}"
         )
 
     major_available = latest[0] > current[0]
@@ -547,7 +550,9 @@ def parse_versions_files(values: List[str], tools: List[str]) -> Dict[str, str]:
     return mapping
 
 
-def build_results(args: argparse.Namespace, repo_root: Path) -> Dict[str, Dict[str, str]]:
+def build_results(
+    args: argparse.Namespace, repo_root: Path
+) -> Dict[str, Dict[str, str]]:
     tools: List[str] = [args.tool] if args.tool else list(TOOL_NAMES)
 
     if args.current is not None and len(tools) != 1:
@@ -560,7 +565,9 @@ def build_results(args: argparse.Namespace, repo_root: Path) -> Dict[str, Dict[s
     results: Dict[str, Dict[str, str]] = {}
     for name in tools:
         t = tool(name)
-        current_text = args.current if args.current is not None else read_pin(repo_root, name)
+        current_text = (
+            args.current if args.current is not None else read_pin(repo_root, name)
+        )
         current = parse_version(
             current_text,
             "--current" if args.current is not None else t.pin_file,
@@ -663,8 +670,7 @@ def write_github_output(path: str, results: Dict[str, Dict[str, str]]) -> None:
 def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
-            "Detect newer stable Gradle / AGP / Kotlin releases than the "
-            "pinned ones."
+            "Detect newer stable Gradle / AGP / Kotlin releases than the pinned ones."
         ),
     )
     parser.add_argument(

--- a/scripts/check_flutter_sdk_update.py
+++ b/scripts/check_flutter_sdk_update.py
@@ -110,8 +110,7 @@ from typing import Any, Dict, List, Optional, Tuple
 # scripts/setup_flutter.sh's default platform; the version/channel data in the
 # macOS and Windows manifests is the same set of releases.
 DEFAULT_RELEASES_URL = (
-    "https://storage.googleapis.com/flutter_infra_release/releases/"
-    "releases_linux.json"
+    "https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json"
 )
 
 # A stable Flutter version is a bare triple. Nothing else is accepted, from the
@@ -188,9 +187,7 @@ def read_pin(repo_root: Path) -> str:
     return pin_file.read_text(encoding="utf-8").strip()
 
 
-def load_manifest(
-    releases_file: Optional[str], releases_url: str
-) -> Dict[str, Any]:
+def load_manifest(releases_file: Optional[str], releases_url: str) -> Dict[str, Any]:
     """Load the release manifest from a file or the official URL."""
     if releases_file is not None:
         path = Path(releases_file)
@@ -262,9 +259,7 @@ def stable_releases(manifest: Dict[str, Any]) -> StableSet:
     notes: List[str] = []
     for index, release in enumerate(releases):
         if not isinstance(release, dict):
-            raise CheckError(
-                f"{origin} entry #{index} is not an object: {release!r}"
-            )
+            raise CheckError(f"{origin} entry #{index} is not an object: {release!r}")
         channel = release.get("channel")
         version_text = release.get("version")
         if channel != _STABLE_CHANNEL:
@@ -275,9 +270,7 @@ def stable_releases(manifest: Dict[str, Any]) -> StableSet:
             skipped.append(str(error))
             continue
         archive = release.get("archive")
-        if not isinstance(archive, str) or not archive.startswith(
-            _ARCHIVE_PREFIX
-        ):
+        if not isinstance(archive, str) or not archive.startswith(_ARCHIVE_PREFIX):
             # A stable row must name the archive that `scripts/setup_flutter.sh`
             # would download, and it must live under stable/. Missing, null,
             # empty or pointing elsewhere all contradict the channel claim, so
@@ -452,9 +445,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         "--github-output",
         help="Append key=value lines for GitHub Actions to this file.",
     )
-    parser.add_argument(
-        "--json", action="store_true", help="Print the result as JSON."
-    )
+    parser.add_argument("--json", action="store_true", help="Print the result as JSON.")
     parser.add_argument(
         "--quiet", action="store_true", help="Suppress the human-readable report."
     )

--- a/scripts/check_linux_runner.py
+++ b/scripts/check_linux_runner.py
@@ -138,7 +138,7 @@ SECURE_STORAGE_SCOPED_EXCEPTION = re.compile(
 # `/` alone is far too common in CMake (every ${VAR}/sub path), so this looks
 # for a quoted or bare token that starts at a real filesystem root.
 ABSOLUTE_PATH_PATTERN = re.compile(
-    r'(?<![\w$/{])/(?:home|Users|root|opt|usr/local|tmp|var|mnt|media)/[\w./-]+'
+    r"(?<![\w$/{])/(?:home|Users|root|opt|usr/local|tmp|var|mnt|media)/[\w./-]+"
 )
 
 
@@ -165,7 +165,9 @@ def _extract(text: str, pattern: str, what: str, where: Path) -> str:
     if not matches:
         raise CheckError(f"{where}: could not find {what}")
     if len(matches) > 1:
-        raise CheckError(f"{where}: found {len(matches)} definitions of {what}, expected 1")
+        raise CheckError(
+            f"{where}: found {len(matches)} definitions of {what}, expected 1"
+        )
     return matches[0]
 
 
@@ -286,9 +288,7 @@ def desktop_entry_problems(root: Path) -> list[str]:
         if actual is None:
             problems.append(f"{where}: no {key}=, expected {expected!r} ({source})")
         elif actual != expected:
-            problems.append(
-                f"{where}: {key}={actual!r} but {source} says {expected!r}"
-            )
+            problems.append(f"{where}: {key}={actual!r} but {source} says {expected!r}")
 
     require("Type", "Application", "a launchable desktop entry")
     require("Name", app_display_name(root), "lib/core/app_info.dart AppInfo.name")
@@ -463,9 +463,7 @@ def check(root: Path) -> list[str]:
 
     def compare(label: str, actual: str, expected: str, source: str) -> None:
         if actual != expected:
-            problems.append(
-                f"{label} is {actual!r} but {source} says {expected!r}"
-            )
+            problems.append(f"{label} is {actual!r} but {source} says {expected!r}")
 
     compare(
         "linux/CMakeLists.txt APPLICATION_ID",

--- a/scripts/check_pr_security_surface.py
+++ b/scripts/check_pr_security_surface.py
@@ -49,7 +49,12 @@ SENSITIVE_PATH_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     # tools/large_library/ is run by the large-library workflow.
     (re.compile(r"^(?:scripts|tool|tools)/"), "repository automation script"),
     (re.compile(r"^(pubspec\.ya?ml|pubspec\.lock)$"), "dependency manifest / lockfile"),
-    (re.compile(r"^android/.*(AndroidManifest\.xml|\.gradle(?:\.kts)?|gradle\.properties)$"), "Android permissions / build configuration"),
+    (
+        re.compile(
+            r"^android/.*(AndroidManifest\.xml|\.gradle(?:\.kts)?|gradle\.properties)$"
+        ),
+        "Android permissions / build configuration",
+    ),
     # The Gradle wrapper decides which Gradle is downloaded and from where
     # (distributionUrl), and the wrapper jar is executed by every Android
     # build. The repository's own toolchain guard covers only the automated
@@ -64,13 +69,19 @@ SENSITIVE_PATH_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     # release APK by android-release-build.yml. The other trees do not exist
     # today; naming them keeps a future `flutter create --platforms=` from
     # landing unclassified privileged code.
-    (re.compile(r"^(?:android|ios|macos|windows)/.*\.(?:kt|java|swift|m|mm)$"), "platform / native app code"),
+    (
+        re.compile(r"^(?:android|ios|macos|windows)/.*\.(?:kt|java|swift|m|mm)$"),
+        "platform / native app code",
+    ),
     (re.compile(r"(?:^|/)gradle/wrapper/"), "build toolchain distribution / wrapper"),
     (re.compile(r"^\.[a-z0-9]+-version$"), "build toolchain pin"),
     # linux/ is the desktop runner; native/ holds the C++ DSP library and the
     # Rust core, both compiled by CI and the Rust one also executed by it
     # (`cargo run --locked` in rust-core.yml).
-    (re.compile(r"^(?:linux|native)/.*\.(?:cc|cpp|cxx|c|h|hpp|hxx|rs|cmake)$"), "native code"),
+    (
+        re.compile(r"^(?:linux|native)/.*\.(?:cc|cpp|cxx|c|h|hpp|hxx|rs|cmake)$"),
+        "native code",
+    ),
     (re.compile(r"(?:^|/)CMakeLists\.txt$"), "native build configuration"),
     # A Cargo dependency may carry a build script, which runs at build time on
     # the CI machine — the same trust boundary pubspec.yaml crosses.
@@ -81,30 +92,71 @@ SENSITIVE_PATH_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     # text is a legal boundary, and signing material is the release identity.
     (re.compile(r"(?:^|/)analysis_options\.ya?ml$"), "static analysis configuration"),
     (re.compile(r"(?:^|/)(?:LICENSE|COPYING|NOTICE)(?:$|\.)"), "licensing"),
-    (re.compile(r"(?:^|/)key\.properties$|\.(?:jks|keystore)$"), "release signing material"),
+    (
+        re.compile(r"(?:^|/)key\.properties$|\.(?:jks|keystore)$"),
+        "release signing material",
+    ),
     # metadata/*.yml is the F-Droid build recipe: its Builds entries carry
     # sudo/prebuild/build commands, and docs/fdroid-submission.md has the
     # maintainer copy it into fdroiddata and run a full build from it. The
     # fastlane changelog and description text beside it really is just text,
     # and stays ordinary.
     (re.compile(r"^metadata/.*\.ya?ml$"), "F-Droid build recipe"),
-    (re.compile(r"^lib/.*(?:auth|credential|token|session|secure|secret)", re.I), "authentication / credential handling"),
-    (re.compile(r"^lib/.*(?:network|http|client|socket|provider|source)", re.I), "network / provider boundary"),
-    (re.compile(r"^lib/.*(?:database|repository|store|storage|persistence|cache)", re.I), "persistent storage"),
+    (
+        re.compile(r"^lib/.*(?:auth|credential|token|session|secure|secret)", re.I),
+        "authentication / credential handling",
+    ),
+    (
+        re.compile(r"^lib/.*(?:network|http|client|socket|provider|source)", re.I),
+        "network / provider boundary",
+    ),
+    (
+        re.compile(
+            r"^lib/.*(?:database|repository|store|storage|persistence|cache)", re.I
+        ),
+        "persistent storage",
+    ),
     # `.gitattributes` can change how git renders a diff (for example marking a
     # path `-diff`), which is a direct attack on this scanner's input.
     (re.compile(r"(?:^|/)\.gitattributes$"), "git diff / attribute behavior"),
     (re.compile(r"(?:^|/)CODEOWNERS$"), "code ownership / review routing"),
-    (re.compile(r"^(?:\.gitmodules|\.github/dependabot\.ya?ml)$"), "supply-chain configuration"),
+    (
+        re.compile(r"^(?:\.gitmodules|\.github/dependabot\.ya?ml)$"),
+        "supply-chain configuration",
+    ),
 )
 
 SENSITIVE_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
-    (re.compile(r"\b(?:HttpClient|WebSocket|Socket)\b|package:http/|\bhttp\.(?:get|post|put|delete|patch)\b"), "new network-capable code"),
-    (re.compile(r"\b(?:SharedPreferences|FlutterSecureStorage|File|Directory|RandomAccessFile)\s*\("), "new local persistence / filesystem access"),
-    (re.compile(r"\b(?:writeAsString|writeAsBytes|openWrite|setString|setStringList)\s*\("), "new write-to-disk behavior"),
+    (
+        re.compile(
+            r"\b(?:HttpClient|WebSocket|Socket)\b|package:http/|\bhttp\.(?:get|post|put|delete|patch)\b"
+        ),
+        "new network-capable code",
+    ),
+    (
+        re.compile(
+            r"\b(?:SharedPreferences|FlutterSecureStorage|File|Directory|RandomAccessFile)\s*\("
+        ),
+        "new local persistence / filesystem access",
+    ),
+    (
+        re.compile(
+            r"\b(?:writeAsString|writeAsBytes|openWrite|setString|setStringList)\s*\("
+        ),
+        "new write-to-disk behavior",
+    ),
     (re.compile(r"\b(?:MethodChannel|EventChannel)\s*\("), "new platform channel"),
-    (re.compile(r"\b(?:authorization|bearer|access[_-]?token|api[_-]?key|password|credential)\b", re.I), "credential-sensitive logic"),
-    (re.compile(r"\b(?:schemaVersion|MigrationStrategy|createIndex|alterTable)\b"), "database schema / migration"),
+    (
+        re.compile(
+            r"\b(?:authorization|bearer|access[_-]?token|api[_-]?key|password|credential)\b",
+            re.I,
+        ),
+        "credential-sensitive logic",
+    ),
+    (
+        re.compile(r"\b(?:schemaVersion|MigrationStrategy|createIndex|alterTable)\b"),
+        "database schema / migration",
+    ),
 )
 
 
@@ -147,6 +199,7 @@ _EXEC_WRAPPER = (
     r"(?:(?:sudo|env|command|exec|nohup|nice|stdbuf|setsid|ionice|timeout)\s+"
     r"(?:[-\w=./]+\s+)*)*"
 )
+
 
 # The download half of the download-then-execute rules, shared by the blocked
 # tier (the file is run) and the sensitive tier (it is only made runnable).
@@ -192,7 +245,9 @@ _PR_TARGET_TRIGGER = _split_literal("pull_request", "_target")
 # would leave a trivial bypass.
 BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     (
-        re.compile(rf"\bProcess{_SEP}\.{_SEP}(?:run|runSync|start|startSync|killPid)\b"),
+        re.compile(
+            rf"\bProcess{_SEP}\.{_SEP}(?:run|runSync|start|startSync|killPid)\b"
+        ),
         "runtime process execution",
     ),
     # Anything but an explicit `false`: `true` enables a shell, and a variable
@@ -224,7 +279,10 @@ BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
         ),
         "runtime FFI / dynamic library loading",
     ),
-    (re.compile(rf"\b{_PR_TARGET_TRIGGER}\b"), f"{_PR_TARGET_TRIGGER} workflow trigger"),
+    (
+        re.compile(rf"\b{_PR_TARGET_TRIGGER}\b"),
+        f"{_PR_TARGET_TRIGGER} workflow trigger",
+    ),
     (
         re.compile(
             r"""\bpermissions\s*:\s*['"]?write-all\b|^[ \t]*['"]?write-all['"]?[ \t]*$""",
@@ -254,13 +312,11 @@ BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
         # keeps this precise: fetching a data file and separately running an
         # unrelated local script does not match.
         re.compile(
-            _download_to_file(_SH_GAP)
-            + rf"(?:[\s;&|(]{_EXEC_WRAPPER}(?:/\S+/)?"
+            _download_to_file(_SH_GAP) + rf"(?:[\s;&|(]{_EXEC_WRAPPER}(?:/\S+/)?"
             rf"(?:sh|bash|zsh|dash|ksh|python3?|perl|ruby|node){_SH_GAP}+"
             # `. f` and `source f` execute the file in the current shell, which
             # is the same capability by a different spelling.
-            rf"|(?:^|[\n;&|(]){_SH_GAP}*(?:\.|source){_SH_GAP}+)"
-            + _SAME_TARGET
+            rf"|(?:^|[\n;&|(]){_SH_GAP}*(?:\.|source){_SH_GAP}+)" + _SAME_TARGET
         ),
         "download-then-execute shell pattern",
     ),
@@ -698,7 +754,12 @@ def classify(
     return dedupe(sensitive), dedupe(blocked)
 
 
-def write_report(report_path: Path, files: list[str], sensitive: list[Finding], blocked: list[Finding]) -> None:
+def write_report(
+    report_path: Path,
+    files: list[str],
+    sensitive: list[Finding],
+    blocked: list[Finding],
+) -> None:
     report_path.parent.mkdir(parents=True, exist_ok=True)
     # backslashreplace: a pathname byte that is not valid UTF-8 survives as a
     # surrogate in `path`, and must render readably here rather than raising.
@@ -709,13 +770,17 @@ def write_report(report_path: Path, files: list[str], sensitive: list[Finding], 
             report.write("### Blocked high-risk additions\n\n")
             for finding in blocked:
                 report.write(f"- `{finding.path}` — {finding.reason}\n")
-            report.write("\nThese patterns require redesign or a separate maintainer-controlled implementation; an approval does not bypass them.\n\n")
+            report.write(
+                "\nThese patterns require redesign or a separate maintainer-controlled implementation; an approval does not bypass them.\n\n"
+            )
         if sensitive:
             report.write("### Sensitive surfaces requiring maintainer review\n\n")
             for finding in sensitive:
                 report.write(f"- `{finding.path}` — {finding.reason}\n")
         else:
-            report.write("No security-sensitive trust boundary was detected in this diff.\n")
+            report.write(
+                "No security-sensitive trust boundary was detected in this diff.\n"
+            )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -735,7 +800,10 @@ def main(argv: list[str] | None = None) -> int:
         files = changed_files(args.base, args.head)
         sources, unresolved_paths = changed_sources(args.base, args.head)
     except ScannerError as error:
-        print(f"::error::PR security surface scan could not inspect the diff: {error}", file=sys.stderr)
+        print(
+            f"::error::PR security surface scan could not inspect the diff: {error}",
+            file=sys.stderr,
+        )
         return 2
 
     sensitive, blocked = classify(files, sources, unresolved_paths)
@@ -743,7 +811,9 @@ def main(argv: list[str] | None = None) -> int:
     write_report(Path(args.report), files, sensitive, blocked)
 
     if args.github_output:
-        with open(args.github_output, "a", encoding="utf-8", errors="backslashreplace") as output:
+        with open(
+            args.github_output, "a", encoding="utf-8", errors="backslashreplace"
+        ) as output:
             output.write(f"sensitive={'true' if sensitive else 'false'}\n")
             output.write(f"blocked={'true' if blocked else 'false'}\n")
 

--- a/scripts/check_repository_integrity.py
+++ b/scripts/check_repository_integrity.py
@@ -72,6 +72,7 @@ def _clamp_report_field(value: str) -> str:
     keep = MAX_REPORT_FIELD_CHARS - len(_TRUNCATION_SUFFIX)
     return _TRUNCATION_SUFFIX + value[-keep:]
 
+
 # Files that must be able to hold literal attack strings, because they are the
 # fixtures this guard is tested against. Only lines carrying the explicit marker
 # below are exempted, and only inside these exact paths.
@@ -80,27 +81,58 @@ SELF_TEST_FIXTURE_PATHS = frozenset({"test/tooling/check_repository_integrity_te
 FIXTURE_EXEMPTION_MARKER = "integrity-guard-fixture"
 
 _EXTERNAL_BLOCKED_PATHS: tuple[tuple[re.Pattern[str], str], ...] = (
-    (re.compile(r"^\.vscode/", re.I), "VS Code workspace configuration is maintainer-controlled"),
-    (re.compile(r"^\.idea/", re.I), "IDE project configuration is maintainer-controlled"),
-    (re.compile(r"(?:^|/).*\.code-workspace$", re.I), "VS Code workspace file is maintainer-controlled"),
-    (re.compile(r"^\.github/workflows/"), "GitHub Actions workflows are maintainer-controlled"),
-    (re.compile(r"^\.github/actions/"), "GitHub composite actions are maintainer-controlled"),
-    (re.compile(r"^(?:scripts|tool|tools)/"), "repository automation scripts are maintainer-controlled"),
-    (re.compile(r"(?:^|/)CODEOWNERS$"), "code-ownership policy is maintainer-controlled"),
-    (re.compile(r"^\.github/dependabot\.ya?ml$"), "dependency-update policy is maintainer-controlled"),
-    (re.compile(r"^\.gitattributes$"), "Git diff/attribute policy is maintainer-controlled"),
+    (
+        re.compile(r"^\.vscode/", re.I),
+        "VS Code workspace configuration is maintainer-controlled",
+    ),
+    (
+        re.compile(r"^\.idea/", re.I),
+        "IDE project configuration is maintainer-controlled",
+    ),
+    (
+        re.compile(r"(?:^|/).*\.code-workspace$", re.I),
+        "VS Code workspace file is maintainer-controlled",
+    ),
+    (
+        re.compile(r"^\.github/workflows/"),
+        "GitHub Actions workflows are maintainer-controlled",
+    ),
+    (
+        re.compile(r"^\.github/actions/"),
+        "GitHub composite actions are maintainer-controlled",
+    ),
+    (
+        re.compile(r"^(?:scripts|tool|tools)/"),
+        "repository automation scripts are maintainer-controlled",
+    ),
+    (
+        re.compile(r"(?:^|/)CODEOWNERS$"),
+        "code-ownership policy is maintainer-controlled",
+    ),
+    (
+        re.compile(r"^\.github/dependabot\.ya?ml$"),
+        "dependency-update policy is maintainer-controlled",
+    ),
+    (
+        re.compile(r"^\.gitattributes$"),
+        "Git diff/attribute policy is maintainer-controlled",
+    ),
     (re.compile(r"^\.gitmodules$"), "Git submodule policy is maintainer-controlled"),
 )
 
 # The self-test paths are maintainer-controlled by construction: an external PR
 # cannot add (or mark) a line that the fixture exemption would then skip.
-EXTERNAL_BLOCKED_PATHS: tuple[tuple[re.Pattern[str], str], ...] = _EXTERNAL_BLOCKED_PATHS + tuple(
-    (
-        re.compile(rf"^{re.escape(path)}$"),
-        "repository-integrity self-test fixtures are maintainer-controlled",
+EXTERNAL_BLOCKED_PATHS: tuple[tuple[re.Pattern[str], str], ...] = (
+    _EXTERNAL_BLOCKED_PATHS
+    + tuple(
+        (
+            re.compile(rf"^{re.escape(path)}$"),
+            "repository-integrity self-test fixtures are maintainer-controlled",
+        )
+        for path in sorted(SELF_TEST_FIXTURE_PATHS)
     )
-    for path in sorted(SELF_TEST_FIXTURE_PATHS)
 )
+
 
 def _u16(data: bytes, offset: int) -> int:
     return int.from_bytes(data[offset : offset + 2], "big")
@@ -127,7 +159,12 @@ def _valid_woff(data: bytes, signature: bytes, header_size: int) -> bool:
 
 def _valid_sfnt(data: bytes) -> bool:
     """TrueType/OpenType: searchRange and friends are derived from numTables."""
-    if len(data) < 12 or data[:4] not in (b"\x00\x01\x00\x00", b"true", b"typ1", b"OTTO"):
+    if len(data) < 12 or data[:4] not in (
+        b"\x00\x01\x00\x00",
+        b"true",
+        b"typ1",
+        b"OTTO",
+    ):
         return False
     num_tables = _u16(data, 4)
     if num_tables == 0 or len(data) < 12 + 16 * num_tables:
@@ -177,7 +214,10 @@ def _valid_gif(data: bytes) -> bool:
     """
     if len(data) < 14 or data[:6] not in (b"GIF87a", b"GIF89a"):
         return False
-    if int.from_bytes(data[6:8], "little") == 0 or int.from_bytes(data[8:10], "little") == 0:
+    if (
+        int.from_bytes(data[6:8], "little") == 0
+        or int.from_bytes(data[8:10], "little") == 0
+    ):
         return False
 
     flags = data[10]
@@ -304,7 +344,11 @@ def _valid_pdf(data: bytes) -> bool:
 
 def _valid_ico(data: bytes) -> bool:
     """Header, directory, and every entry pointing at real image bytes."""
-    if len(data) < 6 or data[:2] != b"\x00\x00" or data[2:4] not in (b"\x01\x00", b"\x02\x00"):
+    if (
+        len(data) < 6
+        or data[:2] != b"\x00\x00"
+        or data[2:4] not in (b"\x01\x00", b"\x02\x00")
+    ):
         return False
     count = int.from_bytes(data[4:6], "little")
     directory_end = 6 + 16 * count
@@ -323,7 +367,18 @@ def _valid_ico(data: bytes) -> bool:
 # objects, xref table, trailer and %%EOF — so the binary backstop would reject
 # legitimate documents. Its structural validator carries the weight instead.
 BINARY_ASSET_SUFFIXES = frozenset(
-    {".woff", ".woff2", ".ttf", ".otf", ".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico"}
+    {
+        ".woff",
+        ".woff2",
+        ".ttf",
+        ".otf",
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".webp",
+        ".ico",
+    }
 )
 
 ASSET_VALIDATORS: dict[str, tuple[str, "Callable[[bytes], bool]"]] = {
@@ -343,8 +398,21 @@ ASSET_VALIDATORS: dict[str, tuple[str, "Callable[[bytes], bool]"]] = {
 # Extensions the guard treats as inert assets. Nothing here should ever carry
 # the executable bit, so the mode is checked independently of the contents.
 ASSET_SUFFIXES = frozenset(
-    {".woff", ".woff2", ".ttf", ".otf", ".eot", ".png", ".jpg", ".jpeg",
-     ".gif", ".webp", ".ico", ".pdf", ".svg"}
+    {
+        ".woff",
+        ".woff2",
+        ".ttf",
+        ".otf",
+        ".eot",
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".webp",
+        ".ico",
+        ".pdf",
+        ".svg",
+    }
 )
 
 
@@ -382,22 +450,22 @@ EXECUTABLE_ASSET_EXTENSIONS = (
 )
 _EXECUTABLE_ASSET_RE = re.compile(
     rf"""(?ix)
-    \b(?:{'|'.join(_INTERPRETERS)})
+    \b(?:{"|".join(_INTERPRETERS)})
     \b[^\n\r]{{0,240}}
-    \.(?:{'|'.join(EXECUTABLE_ASSET_EXTENSIONS)})\b
+    \.(?:{"|".join(EXECUTABLE_ASSET_EXTENSIONS)})\b
     |
     \bchmod\b[^\n\r]{{0,120}}\+x[^\n\r]{{0,160}}
-    \.(?:{'|'.join(EXECUTABLE_ASSET_EXTENSIONS)})\b
+    \.(?:{"|".join(EXECUTABLE_ASSET_EXTENSIONS)})\b
     |
     (?:^|[;&|()])\s*(?:source|\.)\s+[^\n\r]{{0,240}}
-    \.(?:{'|'.join(EXECUTABLE_ASSET_EXTENSIONS)})\b
+    \.(?:{"|".join(EXECUTABLE_ASSET_EXTENSIONS)})\b
     """
 )
 
 _NUMERIC_CHMOD_ASSET_RE = re.compile(
     rf"""(?ix)
     \bchmod\b[^\n\r]{{0,120}}?\b(?P<mode>[0-7]{{3,4}})\b
-    [^\n\r]{{0,160}}\.(?:{'|'.join(EXECUTABLE_ASSET_EXTENSIONS)})\b
+    [^\n\r]{{0,160}}\.(?:{"|".join(EXECUTABLE_ASSET_EXTENSIONS)})\b
     """
 )
 
@@ -439,9 +507,14 @@ def run_git(*args: str, text: bool = True) -> str | bytes:
 
 def changed_files(base: str, head: str) -> list[str]:
     raw = run_git(
-        "-c", "core.quotePath=false",
-        "diff", "--name-only", "-z", "--no-renames",
-        f"{base}...{head}", "--",
+        "-c",
+        "core.quotePath=false",
+        "diff",
+        "--name-only",
+        "-z",
+        "--no-renames",
+        f"{base}...{head}",
+        "--",
     )
     assert isinstance(raw, str)
     return [item for item in raw.split("\0") if item]
@@ -529,7 +602,9 @@ def _ignore_state(rules: list[str], entry: str) -> tuple[bool, str | None]:
 def check_ignore_policy(head: str) -> list[Finding]:
     text = blob_text(head, ".gitignore")
     if text is None:
-        return [Finding(head, ".gitignore", "required repository .gitignore is missing")]
+        return [
+            Finding(head, ".gitignore", "required repository .gitignore is missing")
+        ]
     rules = _ignore_rules(text)
 
     findings: list[Finding] = []
@@ -547,7 +622,9 @@ def check_ignore_policy(head: str) -> list[Finding]:
             )
         else:
             findings.append(
-                Finding(head, ".gitignore", f"required ignore entry `{entry}` was removed")
+                Finding(
+                    head, ".gitignore", f"required ignore entry `{entry}` was removed"
+                )
             )
     return findings
 
@@ -587,7 +664,9 @@ def check_asset_modes(head: str, files: list[str]) -> list[Finding]:
             continue
         if git_mode(head, path) == "100755":
             findings.append(
-                Finding(head, path, "asset file is committed with the executable bit set")
+                Finding(
+                    head, path, "asset file is committed with the executable bit set"
+                )
             )
     return findings
 
@@ -608,12 +687,20 @@ def check_asset_magic(head: str, files: list[str]) -> list[Finding]:
             # that is pure text is a polyglot candidate regardless of how well
             # it fakes a header, so reject it before the format check.
             findings.append(
-                Finding(head, path, f"file extension claims {label} but the file is entirely text")
+                Finding(
+                    head,
+                    path,
+                    f"file extension claims {label} but the file is entirely text",
+                )
             )
             continue
         if not is_valid(data):
             findings.append(
-                Finding(head, path, f"file extension claims {label} but the file is not a valid {label}")
+                Finding(
+                    head,
+                    path,
+                    f"file extension claims {label} but the file is not a valid {label}",
+                )
             )
     return findings
 
@@ -657,7 +744,9 @@ def check_active_svg(head: str, files: list[str]) -> list[Finding]:
             continue
         text = blob_text(head, path)
         if text is not None and svg_is_active(text):
-            findings.append(Finding(head, path, "SVG contains active/external executable content"))
+            findings.append(
+                Finding(head, path, "SVG contains active/external executable content")
+            )
     return findings
 
 
@@ -690,11 +779,15 @@ def asset_execution_finding(path: str, text: str) -> Finding | None:
     normalised = re.sub(r"\\\r?\n", "", "".join(scannable))
     for line in re.split(r"[\r\n]", normalised):
         if _EXECUTABLE_ASSET_RE.search(line):
-            return Finding("", path, "text invokes or marks an asset file as executable")
+            return Finding(
+                "", path, "text invokes or marks an asset file as executable"
+            )
         for match in _NUMERIC_CHMOD_ASSET_RE.finditer(line):
             permission_digits = match.group("mode")[-3:]
             if any(int(digit) & 1 for digit in permission_digits):
-                return Finding("", path, "text invokes or marks an asset file as executable")
+                return Finding(
+                    "", path, "text invokes or marks an asset file as executable"
+                )
     return None
 
 
@@ -730,19 +823,40 @@ def actionable(finding: Finding) -> Finding:
     """
     reason = finding.reason.lower()
     if "executable bit" in reason:
-        rule, remediation = "asset-executable-mode", "Remove the executable permission from the asset and recommit the mode change."
+        rule, remediation = (
+            "asset-executable-mode",
+            "Remove the executable permission from the asset and recommit the mode change.",
+        )
     elif "file extension claims" in reason:
-        rule, remediation = "invalid-disguised-asset", "Replace the invalid asset with a real file of the declared asset type."
+        rule, remediation = (
+            "invalid-disguised-asset",
+            "Replace the invalid asset with a real file of the declared asset type.",
+        )
     elif "svg contains" in reason:
-        rule, remediation = "active-svg-content", "Remove scripts, event handlers, foreign objects, and external active references from the SVG."
+        rule, remediation = (
+            "active-svg-content",
+            "Remove scripts, event handlers, foreign objects, and external active references from the SVG.",
+        )
     elif "invokes or marks an asset" in reason:
-        rule, remediation = "asset-execution-command", "Remove commands that execute the asset or grant it executable permission."
+        rule, remediation = (
+            "asset-execution-command",
+            "Remove commands that execute the asset or grant it executable permission.",
+        )
     elif "gitignore" in reason or "ignore entry" in reason:
-        rule, remediation = "protected-ignore-policy", "Restore the required .idea/ and .vscode/ ignore rules without later negations."
+        rule, remediation = (
+            "protected-ignore-policy",
+            "Restore the required .idea/ and .vscode/ ignore rules without later negations.",
+        )
     elif "symlink" in reason:
-        rule, remediation = "external-symlink", "Remove the Git symlink or move the repository-control change to a maintainer-owned PR."
+        rule, remediation = (
+            "external-symlink",
+            "Remove the Git symlink or move the repository-control change to a maintainer-owned PR.",
+        )
     elif "maintainer-controlled" in reason:
-        rule, remediation = "external-maintainer-controlled-path", "Recreate or rebase the legitimate feature work onto a clean main history, or move this repository-control change to a maintainer-owned PR."
+        rule, remediation = (
+            "external-maintainer-controlled-path",
+            "Recreate or rebase the legitimate feature work onto a clean main history, or move this repository-control change to a maintainer-owned PR.",
+        )
     else:
         rule, remediation = finding.rule, finding.remediation
     return replace(finding, rule=rule, remediation=remediation)
@@ -762,8 +876,15 @@ def commit_parents(commit: str) -> list[str]:
 
 def changed_files_between(old: str, new: str) -> list[str]:
     raw = run_git(
-        "-c", "core.quotePath=false", "diff", "--name-only", "-z",
-        "--no-renames", old, new, "--",
+        "-c",
+        "core.quotePath=false",
+        "diff",
+        "--name-only",
+        "-z",
+        "--no-renames",
+        old,
+        new,
+        "--",
     )
     assert isinstance(raw, str)
     return [item for item in raw.split("\0") if item]
@@ -783,7 +904,9 @@ def commit_introduced_files(commit: str) -> list[str]:
     parents = commit_parents(commit)
     if not parents:
         return changed_files_between(EMPTY_TREE, commit)
-    changed_by_parent = [set(changed_files_between(parent, commit)) for parent in parents]
+    changed_by_parent = [
+        set(changed_files_between(parent, commit)) for parent in parents
+    ]
     return sorted(set.intersection(*changed_by_parent))
 
 
@@ -799,7 +922,9 @@ def introduced_commits(base: str, head: str) -> list[str]:
     return raw.split()
 
 
-def scan_tree(commit: str, files: list[str], external: bool, *, check_ignore: bool) -> list[Finding]:
+def scan_tree(
+    commit: str, files: list[str], external: bool, *, check_ignore: bool
+) -> list[Finding]:
     findings: list[Finding] = []
     if check_ignore:
         findings.extend(check_ignore_policy(commit))
@@ -821,7 +946,9 @@ def scan(base: str, head: str, pr_author: str, repo_owner: str) -> list[Finding]
     findings: list[Finding] = []
     for commit in introduced_commits(base, head):
         files = commit_introduced_files(commit)
-        findings.extend(scan_tree(commit, files, external, check_ignore=".gitignore" in files))
+        findings.extend(
+            scan_tree(commit, files, external, check_ignore=".gitignore" in files)
+        )
 
     # Preserve the final-tree check as defense in depth, but do not attribute a
     # historical violation to a later merge merely because it remains present
@@ -852,8 +979,14 @@ def write_report(path: Path, findings: list[Finding]) -> None:
         )
 
 
-def write_json_report(path: Path, findings: list[Finding], *, pr_number: int,
-                      head: str, head_repository: str) -> None:
+def write_json_report(
+    path: Path,
+    findings: list[Finding],
+    *,
+    pr_number: int,
+    head: str,
+    head_repository: str,
+) -> None:
     """Write the machine-readable artifact the trusted reporter consumes.
 
     The list is capped to the bound the reporter enforces. Without the cap a PR
@@ -872,7 +1005,9 @@ def write_json_report(path: Path, findings: list[Finding], *, pr_number: int,
         "truncated": len(findings) - len(reported),
         "findings": [finding.as_dict() for finding in reported],
     }
-    path.write_text(json.dumps(payload, ensure_ascii=True, sort_keys=True) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(payload, ensure_ascii=True, sort_keys=True) + "\n", encoding="utf-8"
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -893,12 +1028,19 @@ def main(argv: list[str] | None = None) -> int:
     try:
         findings = scan(args.base, args.head, args.pr_author, args.repo_owner)
     except IntegrityError as exc:
-        print(f"::error::Repository integrity scan failed closed: {exc}", file=sys.stderr)
+        print(
+            f"::error::Repository integrity scan failed closed: {exc}", file=sys.stderr
+        )
         return 2
 
     write_report(Path(args.report), findings)
-    write_json_report(Path(args.json_report), findings, pr_number=args.pr_number,
-                      head=args.head, head_repository=args.head_repository)
+    write_json_report(
+        Path(args.json_report),
+        findings,
+        pr_number=args.pr_number,
+        head=args.head,
+        head_repository=args.head_repository,
+    )
 
     if findings:
         print("Repository integrity guard blocked the PR:")

--- a/scripts/check_toolchain_pin_diff.py
+++ b/scripts/check_toolchain_pin_diff.py
@@ -223,7 +223,9 @@ def main(argv: Optional[List[str]] = None) -> int:
     file_mode = args.before_file is not None or args.after_file is not None
     if file_mode:
         if args.base is not None or args.head is not None:
-            parser.error("--before-file/--after-file cannot be combined with --base/--head")
+            parser.error(
+                "--before-file/--after-file cannot be combined with --base/--head"
+            )
         if args.before_file is None or args.after_file is None:
             parser.error("--before-file and --after-file must be given together")
     elif args.base is None:

--- a/scripts/post_reddit_release.py
+++ b/scripts/post_reddit_release.py
@@ -16,9 +16,7 @@ from typing import Any
 
 TOKEN_URL = "https://www.reddit.com/api/v1/access_token"
 OAUTH_BASE = "https://oauth.reddit.com"
-DEFAULT_USER_AGENT = (
-    "linux:io.github.thezupzup.linthra.releases:v1 (by /u/TheZupZup)"
-)
+DEFAULT_USER_AGENT = "linux:io.github.thezupzup.linthra.releases:v1 (by /u/TheZupZup)"
 
 
 class RedditPublishError(RuntimeError):
@@ -32,18 +30,14 @@ def _required_env(name: str) -> str:
     return value
 
 
-def _request_json(
-    request: urllib.request.Request, *, context: str
-) -> dict[str, Any]:
+def _request_json(request: urllib.request.Request, *, context: str) -> dict[str, Any]:
     try:
         with urllib.request.urlopen(request, timeout=30) as response:
             payload = response.read().decode("utf-8")
     except urllib.error.HTTPError as exc:
         # Do not print the body: auth failures can include request details and
         # there is no reason to risk reflecting credentials into Actions logs.
-        raise RedditPublishError(
-            f"{context} failed with HTTP {exc.code}"
-        ) from exc
+        raise RedditPublishError(f"{context} failed with HTTP {exc.code}") from exc
     except urllib.error.URLError as exc:
         raise RedditPublishError(f"{context} failed: {exc.reason}") from exc
 
@@ -102,7 +96,9 @@ def find_existing_announcement(
     payload = _request_json(request, context="Reddit duplicate check")
     children = payload.get("data", {}).get("children", [])
     if not isinstance(children, list):
-        raise RedditPublishError("Reddit duplicate check returned an unexpected listing")
+        raise RedditPublishError(
+            "Reddit duplicate check returned an unexpected listing"
+        )
 
     for child in children:
         if not isinstance(child, dict):
@@ -161,9 +157,7 @@ def submit_post(
                 safe_errors.append(f"{item[0]}: {item[1]}")
             else:
                 safe_errors.append("unknown Reddit API error")
-        raise RedditPublishError(
-            "Reddit rejected the post: " + "; ".join(safe_errors)
-        )
+        raise RedditPublishError("Reddit rejected the post: " + "; ".join(safe_errors))
 
     data_result = json_result.get("data")
     if not isinstance(data_result, dict):

--- a/scripts/prepare_release_bump.py
+++ b/scripts/prepare_release_bump.py
@@ -74,13 +74,15 @@ def version_from_tag(tag):
 
     if minor > _MAX_MINOR:
         raise VersionError(
-            'Minor version {} in tag "{}" exceeds the supported range '
-            "(0..{}).".format(minor, tag, _MAX_MINOR)
+            'Minor version {} in tag "{}" exceeds the supported range (0..{}).'.format(
+                minor, tag, _MAX_MINOR
+            )
         )
     if patch > _MAX_PATCH:
         raise VersionError(
-            'Patch version {} in tag "{}" exceeds the supported range '
-            "(0..{}).".format(patch, tag, _MAX_PATCH)
+            'Patch version {} in tag "{}" exceeds the supported range (0..{}).'.format(
+                patch, tag, _MAX_PATCH
+            )
         )
 
     if tier is None:
@@ -96,12 +98,7 @@ def version_from_tag(tag):
         rank = _TIER_BASE[tier] + pre_n
         name = "{}.{}.{}-{}.{}".format(major, minor, patch, tier, pre_n)
 
-    code = (
-        major * _MAJOR_WEIGHT
-        + minor * _MINOR_WEIGHT
-        + patch * _PATCH_WEIGHT
-        + rank
-    )
+    code = major * _MAJOR_WEIGHT + minor * _MINOR_WEIGHT + patch * _PATCH_WEIGHT + rank
     if code <= 0 or code > _MAX_VERSION_CODE:
         raise VersionError(
             'Derived versionCode {} for tag "{}" is outside the valid Android '
@@ -122,9 +119,7 @@ def update_pubspec(path, version_name, version_code):
     version_line = re.compile(r"^version:[ \t]*(\S+)[ \t]*$", re.MULTILINE)
     match = version_line.search(text)
     if not match:
-        raise VersionError(
-            "pubspec.yaml at {} has no `version:` line.".format(path)
-        )
+        raise VersionError("pubspec.yaml at {} has no `version:` line.".format(path))
     if match.group(1) == full:
         return False
     new_text = version_line.sub("version: {}".format(full), text, count=1)
@@ -140,14 +135,10 @@ def update_app_info(path, version_name):
     """
     if not path.exists():
         raise VersionError(
-            "lib/core/app_info.dart not found at {}; refusing to guess.".format(
-                path
-            )
+            "lib/core/app_info.dart not found at {}; refusing to guess.".format(path)
         )
     text = path.read_text()
-    pattern = re.compile(
-        r"(static\s+const\s+String\s+_devVersionName\s*=\s*)'[^']*'"
-    )
+    pattern = re.compile(r"(static\s+const\s+String\s+_devVersionName\s*=\s*)'[^']*'")
     matches = pattern.findall(text)
     if not matches:
         raise VersionError(

--- a/scripts/recompute_repository_integrity_report.py
+++ b/scripts/recompute_repository_integrity_report.py
@@ -24,6 +24,7 @@ and is read as a git blob without checking out the PR tree. The checker itself
 analyses git objects only; the working tree remains on the trusted default
 branch throughout.
 """
+
 from __future__ import annotations
 
 import argparse

--- a/scripts/reddit_release_announcement.py
+++ b/scripts/reddit_release_announcement.py
@@ -57,7 +57,9 @@ def load_voice(path: Path | None) -> dict[str, Any]:
     voice.update(custom)
     max_bullets = voice.get("max_bullets")
     if not isinstance(max_bullets, int) or not 1 <= max_bullets <= 10:
-        raise AnnouncementError("voice config max_bullets must be an integer from 1 to 10")
+        raise AnnouncementError(
+            "voice config max_bullets must be an integer from 1 to 10"
+        )
     return voice
 
 
@@ -223,9 +225,7 @@ def write_outputs(announcement: dict[str, str], output_dir: Path) -> None:
     (output_dir / "title.txt").write_text(
         announcement["title"] + "\n", encoding="utf-8"
     )
-    (output_dir / "body.md").write_text(
-        announcement["body"] + "\n", encoding="utf-8"
-    )
+    (output_dir / "body.md").write_text(announcement["body"] + "\n", encoding="utf-8")
     (output_dir / "announcement.json").write_text(
         json.dumps(announcement, ensure_ascii=False, indent=2) + "\n",
         encoding="utf-8",

--- a/scripts/render_repository_integrity_comment.py
+++ b/scripts/render_repository_integrity_comment.py
@@ -9,6 +9,7 @@ which binds the artifact to the triggering run and to the live pull request. The
 resulting binding is what this program validates against, so the two programs
 cannot disagree about which PR a report belongs to.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -36,10 +37,14 @@ def safe_text(value: object, field: str) -> str:
         raise ValueError(f"invalid {field}")
     # Numeric entities prevent Markdown, raw HTML, mentions, and links while
     # preserving an exact, readable representation of repository data.
-    return "".join(ch if ch.isalnum() or ch in " .,_/-:" else f"&#{ord(ch)};" for ch in value)
+    return "".join(
+        ch if ch.isalnum() or ch in " .,_/-:" else f"&#{ord(ch)};" for ch in value
+    )
 
 
-def validate(payload: object, binding: object) -> tuple[list[dict[str, str | None]], int]:
+def validate(
+    payload: object, binding: object
+) -> tuple[list[dict[str, str | None]], int]:
     """Validate the report against the binding resolve_repository_integrity_pr.py
     established. That program is the sole authority on which PR this report may
     address; this one refuses to render anything that disagrees with it."""
@@ -52,11 +57,19 @@ def validate(payload: object, binding: object) -> tuple[list[dict[str, str | Non
     expected_repo = binding.get("head_repository")
     if not isinstance(expected_sha, str) or not SHA_RE.fullmatch(expected_sha):
         raise ValueError("invalid head SHA")
-    if not isinstance(expected_pr, int) or isinstance(expected_pr, bool) or expected_pr < 1:
+    if (
+        not isinstance(expected_pr, int)
+        or isinstance(expected_pr, bool)
+        or expected_pr < 1
+    ):
         raise ValueError("invalid bound PR number")
     if not isinstance(expected_repo, str) or not expected_repo:
         raise ValueError("invalid bound head repository")
-    if payload.get("pr_number") != expected_pr or payload.get("head_sha") != expected_sha or payload.get("head_repository") != expected_repo:
+    if (
+        payload.get("pr_number") != expected_pr
+        or payload.get("head_sha") != expected_sha
+        or payload.get("head_repository") != expected_repo
+    ):
         raise ValueError("report does not match the triggering PR")
     findings = payload.get("findings")
     if not isinstance(findings, list) or len(findings) > MAX_FINDINGS:
@@ -71,7 +84,9 @@ def validate(payload: object, binding: object) -> tuple[list[dict[str, str | Non
         if raw["severity"] not in SEVERITIES:
             raise ValueError("invalid severity")
         commit = raw["commit"]
-        if commit is not None and (not isinstance(commit, str) or not SHA_RE.fullmatch(commit)):
+        if commit is not None and (
+            not isinstance(commit, str) or not SHA_RE.fullmatch(commit)
+        ):
             raise ValueError("invalid commit SHA")
         item = {field: safe_text(raw[field], field) for field in FIELDS}
         item.update(severity=raw["severity"], commit=commit)
@@ -82,9 +97,23 @@ def validate(payload: object, binding: object) -> tuple[list[dict[str, str | Non
 def render(findings: list[dict[str, str | None]], truncated: int = 0) -> str:
     lines = [MARKER, "## Repository integrity review", ""]
     if not findings:
-        return "\n".join(lines + ["**CLEAN**", "", "Previously reported repository-integrity findings are resolved."])
+        return "\n".join(
+            lines
+            + [
+                "**CLEAN**",
+                "",
+                "Previously reported repository-integrity findings are resolved.",
+            ]
+        )
     blocked = any(item["severity"] == "blocked" for item in findings)
-    lines += [f"**{'BLOCKED' if blocked else 'REVIEW REQUIRED'}**", "", "Repository integrity blocked this PR." if blocked else "Repository integrity requires explicit maintainer review.", ""]
+    lines += [
+        f"**{'BLOCKED' if blocked else 'REVIEW REQUIRED'}**",
+        "",
+        "Repository integrity blocked this PR."
+        if blocked
+        else "Repository integrity requires explicit maintainer review.",
+        "",
+    ]
     budget = MAX_COMMENT_CHARS - _TAIL_RESERVE
     used = sum(len(line) + 1 for line in lines)
     rendered = 0
@@ -96,7 +125,8 @@ def render(findings: list[dict[str, str | None]], truncated: int = 0) -> str:
             f"- **Path:** `{item['path']}`",
             f"- **Rule:** `{item['rule']}`",
             f"- **Explanation:** {item['reason']}",
-            f"- **How to fix:** {item['remediation']}", "",
+            f"- **How to fix:** {item['remediation']}",
+            "",
         ]
         size = sum(len(line) + 1 for line in block)
         if used + size > budget:
@@ -106,10 +136,14 @@ def render(findings: list[dict[str, str | None]], truncated: int = 0) -> str:
         rendered += 1
     truncated += len(findings) - rendered
     if truncated > 0:
-        lines.append(f"{truncated} further finding(s) were withheld from this comment. "
-                     "The check output lists every finding; all of them block this PR.")
+        lines.append(
+            f"{truncated} further finding(s) were withheld from this comment. "
+            "The check output lists every finding; all of them block this PR."
+        )
         lines.append("")
-    lines.append("This report describes observable repository state and history; it does not infer contributor intent.")
+    lines.append(
+        "This report describes observable repository state and history; it does not infer contributor intent."
+    )
     return "\n".join(lines)
 
 

--- a/scripts/resolve_repository_integrity_pr.py
+++ b/scripts/resolve_repository_integrity_pr.py
@@ -28,6 +28,7 @@ their own pull request.
 Every unresolved, ambiguous, or mismatched case exits non-zero and no comment is
 written. There is no best-effort path.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -190,7 +191,11 @@ def _login(value: object, field: str) -> str:
 
 
 def _identifier(value: object, field: str, maximum: int) -> int:
-    if not isinstance(value, int) or isinstance(value, bool) or not 1 <= value <= maximum:
+    if (
+        not isinstance(value, int)
+        or isinstance(value, bool)
+        or not 1 <= value <= maximum
+    ):
         raise BindingError(f"invalid {field}")
     return value
 
@@ -199,10 +204,16 @@ def trusted_run(event: object, repository: str) -> RunFacts:
     """Establish that this event is the scanner's own run in this repository."""
     payload = _mapping(event, "workflow event")
     run = _mapping(payload.get("workflow_run"), "workflow run")
-    _exact(_mapping(payload.get("repository"), "event repository").get("full_name"),
-           repository, "event repository")
-    _exact(_mapping(run.get("repository"), "run repository").get("full_name"),
-           repository, "run repository")
+    _exact(
+        _mapping(payload.get("repository"), "event repository").get("full_name"),
+        repository,
+        "event repository",
+    )
+    _exact(
+        _mapping(run.get("repository"), "run repository").get("full_name"),
+        repository,
+        "run repository",
+    )
     _exact(run.get("event"), SCANNER_EVENT, "triggering event")
     _exact(run.get("path"), SCANNER_WORKFLOW_PATH, "scanner workflow path")
     _exact(run.get("name"), SCANNER_WORKFLOW_NAME, "scanner workflow name")
@@ -211,16 +222,22 @@ def trusted_run(event: object, repository: str) -> RunFacts:
     if not isinstance(pull_requests, list):
         raise BindingError("invalid pull request list")
     numbers = tuple(
-        _identifier(_mapping(entry, "pull request").get("number"), "pull request number",
-                    MAX_PR_NUMBER)
+        _identifier(
+            _mapping(entry, "pull request").get("number"),
+            "pull request number",
+            MAX_PR_NUMBER,
+        )
         for entry in pull_requests
     )
     return RunFacts(
         run_id=_identifier(run.get("id"), "run id", 2**53 - 1),
         head_sha=_sha(run.get("head_sha"), "run head SHA"),
         head_repository=_repository(
-            _mapping(run.get("head_repository"), "run head repository").get("full_name"),
-            "run head repository"),
+            _mapping(run.get("head_repository"), "run head repository").get(
+                "full_name"
+            ),
+            "run head repository",
+        ),
         head_branch=_branch(run.get("head_branch"), "run head branch"),
         repository=repository,
         pull_requests=numbers,
@@ -279,9 +296,15 @@ def resolve(event: object, payload: object, repository: str) -> Binding:
     else:
         raise BindingError("workflow run identifies more than one PR")
 
-    return Binding(pr_number=pr_number, head_sha=head_sha, head_repository=head_repository,
-                   head_branch=run.head_branch, repository=repository, run_id=run.run_id,
-                   pr_source=source)
+    return Binding(
+        pr_number=pr_number,
+        head_sha=head_sha,
+        head_repository=head_repository,
+        head_branch=run.head_branch,
+        repository=repository,
+        run_id=run.run_id,
+        pr_source=source,
+    )
 
 
 def _head_repository_of(pull_request: dict) -> str | None:
@@ -325,15 +348,22 @@ def select_candidate(candidates: object, binding: Binding) -> int:
         pull_request = _mapping(entry, "associated pull request")
         base = pull_request.get("base")
         base_repo = base.get("repo") if isinstance(base, dict) else None
-        if not isinstance(base_repo, dict) or base_repo.get("full_name") != binding.repository:
+        if (
+            not isinstance(base_repo, dict)
+            or base_repo.get("full_name") != binding.repository
+        ):
             continue
         if _head_repository_of(pull_request) != binding.head_repository:
             continue
-        numbers.add(_identifier(pull_request.get("number"), "associated PR number",
-                                MAX_PR_NUMBER))
+        numbers.add(
+            _identifier(
+                pull_request.get("number"), "associated PR number", MAX_PR_NUMBER
+            )
+        )
     if len(numbers) != 1:
         raise BindingError(
-            f"{len(numbers)} pull requests match this run's head; refusing to guess")
+            f"{len(numbers)} pull requests match this run's head; refusing to guess"
+        )
     resolved = numbers.pop()
     if resolved != binding.pr_number:
         raise BindingError("report PR number is not the PR this run's head belongs to")
@@ -350,14 +380,21 @@ def verify_pull_request(pull_request: object, binding: Binding) -> tuple[bool, B
     if _identifier(live.get("number"), "PR number", MAX_PR_NUMBER) != binding.pr_number:
         raise BindingError("API returned a different pull request")
     base = _mapping(live.get("base"), "PR base")
-    if _mapping(base.get("repo"), "PR base repository").get("full_name") != binding.repository:
+    if (
+        _mapping(base.get("repo"), "PR base repository").get("full_name")
+        != binding.repository
+    ):
         raise BindingError("pull request does not belong to this repository")
     if _head_repository_of(live) != binding.head_repository:
-        raise BindingError("pull request head repository does not match the scanned head")
+        raise BindingError(
+            "pull request head repository does not match the scanned head"
+        )
     head = _mapping(live.get("head"), "PR head")
     if binding.head_branch is not None:
         if _branch(head.get("ref"), "PR head branch") != binding.head_branch:
-            raise BindingError("pull request head branch does not match the scanned head")
+            raise BindingError(
+                "pull request head branch does not match the scanned head"
+            )
     head_sha = _sha(head.get("sha"), "PR head SHA")
     # Both are read from the live pull request, so the re-derivation the reporter
     # performs cannot be steered by anything the scanner run wrote.
@@ -383,7 +420,9 @@ def verify_pull_request(pull_request: object, binding: Binding) -> tuple[bool, B
     bound = replace(
         binding,
         base_sha=_sha(base.get("sha"), "PR base SHA"),
-        pr_author=_login(_mapping(live.get("user"), "PR author").get("login"), "PR author"),
+        pr_author=_login(
+            _mapping(live.get("user"), "PR author").get("login"), "PR author"
+        ),
     )
     # Out-of-order synchronize runs must never restore an older verdict over a
     # newer one. A moved head is not an error, it is a superseded report.
@@ -452,7 +491,8 @@ def api_get(path: str, token: str) -> object:
         if len(collected) > MAX_CANDIDATES:
             raise BindingError(
                 f"GitHub returned more than {MAX_CANDIDATES} results for {path}; "
-                "refusing to select from a set this large")
+                "refusing to select from a set this large"
+            )
         if url is None:
             return collected
     raise BindingError(f"GitHub pagination for {path} did not terminate")
@@ -464,8 +504,9 @@ def _read_json(path: Path, limit: int, label: str) -> object:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def decide(event: object, payload: object, repository: str,
-           fetch: Callable[[str], object]) -> tuple[Binding, bool]:
+def decide(
+    event: object, payload: object, repository: str, fetch: Callable[[str], object]
+) -> tuple[Binding, bool]:
     """Resolve, then confirm against the API. Returns (binding, may_write)."""
     binding = resolve(event, payload, repository)
     # Path segments are re-derived, never interpolated from report text: both
@@ -478,7 +519,8 @@ def decide(event: object, payload: object, repository: str,
         # binding rather than merely suggestive.
         select_candidate(fetch(association_path(binding)), binding)
     may_write, binding = verify_pull_request(
-        fetch(f"/repos/{owner_repo}/pulls/{binding.pr_number}"), binding)
+        fetch(f"/repos/{owner_repo}/pulls/{binding.pr_number}"), binding
+    )
     return binding, may_write
 
 
@@ -504,25 +546,33 @@ def main(argv: list[str] | None = None) -> int:
         repository = _repository(args.repository, "repository")
         event = _read_json(args.event, MAX_EVENT_BYTES, "workflow event")
         payload = _read_json(args.report, MAX_REPORT_BYTES, "report")
-        binding, may_write = decide(event, payload, repository,
-                                    lambda path: api_get(path, token))
+        binding, may_write = decide(
+            event, payload, repository, lambda path: api_get(path, token)
+        )
     except (BindingError, ValueError, OSError, urllib.error.URLError) as exc:
-        print(f"::error::Repository integrity reporter refused to comment: {exc}",
-              file=sys.stderr)
+        print(
+            f"::error::Repository integrity reporter refused to comment: {exc}",
+            file=sys.stderr,
+        )
         _emit("post", "false")
         return 1
 
     if not may_write:
-        print(f"PR #{binding.pr_number} has moved past {binding.head_sha}; "
-              "leaving the existing comment untouched.")
+        print(
+            f"PR #{binding.pr_number} has moved past {binding.head_sha}; "
+            "leaving the existing comment untouched."
+        )
         _emit("post", "false")
         return 0
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(json.dumps(binding.as_dict(), sort_keys=True) + "\n",
-                           encoding="utf-8")
-    print(f"Bound report to PR #{binding.pr_number} at {binding.head_sha} "
-          f"(resolved from {binding.pr_source}).")
+    args.output.write_text(
+        json.dumps(binding.as_dict(), sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(
+        f"Bound report to PR #{binding.pr_number} at {binding.head_sha} "
+        f"(resolved from {binding.pr_source})."
+    )
     _emit("post", "true")
     _emit("pr_number", str(binding.pr_number))
     return 0

--- a/scripts/toolchain_pins.py
+++ b/scripts/toolchain_pins.py
@@ -241,9 +241,7 @@ def replace_pin(text: str, name: str, version: str) -> str:
     """
     t = tool(name)
     find_pin(text, name)  # raises unless there is exactly one place to edit
-    return t.pattern.sub(
-        lambda m: f"{m.group(1)}{version}{m.group(3)}", text, count=1
-    )
+    return t.pattern.sub(lambda m: f"{m.group(1)}{version}{m.group(3)}", text, count=1)
 
 
 def read_pin_file(repo_root: Path, name: str) -> str:

--- a/tool/branding/generate_icons.py
+++ b/tool/branding/generate_icons.py
@@ -74,8 +74,7 @@ BASELINE_FRACTION = 0.80
 VARIANTS = (
     ("neon", (0xB1, 0x4D, 0xFF), (0x22, 0xE0, 0xD6), (0.55, 0.85, 0.70, 0.45)),
     ("gold", (0xFF, 0xE0, 0x8A), (0xE6, 0xA2, 0x00), (0.46, 0.70, 0.56, 0.34)),
-    ("blackwhite", (0xFF, 0xFF, 0xFF), (0xFF, 0xFF, 0xFF),
-     (0.46, 0.70, 0.56, 0.34)),
+    ("blackwhite", (0xFF, 0xFF, 0xFF), (0xFF, 0xFF, 0xFF), (0.46, 0.70, 0.56, 0.34)),
 )
 
 # Every launcher-icon variant must share the *default Classic launcher icon's*
@@ -114,9 +113,7 @@ VARIANT_BACKGROUNDS = {
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 RES_DIR = REPO_ROOT / "android/app/src/main/res"
-FASTLANE_IMAGES = (
-    REPO_ROOT / "fastlane/metadata/android/en-US/images"
-)
+FASTLANE_IMAGES = REPO_ROOT / "fastlane/metadata/android/en-US/images"
 # Brand assets that aren't part of any store-listing folder (e.g. the Google
 # Play high-res icon, which is uploaded by hand in Play Console).
 BRAND_DIR = REPO_ROOT / "assets/brand"
@@ -164,8 +161,13 @@ def _bar_color(y: float, top: float, bottom: float) -> tuple[int, int, int]:
 
 
 def _in_rounded_rect(
-    x: float, y: float, left: float, top: float, right: float,
-    bottom: float, radius: float,
+    x: float,
+    y: float,
+    left: float,
+    top: float,
+    right: float,
+    bottom: float,
+    radius: float,
 ) -> bool:
     if x < left or x > right or y < top or y > bottom:
         return False
@@ -177,7 +179,11 @@ def _in_rounded_rect(
 
 
 def _in_capsule(
-    x: float, y: float, cx: float, half_width: float, top: float,
+    x: float,
+    y: float,
+    cx: float,
+    half_width: float,
+    top: float,
     bottom: float,
 ) -> bool:
     if abs(x - cx) > half_width:
@@ -209,8 +215,7 @@ def _bars(region_left: float, region_top: float, region_size: float):
     return bars
 
 
-def _variant_bars(region_left: float, region_top: float, region_size: float,
-                  heights):
+def _variant_bars(region_left: float, region_top: float, region_size: float, heights):
     """Bar capsules for a variant, sharing the *classic* mark's optical box.
 
     Lays the variant's bar pattern out with the classic footprint, gap-to-bar
@@ -223,8 +228,10 @@ def _variant_bars(region_left: float, region_top: float, region_size: float,
     variant fits the same footprint with proportionally thinner bars.
     """
     count = len(heights)
-    bar_width = region_size * VARIANT_GROUP_FOOTPRINT / (
-        count + VARIANT_GAP_TO_BAR * (count - 1)
+    bar_width = (
+        region_size
+        * VARIANT_GROUP_FOOTPRINT
+        / (count + VARIANT_GAP_TO_BAR * (count - 1))
     )
     gap = bar_width * VARIANT_GAP_TO_BAR
     group_width = count * bar_width + (count - 1) * gap
@@ -246,7 +253,11 @@ def _variant_bars(region_left: float, region_top: float, region_size: float,
 
 
 def _grad_color(
-    y: float, top: float, bottom: float, c_top, c_bottom,
+    y: float,
+    top: float,
+    bottom: float,
+    c_top,
+    c_bottom,
 ) -> tuple[int, int, int]:
     """A vertical gradient from [c_top] at [top] to [c_bottom] at [bottom],
     clamped outside the span — the variant twin of [_bar_color] (which is the
@@ -264,8 +275,15 @@ def _grad_color(
 
 
 def _render_variant(
-    width: int, height: int, ss: int, *, mode: str,
-    gradient_top, gradient_bottom, heights, tile_bg=None,
+    width: int,
+    height: int,
+    ss: int,
+    *,
+    mode: str,
+    gradient_top,
+    gradient_bottom,
+    heights,
+    tile_bg=None,
 ) -> bytearray:
     """Renders a variant launcher icon: the same dark squircle as the classic
     tile (mode "tile") or a transparent adaptive foreground (mode "foreground"),
@@ -291,9 +309,7 @@ def _render_variant(
         tile_right = sw - margin
         tile_bottom = (sh + region) / 2 - margin
         corner = (tile_right - tile_left) * 0.225
-        bars = _variant_bars(
-            tile_left, tile_top, tile_right - tile_left, heights
-        )
+        bars = _variant_bars(tile_left, tile_top, tile_right - tile_left, heights)
     else:  # "foreground": bars in the adaptive safe zone, transparent elsewhere
         safe = region * 0.62
         bars = _variant_bars((sw - safe) / 2, (sh - safe) / 2, safe, heights)
@@ -307,9 +323,7 @@ def _render_variant(
     hi = bytearray(sw * sh * 4)
     for sy in range(sh):
         bg = tile_bg if tile_bg is not None else _bg_row(sy, sh)
-        bar = _grad_color(
-            sy, bar_top, bar_bottom, gradient_top, gradient_bottom
-        )
+        bar = _grad_color(sy, bar_top, bar_bottom, gradient_top, gradient_bottom)
         row = sy * sw * 4
         for sx in range(sw):
             r = g = b = a = 0
@@ -317,7 +331,7 @@ def _render_variant(
                 sx, sy, tile_left, tile_top, tile_right, tile_bottom, corner
             ):
                 r, g, b, a = bg[0], bg[1], bg[2], 255
-            for (cx, hw, top, bottom) in bars:
+            for cx, hw, top, bottom in bars:
                 if _in_capsule(sx, sy, cx, hw, top, bottom):
                     r, g, b, a = bar[0], bar[1], bar[2], 255
                     break
@@ -331,7 +345,8 @@ def _render_variant(
 
 
 def _write_adaptive_xml(
-    variant_id: str, background: str = DEFAULT_ADAPTIVE_BACKGROUND,
+    variant_id: str,
+    background: str = DEFAULT_ADAPTIVE_BACKGROUND,
 ) -> None:
     """Writes the per-variant adaptive-icon XML (the [background] drawable + this
     variant's foreground) to mipmap-anydpi-v26/ic_launcher_<id>.xml."""
@@ -411,7 +426,7 @@ def _render(width: int, height: int, ss: int, *, mode: str) -> bytearray:
                 sx, sy, tile_left, tile_top, tile_right, tile_bottom, corner
             ):
                 r, g, b, a = bg[0], bg[1], bg[2], 255
-            for (cx, hw, top, bottom) in bars:
+            for cx, hw, top, bottom in bars:
                 if _in_capsule(sx, sy, cx, hw, top, bottom):
                     r, g, b, a = bar[0], bar[1], bar[2], 255
                     break
@@ -458,12 +473,14 @@ def _write_png(path: Path, width: int, height: int, rgba: bytearray) -> None:
     stride = width * 4
     for y in range(height):
         raw.append(0)  # filter type 0 (None)
-        raw.extend(rgba[y * stride:(y + 1) * stride])
+        raw.extend(rgba[y * stride : (y + 1) * stride])
 
     def chunk(tag: bytes, data: bytes) -> bytes:
         body = tag + data
-        return struct.pack(">I", len(data)) + body + struct.pack(
-            ">I", zlib.crc32(body) & 0xFFFFFFFF
+        return (
+            struct.pack(">I", len(data))
+            + body
+            + struct.pack(">I", zlib.crc32(body) & 0xFFFFFFFF)
         )
 
     ihdr = struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0)
@@ -485,7 +502,9 @@ def main() -> None:
         rgba = _render(size, size, ss=3, mode="foreground")
         _write_png(
             RES_DIR / f"mipmap-{density}/ic_launcher_foreground.png",
-            size, size, rgba,
+            size,
+            size,
+            rgba,
         )
 
     icon = _render(512, 512, ss=3, mode="tile")
@@ -511,24 +530,36 @@ def main() -> None:
         )
         for density, size in LEGACY_SIZES.items():
             rgba = _render_variant(
-                size, size, ss=3, mode="tile",
-                gradient_top=gradient_top, gradient_bottom=gradient_bottom,
-                heights=heights, tile_bg=tile_bg,
+                size,
+                size,
+                ss=3,
+                mode="tile",
+                gradient_top=gradient_top,
+                gradient_bottom=gradient_bottom,
+                heights=heights,
+                tile_bg=tile_bg,
             )
             _write_png(
                 RES_DIR / f"mipmap-{density}/ic_launcher_{variant_id}.png",
-                size, size, rgba,
+                size,
+                size,
+                rgba,
             )
         for density, size in FOREGROUND_SIZES.items():
             rgba = _render_variant(
-                size, size, ss=3, mode="foreground",
-                gradient_top=gradient_top, gradient_bottom=gradient_bottom,
+                size,
+                size,
+                ss=3,
+                mode="foreground",
+                gradient_top=gradient_top,
+                gradient_bottom=gradient_bottom,
                 heights=heights,
             )
             _write_png(
-                RES_DIR
-                / f"mipmap-{density}/ic_launcher_{variant_id}_foreground.png",
-                size, size, rgba,
+                RES_DIR / f"mipmap-{density}/ic_launcher_{variant_id}_foreground.png",
+                size,
+                size,
+                rgba,
             )
         _write_adaptive_xml(variant_id, background=adaptive_background)
 

--- a/tools/large_library/benchmark_sqlite.py
+++ b/tools/large_library/benchmark_sqlite.py
@@ -33,7 +33,9 @@ QUERIES: tuple[tuple[str, str, tuple[object, ...]], ...] = (
 )
 
 
-def query_plan(connection: sqlite3.Connection, sql: str, params: tuple[object, ...]) -> str:
+def query_plan(
+    connection: sqlite3.Connection, sql: str, params: tuple[object, ...]
+) -> str:
     rows = connection.execute(f"EXPLAIN QUERY PLAN {sql}", params).fetchall()
     return " | ".join(str(row[3]) for row in rows)
 
@@ -78,8 +80,7 @@ def main() -> None:
             )
             results.append((name, average_ms, p95_ms, max_ms))
             print(
-                f"{name:16} avg={average_ms:8.3f} ms "
-                f"p95={p95_ms:8.3f} ms plan={plan}"
+                f"{name:16} avg={average_ms:8.3f} ms p95={p95_ms:8.3f} ms plan={plan}"
             )
 
             # Every benchmark query has a matching index in schema.sql. A full
@@ -97,9 +98,7 @@ def main() -> None:
 
         total_average_ms = sum(average_ms for _, average_ms, _, _ in results)
         average_query_ms = total_average_ms / len(results)
-        slowest_name, _, _, slowest_max_ms = max(
-            results, key=lambda result: result[3]
-        )
+        slowest_name, _, _, slowest_max_ms = max(results, key=lambda result: result[3])
 
         print()
         print("benchmark summary")


### PR DESCRIPTION
Closes #353

Linthra's Dart contributors get a format check and static analysis on every PR; the Python under `scripts/`, `tool/` and `tools/` got nothing. This adds one fast tool, one CI check, and the local commands — no Python tooling stack.

Five commits, deliberately separated so the mechanical one can be reviewed as mechanical:

1. **`ruff.toml` + the one real lint fix**
2. **`ruff format` applied** — no logic, no behaviour
3. **CI workflow + docs**
4. **A one-comment fix** after CI caught a guardrail interaction — see *How CI caught this PR*
5. **A docs/comments correction** — see *Correction: the documented commands are the CI paths*

## Configuration

`ruff.toml` at the repository root, **not** a new `pyproject.toml`. Linthra is a Flutter app, not a Python distribution — a root `pyproject.toml` would imply a package that does not exist and that nothing builds or installs. `ruff.toml` is unambiguous and holds only Ruff config.

```toml
target-version = "py311"
select = ["E4", "E7", "E9", "F", "I", "B"]
```

Ruff's default set (`E4`/`E7`/`E9` + `F`) plus `I` (import sorting) and `B` (bugbear). `py311` matches the `actions/setup-python` version every existing Linthra workflow already pins.

**`E501` (line-too-long) is deliberately not selected.** `ruff format` already owns line width, and `E501` only fires on lines the formatter *cannot* split — long URLs, literal SHA-256 digests, and error strings quoted verbatim from the tools these scripts wrap. It reported 86 hits, every one of them a `# noqa` for no correctness gain.

## Lint fixes that were actually needed

Exactly one, across all three trees:

| File | Rule | Fix |
| --- | --- | --- |
| `scripts/check_android_toolchain_update.py` | `F401` unused-import | removed `Any` from `from typing import Any, Dict, List, Optional, Tuple` |

That is the whole of `ruff check`. `I` and `B` reported zero — imports were already sorted and there were no bugbear findings. The remaining `Dict`/`List`/`Optional`/`Tuple` imports are still used and were left alone; modernising them to PEP 585/604 is a refactor, not a lint fix, so `UP` was not selected.

`ruff format` reformatted 15 files. No line length avoids this — the code was hand-wrapped near 79 columns but not consistently, so it is a genuine one-off catch-up. Doing it now means every later Python PR shows only its own change.

## Verifying the reformat changed nothing

Each of the 15 files was parsed before and after and compared as an AST:

```
files compared: 15
AST DIFFERENCES: none — every reformat is purely cosmetic
```

On top of that, all nine Python tooling test suites under `test/tooling/` pass, and the scripts still run (`check_linux_runner.py` end-to-end, plus the `--help` paths).

## CI

New `.github/workflows/python-lint.yml`, following the pattern of the repo's existing Python workflows — `actions/setup-python` at 3.11, paths-filtered, `permissions: contents: read`, no secrets, so it runs identically on fork PRs.

```yaml
- run: python3 -m pip install --quiet "ruff==0.15.8"
- run: ruff check scripts tool tools
- run: ruff format --check scripts tool tools
```

**The Ruff version is pinned exactly.** A new release can add rules or change formatter output, which would turn an unrelated PR red for reasons its author did not cause. Bumping the pin is then its own reviewable change, the same way `.flutter-version` is.

The linted scope is exactly the three paths on those command lines, so nothing vendored or generated is linted. `ruff.toml` additionally excludes `build/` and `third_party/` — the same boundary `analysis_options.yaml` already draws for Dart analysis — so neither can start being linted by accident if Python ever appears there.

## Correction: the documented commands are the CI paths

An earlier revision of this PR claimed that `ruff check .` / `ruff format --check .` from the repository root reports exactly what CI gates on. **That was wrong, and commit 5 fixes it.**

`ruff.toml` carries `extend-exclude` but no include/allowlist. Ruff lints whatever path it is *given*, minus those excludes — the scope comes from the command line, not the config. The two only agree today because no Python exists outside the three trees.

Demonstrated with one throwaway `.py` under `native/`:

```
ruff check .                    → Found 1 error   (unused import)
ruff check scripts tool tools   → All checks passed!
```

So a Python file added elsewhere in the repository would be checked locally and silently skipped by CI — exactly the drift that claim invites. The docs and comments now recommend the CI commands with their paths, in all five places that made the claim (`ruff.toml`, the workflow header, `docs/development.md`, `CONTRIBUTING.md`, `docs/language-areas.md`).

That commit is prose only: no rule, version, CI step, path list or Python file changed.

## How CI caught this PR

Worth recording, because the fix looks like an odd comment otherwise.

The first push went red on `Flutter checks` and `Build Linux desktop` — both with *3820 tests passed, 1 failed*. The failure was `test/tooling/toolchain_pins_test.dart`, *"every workflow that runs Flutter sets it up from the pin"*:

```
Expected: contains 'uses: ./.github/actions/setup-flutter'
  Actual: 'name: Python lint …
```

That guard reads every workflow as **raw text** and matches `\bflutter\s+(pub|test|analyze|build|doctor)\b`. My header comment introduced the job by contrast with Dart's checks and named them by their literal command strings — so the prose alone made CI demand a Flutter SDK install in a job that only runs Ruff.

Fixed by rewording the comment. **The guardrail was left alone**: it is right to be text-based, since it cannot tell prose from a `run:` step, and this job genuinely does not need the SDK. The reason is now recorded in the workflow comment so it does not get reintroduced.

Since Flutter is not installed in the environment this was developed in, that test's five workflow assertions were ported to Python to reproduce it. The port failed on exactly `[runs-flutter-without-setup] python-lint.yml — matched 'flutter analyze'` before the change and passed after — and CI is now green on both jobs.

## The one exception, and why

`test/tooling/*.py` is outside the linted paths, and also named in `ruff.toml`'s excludes so the decision is recorded rather than implicit. Those are the unit tests for the very scripts being linted, so they *should* be covered — but #353 scopes this to `scripts/`, `tool/` and `tools/`, and pulling them in means reformatting nine more files. That belongs in its own PR: adding `test/tooling` to the CI paths and re-running `ruff format` is the entire follow-up.

It is a named directory with a stated reason, not a rule switched off repo-wide.

## Docs

Local commands in three places a contributor actually looks:

- **`docs/development.md`** — a new *Python tooling checks (Ruff)* section under Continuous integration
- **`CONTRIBUTING.md`** — the per-area setup list, next to the Cargo/CMake/Flatpak entries
- **`docs/language-areas.md`** — the Python / tooling section

```bash
pip install 'ruff==0.15.8'
ruff check scripts tool tools
ruff format --check scripts tool tools
```

## Checks run locally

- `ruff check scripts tool tools` → clean
- `ruff format --check scripts tool tools` → 17 files already formatted
- all 9 `test/tooling/` Python suites → pass
- all 24 workflow YAML files parse, including the new one
- `./scripts/check_secrets.sh` → clean
- `scripts/check_repository_integrity.py` → **passed** for a maintainer-authored PR
- the ported `toolchain_pins_test.dart` workflow assertions → pass

## One thing worth knowing before review

**`check_pr_security_surface.py` flags this PR**, listing itself under *new network-capable code* / *credential-sensitive logic*. That is an artifact: the formatter re-wrapped the lines holding the scanner's own detection patterns (`token|password|credential`, `HttpClient|WebSocket`), so it matches its own regexes on its own re-indented source. No capability was added — the AST check above covers this file too.

Relatedly, `check_repository_integrity.py` would block this PR if it were opened by a non-maintainer account: every file under `scripts/`, `tool/` and `tools/` is maintainer-controlled by that guard, and a formatter adoption necessarily touches all of them. Nothing to fix — just the guard doing its job on a PR that unavoidably has this shape.