### PR TITLE
fix(android-auto): serve Songs in bounded browse pages

### DIFF
--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -189,17 +189,30 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   /// [_lastQueueStart] to get the absolute position in history + current +
   /// up-next, which then maps onto the controller's history/up-next jumps.
   ///
-  /// Out-of-range — a stale row from a window published before the queue
-  /// shrank — and the current row are safe no-ops. It never bypasses the
+  /// The row is validated against the **published window** before it is
+  /// translated, not merely against the controller's queue afterwards. Those
+  /// are different checks once the window has slid: with a 200k queue and a
+  /// window at 99 950, row 255 does not exist (the window is 250 rows) yet its
+  /// absolute position 100 205 sits comfortably inside the controller's queue.
+  /// Validating only the translated index would accept that row and jump to a
+  /// track the car never showed. So a row outside what was actually published
+  /// is rejected up front.
+  ///
+  /// Out-of-range — a stale row from a window published before the queue moved
+  /// or shrank — and the current row are safe no-ops. It never bypasses the
   /// controller, so Cast routing and "no duplicate local playback" hold exactly
   /// as for a skip.
   @override
   Future<void> skipToQueueItem(int index) async {
-    if (index < 0) return;
+    // Only rows that exist in the queue this handler last published are real.
+    final int publishedLength = _lastQueueTracks?.length ?? 0;
+    if (index < 0 || index >= publishedLength) return;
+
     final PlaybackState state = _controller.state;
     final int historyLength = state.previous.length;
-    final int total = _queueTracksFor(state).length;
+    final int total = _queueLengthOf(state);
     final int absolute = _lastQueueStart + index;
+    // The queue can still have shrunk since that window was published.
     if (absolute < 0 || absolute >= total) return;
     if (absolute < historyLength) {
       await _controller.playFromHistory(absolute);
@@ -306,14 +319,9 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
     // is lost — the car just sees a slice of it, and the window follows playback.
     // Like the media item, it is pushed only when the window's contents, order,
     // or offset change — never on a position tick (which would thrash the list).
-    final List<Track> allTracks = _queueTracksFor(state);
-    final int start =
-        _publishedQueueStart(allTracks.length, state.previous.length);
-    final List<Track> window = allTracks.sublist(
-        start,
-        start + maxPublishedQueueItems > allTracks.length
-            ? allTracks.length
-            : start + maxPublishedQueueItems);
+    final int total = _queueLengthOf(state);
+    final int start = _publishedQueueStart(total, state.previous.length);
+    final List<Track> window = _publishedWindow(state, start, total);
     if (!_seeded ||
         start != _lastQueueStart ||
         !_sameQueue(window, _lastQueueTracks)) {
@@ -455,16 +463,42 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
     return start;
   }
 
-  /// The live queue as one flat, ordered list: history, then the current track,
-  /// then up-next. This is the *full* queue; only a window of it
-  /// ([_publishedQueueStart]) is published to the platform session, and
-  /// [skipToQueueItem] maps a published row back onto this list.
-  static List<Track> _queueTracksFor(PlaybackState state) {
+  /// How many tracks the controller's queue holds, as the flat
+  /// history + current + up-next list the published window indexes into.
+  ///
+  /// Counted rather than materialized: this runs on every state event, position
+  /// ticks included, and a logical queue may hold 200k tracks. Concatenating it
+  /// several times a second just to read a length (or to slice 250 rows off it)
+  /// would allocate the whole library over and over for no benefit.
+  static int _queueLengthOf(PlaybackState state) =>
+      state.previous.length +
+      (state.currentTrack == null ? 0 : 1) +
+      state.upNext.length;
+
+  /// The track at flat position [index] of history + current + up-next, without
+  /// building that list. Callers stay inside `0 ..< _queueLengthOf(state)`.
+  static Track _queueTrackAt(PlaybackState state, int index) {
+    final List<Track> previous = state.previous;
+    if (index < previous.length) return previous[index];
     final Track? current = state.currentTrack;
+    if (current == null) return state.upNext[index - previous.length];
+    if (index == previous.length) return current;
+    return state.upNext[index - previous.length - 1];
+  }
+
+  /// The rows to publish: at most [maxPublishedQueueItems] tracks starting at
+  /// flat position [start] of a queue holding [total] of them. Materializes only
+  /// what is published — 250 tracks at most, whatever the queue's real size.
+  static List<Track> _publishedWindow(
+    PlaybackState state,
+    int start,
+    int total,
+  ) {
+    final int end = start + maxPublishedQueueItems > total
+        ? total
+        : start + maxPublishedQueueItems;
     return <Track>[
-      ...state.previous,
-      if (current != null) current,
-      ...state.upNext,
+      for (int i = start; i < end; i++) _queueTrackAt(state, i),
     ];
   }
 

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -111,12 +111,34 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   audio.MediaItem? _lastItem;
   audio.PlaybackState? _lastPlaybackState;
 
-  // The queue (as a flat track list) last published to the platform session.
+  // The queue window last published to the platform session, and the absolute
+  // index in the controller's queue that its first row corresponds to.
   // Re-publishing the queue on every position tick would thrash the car's
-  // "Up Next" list, so [_broadcast] pushes it only when the queue's contents or
-  // order actually change. Null until the first broadcast.
+  // "Up Next" list, so [_broadcast] pushes it only when the window's contents,
+  // order, or offset actually change. Null until the first broadcast.
   List<Track>? _lastQueueTracks;
+  int _lastQueueStart = 0;
   bool _seeded = false;
+
+  /// The most rows the platform session's queue ever carries.
+  ///
+  /// The published queue is delivered to every media controller — Android Auto
+  /// included — in a single Binder transaction (`MediaSessionCompat.setQueue`),
+  /// exactly like a browse response and against the same ~1 MB per-process
+  /// buffer. Selecting one song from the Songs list hands the controller the
+  /// whole catalog, so an unbounded mirror would publish a six-figure queue and
+  /// recreate the browse bug on the playback path — and, because
+  /// `AudioServicePlugin.raw2queue` runs every row through
+  /// `createMediaMetadata`, would also add one permanently-cached
+  /// `MediaMetadataCompat` per row to `AudioService`'s static
+  /// `mediaMetadataCache`. So the session sees a *window*, while the controller
+  /// keeps the real, complete queue.
+  static const int maxPublishedQueueItems = 250;
+
+  /// How many already-played rows stay visible behind the current track in the
+  /// published window, so the car's list still scrolls back a little rather than
+  /// starting abruptly at what is playing now.
+  static const int publishedQueueHistory = 50;
 
   /// How far the reported position may drift before a fresh playback-state push
   /// re-syncs the session — so steady playback produces only this ~1 Hz
@@ -157,25 +179,34 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   @override
   Future<void> skipToPrevious() => _controller.skipToPrevious();
 
-  /// Jumps to the [index]-th item of the published [queue] — the row a head
-  /// unit / Android Auto's "Up Next" list reports when tapped. The queue is
-  /// published as history, then the current track, then up-next (see
-  /// [_queueTracksFor]), so this maps the flat index back onto the controller's
-  /// history/up-next jumps. Out-of-range (a stale row after the queue shrank)
-  /// and the current row are safe no-ops; it never bypasses the controller, so
-  /// Cast routing and "no duplicate local playback" hold exactly as for a skip.
+  /// Jumps to the [index]-th row of the published [queue] — what a head unit /
+  /// Android Auto's "Up Next" list reports when tapped.
+  ///
+  /// The published queue is a *window* onto the controller's full queue (see
+  /// [maxPublishedQueueItems]), and `audio_service` numbers its rows from zero
+  /// within whatever list was published (`raw2queue` assigns
+  /// `QueueItem(description, i)`). So a tapped row is offset by
+  /// [_lastQueueStart] to get the absolute position in history + current +
+  /// up-next, which then maps onto the controller's history/up-next jumps.
+  ///
+  /// Out-of-range — a stale row from a window published before the queue
+  /// shrank — and the current row are safe no-ops. It never bypasses the
+  /// controller, so Cast routing and "no duplicate local playback" hold exactly
+  /// as for a skip.
   @override
   Future<void> skipToQueueItem(int index) async {
+    if (index < 0) return;
     final PlaybackState state = _controller.state;
     final int historyLength = state.previous.length;
     final int total = _queueTracksFor(state).length;
-    if (index < 0 || index >= total) return;
-    if (index < historyLength) {
-      await _controller.playFromHistory(index);
-    } else if (index > historyLength) {
-      await _controller.playFromQueue(index - historyLength - 1);
+    final int absolute = _lastQueueStart + index;
+    if (absolute < 0 || absolute >= total) return;
+    if (absolute < historyLength) {
+      await _controller.playFromHistory(absolute);
+    } else if (absolute > historyLength) {
+      await _controller.playFromQueue(absolute - historyLength - 1);
     }
-    // index == historyLength is the current track: leave it playing untouched.
+    // absolute == historyLength is the current track: leave it playing.
   }
 
   @override
@@ -196,28 +227,36 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
 
   /// The children a media browser (Android Auto) asked for.
   ///
-  /// [options] carries Android's `MediaBrowserCompat` browse options, including
-  /// `EXTRA_PAGE`/`EXTRA_PAGE_SIZE`, and they are deliberately **not** applied
-  /// here. `MediaBrowserServiceCompat` already slices the list this handler
-  /// returns against the very same options before delivering it
-  /// (`Result.onResultSent` → `applyOptions`), so an app that paged as well
-  /// would page twice: page 1 of an already-page-sized list is empty, and every
-  /// page after the first would come back blank. The contract through
-  /// `audio_service` is therefore "return this node's *complete* child list";
-  /// [MediaBrowserTree] keeps that list bounded by splitting big sections into
-  /// browsable `page/` containers instead, which the framework's own paging
-  /// still composes with correctly.
+  /// [options] carries Android's `MediaBrowserCompat` browse options. When the
+  /// client asked for a page (`EXTRA_PAGE` / `EXTRA_PAGE_SIZE`), this honours it
+  /// — and it must, because nothing else on this stack does:
+  /// `MediaBrowserServiceCompat` applies its own `applyOptions` only under
+  /// `RESULT_FLAG_OPTION_NOT_HANDLED`, which the base class sets only for
+  /// services that leave `onLoadChildren(parentId, result, options)`
+  /// unoverridden. `audio_service`'s `AudioService` overrides it and calls
+  /// `result.sendResult(...)` directly, so whatever this returns reaches the
+  /// client verbatim. Without the window below, a head unit asking for page 1
+  /// would be handed page 0's children again.
+  ///
+  /// Paging is applied *on top of* the tree's own bound rather than instead of
+  /// it: a client may subscribe with no options at all (Android's two-argument
+  /// `onLoadChildren` path, which reaches Dart as a null [options]), and that
+  /// request must still be answerable in one Binder transaction. So
+  /// [MediaBrowserTree] caps every node's child list and the window here narrows
+  /// it further when asked.
   @override
   Future<List<audio.MediaItem>> getChildren(
     String parentMediaId, [
     Map<String, dynamic>? options,
   ]) async {
     final nodes = await _tree.childrenOf(parentMediaId, _controller.state);
+    final page = MediaBrowseOptions.applyPage(nodes, options);
     // Secret-free browse trace: confirms Android Auto bound and is requesting
     // children, and shows whether a node returned content (vs. an empty
     // "library not synced yet" case) — without logging any id, title, or URI.
-    _log('browse: ${_categoryOf(parentMediaId)} -> ${nodes.length} children');
-    return nodes.map(_mediaItemForNode).toList();
+    _log('browse: ${_categoryOf(parentMediaId)} -> ${page.length}'
+        '${page.length == nodes.length ? '' : ' of ${nodes.length}'} children');
+    return page.map(_mediaItemForNode).toList();
   }
 
   @override
@@ -262,16 +301,36 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
     }
     // Publish the play queue so the car / head-unit "Up Next" list mirrors the
     // controller's queue and a tapped row (skipToQueueItem) lands on the right
-    // track. Like the media item, it is pushed only when the queue's contents
-    // or order change — never on a position tick (which would thrash the list).
-    final List<Track> queueTracks = _queueTracksFor(state);
-    if (!_seeded || !_sameQueue(queueTracks, _lastQueueTracks)) {
-      _lastQueueTracks = queueTracks;
+    // track. Only a bounded window around the current track is published (see
+    // [maxPublishedQueueItems]); the controller keeps the full queue, so nothing
+    // is lost — the car just sees a slice of it, and the window follows playback.
+    // Like the media item, it is pushed only when the window's contents, order,
+    // or offset change — never on a position tick (which would thrash the list).
+    final List<Track> allTracks = _queueTracksFor(state);
+    final int start =
+        _publishedQueueStart(allTracks.length, state.previous.length);
+    final List<Track> window = allTracks.sublist(
+        start,
+        start + maxPublishedQueueItems > allTracks.length
+            ? allTracks.length
+            : start + maxPublishedQueueItems);
+    if (!_seeded ||
+        start != _lastQueueStart ||
+        !_sameQueue(window, _lastQueueTracks)) {
+      _lastQueueTracks = window;
+      _lastQueueStart = start;
       queue.add(<audio.MediaItem>[
-        for (final Track t in queueTracks) _trackMediaItem(t, id: t.id),
+        for (final Track t in window) _trackMediaItem(t, id: t.id),
       ]);
     }
-    final audio.PlaybackState next = _playbackStateFor(state);
+    // The active row, numbered within the published window so the car
+    // highlights the right one — a window-relative index, matching the ids
+    // `audio_service` assigns the rows it published.
+    final audio.PlaybackState next = _playbackStateFor(
+      state,
+      queueIndex:
+          state.currentTrack == null ? null : state.previous.length - start,
+    );
     if (!_seeded || _shouldPushPlayback(next, _lastPlaybackState)) {
       _lastPlaybackState = next;
       playbackState.add(next);
@@ -355,6 +414,9 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
         next.processingState != last.processingState ||
         next.shuffleMode != last.shuffleMode ||
         next.repeatMode != last.repeatMode ||
+        // The highlighted row moves as playback advances, even when nothing
+        // else about the state does.
+        next.queueIndex != last.queueIndex ||
         !_sameControls(next.controls, last.controls)) {
       return true;
     }
@@ -373,10 +435,30 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
     return true;
   }
 
+  /// Where the published window starts within the flat history+current+up-next
+  /// list of [total] tracks, given the current track sits at [currentIndex].
+  ///
+  /// A queue that already fits is published whole (start 0), so small libraries
+  /// and ordinary playlists behave exactly as before. A larger one keeps
+  /// [publishedQueueHistory] rows behind the current track and fills the rest of
+  /// the budget forward, sliding back at the end of the queue so the window is
+  /// always [maxPublishedQueueItems] long. The current track is therefore always
+  /// inside the window, which is what lets the car highlight it and what makes
+  /// [skipToQueueItem]'s offset unambiguous.
+  static int _publishedQueueStart(int total, int currentIndex) {
+    if (total <= maxPublishedQueueItems) return 0;
+    int start = currentIndex - publishedQueueHistory;
+    if (start < 0) start = 0;
+    if (start + maxPublishedQueueItems > total) {
+      start = total - maxPublishedQueueItems;
+    }
+    return start;
+  }
+
   /// The live queue as one flat, ordered list: history, then the current track,
-  /// then up-next. This is the exact order published to the platform session's
-  /// [queue], so [skipToQueueItem] can map a flat row index straight back onto
-  /// the controller's history / up-next jumps.
+  /// then up-next. This is the *full* queue; only a window of it
+  /// ([_publishedQueueStart]) is published to the platform session, and
+  /// [skipToQueueItem] maps a published row back onto this list.
   static List<Track> _queueTracksFor(PlaybackState state) {
     final Track? current = state.currentTrack;
     return <Track>[
@@ -435,8 +517,12 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
     );
   }
 
-  audio.PlaybackState _playbackStateFor(PlaybackState state) {
+  audio.PlaybackState _playbackStateFor(
+    PlaybackState state, {
+    int? queueIndex,
+  }) {
     return audio.PlaybackState(
+      queueIndex: queueIndex,
       controls: _controlsFor(state),
       // The transport capabilities the platform (notification, lock screen,
       // Android Auto, Bluetooth/steering-wheel media buttons) may invoke on the

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -30,6 +30,7 @@ void _log(String message) => developer.log(message, name: _logName);
 /// fixed label set — never the id itself — so a track id, playlist id, URI, or
 /// token can never reach the log.
 String _categoryOf(String id) {
+  if (MediaId.isBrowsePage(id)) return 'browse-page';
   if (id == MediaId.root) return 'root';
   if (id == MediaId.library) return 'library';
   if (id == MediaId.albums) return 'albums';
@@ -193,6 +194,19 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
 
   // --- Android Auto / media browser ---------------------------------------
 
+  /// The children a media browser (Android Auto) asked for.
+  ///
+  /// [options] carries Android's `MediaBrowserCompat` browse options, including
+  /// `EXTRA_PAGE`/`EXTRA_PAGE_SIZE`, and they are deliberately **not** applied
+  /// here. `MediaBrowserServiceCompat` already slices the list this handler
+  /// returns against the very same options before delivering it
+  /// (`Result.onResultSent` → `applyOptions`), so an app that paged as well
+  /// would page twice: page 1 of an already-page-sized list is empty, and every
+  /// page after the first would come back blank. The contract through
+  /// `audio_service` is therefore "return this node's *complete* child list";
+  /// [MediaBrowserTree] keeps that list bounded by splitting big sections into
+  /// browsable `page/` containers instead, which the framework's own paging
+  /// still composes with correctly.
   @override
   Future<List<audio.MediaItem>> getChildren(
     String parentMediaId, [

--- a/lib/core/services/media_browser_tree.dart
+++ b/lib/core/services/media_browser_tree.dart
@@ -229,6 +229,57 @@ abstract final class MediaId {
   }
 }
 
+/// Android's `MediaBrowserCompat` browse options — the page window a media
+/// browser client asks for when it subscribes — and how to apply one.
+///
+/// Applying these is the **app's** job on this stack, and only the app's.
+/// `MediaBrowserServiceCompat.performLoadChildren` filters a result through its
+/// own `applyOptions` *only* when `RESULT_FLAG_OPTION_NOT_HANDLED` is set, and
+/// that flag is set only by the base-class `onLoadChildren(parentId, result,
+/// options)` — the compatibility shim for services that don't handle options.
+/// `audio_service`'s `AudioService` overrides that three-argument method, so the
+/// flag is never set on Linthra's path and the framework passes the returned
+/// list through untouched. Applying the window here is therefore correct and
+/// carries no double-paging risk: without it a client that asks for page 1 would
+/// silently receive page 0's list all over again.
+abstract final class MediaBrowseOptions {
+  /// `MediaBrowserCompat.EXTRA_PAGE` — the zero-based page index requested.
+  static const String extraPage = 'android.media.browse.extra.PAGE';
+
+  /// `MediaBrowserCompat.EXTRA_PAGE_SIZE` — how many children per page.
+  static const String extraPageSize = 'android.media.browse.extra.PAGE_SIZE';
+
+  /// [children] narrowed to the page [options] asks for, or all of them when no
+  /// (or no usable) page is requested.
+  ///
+  /// Deliberately a byte-for-byte port of `MediaBrowserServiceCompat`'s own
+  /// `applyOptions`, including its edge cases — a page beyond the end and a
+  /// nonsensical window both yield an empty list (which is how a client learns
+  /// it has reached the end), and a partly-specified window is treated exactly
+  /// as the framework would. Matching it means enabling or disabling app-side
+  /// paging can never change what a client sees.
+  static List<T> applyPage<T>(List<T> children, Map<String, dynamic>? options) {
+    if (options == null) return children;
+    final int page = _intOf(options[extraPage]);
+    final int pageSize = _intOf(options[extraPageSize]);
+    if (page == -1 && pageSize == -1) return children;
+    final int fromIndex = pageSize * page;
+    if (page < 0 || pageSize < 1 || fromIndex >= children.length) {
+      return <T>[];
+    }
+    final int toIndex = fromIndex + pageSize > children.length
+        ? children.length
+        : fromIndex + pageSize;
+    return children.sublist(fromIndex, toIndex);
+  }
+
+  /// A bundle value as an int, or -1 ("absent") when it isn't one. The platform
+  /// hands these over as Java `Integer`s, but a head unit is free to put
+  /// anything in the bundle, so a non-integer is treated as absent rather than
+  /// throwing out of a browse.
+  static int _intOf(Object? value) => value is int ? value : -1;
+}
+
 /// The section and half-open window `[start, end)` a `page/...` container names.
 @immutable
 class BrowsePage {
@@ -330,6 +381,12 @@ class MediaBrowserTree {
   /// the client simply never receives `onChildrenLoaded` and spins forever. At
   /// this size a page of rich track rows is on the order of 150 kB, comfortably
   /// inside the buffer even alongside other in-flight transactions.
+  ///
+  /// A client's own `EXTRA_PAGE` window (honoured in `LinthraAudioHandler`, see
+  /// [MediaBrowseOptions]) does not replace this bound: a client may subscribe
+  /// with no options at all, and on this stack nothing between here and the car
+  /// shortens an over-long list on its own. So the tree is bounded first, and a
+  /// requested page narrows it further.
   static const int browsePageSize = 250;
 
   /// How long one catalog read is reused across browse requests.

--- a/lib/core/services/media_browser_tree.dart
+++ b/lib/core/services/media_browser_tree.dart
@@ -32,18 +32,24 @@ import '../repositories/playlist_repository.dart';
 ///  - `queue/<index>` — a position in the live play queue.
 ///  - `favorite/<index>` — a position in the (catalog-ordered) favourites list.
 ///  - `offline/<index>` — a position in the (catalog-ordered) downloaded list.
+///  - `page/<sectionId>/<start>-<end>` — a *browse page* container: the
+///    half-open window `[start, end)` of some other section's children. Always
+///    browsable, never playable (see [MediaBrowserTree] for why big sections are
+///    served as pages).
 ///
 /// The namespaces never collide: a bare category word (`albums`) never starts
 /// with the matching container prefix (`album/`), a container `album/<id>` has
 /// no trailing `/<index>`, and an album/artist id is a URL-safe base64url token
 /// (or an `al-`/`ar-`/`unknown-...` sentinel) that never itself contains a `/`.
+/// The `page/` prefix is likewise distinct from every playable-leaf prefix, so a
+/// page container can never be mistaken for — or resolved as — a track.
 ///
 /// Security invariant: every id is built only from non-secret, opaque ids — a
 /// derived album/artist grouping id, a local playlist id, a small integer index,
-/// or an opaque hash of the track uri (the Songs leaf). No id ever carries a
-/// `jellyfin:`/`subsonic:` uri, a local file path, a Jellyfin/Subsonic access
-/// token, or an authenticated stream URL; the stream URL is minted lazily at play
-/// time by the resolver, never here.
+/// a browse-page window (two integers), or an opaque hash of the track uri (the
+/// Songs leaf). No id ever carries a `jellyfin:`/`subsonic:` uri, a local file
+/// path, a Jellyfin/Subsonic access token, or an authenticated stream URL; the
+/// stream URL is minted lazily at play time by the resolver, never here.
 abstract final class MediaId {
   /// The root the platform requests first (audio_service's `browsableRootId`).
   static const String root = 'root';
@@ -70,6 +76,7 @@ abstract final class MediaId {
   static const String _playlistPrefix = 'playlist/';
   static const String _favoritePrefix = 'favorite/';
   static const String _offlinePrefix = 'offline/';
+  static const String _pagePrefix = 'page/';
 
   /// A playable leaf for a flat-"Songs" track, keyed by an opaque hash of the
   /// track's provider-namespaced [Track.uri]. Hashing (not the raw uri) keeps the
@@ -112,6 +119,41 @@ abstract final class MediaId {
 
   static String favoriteItem(int index) => '$_favoritePrefix$index';
   static String offlineItem(int index) => '$_offlinePrefix$index';
+
+  /// A *browse page* container: the half-open window `[start, end)` of the
+  /// children of [sectionId]. Browsable only — deliberately in its own `page/`
+  /// namespace so it can never be confused with (or resolved as) a playable
+  /// leaf, and deterministic: the same section at the same size always yields
+  /// the same page ids, so repeated browses are byte-identical.
+  ///
+  /// [sectionId] may itself contain a `/` (e.g. `album/<id>`); the window is
+  /// always the last `/`-segment, so parsing back is unambiguous.
+  static String browsePage(String sectionId, int start, int end) =>
+      '$_pagePrefix$sectionId/$start-$end';
+
+  static bool isBrowsePage(String id) => id.startsWith(_pagePrefix);
+
+  /// The section and window encoded in a `page/...` id, or null when [id] isn't
+  /// a well-formed page container. A malformed or hostile id (a negative bound,
+  /// an empty section, a nested `page/page/...`) yields null rather than
+  /// throwing, so a stale or crafted browse request is a safe dead-stop.
+  static BrowsePage? browsePageOf(String id) {
+    if (!isBrowsePage(id)) return null;
+    final String rest = id.substring(_pagePrefix.length);
+    final int slash = rest.lastIndexOf('/');
+    if (slash <= 0) return null;
+    final String sectionId = rest.substring(0, slash);
+    // A page of a page is never generated (sub-pages keep the original section
+    // id), so treat one as malformed rather than recursing into it.
+    if (sectionId.startsWith(_pagePrefix)) return null;
+    final String window = rest.substring(slash + 1);
+    final int dash = window.indexOf('-');
+    if (dash <= 0) return null;
+    final int? start = int.tryParse(window.substring(0, dash));
+    final int? end = int.tryParse(window.substring(dash + 1));
+    if (start == null || end == null || start < 0 || end <= start) return null;
+    return BrowsePage(sectionId: sectionId, start: start, end: end);
+  }
 
   static bool isLibraryTrack(String id) => id.startsWith(_libraryPrefix);
   static bool isQueueItem(String id) => id.startsWith(_queuePrefix);
@@ -187,6 +229,25 @@ abstract final class MediaId {
   }
 }
 
+/// The section and half-open window `[start, end)` a `page/...` container names.
+@immutable
+class BrowsePage {
+  const BrowsePage({
+    required this.sectionId,
+    required this.start,
+    required this.end,
+  });
+
+  /// The id of the section being paged (`library`, `albums`, `album/<id>`, …).
+  final String sectionId;
+
+  /// First child index in this page (inclusive).
+  final int start;
+
+  /// One past the last child index in this page (exclusive).
+  final int end;
+}
+
 /// One node in the browsable media tree, kept free of any `audio_service` type.
 ///
 /// Browsable nodes (categories/containers) have [playable] `false`; track leaves
@@ -248,16 +309,52 @@ class MediaPlaybackRequest {
 /// stale id yields an empty list / null rather than throwing, so a browse or
 /// selection request can never crash the media service.
 class MediaBrowserTree {
-  const MediaBrowserTree(
+  MediaBrowserTree(
     this._library, {
     PlaylistRepository? playlists,
     FavoritesRepository? favorites,
     DownloadRepository? downloads,
+    Duration catalogSnapshotTtl = _defaultCatalogSnapshotTtl,
   })  : _playlists = playlists,
         _favorites = favorites,
-        _downloads = downloads;
+        _downloads = downloads,
+        _catalogSnapshotTtl = catalogSnapshotTtl;
+
+  /// The largest number of children this tree ever returns for one browse
+  /// request. Sections bigger than this are served as `page/` containers.
+  ///
+  /// The bound exists because the whole child list is delivered to the media
+  /// browser client in a single Binder transaction, whose per-process buffer is
+  /// ~1 MB; a Songs response crosses that at roughly 1.5k tracks, and the
+  /// resulting `RemoteException` is swallowed by `MediaBrowserServiceCompat` —
+  /// the client simply never receives `onChildrenLoaded` and spins forever. At
+  /// this size a page of rich track rows is on the order of 150 kB, comfortably
+  /// inside the buffer even alongside other in-flight transactions.
+  static const int browsePageSize = 250;
+
+  /// How long one catalog read is reused across browse requests.
+  ///
+  /// Android Auto issues a burst of `getChildren` calls for a single user
+  /// action (and `audio_service` re-requests each node once more, because its
+  /// default `subscribeToChildren` stream is seeded and immediately triggers a
+  /// `notifyChildrenChanged`). Re-reading a 200k-row catalog for each of those
+  /// is the second half of the "endless scanning" symptom, and it would also let
+  /// the page windows shift mid-scroll if a sync landed between two requests.
+  /// One short-lived snapshot makes a browse session cheap *and* internally
+  /// consistent, while staying short enough that a freshly synced library shows
+  /// up without reconnecting.
+  static const Duration _defaultCatalogSnapshotTtl = Duration(seconds: 30);
 
   final MusicLibraryRepository _library;
+
+  final Duration _catalogSnapshotTtl;
+
+  /// The last catalog read, its timestamp, and the read currently in flight —
+  /// see [_defaultCatalogSnapshotTtl]. `_inFlight` collapses the concurrent
+  /// browse requests Android Auto issues into a single repository read.
+  List<Track>? _catalogSnapshot;
+  DateTime? _catalogSnapshotAt;
+  Future<List<Track>>? _catalogInFlight;
 
   /// User playlists, or null when not wired (tests, or a build without the
   /// playlist feature). When null, no Playlists node is offered.
@@ -274,40 +371,121 @@ class MediaBrowserTree {
   /// The children of [parentId], for the given live [playback] snapshot.
   /// Unknown parents yield an empty list rather than throwing, so an unexpected
   /// browse request can never crash the media service.
+  ///
+  /// The result is always at most [browsePageSize] nodes: a section with more
+  /// children than that is served as a list of `page/` containers spanning it
+  /// (see [_bounded]), so no browse response can ever outgrow the media
+  /// browser's Binder transaction — while every child stays reachable by
+  /// walking into the page it falls in.
   Future<List<MediaNode>> childrenOf(
     String parentId,
     PlaybackState playback,
   ) async {
-    switch (parentId) {
+    final BrowsePage? page = MediaId.browsePageOf(parentId);
+    if (page != null) {
+      final _Section section = await _sectionOf(page.sectionId, playback);
+      return _bounded(section, page.sectionId, page.start, page.end);
+    }
+    final _Section section = await _sectionOf(parentId, playback);
+    return _bounded(section, parentId, 0, section.length);
+  }
+
+  /// The children of [sectionId] as a lazily-indexable list, so paging a huge
+  /// section materializes only the window it returns. Unknown sections yield an
+  /// empty section rather than throwing.
+  Future<_Section> _sectionOf(String sectionId, PlaybackState playback) async {
+    switch (sectionId) {
       case MediaId.root:
-        return _rootNodes();
+        return _Section.of(await _rootNodes());
       case MediaId.library:
-        return _songNodes();
+        return _songSection();
       case MediaId.albums:
-        return _albumCategoryNodes();
+        return _Section.of(await _albumCategoryNodes());
       case MediaId.artists:
-        return _artistCategoryNodes();
+        return _Section.of(await _artistCategoryNodes());
       case MediaId.queue:
-        return _queueNodes(playback);
+        return _Section.of(_queueNodes(playback));
       case MediaId.playlists:
-        return _playlistCategoryNodes();
+        return _Section.of(await _playlistCategoryNodes());
       case MediaId.favorites:
-        return _favoriteNodes();
+        return _Section.of(await _favoriteNodes());
       case MediaId.offline:
-        return _offlineNodes();
+        return _Section.of(await _offlineNodes());
       case MediaId.empty:
-        return const <MediaNode>[];
+        return _Section.empty;
     }
-    if (MediaId.isAlbumCategory(parentId)) {
-      return _albumTrackNodes(MediaId.albumCategoryId(parentId));
+    if (MediaId.isAlbumCategory(sectionId)) {
+      return _Section.of(
+          await _albumTrackNodes(MediaId.albumCategoryId(sectionId)));
     }
-    if (MediaId.isArtistCategory(parentId)) {
-      return _artistTrackNodes(MediaId.artistCategoryId(parentId));
+    if (MediaId.isArtistCategory(sectionId)) {
+      return _Section.of(
+          await _artistTrackNodes(MediaId.artistCategoryId(sectionId)));
     }
-    if (MediaId.isPlaylistCategory(parentId)) {
-      return _playlistTrackNodes(MediaId.playlistCategoryId(parentId));
+    if (MediaId.isPlaylistCategory(sectionId)) {
+      return _Section.of(
+          await _playlistTrackNodes(MediaId.playlistCategoryId(sectionId)));
     }
-    return const <MediaNode>[];
+    return _Section.empty;
+  }
+
+  /// The window `[start, end)` of [section], bounded to [browsePageSize] nodes.
+  ///
+  /// A window that already fits is materialized as-is. A larger one is covered
+  /// by evenly sized `page/` containers instead — at most [browsePageSize] of
+  /// them, by growing the step in powers of [browsePageSize] — so browsing
+  /// recurses into narrower windows until it reaches real children. Two levels
+  /// already span 62 500 children and three span 15 million, so the tree stays
+  /// shallow for any realistic library.
+  ///
+  /// The split is a pure function of the window and the section's size, so
+  /// repeated browses of an unchanged section produce byte-identical page ids.
+  /// Out-of-range windows (a stale page id whose section has since shrunk) clamp
+  /// to what exists, and an empty one yields no children rather than throwing.
+  List<MediaNode> _bounded(
+    _Section section,
+    String sectionId,
+    int windowStart,
+    int windowEnd,
+  ) {
+    final int start = windowStart < 0 ? 0 : windowStart;
+    final int end = windowEnd > section.length ? section.length : windowEnd;
+    if (end <= start) return const <MediaNode>[];
+
+    final int span = end - start;
+    if (span <= browsePageSize) {
+      return <MediaNode>[
+        for (int i = start; i < end; i++) section.nodeAt(i),
+      ];
+    }
+
+    int step = browsePageSize;
+    while (span > step * browsePageSize) {
+      step *= browsePageSize;
+    }
+    final List<MediaNode> pages = <MediaNode>[];
+    for (int from = start; from < end; from += step) {
+      final int to = from + step > end ? end : from + step;
+      pages.add(MediaNode(
+        // Browsable, never playable: the `page/` namespace resolves to nothing
+        // in [resolve], so selecting a page row can't start playback.
+        id: MediaId.browsePage(sectionId, from, to),
+        title: '${from + 1} – $to',
+        subtitle: '${_pageLabel(section.nodeAt(from))} … '
+            '${_pageLabel(section.nodeAt(to - 1))}',
+      ));
+    }
+    return pages;
+  }
+
+  /// A page row's endpoint hint: the child's title, shortened so a long track
+  /// name can't push the row's subtitle out of the car's single line. Titles
+  /// only — never a uri or a path.
+  static String _pageLabel(MediaNode node) {
+    const int maxLength = 24;
+    final String title = node.title;
+    if (title.length <= maxLength) return title;
+    return '${title.substring(0, maxLength - 1).trimRight()}…';
   }
 
   /// Resolves a selected leaf [mediaId] to what should play, or null when it
@@ -316,6 +494,10 @@ class MediaBrowserTree {
     String mediaId,
     PlaybackState playback,
   ) async {
+    // A `page/` container is a browse-only node. It is checked first (and
+    // explicitly) so a page row can never be played, even if a future leaf
+    // namespace were to overlap it.
+    if (MediaId.isBrowsePage(mediaId)) return null;
     if (MediaId.isLibraryTrack(mediaId)) {
       final List<Track> tracks = await _allTracks();
       // Match by the uri hash, so two providers' same-id songs resolve to the
@@ -387,15 +569,22 @@ class MediaBrowserTree {
 
   Future<bool> _hasOffline() async => (await _downloadedKeys()).isNotEmpty;
 
-  Future<List<MediaNode>> _songNodes() async {
+  /// The flat Songs section, kept *lazy*: it reports the catalog size and builds
+  /// a leaf only for the index actually asked for. That is what keeps a 200k
+  /// library cheap to browse — a page request materializes 250 nodes, not
+  /// 200 000 of which 249 750 are immediately discarded.
+  Future<_Section> _songSection() async {
     final List<Track> tracks = await _allTracks();
-    if (tracks.isEmpty) return _placeholder('Sync your library first');
-    return <MediaNode>[
-      for (final Track track in tracks)
-        // Key the leaf by a hash of the provider-namespaced uri so two same-id
-        // songs from different providers get distinct, collision-free media ids.
-        _trackNode(MediaId.libraryTrack(track.uri), track),
-    ];
+    if (tracks.isEmpty) {
+      return _Section.of(_placeholder('Sync your library first'));
+    }
+    return _Section(
+      tracks.length,
+      // Key each leaf by a hash of the provider-namespaced uri so two same-id
+      // songs from different providers get distinct, collision-free media ids —
+      // and so a leaf id stays the same whichever page it was listed on.
+      (int i) => _trackNode(MediaId.libraryTrack(tracks[i].uri), tracks[i]),
+    );
   }
 
   Future<List<MediaNode>> _albumCategoryNodes() async {
@@ -603,11 +792,35 @@ class MediaBrowserTree {
 
   /// All catalog tracks, guarded so a catalog read error yields an empty list
   /// rather than throwing out of a browse/resolve.
-  Future<List<Track>> _allTracks() async {
+  ///
+  /// Served from a short-lived snapshot (see [_defaultCatalogSnapshotTtl]) so
+  /// the burst of browse requests behind one car interaction costs a single
+  /// catalog read and sees one consistent list — otherwise every page of a
+  /// large library would re-scan the whole catalog, and a sync landing
+  /// mid-scroll could shift the page windows underneath the user. Concurrent
+  /// callers share the in-flight read rather than each starting their own.
+  /// Failures are not cached, so a transient catalog error retries at once.
+  Future<List<Track>> _allTracks() {
+    final List<Track>? snapshot = _catalogSnapshot;
+    final DateTime? takenAt = _catalogSnapshotAt;
+    if (snapshot != null &&
+        takenAt != null &&
+        DateTime.now().difference(takenAt) < _catalogSnapshotTtl) {
+      return Future<List<Track>>.value(snapshot);
+    }
+    return _catalogInFlight ??= _readCatalog();
+  }
+
+  Future<List<Track>> _readCatalog() async {
     try {
-      return await _library.getAllTracks();
+      final List<Track> tracks = await _library.getAllTracks();
+      _catalogSnapshot = tracks;
+      _catalogSnapshotAt = DateTime.now();
+      return tracks;
     } catch (_) {
       return const <Track>[];
+    } finally {
+      _catalogInFlight = null;
     }
   }
 
@@ -644,3 +857,26 @@ class MediaBrowserTree {
     return '$albums • $songs';
   }
 }
+
+/// A browse section as a lazily-indexable list of nodes: how many children it
+/// has, and how to build the one at a given index.
+///
+/// Sections that are already materialized (albums, playlists, the queue) wrap
+/// their list with [_Section.of]; the flat Songs section stays lazy so paging a
+/// six-figure catalog builds only the page it returns.
+@immutable
+class _Section {
+  const _Section(this.length, this.nodeAt);
+
+  factory _Section.of(List<MediaNode> nodes) =>
+      _Section(nodes.length, (int i) => nodes[i]);
+
+  final int length;
+  final MediaNode Function(int index) nodeAt;
+
+  /// A section with no children — an unknown or dead-stop node.
+  static const _Section empty = _Section(0, _noNode);
+}
+
+MediaNode _noNode(int index) =>
+    throw StateError('empty browse section has no child at $index');

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -1113,6 +1113,403 @@ void main() {
       });
     });
 
+    // Follow-up coverage for #539 review point 3: a published row must be
+    // validated against the window that was actually published, before it is
+    // translated to an absolute position. Those are different checks once the
+    // window has slid — an out-of-window row can still translate to a perfectly
+    // valid absolute index, and would then jump to a track the car never showed.
+    group('published queue rows are validated before translation (#539)', () {
+      const int maxQueue = LinthraAudioHandler.maxPublishedQueueItems;
+      const int history = LinthraAudioHandler.publishedQueueHistory;
+
+      List<Track> catalog(int n) => <Track>[
+            for (int i = 0; i < n; i++)
+              Track(
+                id: 'jellyfin:$i',
+                title: 'Song ${i.toString().padLeft(6, '0')}',
+                uri: 'jellyfin:track/$i',
+              ),
+          ];
+
+      (LinthraAudioHandler, FakePlaybackController) rig(List<Track> tracks) {
+        final controller = FakePlaybackController();
+        final handler = LinthraAudioHandler(
+          controller,
+          MediaBrowserTree(FakeMusicLibraryRepository(tracks: tracks)),
+        );
+        addTearDown(() async {
+          await handler.dispose();
+          await controller.dispose();
+        });
+        return (handler, controller);
+      }
+
+      /// A handler whose published window sits in the middle of a long queue,
+      /// so `_lastQueueStart` is well above zero and the off-by-window bug is
+      /// reachable.
+      Future<(LinthraAudioHandler, FakePlaybackController, List<Track>)>
+          midWindow() async {
+        final tracks = catalog(20000);
+        final (handler, controller) = rig(tracks);
+        await handler.playFromMediaId(MediaId.libraryTrack(tracks[10000].uri));
+        await _settle();
+        // Window start is 10000 - history; the current row sits at `history`.
+        expect(handler.queue.value, hasLength(maxQueue));
+        expect(handler.playbackState.value.queueIndex, history);
+        return (handler, controller, tracks);
+      }
+
+      test('row 0 and the last published row are valid', () async {
+        final (handler, controller, tracks) = await midWindow();
+        const int start = 10000 - history;
+
+        await handler.skipToQueueItem(0);
+        await _settle();
+        expect(controller.state.currentTrack!.uri, tracks[start].uri);
+
+        // Back to the middle, then the final published row.
+        await handler.playFromMediaId(MediaId.libraryTrack(tracks[10000].uri));
+        await _settle();
+        await handler.skipToQueueItem(maxQueue - 1);
+        await _settle();
+        expect(controller.state.currentTrack!.uri,
+            tracks[start + maxQueue - 1].uri);
+      });
+
+      test('row 250 is a no-op even though its absolute index is valid',
+          () async {
+        final (handler, controller, tracks) = await midWindow();
+
+        // The window is [9950, 10200). Row 250 translates to absolute 10200 —
+        // a real track in the controller's 20 000-track queue — but it was
+        // never published, so it must be rejected.
+        const int absolute = (10000 - history) + maxQueue;
+        expect(absolute, lessThan(tracks.length),
+            reason: 'the translated index must be valid for this to bite');
+
+        final int playsBefore = controller.playedTracks.length;
+        await handler.skipToQueueItem(maxQueue);
+        await _settle();
+
+        expect(controller.playedTracks, hasLength(playsBefore));
+        expect(controller.state.currentTrack!.uri, tracks[10000].uri);
+      });
+
+      test('row 255 is a no-op even though its absolute index is valid',
+          () async {
+        final (handler, controller, tracks) = await midWindow();
+
+        const int absolute = (10000 - history) + 255;
+        expect(absolute, lessThan(tracks.length));
+
+        final int playsBefore = controller.playedTracks.length;
+        await handler.skipToQueueItem(255);
+        await _settle();
+
+        expect(controller.playedTracks, hasLength(playsBefore));
+        expect(controller.state.currentTrack!.uri, tracks[10000].uri);
+      });
+
+      test('a negative row is a no-op', () async {
+        final (handler, controller, tracks) = await midWindow();
+        final int playsBefore = controller.playedTracks.length;
+
+        await handler.skipToQueueItem(-1);
+        await handler.skipToQueueItem(-999);
+        await _settle();
+
+        expect(controller.playedTracks, hasLength(playsBefore));
+        expect(controller.state.currentTrack!.uri, tracks[10000].uri);
+      });
+
+      test('every valid row maps to the exact track it displays', () async {
+        final (handler, controller, tracks) = await midWindow();
+        final published = handler.queue.value;
+
+        for (final int row in <int>[
+          0,
+          1,
+          history - 1,
+          history + 1,
+          maxQueue ~/ 2,
+          maxQueue - 2,
+          maxQueue - 1,
+        ]) {
+          await handler
+              .playFromMediaId(MediaId.libraryTrack(tracks[10000].uri));
+          await _settle();
+          final String shown = handler.queue.value[row].title;
+          await handler.skipToQueueItem(row);
+          await _settle();
+          expect(controller.state.currentTrack!.title, shown,
+              reason: 'row $row');
+        }
+        expect(published, hasLength(maxQueue));
+      });
+
+      test('the published current row stays a no-op and never restarts',
+          () async {
+        final (handler, controller, tracks) = await midWindow();
+        final int playsBefore = controller.playedTracks.length;
+
+        await handler.skipToQueueItem(history); // the current row
+        await _settle();
+
+        expect(controller.playedTracks, hasLength(playsBefore));
+        expect(controller.state.currentTrack!.uri, tracks[10000].uri);
+      });
+
+      test('rows are rejected before anything has been published', () async {
+        // Nothing playing: the published queue is empty, so every row is stale.
+        final (handler, controller) = rig(catalog(20000));
+
+        await handler.skipToQueueItem(0);
+        await handler.skipToQueueItem(10);
+        await _settle();
+
+        expect(controller.playedTracks, isEmpty);
+        expect(controller.state.currentTrack, isNull);
+      });
+    });
+
+    // Follow-up coverage for #539 review point 2: the robustness target is a
+    // *logical* queue of up to 200 000 tracks. The controller may own all of
+    // them; the media session must never be handed them. This suite proves the
+    // native payload is a function of the window size, not the queue size.
+    //
+    // Deliberately efficient: the 200k catalog is built once for the group and
+    // the assertions are O(window), not O(queue). The exhaustive traversal
+    // tests live in the smaller-catalog groups above.
+    group('a 200k logical queue never reaches the media session (#539)', () {
+      const int target = 200000;
+      const int maxQueue = LinthraAudioHandler.maxPublishedQueueItems;
+      const int history = LinthraAudioHandler.publishedQueueHistory;
+
+      // Built once on first use and shared by every test in this group.
+      late final List<Track> huge = <Track>[
+        for (int i = 0; i < target; i++)
+          Track(
+            id: 'jellyfin:$i',
+            title: 'Song ${i.toString().padLeft(6, '0')}',
+            uri: 'jellyfin:track/$i',
+          ),
+      ];
+
+      /// A rig that records every queue the handler ever publishes, so a test
+      /// can prove no oversized payload was emitted at any point — not just
+      /// that the final one happens to be small.
+      (LinthraAudioHandler, FakePlaybackController, List<int>) rig() {
+        final controller = FakePlaybackController();
+        final handler = LinthraAudioHandler(
+          controller,
+          MediaBrowserTree(FakeMusicLibraryRepository(tracks: huge)),
+        );
+        final publishedLengths = <int>[];
+        final sub =
+            handler.queue.listen((items) => publishedLengths.add(items.length));
+        addTearDown(() async {
+          await sub.cancel();
+          await handler.dispose();
+          await controller.dispose();
+        });
+        return (handler, controller, publishedLengths);
+      }
+
+      /// Asserts the session-facing invariants that must hold after any change
+      /// of current track, for a queue of [target] tracks positioned at [index].
+      void expectBoundedAt(
+        LinthraAudioHandler handler,
+        FakePlaybackController controller,
+        int index,
+      ) {
+        final published = handler.queue.value;
+        final int? active = handler.playbackState.value.queueIndex;
+
+        // The controller owns the whole logical queue...
+        expect(
+            controller.state.previous.length +
+                1 +
+                controller.state.upNext.length,
+            target,
+            reason: 'controller queue at $index');
+        // ...the session sees only a window of it.
+        expect(published.length, lessThanOrEqualTo(maxQueue),
+            reason: 'published rows at $index');
+        expect(published, hasLength(maxQueue), reason: 'window full at $index');
+        // The current track is inside the window, at a valid row...
+        expect(active, isNotNull, reason: 'queueIndex at $index');
+        expect(active, inInclusiveRange(0, published.length - 1),
+            reason: 'queueIndex in range at $index');
+        // ...and that row really is what is playing.
+        expect(published[active!].title, huge[index].title,
+            reason: 'highlighted row at $index');
+        expect(controller.state.currentTrack!.uri, huge[index].uri,
+            reason: 'current track at $index');
+      }
+
+      test('selecting near the beginning keeps the payload bounded', () async {
+        final (handler, controller, lengths) = rig();
+
+        await handler.playFromMediaId(MediaId.libraryTrack(huge[3].uri));
+        await _settle();
+
+        expectBoundedAt(handler, controller, 3);
+        expect(handler.playbackState.value.queueIndex, 3);
+        expect(lengths.every((n) => n <= maxQueue), isTrue);
+      });
+
+      test('selecting around index 100 000 keeps the payload bounded',
+          () async {
+        final (handler, controller, lengths) = rig();
+
+        await handler.playFromMediaId(MediaId.libraryTrack(huge[100000].uri));
+        await _settle();
+
+        expectBoundedAt(handler, controller, 100000);
+        expect(handler.playbackState.value.queueIndex, history);
+        expect(lengths.every((n) => n <= maxQueue), isTrue);
+      });
+
+      test('selecting the last track keeps the payload bounded', () async {
+        final (handler, controller, lengths) = rig();
+
+        await handler.playFromMediaId(MediaId.libraryTrack(huge.last.uri));
+        await _settle();
+
+        expectBoundedAt(handler, controller, target - 1);
+        // At the end the window slides back so it is still full, and the
+        // current track is its final row.
+        expect(handler.playbackState.value.queueIndex, maxQueue - 1);
+        expect(lengths.every((n) => n <= maxQueue), isTrue);
+      });
+
+      test('no queue emission ever carries the whole 200k queue', () async {
+        final (handler, controller, lengths) = rig();
+
+        // Exercise the paths that republish: a selection, skips, and a jump.
+        await handler.playFromMediaId(MediaId.libraryTrack(huge[100000].uri));
+        await _settle();
+        await handler.skipToNext();
+        await handler.skipToNext();
+        await handler.skipToPrevious();
+        await handler.skipToQueueItem(history + 5);
+        await _settle();
+
+        expect(lengths, isNotEmpty);
+        expect(lengths.reduce((a, b) => a > b ? a : b),
+            lessThanOrEqualTo(maxQueue));
+        // Even summed across every republish, the session saw a small multiple
+        // of the window — never anything proportional to 200 000.
+        expect(lengths.reduce((a, b) => a + b), lessThan(20 * maxQueue));
+        expect(
+            controller.state.previous.length +
+                1 +
+                controller.state.upNext.length,
+            target);
+      });
+
+      test('skipToQueueItem maps correctly inside a middle window', () async {
+        final (handler, controller, _) = rig();
+        await handler.playFromMediaId(MediaId.libraryTrack(huge[100000].uri));
+        await _settle();
+
+        const int start = 100000 - history;
+
+        await handler.skipToQueueItem(0);
+        await _settle();
+        expect(controller.state.currentTrack!.uri, huge[start].uri);
+
+        await handler.playFromMediaId(MediaId.libraryTrack(huge[100000].uri));
+        await _settle();
+        await handler.skipToQueueItem(maxQueue - 1);
+        await _settle();
+        expect(
+            controller.state.currentTrack!.uri, huge[start + maxQueue - 1].uri);
+      });
+
+      test('rows 250 and 255 stay no-ops though their absolute index is valid',
+          () async {
+        final (handler, controller, _) = rig();
+        await handler.playFromMediaId(MediaId.libraryTrack(huge[100000].uri));
+        await _settle();
+
+        // The window is [99 950, 100 200). Rows 250 and 255 translate to
+        // 100 200 and 100 205 — real tracks in the 200k controller queue that
+        // were never published.
+        for (final int row in <int>[maxQueue, 255]) {
+          expect((100000 - history) + row, lessThan(target),
+              reason: 'translated index must be valid for row $row to bite');
+        }
+
+        final int playsBefore = controller.playedTracks.length;
+        await handler.skipToQueueItem(maxQueue);
+        await handler.skipToQueueItem(255);
+        await handler.skipToQueueItem(-1);
+        await _settle();
+
+        expect(controller.playedTracks, hasLength(playsBefore));
+        expect(controller.state.currentTrack!.uri, huge[100000].uri);
+      });
+
+      test('next and previous keep the sliding window correct', () async {
+        final (handler, controller, lengths) = rig();
+        await handler.playFromMediaId(MediaId.libraryTrack(huge[100000].uri));
+        await _settle();
+
+        for (int step = 1; step <= 3; step++) {
+          await handler.skipToNext();
+          await _settle();
+          expectBoundedAt(handler, controller, 100000 + step);
+        }
+        for (int step = 2; step >= 0; step--) {
+          await handler.skipToPrevious();
+          await _settle();
+          expectBoundedAt(handler, controller, 100000 + step);
+        }
+        expect(lengths.every((n) => n <= maxQueue), isTrue);
+      });
+
+      test('position ticks do not rebuild the 200k queue', () async {
+        // The bridge must materialize only what it publishes. Rebuilding the
+        // flat history+current+up-next list on every state event — position
+        // ticks arrive several times a second — costs a full 200k allocation
+        // each time even when the window is unchanged and nothing is
+        // republished. Measured on this suite: ~2 785 ms before, ~16 ms after,
+        // for 300 ticks (about a minute of playback). The threshold is
+        // deliberately loose — 30x the observed cost, still 5x under the old
+        // one — so it catches a regression to O(queue) without being timing
+        // flaky.
+        final (handler, controller, lengths) = rig();
+        await controller.playTracks(huge, startIndex: 100000);
+        await _settle();
+        final int publishesAfterSelect = lengths.length;
+
+        final Stopwatch sw = Stopwatch()..start();
+        for (int i = 0; i < 300; i++) {
+          controller.emit(controller.state
+              .copyWith(position: Duration(milliseconds: i * 200)));
+        }
+        await _settle();
+        sw.stop();
+
+        // Nothing about the window changed, so nothing was republished...
+        expect(lengths, hasLength(publishesAfterSelect));
+        // ...and the ticks stayed cheap.
+        expect(sw.elapsedMilliseconds, lessThan(500),
+            reason: 'position ticks look O(queue), not O(window)');
+      });
+
+      test('a 200k selection starts exactly one track — no duplicate playback',
+          () async {
+        final (handler, controller, _) = rig();
+
+        await handler.playFromMediaId(MediaId.libraryTrack(huge[100000].uri));
+        await _settle();
+
+        expect(controller.playedTracks, <Track>[huge[100000]]);
+      });
+    });
+
     group('offline & favorites browsing', () {
       late FakePlaybackController offController;
       late LinthraAudioHandler offHandler;

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -675,6 +675,444 @@ void main() {
       });
     });
 
+    // Follow-up coverage for #539 review point 1: the browse options Android
+    // Auto sends are honoured here, because nothing below this handler applies
+    // them. MediaBrowserServiceCompat runs its own applyOptions only under
+    // RESULT_FLAG_OPTION_NOT_HANDLED, which the base class sets only when the
+    // service leaves onLoadChildren(parentId, result, options) unoverridden —
+    // and audio_service's AudioService overrides it, calling
+    // result.sendResult(...) directly. So an unhandled page request would hand
+    // the client page 0 over and over.
+    group('browse page options are honoured (#539)', () {
+      const String extraPage = MediaBrowseOptions.extraPage;
+      const String extraPageSize = MediaBrowseOptions.extraPageSize;
+
+      List<Track> catalog(int n) => <Track>[
+            for (int i = 0; i < n; i++)
+              Track(
+                id: 'jellyfin:$i',
+                title: 'Song ${i.toString().padLeft(5, '0')}',
+                uri: 'jellyfin:https://host.example/Items/$i?api_key=SECRET',
+              ),
+          ];
+
+      LinthraAudioHandler handlerFor(List<Track> tracks) {
+        final controller = FakePlaybackController();
+        final handler = LinthraAudioHandler(
+          controller,
+          MediaBrowserTree(FakeMusicLibraryRepository(tracks: tracks)),
+        );
+        addTearDown(() async {
+          await handler.dispose();
+          await controller.dispose();
+        });
+        return handler;
+      }
+
+      test('page 0 and a non-zero page return different, adjacent windows',
+          () async {
+        // 200 songs: one flat, unpaged node, browsed 50 at a time.
+        final handler = handlerFor(catalog(200));
+
+        final unpaged = await handler.getChildren(MediaId.library);
+        final page0 = await handler.getChildren(MediaId.library,
+            <String, dynamic>{extraPage: 0, extraPageSize: 50});
+        final page1 = await handler.getChildren(MediaId.library,
+            <String, dynamic>{extraPage: 1, extraPageSize: 50});
+        final page3 = await handler.getChildren(MediaId.library,
+            <String, dynamic>{extraPage: 3, extraPageSize: 50});
+
+        expect(unpaged, hasLength(200));
+        expect(page0, hasLength(50));
+        expect(page1, hasLength(50));
+        expect(page3, hasLength(50));
+        // The regression this guards: page 1 must not repeat page 0.
+        expect(page1.map((i) => i.id), isNot(page0.map((i) => i.id)));
+        expect(page0.map((i) => i.id), unpaged.take(50).map((i) => i.id));
+        expect(
+            page1.map((i) => i.id), unpaged.skip(50).take(50).map((i) => i.id));
+        expect(page3.map((i) => i.id),
+            unpaged.skip(150).take(50).map((i) => i.id));
+      });
+
+      test('paging tiles a node exactly, with no gap, overlap or loss',
+          () async {
+        final handler = handlerFor(catalog(200));
+
+        final seen = <String>[];
+        for (int page = 0;; page++) {
+          final items = await handler.getChildren(MediaId.library,
+              <String, dynamic>{extraPage: page, extraPageSize: 30});
+          if (items.isEmpty) break;
+          seen.addAll(items.map((i) => i.id));
+          expect(page, lessThan(20), reason: 'paging did not terminate');
+        }
+
+        final all = await handler.getChildren(MediaId.library);
+        expect(seen, all.map((i) => i.id).toList());
+        expect(seen.toSet(), hasLength(200));
+      });
+
+      test('a partial last page, then an empty one, ends the walk', () async {
+        // 200 songs at 60 per page: 3 full pages, a 20-row remainder, then end.
+        final handler = handlerFor(catalog(200));
+
+        Future<int> sizeOf(int page) async => (await handler.getChildren(
+              MediaId.library,
+              <String, dynamic>{extraPage: page, extraPageSize: 60},
+            ))
+                .length;
+
+        expect(await sizeOf(2), 60);
+        expect(await sizeOf(3), 20);
+        expect(await sizeOf(4), 0);
+      });
+
+      test('paging composes with the tree bound on a large catalog', () async {
+        // 4 pages' worth of page containers, browsed 2 rows at a time.
+        final handler =
+            handlerFor(catalog(4 * MediaBrowserTree.browsePageSize));
+
+        final containers = await handler.getChildren(MediaId.library);
+        expect(containers, hasLength(4));
+        expect(containers.every((i) => MediaId.isBrowsePage(i.id)), isTrue);
+
+        final second = await handler.getChildren(
+            MediaId.library, <String, dynamic>{extraPage: 1, extraPageSize: 2});
+        expect(second.map((i) => i.id),
+            containers.skip(2).take(2).map((i) => i.id));
+
+        // And a page *inside* a container still pages correctly.
+        final inside = await handler.getChildren(containers.first.id,
+            <String, dynamic>{extraPage: 1, extraPageSize: 50});
+        final whole = await handler.getChildren(containers.first.id);
+        expect(
+            inside.map((i) => i.id), whole.skip(50).take(50).map((i) => i.id));
+      });
+
+      test('absent, empty or nonsensical options return the whole node',
+          () async {
+        final handler = handlerFor(catalog(10));
+
+        // No options at all: Android's two-argument onLoadChildren path.
+        expect(await handler.getChildren(MediaId.library), hasLength(10));
+        expect(await handler.getChildren(MediaId.library, <String, dynamic>{}),
+            hasLength(10));
+        // Only one half of the window specified, or a junk type: treated
+        // exactly as MediaBrowserServiceCompat.applyOptions would.
+        expect(
+          await handler.getChildren(
+              MediaId.library, <String, dynamic>{extraPage: 'nope'}),
+          hasLength(10),
+        );
+        expect(
+          await handler.getChildren(MediaId.library,
+              <String, dynamic>{extraPage: -1, extraPageSize: -1}),
+          hasLength(10),
+        );
+        // A negative page, a zero page size, and a page past the end are all
+        // empty — how a client learns it has run out.
+        expect(
+          await handler.getChildren(MediaId.library,
+              <String, dynamic>{extraPage: -2, extraPageSize: 5}),
+          isEmpty,
+        );
+        expect(
+          await handler.getChildren(MediaId.library,
+              <String, dynamic>{extraPage: 0, extraPageSize: 0}),
+          isEmpty,
+        );
+        expect(
+          await handler.getChildren(MediaId.library,
+              <String, dynamic>{extraPage: 99, extraPageSize: 5}),
+          isEmpty,
+        );
+      });
+
+      test('paged rows stay token-, path- and scheme-free', () async {
+        final handler = handlerFor(catalog(200));
+
+        final items = await handler.getChildren(MediaId.library,
+            <String, dynamic>{extraPage: 2, extraPageSize: 50});
+
+        expect(items, isNotEmpty);
+        for (final item in items) {
+          for (final String text in <String>[
+            item.id,
+            item.title,
+            item.displaySubtitle ?? '',
+          ]) {
+            expect(text, isNot(contains('api_key')));
+            expect(text.toLowerCase(), isNot(contains('secret')));
+            expect(text, isNot(contains('://')));
+          }
+        }
+      });
+    });
+
+    // Follow-up coverage for #539 review point 2: fixing the browse response
+    // must not move the oversized-payload problem onto the playback path.
+    // Selecting a song still hands the controller the whole catalog, and
+    // `queue.add(...)` becomes a native MediaSessionCompat queue delivered in
+    // one Binder transaction — so the *published* queue is a bounded window,
+    // while the controller keeps the full queue.
+    group('the published media-session queue stays bounded (#539)', () {
+      const int maxQueue = LinthraAudioHandler.maxPublishedQueueItems;
+      const int history = LinthraAudioHandler.publishedQueueHistory;
+
+      // 10k+, well past the ~1.5k Binder threshold, but cheap to build.
+      const int bigCatalog = 12000;
+
+      List<Track> catalog(int n) => <Track>[
+            for (int i = 0; i < n; i++)
+              Track(
+                id: 'jellyfin:$i',
+                title: 'Song ${i.toString().padLeft(5, '0')}',
+                uri: 'jellyfin:https://host.example/Items/$i?api_key=SECRET',
+                artistName: 'Artist ${i % 40}',
+                albumName: 'Album ${i % 90}',
+              ),
+          ];
+
+      /// A handler plus its controller, torn down with the test.
+      (LinthraAudioHandler, FakePlaybackController) rig(List<Track> tracks) {
+        final controller = FakePlaybackController();
+        final handler = LinthraAudioHandler(
+          controller,
+          MediaBrowserTree(FakeMusicLibraryRepository(tracks: tracks)),
+        );
+        addTearDown(() async {
+          await handler.dispose();
+          await controller.dispose();
+        });
+        return (handler, controller);
+      }
+
+      /// The Songs leaf id for [track] — position-independent, so it is the
+      /// same id whichever page of the browse tree listed it.
+      String leafIdFor(Track track) => MediaId.libraryTrack(track.uri);
+
+      test('selecting a song from a 12k library publishes a bounded queue',
+          () async {
+        final tracks = catalog(bigCatalog);
+        final (handler, controller) = rig(tracks);
+
+        await handler.playFromMediaId(leafIdFor(tracks[0]));
+        await _settle();
+
+        // The controller really does own the whole catalog...
+        expect(controller.state.upNext.length + 1, tracks.length);
+        // ...but the session only ever sees a window of it.
+        expect(handler.queue.value, hasLength(maxQueue));
+        expect(handler.queue.value.length, lessThan(tracks.length));
+      });
+
+      test('the window follows playback and always holds the current track',
+          () async {
+        final tracks = catalog(bigCatalog);
+        final (handler, controller) = rig(tracks);
+
+        Future<void> selectAndCheck(int index) async {
+          await handler.playFromMediaId(leafIdFor(tracks[index]));
+          await _settle();
+
+          final published = handler.queue.value;
+          expect(published, hasLength(maxQueue), reason: 'at $index');
+          final int active = handler.playbackState.value.queueIndex!;
+          expect(active, inInclusiveRange(0, published.length - 1),
+              reason: 'at $index');
+          // The highlighted row is the track that is actually playing.
+          expect(published[active].title, tracks[index].title,
+              reason: 'at $index');
+          expect(controller.state.currentTrack!.uri, tracks[index].uri,
+              reason: 'at $index');
+        }
+
+        await selectAndCheck(0); // first
+        await selectAndCheck(bigCatalog ~/ 2); // middle
+        await selectAndCheck(bigCatalog - 1); // last
+      });
+
+      test('first, middle and last selections keep the window in range',
+          () async {
+        final tracks = catalog(bigCatalog);
+        final (handler, _) = rig(tracks);
+
+        // First track: nothing behind it, so the window starts at 0.
+        await handler.playFromMediaId(leafIdFor(tracks.first));
+        await _settle();
+        expect(handler.playbackState.value.queueIndex, 0);
+        expect(handler.queue.value.first.title, tracks.first.title);
+
+        // Middle: the configured amount of history sits behind the current row.
+        await handler.playFromMediaId(leafIdFor(tracks[5000]));
+        await _settle();
+        expect(handler.playbackState.value.queueIndex, history);
+
+        // Last track: the window slides back so it is still full, and the
+        // current row is its final entry.
+        await handler.playFromMediaId(leafIdFor(tracks.last));
+        await _settle();
+        expect(handler.queue.value, hasLength(maxQueue));
+        expect(handler.playbackState.value.queueIndex, maxQueue - 1);
+        expect(handler.queue.value.last.title, tracks.last.title);
+      });
+
+      test('a small library publishes its whole queue, unchanged', () async {
+        final (handler, _) = rig(_library);
+
+        await handler.playFromMediaId(MediaId.libraryTrack('/a.mp3'));
+        await _settle();
+
+        expect(handler.queue.value.map((i) => i.title),
+            _library.map((t) => t.title));
+        expect(handler.playbackState.value.queueIndex, 0);
+      });
+
+      test('next and previous cross the window boundary correctly', () async {
+        final tracks = catalog(bigCatalog);
+        final (handler, controller) = rig(tracks);
+
+        // Start where the window is full and sliding: current at `history`.
+        await handler.playFromMediaId(leafIdFor(tracks[1000]));
+        await _settle();
+        expect(handler.playbackState.value.queueIndex, history);
+
+        // Walk forward past where the window must slide, and check the session
+        // keeps naming the right track at the right row every step.
+        for (int step = 1; step <= 3; step++) {
+          await handler.skipToNext();
+          await _settle();
+          final published = handler.queue.value;
+          final int active = handler.playbackState.value.queueIndex!;
+          expect(controller.state.currentTrack!.uri, tracks[1000 + step].uri);
+          expect(published[active].title, tracks[1000 + step].title);
+          expect(published, hasLength(maxQueue));
+        }
+
+        // And back again.
+        for (int step = 2; step >= 0; step--) {
+          await handler.skipToPrevious();
+          await _settle();
+          final published = handler.queue.value;
+          final int active = handler.playbackState.value.queueIndex!;
+          expect(controller.state.currentTrack!.uri, tracks[1000 + step].uri);
+          expect(published[active].title, tracks[1000 + step].title);
+        }
+      });
+
+      test('skipToQueueItem maps a windowed row to the right track', () async {
+        final tracks = catalog(bigCatalog);
+        final (handler, controller) = rig(tracks);
+
+        await handler.playFromMediaId(leafIdFor(tracks[5000]));
+        await _settle();
+
+        // Row 0 of the published window is `history` tracks behind the current
+        // one — the offset that a naive index-as-absolute mapping would get
+        // wrong.
+        await handler.skipToQueueItem(0);
+        await _settle();
+        expect(controller.state.currentTrack!.uri, tracks[5000 - history].uri);
+
+        // A forward row within the same window.
+        await handler.playFromMediaId(leafIdFor(tracks[5000]));
+        await _settle();
+        await handler.skipToQueueItem(history + 10);
+        await _settle();
+        expect(controller.state.currentTrack!.uri, tracks[5010].uri);
+
+        // The published row for the current track is a no-op, not a restart.
+        await handler.playFromMediaId(leafIdFor(tracks[5000]));
+        await _settle();
+        final int playsBefore = controller.playedTracks.length;
+        await handler.skipToQueueItem(handler.playbackState.value.queueIndex!);
+        await _settle();
+        expect(controller.playedTracks, hasLength(playsBefore));
+        expect(controller.state.currentTrack!.uri, tracks[5000].uri);
+      });
+
+      test('every published row maps back to the track it displays', () async {
+        final tracks = catalog(bigCatalog);
+        final (handler, controller) = rig(tracks);
+
+        await handler.playFromMediaId(leafIdFor(tracks[5000]));
+        await _settle();
+        final published = handler.queue.value;
+
+        // Spot-check across the whole window, including both ends.
+        for (final int row in <int>[
+          0,
+          1,
+          history - 1,
+          history + 1,
+          published.length ~/ 2,
+          published.length - 1
+        ]) {
+          await handler.playFromMediaId(leafIdFor(tracks[5000]));
+          await _settle();
+          final String expectedTitle = handler.queue.value[row].title;
+          await handler.skipToQueueItem(row);
+          await _settle();
+          expect(controller.state.currentTrack!.title, expectedTitle,
+              reason: 'row $row');
+        }
+      });
+
+      test('an out-of-window row is a safe no-op, never a wrong track',
+          () async {
+        final tracks = catalog(bigCatalog);
+        final (handler, controller) = rig(tracks);
+
+        await handler.playFromMediaId(leafIdFor(tracks.last));
+        await _settle();
+        final int playsBefore = controller.playedTracks.length;
+
+        // Rows that do not exist in the published window.
+        await handler.skipToQueueItem(-1);
+        await handler.skipToQueueItem(maxQueue + 5);
+        await handler.skipToQueueItem(bigCatalog + 100);
+        await _settle();
+
+        expect(controller.playedTracks, hasLength(playsBefore));
+        expect(controller.state.currentTrack!.uri, tracks.last.uri);
+      });
+
+      test('selecting a song starts it exactly once — no duplicate playback',
+          () async {
+        final tracks = catalog(bigCatalog);
+        final (handler, controller) = rig(tracks);
+
+        await handler.playFromMediaId(leafIdFor(tracks[7000]));
+        await _settle();
+
+        expect(controller.playedTracks, <Track>[tracks[7000]]);
+        expect(controller.state.currentTrack!.uri, tracks[7000].uri);
+      });
+
+      test('published queue rows carry no token, path or scheme', () async {
+        final tracks = catalog(bigCatalog);
+        final (handler, _) = rig(tracks);
+
+        await handler.playFromMediaId(leafIdFor(tracks[5000]));
+        await _settle();
+
+        for (final item in handler.queue.value) {
+          for (final String text in <String>[
+            item.id,
+            item.title,
+            item.artist ?? '',
+            item.album ?? '',
+          ]) {
+            expect(text, isNot(contains('api_key')));
+            expect(text.toLowerCase(), isNot(contains('secret')));
+            expect(text, isNot(contains('://')));
+          }
+          expect(item.extras, anyOf(isNull, isEmpty));
+        }
+      });
+    });
+
     group('offline & favorites browsing', () {
       late FakePlaybackController offController;
       late LinthraAudioHandler offHandler;

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -481,6 +481,200 @@ void main() {
       });
     });
 
+    // Regression coverage for #539, at the audio_service boundary: whatever the
+    // browse tree decides, the MediaItems this handler hands to
+    // MediaBrowserServiceCompat must stay a bounded, complete, playable-vs-
+    // browsable-correct set — that list is delivered to Android Auto in one
+    // Binder transaction, and an oversized one is dropped silently, leaving the
+    // car spinning forever.
+    group('large Songs catalogs page instead of flooding the browser (#539)',
+        () {
+      const int pageSize = MediaBrowserTree.browsePageSize;
+
+      List<Track> catalog(int n) => <Track>[
+            for (int i = 0; i < n; i++)
+              Track(
+                id: 'jellyfin:$i',
+                title: 'Song ${i.toString().padLeft(5, '0')}',
+                uri: 'jellyfin:https://host.example/Items/$i?api_key=SECRET',
+                artistName: 'Artist ${i % 40}',
+                albumName: 'Album ${i % 90}',
+              ),
+          ];
+
+      /// A handler over [tracks], torn down with the test.
+      LinthraAudioHandler handlerFor(List<Track> tracks) {
+        final controller = FakePlaybackController();
+        final handler = LinthraAudioHandler(
+          controller,
+          MediaBrowserTree(FakeMusicLibraryRepository(tracks: tracks)),
+        );
+        addTearDown(() async {
+          await handler.dispose();
+          await controller.dispose();
+        });
+        return handler;
+      }
+
+      /// Every playable MediaItem reachable under [parentId], descending
+      /// through page containers.
+      Future<List<audio.MediaItem>> leaves(
+        LinthraAudioHandler handler,
+        String parentId,
+      ) async {
+        final out = <audio.MediaItem>[];
+        for (final audio.MediaItem item
+            in await handler.getChildren(parentId)) {
+          if (MediaId.isBrowsePage(item.id)) {
+            out.addAll(await leaves(handler, item.id));
+          } else {
+            out.add(item);
+          }
+        }
+        return out;
+      }
+
+      test('no getChildren response exceeds the browse bound', () async {
+        final handler = handlerFor(catalog(4 * pageSize + 7));
+
+        final top = await handler.getChildren(MediaId.library);
+        expect(top.length, lessThanOrEqualTo(pageSize));
+        for (final page in top) {
+          expect((await handler.getChildren(page.id)).length,
+              lessThanOrEqualTo(pageSize));
+        }
+      });
+
+      test('every song still reaches Android Auto exactly once', () async {
+        final tracks = catalog(4 * pageSize + 7);
+        final handler = handlerFor(tracks);
+
+        final items = await leaves(handler, MediaId.library);
+
+        expect(items, hasLength(tracks.length));
+        expect(items.map((i) => i.id).toSet(), hasLength(tracks.length));
+        expect(items.map((i) => i.id),
+            tracks.map((t) => MediaId.libraryTrack(t.uri)));
+        expect(items.every((i) => i.playable == true), isTrue);
+      });
+
+      test('page rows are browsable containers, not playable items', () async {
+        final handler = handlerFor(catalog(4 * pageSize + 7));
+
+        final top = await handler.getChildren(MediaId.library);
+
+        expect(top, isNotEmpty);
+        expect(top.every((i) => MediaId.isBrowsePage(i.id)), isTrue);
+        expect(top.every((i) => i.playable == false), isTrue);
+        // A page row carries no track metadata that would make a head unit
+        // treat it as a song.
+        expect(top.every((i) => i.duration == null), isTrue);
+        expect(top.every((i) => i.artist == null), isTrue);
+      });
+
+      test('selecting a page row starts no playback', () async {
+        final controller = FakePlaybackController();
+        final handler = LinthraAudioHandler(
+          controller,
+          MediaBrowserTree(
+              FakeMusicLibraryRepository(tracks: catalog(4 * pageSize + 7))),
+        );
+        addTearDown(() async {
+          await handler.dispose();
+          await controller.dispose();
+        });
+
+        final page = (await handler.getChildren(MediaId.library)).first;
+        await handler.playFromMediaId(page.id);
+        await _settle();
+
+        expect(controller.playedTracks, isEmpty);
+        expect(controller.state.currentTrack, isNull);
+      });
+
+      test('selecting a paged song plays the whole catalog at its index',
+          () async {
+        final tracks = catalog(4 * pageSize + 7);
+        final controller = FakePlaybackController();
+        final handler = LinthraAudioHandler(
+          controller,
+          MediaBrowserTree(FakeMusicLibraryRepository(tracks: tracks)),
+        );
+        addTearDown(() async {
+          await handler.dispose();
+          await controller.dispose();
+        });
+
+        // The first row of the *third* page — a song that the old flat list
+        // would have buried past the Binder limit.
+        final pages = await handler.getChildren(MediaId.library);
+        final third = await handler.getChildren(pages[2].id);
+        await handler.playFromMediaId(third.first.id);
+        await _settle();
+
+        // The whole catalog became the queue, positioned on the selected song —
+        // exactly as an unpaged Songs selection always did.
+        final PlaybackState state = controller.state;
+        expect(controller.playedTracks, <Track>[tracks[2 * pageSize]]);
+        expect(state.currentTrack!.uri, tracks[2 * pageSize].uri);
+        expect(state.previous, hasLength(2 * pageSize));
+        expect(state.previous.length + 1 + state.upNext.length, tracks.length);
+      });
+
+      test('paged browse output stays token-, path- and scheme-free', () async {
+        final handler = handlerFor(catalog(pageSize + 5));
+
+        for (final audio.MediaItem item in <audio.MediaItem>[
+          ...await handler.getChildren(MediaId.library),
+          ...await leaves(handler, MediaId.library),
+        ]) {
+          for (final String text in <String>[
+            item.id,
+            item.title,
+            item.displaySubtitle ?? '',
+            item.artist ?? '',
+            item.album ?? '',
+          ]) {
+            expect(text, isNot(contains('api_key')));
+            expect(text.toLowerCase(), isNot(contains('secret')));
+            expect(text, isNot(contains('jellyfin:')));
+            expect(text, isNot(contains('://')));
+          }
+          expect(item.extras, anyOf(isNull, isEmpty));
+        }
+      });
+
+      test('repeated browse requests are byte-identical (no rebuild loop)',
+          () async {
+        final handler = handlerFor(catalog(4 * pageSize + 7));
+
+        List<String> shapeOf(List<audio.MediaItem> items) => <String>[
+              for (final i in items) '${i.id}|${i.title}|${i.playable}',
+            ];
+
+        final first = shapeOf(await handler.getChildren(MediaId.library));
+        final second = shapeOf(await handler.getChildren(MediaId.library));
+        final third = shapeOf(await handler.getChildren(MediaId.library));
+
+        expect(second, first);
+        expect(third, first);
+      });
+
+      test('a small library is untouched — still one flat Songs list',
+          () async {
+        final handler = handlerFor(_library);
+
+        final items = await handler.getChildren(MediaId.library);
+
+        expect(items.map((i) => i.id), [
+          MediaId.libraryTrack('/a.mp3'),
+          MediaId.libraryTrack('/b.mp3'),
+          MediaId.libraryTrack('/c.mp3'),
+        ]);
+        expect(items.every((i) => i.playable == true), isTrue);
+      });
+    });
+
     group('offline & favorites browsing', () {
       late FakePlaybackController offController;
       late LinthraAudioHandler offHandler;

--- a/test/core/services/media_browser_tree_test.dart
+++ b/test/core/services/media_browser_tree_test.dart
@@ -42,6 +42,40 @@ Future<List<MediaNode>> _kids(MediaBrowserTree t, String id) =>
 Future<MediaPlaybackRequest?> _pick(MediaBrowserTree t, String id) =>
     t.resolve(id, PlaybackState.idle);
 
+/// Walks a browse branch depth-first and returns its playable leaves in browse
+/// order, descending through however many `page/` container levels the tree
+/// chose. This is what "every song is still reachable" means from the car: a
+/// user can always get to a track by opening rows, without the test having to
+/// know the shape the tree picked.
+Future<List<MediaNode>> _walkLeaves(MediaBrowserTree t, String parentId) async {
+  final leaves = <MediaNode>[];
+  for (final MediaNode node in await _kids(t, parentId)) {
+    if (MediaId.isBrowsePage(node.id)) {
+      leaves.addAll(await _walkLeaves(t, node.id));
+    } else {
+      leaves.add(node);
+    }
+  }
+  return leaves;
+}
+
+Future<List<MediaNode>> _allSongLeaves(MediaBrowserTree t) =>
+    _walkLeaves(t, MediaId.library);
+
+/// A synthetic catalog of [n] tracks with realistic, distinct metadata.
+List<Track> _bigCatalog(int n) => <Track>[
+      for (int i = 0; i < n; i++)
+        Track(
+          id: 'jellyfin:$i',
+          title: 'Song ${i.toString().padLeft(6, '0')}',
+          uri: 'jellyfin:https://music.example.org/Items/$i/stream?api_key=SEC',
+          artistName: 'Artist ${i % 500}',
+          albumName: 'Album ${i % 2000}',
+          artworkUri: Uri.parse(
+              'https://music.example.org/Items/al-${i % 2000}/Images/Primary'),
+        ),
+    ];
+
 void main() {
   group('MediaBrowserTree', () {
     final library = <Track>[
@@ -625,15 +659,384 @@ void main() {
         final repo = _CountingLibraryRepository(big);
         final tree = MediaBrowserTree(repo);
 
+        // 600 songs is past the browse bound, so Songs answers with the page
+        // containers that span them; albums/artists are below it and stay flat.
         final songs = await _kids(tree, MediaId.library);
         final albums = await _kids(tree, MediaId.albums);
         final artists = await _kids(tree, MediaId.artists);
 
-        expect(songs, hasLength(600));
+        expect(songs, hasLength(3)); // 0-250, 250-500, 500-600
+        expect(await _allSongLeaves(tree), hasLength(600));
         expect(albums, hasLength(groupAlbums(big).length));
         expect(artists, hasLength(groupArtists(big).length));
-        // Each browse is one bounded catalog read — no per-track or remote fan-out.
-        expect(repo.getAllTracksCalls, 3);
+        // One bounded catalog read serves the whole browse burst — no per-track
+        // fan-out, no remote call, and no re-scan per section or per page.
+        expect(repo.getAllTracksCalls, 1);
+      });
+    });
+
+    // Regression coverage for #539: Android Auto's Songs branch used to answer
+    // with one MediaItem per catalog track. Past ~1.5k tracks that single
+    // response outgrows the media browser's ~1 MB Binder transaction, the
+    // RemoteException is swallowed by MediaBrowserServiceCompat, and the car
+    // never receives onChildrenLoaded — the endless "scanning" spinner. Songs is
+    // now served as deterministic `page/` containers so no response can outgrow
+    // the transaction, while every song stays reachable.
+    group('large Songs catalogs are browsed in bounded pages (#539)', () {
+      const int pageSize = MediaBrowserTree.browsePageSize;
+
+      // Deliberately not a multiple of the page size, so the last page is a
+      // partial one and the page boundaries are exercised for real.
+      final huge = _bigCatalog(3 * pageSize * pageSize + 137); // 187 637 tracks
+
+      MediaBrowserTree bigTree([List<Track>? tracks]) =>
+          MediaBrowserTree(FakeMusicLibraryRepository(
+              tracks: tracks ?? _bigCatalog(4 * pageSize + 7)));
+
+      test('no browse response ever exceeds the page bound', () async {
+        final tree = MediaBrowserTree(FakeMusicLibraryRepository(tracks: huge));
+
+        // Walk the whole Songs branch and assert the bound holds at every node,
+        // not just the top one.
+        Future<void> checkNode(String id, int depth) async {
+          final nodes = await _kids(tree, id);
+          expect(nodes.length, lessThanOrEqualTo(pageSize),
+              reason: 'node $id returned ${nodes.length} children');
+          if (depth == 0) return;
+          for (final node in nodes) {
+            if (MediaId.isBrowsePage(node.id)) {
+              await checkNode(node.id, depth - 1);
+            }
+          }
+        }
+
+        await checkNode(MediaId.library, 3);
+      });
+
+      test('every song is reachable exactly once, in catalog order', () async {
+        final catalog = _bigCatalog(4 * pageSize + 7);
+        final tree =
+            MediaBrowserTree(FakeMusicLibraryRepository(tracks: catalog));
+
+        final leaves = await _allSongLeaves(tree);
+
+        expect(leaves, hasLength(catalog.length));
+        // Same order as the catalog, and every leaf is a distinct playable song.
+        expect(
+          leaves.map((n) => n.track!.uri),
+          catalog.map((t) => t.uri),
+        );
+        expect(leaves.map((n) => n.id).toSet(), hasLength(catalog.length));
+        expect(leaves.every((n) => n.playable), isTrue);
+      });
+
+      test('page containers tile the catalog with no gap or overlap', () async {
+        final catalog = _bigCatalog(4 * pageSize + 7);
+        final tree =
+            MediaBrowserTree(FakeMusicLibraryRepository(tracks: catalog));
+
+        final pages = await _kids(tree, MediaId.library);
+        expect(pages.length, 5); // 4 full pages + the 7-track remainder
+        expect(pages.every((p) => MediaId.isBrowsePage(p.id)), isTrue);
+
+        int expectedStart = 0;
+        for (final MediaNode page in pages) {
+          final BrowsePage window = MediaId.browsePageOf(page.id)!;
+          expect(window.sectionId, MediaId.library);
+          expect(window.start, expectedStart);
+          final children = await _kids(tree, page.id);
+          expect(children, hasLength(window.end - window.start));
+          expect(
+            children.map((n) => n.track!.uri),
+            catalog.sublist(window.start, window.end).map((t) => t.uri),
+          );
+          expectedStart = window.end;
+        }
+        expect(expectedStart, catalog.length);
+      });
+
+      test('the first and last tracks are both reachable and playable',
+          () async {
+        final catalog = _bigCatalog(4 * pageSize + 7);
+        final tree =
+            MediaBrowserTree(FakeMusicLibraryRepository(tracks: catalog));
+
+        final leaves = await _allSongLeaves(tree);
+
+        expect(leaves.first.id, MediaId.libraryTrack(catalog.first.uri));
+        expect(leaves.last.id, MediaId.libraryTrack(catalog.last.uri));
+
+        for (final int index in <int>[0, catalog.length - 1]) {
+          final request = await _pick(tree, leaves[index].id);
+          expect(request, isNotNull);
+          expect(request!.startIndex, index);
+          expect(request.tracks, hasLength(catalog.length));
+          expect(request.tracks[request.startIndex].uri, catalog[index].uri);
+        }
+      });
+
+      test('a track picked from a page plays the whole catalog at its index',
+          () async {
+        final catalog = _bigCatalog(4 * pageSize + 7);
+        final tree =
+            MediaBrowserTree(FakeMusicLibraryRepository(tracks: catalog));
+
+        // Straddle a page boundary: the last row of page 1 and the first of
+        // page 2 must resolve to adjacent catalog positions.
+        final pages = await _kids(tree, MediaId.library);
+        final firstPage = await _kids(tree, pages[0].id);
+        final secondPage = await _kids(tree, pages[1].id);
+
+        final lastOfFirst = await _pick(tree, firstPage.last.id);
+        final firstOfSecond = await _pick(tree, secondPage.first.id);
+
+        expect(lastOfFirst!.startIndex, pageSize - 1);
+        expect(firstOfSecond!.startIndex, pageSize);
+        expect(lastOfFirst.tracks, hasLength(catalog.length));
+        expect(firstOfSecond.tracks, hasLength(catalog.length));
+        expect(firstOfSecond.tracks[firstOfSecond.startIndex].uri,
+            catalog[pageSize].uri);
+      });
+
+      test('leaf ids are stable across repeated browses, and page ids too',
+          () async {
+        final tree = bigTree();
+
+        final firstPass = await _allSongLeaves(tree);
+        final firstPages =
+            (await _kids(tree, MediaId.library)).map((n) => n.id).toList();
+        final secondPass = await _allSongLeaves(tree);
+        final secondPages =
+            (await _kids(tree, MediaId.library)).map((n) => n.id).toList();
+
+        expect(secondPages, firstPages);
+        expect(secondPass.map((n) => n.id), firstPass.map((n) => n.id));
+        expect(secondPass.map((n) => n.title), firstPass.map((n) => n.title));
+      });
+
+      test('repeated browses reuse one catalog snapshot (no rescan loop)',
+          () async {
+        final repo = _CountingLibraryRepository(_bigCatalog(4 * pageSize + 7));
+        final tree = MediaBrowserTree(repo);
+
+        final pages = await _kids(tree, MediaId.library);
+        for (final page in pages) {
+          await _kids(tree, page.id);
+        }
+        await _kids(tree, MediaId.library);
+        await _kids(tree, MediaId.albums);
+
+        // Android Auto (and audio_service's own seeded re-request) browses the
+        // same branch repeatedly; that must not re-scan the catalog each time.
+        expect(repo.getAllTracksCalls, 1);
+      });
+
+      test('concurrent browse requests share a single catalog read', () async {
+        final repo = _CountingLibraryRepository(_bigCatalog(4 * pageSize + 7));
+        final tree = MediaBrowserTree(repo);
+
+        await Future.wait(<Future<List<MediaNode>>>[
+          _kids(tree, MediaId.library),
+          _kids(tree, MediaId.albums),
+          _kids(tree, MediaId.artists),
+        ]);
+
+        expect(repo.getAllTracksCalls, 1);
+      });
+
+      test('a page container is browsable, never playable', () async {
+        final tree = bigTree();
+        final pages = await _kids(tree, MediaId.library);
+
+        expect(pages.every((p) => p.playable), isFalse);
+        expect(pages.every((p) => p.track == null), isTrue);
+        for (final page in pages) {
+          expect(await _pick(tree, page.id), isNull);
+        }
+      });
+
+      test('duplicate provider-side bare ids stay distinct across pages',
+          () async {
+        // Two providers whose songs share bare ids 0..n, interleaved so the
+        // colliding pair lands on different pages.
+        const int n = pageSize + 4;
+        final catalog = <Track>[
+          for (int i = 0; i < n; i++)
+            Track(id: '$i', title: 'Song $i', uri: 'jellyfin:$i'),
+          for (int i = 0; i < n; i++)
+            Track(id: '$i', title: 'Song $i', uri: 'subsonic:$i'),
+        ];
+        final tree =
+            MediaBrowserTree(FakeMusicLibraryRepository(tracks: catalog));
+
+        final leaves = await _allSongLeaves(tree);
+
+        expect(leaves.map((n) => n.id).toSet(), hasLength(catalog.length));
+        final jellyfin = await _pick(tree, MediaId.libraryTrack('jellyfin:7'));
+        final subsonic = await _pick(tree, MediaId.libraryTrack('subsonic:7'));
+        expect(jellyfin!.tracks[jellyfin.startIndex].uri, 'jellyfin:7');
+        expect(subsonic!.tracks[subsonic.startIndex].uri, 'subsonic:7');
+      });
+
+      test('page ids and paged leaf ids stay secret-free', () async {
+        final tree = bigTree();
+
+        Future<void> expectSafe(String parentId, int depth) async {
+          for (final MediaNode node in await _kids(tree, parentId)) {
+            for (final String text in <String>[
+              node.id,
+              node.title,
+              node.subtitle ?? '',
+            ]) {
+              expect(text, isNot(contains('api_key')));
+              expect(text.toLowerCase(), isNot(contains('token')));
+              expect(text, isNot(contains('jellyfin:')));
+              expect(text, isNot(contains('://')));
+            }
+            if (depth > 0 && MediaId.isBrowsePage(node.id)) {
+              await expectSafe(node.id, depth - 1);
+            }
+          }
+        }
+
+        await expectSafe(MediaId.library, 2);
+      });
+
+      test('a catalog at exactly the bound is still one flat list', () async {
+        final tree = bigTree(_bigCatalog(pageSize));
+
+        final nodes = await _kids(tree, MediaId.library);
+
+        expect(nodes, hasLength(pageSize));
+        expect(nodes.every((n) => n.playable), isTrue);
+        expect(nodes.any((n) => MediaId.isBrowsePage(n.id)), isFalse);
+      });
+
+      test('one track past the bound switches to pages', () async {
+        final tree = bigTree(_bigCatalog(pageSize + 1));
+
+        final nodes = await _kids(tree, MediaId.library);
+
+        expect(nodes, hasLength(2));
+        expect(nodes.every((n) => MediaId.isBrowsePage(n.id)), isTrue);
+        expect(await _allSongLeaves(tree), hasLength(pageSize + 1));
+      });
+
+      test('a six-figure catalog nests pages instead of widening them',
+          () async {
+        final tree = MediaBrowserTree(FakeMusicLibraryRepository(tracks: huge));
+
+        final top = await _kids(tree, MediaId.library);
+        expect(top, hasLength(4)); // 3 full pageSize^2 blocks + a remainder
+        expect(top.every((n) => MediaId.isBrowsePage(n.id)), isTrue);
+
+        // The first block splits again rather than returning 62 500 rows.
+        final second = await _kids(tree, top.first.id);
+        expect(second, hasLength(pageSize));
+        expect(second.every((n) => MediaId.isBrowsePage(n.id)), isTrue);
+
+        // And the third level is real songs.
+        final third = await _kids(tree, second.first.id);
+        expect(third, hasLength(pageSize));
+        expect(third.every((n) => n.playable), isTrue);
+        expect(third.first.id, MediaId.libraryTrack(huge.first.uri));
+
+        // The tail block covers the odd 137-track remainder. It is already
+        // under the bound, so it holds songs directly rather than splitting
+        // again — and it ends on the catalog's very last track.
+        final tail = await _kids(tree, top.last.id);
+        expect(tail, hasLength(137));
+        expect(tail.every((n) => n.playable), isTrue);
+        expect(tail.last.id, MediaId.libraryTrack(huge.last.uri));
+      });
+
+      test('an empty catalog still shows the friendly placeholder', () async {
+        final tree = MediaBrowserTree(
+            FakeMusicLibraryRepository(tracks: const <Track>[]));
+
+        final nodes = await _kids(tree, MediaId.library);
+
+        expect(nodes.single.id, MediaId.empty);
+        expect(nodes.single.title, 'Sync your library first');
+        expect(nodes.single.playable, isFalse);
+      });
+
+      test('a stale or malformed page id is a safe dead-stop', () async {
+        final tree = bigTree();
+
+        for (final String id in <String>[
+          MediaId.browsePage(MediaId.library, 900000, 900250), // past the end
+          MediaId.browsePage('nope', 0, 250), // unknown section
+          'page/', // no section, no window
+          'page/library/notanumber', // no window
+          'page/library/250-100', // inverted window
+          'page/library/-5-10', // negative start
+          'page/page/library/0-250', // nested page
+        ]) {
+          expect(await _kids(tree, id), isEmpty, reason: id);
+          expect(await _pick(tree, id), isNull, reason: id);
+        }
+      });
+
+      test('the catalog snapshot is a TTL, not a freeze', () async {
+        // With no TTL every browse re-reads, so a library that changed between
+        // two browses is still picked up — the snapshot only collapses a burst.
+        final repo = _CountingLibraryRepository(_bigCatalog(4 * pageSize + 7));
+        final tree = MediaBrowserTree(repo, catalogSnapshotTtl: Duration.zero);
+
+        await _kids(tree, MediaId.library);
+        await _kids(tree, MediaId.library);
+
+        expect(repo.getAllTracksCalls, 2);
+      });
+
+      // The bound is generic, so the same defect latent in the other flat
+      // sections is fixed by the same code — no section-specific paging.
+      test('large Albums and Artists sections are bounded and complete',
+          () async {
+        // Enough distinct albums/artists to blow past the bound on both.
+        final catalog = <Track>[
+          for (int i = 0; i < 2 * pageSize + 11; i++)
+            _track('t$i', artist: 'Artist $i', album: 'Album $i'),
+        ];
+        final tree =
+            MediaBrowserTree(FakeMusicLibraryRepository(tracks: catalog));
+
+        for (final String section in <String>[
+          MediaId.albums,
+          MediaId.artists,
+        ]) {
+          final pages = await _kids(tree, section);
+          expect(pages, hasLength(3), reason: section);
+          expect(pages.every((n) => MediaId.isBrowsePage(n.id)), isTrue,
+              reason: section);
+
+          final containers = await _walkLeaves(tree, section);
+          expect(containers, hasLength(catalog.length), reason: section);
+          expect(containers.map((n) => n.id).toSet(), hasLength(catalog.length),
+              reason: section);
+          // Album/artist rows stay browsable containers, as before.
+          expect(containers.every((n) => n.playable), isFalse, reason: section);
+        }
+
+        // And opening one of those containers still lists its tracks.
+        final firstAlbum = (await _walkLeaves(tree, MediaId.albums)).first;
+        final tracks = await _kids(tree, firstAlbum.id);
+        expect(tracks, hasLength(1));
+        expect(tracks.single.playable, isTrue);
+      });
+
+      test('a page whose section shrank clamps to what still exists', () async {
+        // A page id minted for a 4-page catalog, replayed against a catalog that
+        // has since shrunk to a partial final page.
+        final wide =
+            MediaId.browsePage(MediaId.library, pageSize, 2 * pageSize);
+        final tree = bigTree(_bigCatalog(pageSize + 10));
+
+        final nodes = await _kids(tree, wide);
+
+        expect(nodes, hasLength(10));
+        expect(nodes.every((n) => n.playable), isTrue);
       });
     });
 


### PR DESCRIPTION
Closes #539

> **Correction (2nd commit).** An earlier revision of this description claimed that applying `EXTRA_PAGE` / `EXTRA_PAGE_SIZE` in Dart would double-paginate. **That was wrong** — see *Native paging: the verified behaviour*. The browse-container design is unchanged and still needed, but for a different reason than originally stated, and the handler now honours page options.

## Bounds at a glance

| Layer | Bound | Validated to |
|---|---|---|
| Logical `PlaybackController` queue | **unbounded by design** | **200 000 tracks** |
| Native browse response (`getChildren`) | ≤ `browsePageSize` = **250** rows | 187 637-track branch, every node |
| Native MediaSession queue (`setQueue`) | ≤ `maxPublishedQueueItems` = **250** rows | 200 000-track queue |
| Queue rows accepted from the session | only rows in the **published window** | rejected *before* absolute-index translation |

Linthra may hold a 200 000-track logical queue; Android never receives it. Native payload size is a function of the window, not the queue.

```text
Logical PlaybackController queue   up to 200,000 tracks
        |
        v
LinthraAudioHandler                bounded published window, <= 250 rows
        |
        v
Android MediaSession / Auto        safe bounded payload
```

## Confirmed root cause

Not a Songs-specific bug — an **unbounded browse response** that only Songs was big enough to hit.

The child list a media-browser node returns is delivered to the client in **one Binder transaction**, and the per-process Binder buffer is ~1 MB. `MediaBrowserTree._songNodes()` materialized one `MediaItem` per catalog track, so past a certain library size that single response no longer fits. `MediaBrowserServiceCompat` **swallows** the resulting `RemoteException` (it just logs `Calling onLoadChildren() failed for id=...`), so Android Auto never receives `onChildrenLoaded` — no error, no empty list, just a spinner that never resolves. Exactly the reported symptom.

| Tracks | Songs rows | Est. Binder payload | Over the ~1 MB limit |
|---|---|---|---|
| 1 000 | 1 000 | 0.64 MB | no |
| **~1 559** | ~1 559 | **1.00 MB** | **threshold** |
| 10 000 | 10 000 | 6.5 MB | yes (6×) |
| 50 000 | 50 000 | 32.4 MB | yes (32×) |
| 200 000 | 200 000 | 129.5 MB | yes (129×) |

Two aggravating factors, both fixed:

- **Every browse re-read the whole catalog.** `_allTracks()` hit the repository on each `getChildren`, and `audio_service`'s default `subscribeToChildren` returns a *seeded* `BehaviorSubject`, so each node was loaded **twice**. (Not a cycle — the per-parent subscription is memoized.)
- **`audio_service` caches every item it converts, forever.** `AudioService.createMediaMetadata` writes into a `private static final HashMap` (`AudioService.java:107,167`) cleared only on service destroy.

## Why Albums/Artists worked and Songs didn't

Only cardinality — they collapse the same catalog into 1–2 orders of magnitude fewer rows. They are **not** immune; for a 200k-track catalog (~12k albums, ~3k artists): Songs 129.5 MB, Albums 5.46 MB, Artists 1.36 MB. So the bound is applied generically rather than to Songs alone.

## Native paging: the verified behaviour

Traced against the exact stack: `audio_service 0.18.18` → its `AudioService` / `AudioServicePlugin` → `androidx.media:media:1.7.0`.

*(Java generics and the bitwise-and are spelled out in words — this description field mangles those characters.)*

**Options do reach Dart.** `AudioService.onLoadChildren(parentMediaId, result, options)` → `AudioServicePlugin` puts `bundleToMap(options)` on the `getChildren` method call → `AudioServiceHandler._onLoadChildren` forwards it verbatim. Keys arrive as `android.media.browse.extra.PAGE` and `android.media.browse.extra.PAGE_SIZE`.

**The framework does *not* page for us.** In `MediaBrowserServiceCompat.performLoadChildren` (line 1320) the result is filtered *only* when a flag is set — in words: `filteredList` is `applyOptions(list, options)` when `getFlags()` bitwise-and `RESULT_FLAG_OPTION_NOT_HANDLED` is non-zero, else plain `list`. That flag is set in exactly one place (line 1077): the base-class three-argument overload, the compatibility shim for services that don't handle options. Its own comment says so —

> `// To support backward compatibility, when the implementation of MediaBrowserService doesn't override onLoadChildren() with options, onLoadChildren() without options will be used instead, and the options will be applied in the implementation of result.onResultSent().`

`audio_service`'s `AudioService` **overrides** that method (`AudioService.java:834`) and calls `result.sendResult(mediaItems)` directly (`AudioServicePlugin.java:570`). So the flag is never set here, `applyOptions` never runs, and whatever Dart returns reaches the client untouched.

Consequences, both the opposite of what this PR first said:

1. **No double-pagination hazard.** App-side paging is safe — and is the *only* thing that can page on this stack.
2. **Ignoring `options` was a live bug**: a head unit asking for page 1 was handed page 0's children again. Fixed — `getChildren` applies the window as a byte-for-byte port of the framework's own `applyOptions`, edge cases included.

It also **strengthens** the root cause: nothing pages for us, so a paging client received the entire unfiltered list too. The oversized transaction happened whether or not Android Auto paged.

**The browse containers stay.** A client may subscribe with no options at all (Android's two-argument `onLoadChildren`, a null `options` map in Dart), and nothing below the handler shortens an over-long list. So `MediaBrowserTree` caps every node at 250 and covers a larger section with browsable `page/{sectionId}/{start}-{end}` containers, splitting in powers of 250 (two levels span 62 500, three span 15 million); the requested page then narrows that. The split is a pure function of the window and section size, so repeated browses are byte-identical. Catalog order unchanged.

Supporting changes: the Songs section is **lazy** (a page materializes 250 nodes, not 200 000 discarded), and one **short-lived catalog snapshot** (30 s TTL, single-flight) serves a whole browse burst. It stays a TTL, not a freeze — a test pins that.

## The MediaSession queue

Bounding the browse response left the same payload on the playback path: selecting a Songs leaf resolves to the whole catalog, and `_broadcast` mirrored that into `queue.add(...)` → `setQueue` → `raw2queue` → `MediaSessionCompat.setQueue`, one Binder transaction against the same ~1 MB buffer, each row also feeding the static `mediaMetadataCache`.

| Library | Controller queue | Published rows (before) | Payload (before) | Published (after) | Payload (after) |
|---|---|---|---|---|---|
| 10 000 | 10 000 | 10 000 | ~4.8 MB | 250 | **124 kB** |
| 50 000 | 50 000 | 50 000 | ~24.2 MB | 250 | **124 kB** |
| 200 000 | 200 000 | 200 000 | ~97.1 MB | 250 | **124 kB** |

The session sees at most 250 rows — 50 already-played rows behind the current track, the rest forward, sliding back at the end so the window stays full, so the current track is always inside it. The controller keeps the real, complete queue.

- `playbackState` carries a window-relative `queueIndex`, so `setActiveQueueItemId` highlights the row actually playing. It was previously never set.
- A queue that already fits is published whole — small libraries and ordinary playlists are byte-identical to before.

### Invalid queue rows are rejected before translation (3rd commit)

`skipToQueueItem` validated only the *translated* absolute index against the controller's queue, never the incoming row against what was actually published. Those diverge once the window slides: with a 200k queue and a window at 99 950, **row 255 does not exist** (the window is 250 rows) yet its absolute position 100 205 is a real track — so the jump was accepted and playback moved to a track the car never showed.

The row is now checked against the published window first:

```dart
final int publishedLength = _lastQueueTracks?.length ?? 0;
if (index < 0 || index >= publishedLength) return;
```

then translated by `_lastQueueStart` exactly as before. The absolute-index check stays, since the queue can also shrink after a window was published. The offset itself is required because `audio_service`'s `raw2queue` assigns `QueueItem(description, i)` — rows are numbered from zero **within whatever list was published**.

### No duplicated logical queue (3rd commit)

`_broadcast` rebuilt the flat history + current + up-next list on **every state event** — position ticks included, several times a second — then sliced 250 rows off it. A 200k queue was reallocated in full even when the window was unchanged and nothing was republished. The window is now materialized by indexing the three segments directly, and `skipToQueueItem` counts the queue instead of concatenating it.

Measured on the 200k suite: **300 position ticks (about a minute of playback) go from ~2 785 ms to ~16 ms**, a ~174× reduction, with a loose timing test guarding against a regression to O(queue).

The bridge now materializes only what it publishes: no second 200k copy, no 200k `MediaItem`s, no 200k `MediaMetadataCompat` entries, no full-queue rebuild per tick, and no extra catalog read when the window moves. The controller retaining the logical `Track` queue is Linthra's normal playback model and is unchanged. (Observation, not changed: `PlaybackQueue.previous` / `upNext` copy via `sublist`, so the *model* still copies on state emission — that is the same cost the phone UI already pays and sits outside this bridge.)

## Artwork

`artUri` is ~21% of the Songs payload at every size measured. Real, but not the cause — dropping it entirely still leaves 200k tracks at ~102 MB against a 1 MB limit. **Artwork is unchanged.**

## Preserved

Browse page size, published window size, published history size, `page/` id format, controller ownership, Cast routing, phone UI queue semantics, provider abstraction, artwork behaviour — all unchanged. Small queues and playlists behave exactly as before. Every jump still goes through `PlaybackController`. Songs leaves are still the opaque SHA-256 uri hash, identical whichever page listed them; `playFromMediaId` still queues the full catalog at the selected index. Page ids carry only a section name and two integers, resolve to null, and can never be played. Malformed, hostile and stale ids are safe dead-stops.

## Tests

**200 000-track logical queue (9).** Controller owns all 200k while selections near the start, at 100 000, and at the end each keep the published queue ≤ 250 with the current track inside the window and a valid, correctly-highlighting `queueIndex`; **no queue emission ever carries the whole queue** (every emission recorded and bounded, summed across republishes too); `skipToQueueItem` maps correctly inside a middle window; rows 250 and 255 stay no-ops though their absolute index is valid in the 200k queue; next/previous keep the sliding window correct; no duplicate playback; position ticks stay O(window).

**Invalid published rows (8),** on a mid-queue window: rows 0 and 249 valid; 250, 255 and negative are no-ops; valid rows map to the exact displayed track; the current row stays a no-op without restarting; rows rejected before anything has been published.

**MediaSession queue (10)** on a 12 000-track library, and **browse paging (8)** — page 0 vs. a non-zero page return different adjacent windows (the exact regression), paging tiles a node with no gap or loss, a partial then empty page ends the walk, paging composes with the tree bound including inside a container, and absent/empty/partial/junk/negative/zero/past-the-end options behave exactly as `applyOptions` would.

**Browse tree (15).** Bound checked at *every* node of a 187 637-track branch; every song reachable exactly once in catalog order; containers tile with no gap/overlap; first and last track reachable; page-boundary straddle; ids stable across repeated browses; one catalog snapshot per burst, shared by concurrent browses, TTL not freeze; containers browsable never playable; duplicate bare ids distinct across pages; ids secret-free; exactly-at-bound flat, one past it paged; six-figure catalog nests rather than widens; empty-catalog placeholder; stale/malformed ids safe; large Albums **and** Artists bounded and complete.

Each fix was verified to fail its tests when reverted: 5 of 10 queue tests without the window bound, both row-250/255 tests without the published-row guard.

One existing test changed intentionally: *browsing a large catalog reads only the synced catalog* asserted 600 songs in one response and 3 catalog reads — the behaviour this PR fixes.

## Validation

`./scripts/verify_android.sh` passes end to end: `pub get --enforce-lockfile`, `dart format --set-exit-if-changed`, `flutter analyze` (no issues), **3 880 tests green**, secret/privacy scan clean. The local APK build step skipped (no Android SDK in this environment); CI's *Build debug APK*, including `lintVitalRelease`, passed on the earlier commits.

Still worth doing on-device per #82: DHU / real head-unit confirmation. All three failure modes are now bounded by construction, but none has been seen in a car from here.