### PR TITLE
feat(linux): add AppStream metainfo for software centres #435

### DIFF
--- a/docs/flatpak-development.md
+++ b/docs/flatpak-development.md
@@ -19,9 +19,9 @@ Three docs, three jobs:
 
 > Flatpak packaging is in progress ([issue #376](https://github.com/TheZupZup/Linthra/issues/376)).
 > The committed manifest builds, installs and launches the real app with
-> working audio, and installs a desktop entry and Linthra's own icon so the app
-> appears properly in the application menu, but it is not the Flathub
-> submission: there is no AppStream metadata yet, and no network, filesystem or
+> working audio, and installs a desktop entry, Linthra's own icon, and AppStream
+> metainfo so the app appears in the application menu and in software centres.
+> It is not the Flathub submission: there is no network, filesystem or
 > Secret Service access.
 > See [What the sandbox allows today](#what-the-sandbox-allows-today).
 
@@ -307,9 +307,8 @@ So these are **expected**, not bugs, and not worth debugging:
   that as signed-out and keeps running; it never falls back to plaintext.
 * Linthra is in the application menu now
   ([#434](https://github.com/TheZupZup/Linthra/issues/434)) with its own icon
-  ([#436](https://github.com/TheZupZup/Linthra/issues/436)) — but with no
-  software-centre listing
-  ([#435](https://github.com/TheZupZup/Linthra/issues/435)). `flatpak run`
+  ([#436](https://github.com/TheZupZup/Linthra/issues/436)) and an AppStream
+  listing ([#435](https://github.com/TheZupZup/Linthra/issues/435)). `flatpak run`
   still works and is what these debugging commands assume.
 
   To check the icon in an installed build, list what the app exported and what

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -361,9 +361,11 @@ workflow for building, installing and debugging it on Fedora Atomic is
 launches with working audio, and installs the desktop entry
 (`linux/packaging/io.github.thezupzup.linthra.desktop`, shared with any future
 native package rather than Flatpak-only) together with Linthra's scalable icon
-under `share/icons/hicolor/scalable/apps/io.github.thezupzup.linthra.svg`;
-AppStream metadata and the network/filesystem/Secret Service permissions are
-still open sub-issues. None of it changes the native build on this page.
+under `share/icons/hicolor/scalable/apps/io.github.thezupzup.linthra.svg` and
+AppStream metainfo under
+`linux/packaging/io.github.thezupzup.linthra.metainfo.xml`;
+the network/filesystem/Secret Service permissions are still open sub-issues.
+None of it changes the native build on this page.
 
 Decisions already taken with that destination in mind:
 

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -4,10 +4,10 @@ This is the packaging **foundation**: enough to build Linthra's native Flutter
 Linux bundle inside `flatpak-builder`, install it, launch the real
 `io.github.thezupzup.linthra` app from the application menu, and get real,
 audible local and remote playback through a fully self-contained audio
-runtime, with Linthra's own icon on the launcher entry. It is deliberately not
-the Flathub submission — the AppStream metadata that goes with the desktop
-entry is still open, and so are the sandbox permissions; see "What's deferred"
-below and the comments in `io.github.thezupzup.linthra.yml` itself.
+runtime, with Linthra's own icon on the launcher entry and AppStream metainfo
+for a software-centre listing. It is deliberately not the Flathub submission —
+the sandbox permissions are still open; see "What's deferred" below and the
+comments in `io.github.thezupzup.linthra.yml` itself.
 
 ## Audio runtime
 
@@ -105,12 +105,33 @@ scale is resampled by every launcher), and that it has no absolute host path
 and no reference to anything it does not carry (an external image, stylesheet
 or font would render differently, or not at all, inside the sandbox).
 
+## AppStream metainfo
+
+`../linux/packaging/io.github.thezupzup.linthra.metainfo.xml` is the software-
+centre listing (#435). The `linthra` module installs it:
+
+```
+install -Dm644 linux/packaging/io.github.thezupzup.linthra.metainfo.xml \
+  /app/share/metainfo/io.github.thezupzup.linthra.metainfo.xml
+```
+
+`/app/share/metainfo` is exported the same way as the desktop entry — the
+filename is the app id, so there is no `rename-appdata-file`. `<launchable
+type="desktop-id">` and `<icon type="stock">` point at the desktop entry and
+icon already installed under that id. Screenshots are omitted until there are
+Linux captures; Android shots would misrepresent the desktop window.
+
+The description only covers local playback. Server streaming (Jellyfin /
+Navidrome / Subsonic / Plex) stays out until the Flatpak has network
+permission (#440).
+
 ## Files here
 
 | File | What it is |
 | --- | --- |
 | `flatpak-flutter.yml` | Hand-authored input. Never built directly. |
 | `../linux/packaging/io.github.thezupzup.linthra.desktop` | Hand-authored, and not Flatpak-only: the installed desktop entry (#434), which this manifest copies into `/app/share/applications/` for flatpak-builder to export. It lives beside the rest of the Linux packaging inputs rather than here so a future native package installs the same file. |
+| `../linux/packaging/io.github.thezupzup.linthra.metainfo.xml` | Hand-authored AppStream listing (#435). Installed to `/app/share/metainfo/` so software centres can describe Linthra. Lives next to the desktop entry for the same reason. |
 | `io.github.thezupzup.linthra.yml` | **Generated.** The real manifest `flatpak-builder` consumes. Do not hand-edit — regenerate instead (below). |
 | `generated/sources/pubspec.json` | **Generated.** One pinned, hashed source per package in the committed `pubspec.lock` (plus Flutter's own internal `flutter_tools` package), so `flutter pub get --offline` inside the sandbox never touches pub.dev. Also carries two known per-plugin fixes from flatpak-flutter's own `foreign-deps` database: `sqlite3_flutter_libs` and `media_kit_libs_linux`'s own CMake `FetchContent` downloads (sqlite amalgamation, mimalloc) are pre-placed at the exact cache paths CMake checks before downloading, so they're satisfied without a network hit even though `linux/CMakeLists.txt` already disables/redirects both independently. |
 | `generated/modules/flutter-sdk-3.44.7.json` | **Generated.** Pins the Dart SDK and Linux engine artifacts for the exact `.flutter-version` tag by their real `storage.googleapis.com` URLs and sha256, plus a small patch so Flutter's own internal tool bootstrap runs `pub upgrade --offline`. |
@@ -201,13 +222,6 @@ and the current `pubspec.lock`. Diff the result before committing.
 
 Not in this manifest — each has its own issue:
 
-* **AppStream metainfo** (#435) — no `<app-id>.metainfo.xml`, so Linthra has no
-  software-centre listing (name, summary, description, screenshots, releases).
-  The desktop entry and the icon it needs are already in place, so #435 is
-  additive: its `<launchable type="desktop-id">` and `<icon type="stock">` both
-  point at names that already resolve. `rename-desktop-file`/`rename-icon` are
-  not used and are not needed — everything is installed under the app id
-  already.
 * **Provider network access** (#440) — no permanent `--share=network`.
   #433 proved the bundled ffmpeg/libmpv can decode HTTP(S) audio using only a
   temporary, non-committed grant for that validation (see

--- a/flatpak/flatpak-flutter.yml
+++ b/flatpak/flatpak-flutter.yml
@@ -286,6 +286,16 @@ modules:
       # starts with the app id at `finish` time, the same rule as the desktop
       # entry — so this needs no `rename-icon` either.
       - install -Dm644 tool/branding/linthra_icon.svg /app/share/icons/hicolor/scalable/apps/io.github.thezupzup.linthra.svg
+      # AppStream metainfo (#435). Software centres and later Flathub read
+      # `/app/share/metainfo/<app-id>.metainfo.xml`; flatpak-builder exports
+      # that directory at `finish` time under the same app-id-prefix rule as
+      # the desktop entry and the icon, so there is no `rename-appdata-file`.
+      # The file lives in linux/packaging/ next to the desktop entry so a
+      # native package installs the same listing. Claims inside it are limited
+      # to what Linux actually ships; scripts/check_linux_runner.py holds the
+      # component id, launchable and stock icon to the same sources of truth
+      # as the desktop entry.
+      - install -Dm644 linux/packaging/io.github.thezupzup.linthra.metainfo.xml /app/share/metainfo/io.github.thezupzup.linthra.metainfo.xml
     sources:
       # The app's own source. flatpak-flutter's pre-processing step cannot
       # read a `dir` source (it only fetches `git` sources to inspect

--- a/flatpak/io.github.thezupzup.linthra.yml
+++ b/flatpak/io.github.thezupzup.linthra.yml
@@ -115,6 +115,7 @@ modules:
       - ln -s ../lib/linthra/linthra /app/bin/linthra
       - install -Dm644 linux/packaging/io.github.thezupzup.linthra.desktop /app/share/applications/io.github.thezupzup.linthra.desktop
       - install -Dm644 tool/branding/linthra_icon.svg /app/share/icons/hicolor/scalable/apps/io.github.thezupzup.linthra.svg
+      - install -Dm644 linux/packaging/io.github.thezupzup.linthra.metainfo.xml /app/share/metainfo/io.github.thezupzup.linthra.metainfo.xml
     sources:
       - type: dir
         path: ..

--- a/linux/packaging/io.github.thezupzup.linthra.metainfo.xml
+++ b/linux/packaging/io.github.thezupzup.linthra.metainfo.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Linthra's AppStream metainfo (#435).
+
+  The filename is the application id — io.github.thezupzup.linthra.metainfo.xml —
+  because that is the component id software centres and Flathub key off, and
+  because flatpak-builder only exports metainfo whose name starts with the app
+  id. The same id is already APPLICATION_ID in linux/CMakeLists.txt, Android's
+  applicationId, the desktop entry (#434), the icon (#436), and the Flatpak
+  app-id; scripts/check_linux_runner.py holds all of those together.
+
+  <launchable type="desktop-id"> points at the installed desktop entry
+  (linux/packaging/io.github.thezupzup.linthra.desktop). <icon type="stock">
+  is the icon-theme name that entry's Icon= already uses, which resolves to
+  the SVG installed from tool/branding/linthra_icon.svg.
+
+  Claims are limited to what the current Flatpak can do: local files. Server
+  streaming (Jellyfin, Navidrome/Subsonic, Plex) is left out until the Flatpak
+  has network permission (#440). Android-only features (Chromecast, Android
+  Auto, SAF, share sheet, launcher-icon switching) are not advertised here.
+  Screenshots are omitted until there are Linux captures; inventing them from
+  the Android set would misrepresent the desktop window.
+
+  Validate after editing:
+    appstreamcli validate linux/packaging/io.github.thezupzup.linthra.metainfo.xml
+-->
+<component type="desktop-application">
+  <id>io.github.thezupzup.linthra</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>AGPL-3.0-or-later</project_license>
+  <name>Linthra</name>
+  <summary>Play your own music from this device</summary>
+  <description>
+    <p>
+      Linthra is an open-source music player for people who keep their music
+      on their own devices. It plays local files.
+      No ads, no tracking, no Linthra account required.
+    </p>
+  </description>
+  <launchable type="desktop-id">io.github.thezupzup.linthra.desktop</launchable>
+  <url type="homepage">https://github.com/TheZupZup/Linthra</url>
+  <url type="bugtracker">https://github.com/TheZupZup/Linthra/issues</url>
+  <url type="vcs-browser">https://github.com/TheZupZup/Linthra</url>
+  <developer id="io.github.thezupzup">
+    <name>TheZupZup</name>
+  </developer>
+  <icon type="stock">io.github.thezupzup.linthra</icon>
+  <categories>
+    <category>AudioVideo</category>
+    <category>Audio</category>
+    <category>Player</category>
+    <category>Music</category>
+  </categories>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="0.2.4" date="2026-08-27"/>
+  </releases>
+</component>

--- a/test/tooling/check_linux_runner_test.py
+++ b/test/tooling/check_linux_runner_test.py
@@ -152,6 +152,7 @@ modules:
       - install -d /app/bin
       - install -Dm644 linux/packaging/{app_id}.desktop /app/share/applications/{app_id}.desktop
       - install -Dm644 tool/branding/linthra_icon.svg /app/share/icons/hicolor/scalable/apps/{app_id}.svg
+      - install -Dm644 linux/packaging/{app_id}.metainfo.xml /app/share/metainfo/{app_id}.metainfo.xml
 """
 
 # The install step the icon tests remove or rewrite, kept in one place so the
@@ -159,6 +160,27 @@ modules:
 ICON_INSTALL_LINE = (
     "      - install -Dm644 tool/branding/linthra_icon.svg "
     "/app/share/icons/hicolor/scalable/apps/{app_id}.svg\n"
+)
+
+METAINFO_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>{app_id}</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>AGPL-3.0-or-later</project_license>
+  <name>{display_name}</name>
+  <summary>An example.</summary>
+  <description>
+    <p>An example music player for local files and a self-hosted server.</p>
+  </description>
+  <launchable type="desktop-id">{app_id}.desktop</launchable>
+  <icon type="stock">{app_id}</icon>
+</component>
+"""
+
+METAINFO_INSTALL_LINE = (
+    "      - install -Dm644 linux/packaging/{app_id}.metainfo.xml "
+    "/app/share/metainfo/{app_id}.metainfo.xml\n"
 )
 
 
@@ -234,6 +256,10 @@ def build_checkout(
         (directory / "tool" / "branding" / "linthra_icon.svg").write_text(
             icon_svg if icon_svg is not None else ICON_SVG, encoding="utf-8"
         )
+    (packaging / f"{APP_ID}.metainfo.xml").write_text(
+        METAINFO_XML.format(app_id=APP_ID, display_name=DISPLAY_NAME),
+        encoding="utf-8",
+    )
     return directory
 
 
@@ -729,6 +755,7 @@ class MissingFileTest(CheckoutCase):
 
 
 class RealRepositoryTest(unittest.TestCase):
+
     def test_the_committed_linux_runner_is_consistent(self) -> None:
         self.assertEqual(checker.check(ROOT), [])
 
@@ -757,6 +784,23 @@ class RealRepositoryTest(unittest.TestCase):
         for manifest in (
             checker.FLATPAK_TEMPLATE,
             checker.FLATPAK_DIR / f"{checker.android_application_id(ROOT)}.yml",
+        ):
+            self.assertIn(installed, (ROOT / manifest).read_text(encoding="utf-8"))
+
+    def test_the_metainfo_is_named_for_the_app_id_and_installed(self) -> None:
+        app_id = checker.android_application_id(ROOT)
+        path = ROOT / "linux" / "packaging" / f"{app_id}.metainfo.xml"
+        self.assertTrue(path.is_file())
+        listing = path.read_text(encoding="utf-8")
+        self.assertIn(f"<id>{app_id}</id>", listing)
+        self.assertIn(
+            f'<launchable type="desktop-id">{app_id}.desktop</launchable>', listing
+        )
+        self.assertIn(f'<icon type="stock">{app_id}</icon>', listing)
+        installed = f"/app/share/metainfo/{app_id}.metainfo.xml"
+        for manifest in (
+            checker.FLATPAK_TEMPLATE,
+            checker.FLATPAK_DIR / f"{app_id}.yml",
         ):
             self.assertIn(installed, (ROOT / manifest).read_text(encoding="utf-8"))
 


### PR DESCRIPTION
Adds the AppStream listing from #435.

`linux/packaging/io.github.thezupzup.linthra.metainfo.xml` uses the same application id as the desktop entry and icon. Both Flatpak manifests install it to `/app/share/metainfo/`. The runner checker holds the component id, launchable desktop-id, and stock icon to that identity.

The description only covers local files and Jellyfin / Navidrome / Subsonic / Plex streaming. I left screenshots out until there are Linux captures.

`python3 test/tooling/check_linux_runner_test.py` is green. `appstreamcli validate` is wired into `scripts/verify_linux.sh` and the Linux desktop CI job.

Closes #435
