### PR TITLE
feat(linux): pick music folders through xdg-desktop-portal (#438)

### DIFF
--- a/docs/flatpak-development.md
+++ b/docs/flatpak-development.md
@@ -21,8 +21,9 @@ Three docs, three jobs:
 > The committed manifest builds, installs and launches the real app with
 > working audio, and installs a desktop entry, Linthra's own icon, and AppStream
 > metainfo so the app appears in the application menu and in software centres.
-> It is not the Flathub submission: there is no network, filesystem or
-> Secret Service access.
+> It is not the Flathub submission: there is no network or Secret Service
+> access, and no filesystem grant beyond the folders the user picks through
+> the desktop portal.
 > See [What the sandbox allows today](#what-the-sandbox-allows-today).
 
 All commands are relative to the repository. Run them from the repository root
@@ -299,9 +300,12 @@ So these are **expected**, not bugs, and not worth debugging:
 
 * Jellyfin, Navidrome/Subsonic and Plex cannot reach a server — there is no
   `--share=network` yet ([#440](https://github.com/TheZupZup/Linthra/issues/440)).
-* No local music folder is visible — no filesystem or portal access yet
-  ([#438](https://github.com/TheZupZup/Linthra/issues/438) /
-  [#439](https://github.com/TheZupZup/Linthra/issues/439)).
+* Unrelated host files are invisible — there is no `--filesystem=` grant
+  ([#439](https://github.com/TheZupZup/Linthra/issues/439) is the remaining
+  permission audit). Picking a **music folder** does work, and needs no grant:
+  the chooser goes through xdg-desktop-portal and the folder comes back through
+  the document portal ([#438](https://github.com/TheZupZup/Linthra/issues/438),
+  see [`flatpak/README.md`](../flatpak/README.md#local-music-folders)).
 * Saved sessions come back as "not signed in" — no Secret Service access yet
   ([#441](https://github.com/TheZupZup/Linthra/issues/441)). Linthra treats
   that as signed-out and keeps running; it never falls back to plaintext.
@@ -371,6 +375,22 @@ Until #445/#446 land, the manual pass for a packaging change is:
    or `--share=network` for a stream, per
    [`flatpak/README.md`](../flatpak/README.md#testing-audio-locally). It lasts
    for that launch only.
-4. `flatpak info --show-permissions io.github.thezupzup.linthra` → still only
+4. Local music without any grant: launch plainly
+   (`flatpak run io.github.thezupzup.linthra`), then Settings ▸ Local music ▸
+   *Select a folder*. The system's own folder chooser opens (the portal, run on
+   the host), and the folder you pick scans. Check that it really went through
+   the portal rather than a filesystem grant:
+
+   ```bash
+   flatpak documents io.github.thezupzup.linthra
+   flatpak run --command=ls io.github.thezupzup.linthra "$XDG_RUNTIME_DIR/doc"
+   ```
+
+   The first lists what the portal exported for the app and the second shows it
+   inside the sandbox; the scanned path is under there. Quit and relaunch and
+   the same folder still scans. `flatpak document-unexport /path/to/test-music`
+   on the host revokes it, after which Linthra says the folder can no longer be
+   reached and keeps the library it already indexed instead of emptying it.
+5. `flatpak info --show-permissions io.github.thezupzup.linthra` → still only
    the five finish-args listed above, i.e. you did not widen the sandbox by
    accident.

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -213,6 +213,8 @@ undeclared network access to an isolated `flatpak-builder` build.
 | Media notification + `POST_NOTIFICATIONS` | Android-only, by design | There is no equivalent gate on Linux; desktop controls arrive with MPRIS. |
 | Android audio focus | Android-only, by design | `JustAudioPlaybackController` already scopes its focus handling to Android/iOS. |
 | SAF (`content://` folders) | Android-only, by design | Linux picks a real filesystem path. The scanner's desktop path is the one that runs. |
+| Folder chooser | Supported | Linthra's own runner channel (`linux/runner/folder_picker_channel.cc`) opens `GtkFileChooserNative`: the ordinary GTK dialog natively, and the xdg-desktop-portal chooser inside the Flatpak, where `file_picker`'s `zenity`/`kdialog` do not exist ([issue #438](https://github.com/TheZupZup/Linthra/issues/438)). `scripts/check_linux_runner.py` holds the runner's channel name to the Dart side's. |
+| Lost folder access | Supported | A selected folder that stops resolving (unmounted drive, deleted folder, revoked portal document) is reported as a recoverable "select it again" state on the Local music card, and the indexed catalog is left alone rather than replaced with an empty scan. |
 | Local tag/artwork reading | Unsupported | `UnsupportedLocalMetadataReader` on every filesystem scan, Android included. Tracks fall back to filename/folder derivation. A real desktop reader is later work in #376. |
 | Chromecast | Android/iOS only | Already gated in `cast_providers.dart`; Linux keeps the honest "cast unavailable" service. |
 | Share sheet, launcher-icon switching | Android-only, by design | No desktop equivalent; the UI simply omits them. |
@@ -244,7 +246,7 @@ The seams that branch on it:
 | --- | --- | --- |
 | `PlatformMediaSessionBinding` | `audio_service` session | inert, never touches `audio_service` |
 | `localPlaybackControllerProvider` | `JustAudioPlaybackController` (ExoPlayer) | `LinuxPlaybackController` (media_kit/libmpv) |
-| `PlatformFolderPickerService` | SAF tree picker | `file_picker` filesystem chooser |
+| `PlatformFolderPickerService` | SAF tree picker | runner GTK chooser (`GtkFileChooserNative`), which GTK routes to xdg-desktop-portal inside the Flatpak; `file_picker` only as a fallback |
 | `PlatformAudioFileScanner` | SAF content-resolver walk | `dart:io` walk |
 | `safDocumentListerProvider` | native content resolver | unsupported |
 | `safPermissionProbeProvider` | native grant probe | unsupported |

--- a/docs/local-music.md
+++ b/docs/local-music.md
@@ -14,9 +14,11 @@ There are two equivalent entry points; both end up at the same place:
 - **Library ▸ (empty state) ▸ Select / Change folder** — the same pick-and-scan
   flow, offered where you first notice an empty library.
 
-When you pick a folder, Android shows its system folder chooser. Linthra keeps
-**only** the access you grant for that one folder — no broad "all files" or media
-permission is requested.
+When you pick a folder, the system's own folder chooser opens — Android's on a
+phone, the desktop's on Linux. Linthra keeps **only** the access you grant for
+that one folder; it never asks for a broad "all files" or media permission, and
+on Linux it needs no host filesystem permission at all (see
+[On Linux](#on-linux-including-the-flatpak)).
 
 ## What's supported
 
@@ -80,13 +82,31 @@ store — it looks fine but can't be read under scoped storage. If you selected 
 folder in a much older build and see "no music found", just **choose the folder
 again**: the new selection grants and persists proper access.
 
+### On Linux (including the Flatpak)
+
+Linux stores a real filesystem path rather than a `content://` URI, and the scan
+is an ordinary `dart:io` walk. What differs is where the path comes from:
+
+1. The folder chooser is GTK's own (`GtkFileChooserNative`, opened by Linthra's
+   Linux runner). On a native build that is the familiar in-process dialog.
+2. Inside the **Flatpak**, GTK routes exactly the same chooser to
+   **xdg-desktop-portal**, which runs it on the host. Only the folder you picked
+   is handed back to the sandbox, exported through the document portal, and it
+   stays readable after a restart. Nothing else on the host becomes visible, and
+   Linthra ships no `--filesystem=host` or `--filesystem=home` permission — see
+   [`flatpak/README.md`](../flatpak/README.md#local-music-folders).
+3. If the folder later stops resolving — an unplugged drive, a folder you moved
+   or deleted, or a portal grant you revoked — Linthra says so and asks you to
+   select it again. It does **not** treat that as "this folder is empty now", so
+   your indexed library stays as it is until you choose.
+
 ## Local music vs Offline downloads vs Cache
 
 These three are easy to confuse but are distinct:
 
 | Concept | What it is | Where |
 | --- | --- | --- |
-| **Local music** | Music files that already live on the device or SD card, played in place from a folder you chose via SAF. Linthra never moves or copies them. | Settings ▸ Local music |
+| **Local music** | Music files that already live on the device, SD card or computer, played in place from a folder you chose in the system chooser (SAF on Android, the desktop/portal chooser on Linux). Linthra never moves or copies them. | Settings ▸ Local music |
 | **Offline downloads** | Copies Linthra makes of **server** tracks (Jellyfin / Subsonic) so they play without a network. You choose what to download. | The download action / Settings ▸ Offline |
 | **Cache** | Linthra-managed **temporary** storage (e.g. streamed/pre-cached audio), bounded by a size limit and reclaimable at any time. | Settings ▸ Cache — see [offline-cache.md](./offline-cache.md) |
 
@@ -100,8 +120,9 @@ Settings ▸ Diagnostics (and the "Report a bug" flow) include **secret-free** s
 counters — counts only, never a path, file name, or URI:
 
 - **Local folder**: selected / not selected
-- **Local folder access**: persisted / not persisted (the SAF grant — the
-  removable-SD-card-after-reboot signal)
+- **Local folder access**: persisted / not persisted (on Android the SAF grant —
+  the removable-SD-card-after-reboot signal; on Linux whether the chosen folder
+  can still be listed at all)
 - **Local scan**: files visited, folders visited, audio candidates, imported,
   skipped (unsupported), read failures
 - **Local scan recursive**: yes / no
@@ -117,7 +138,9 @@ Reading them:
 - `audio 0, skipped N` means files were found but none matched a supported audio
   type.
 - `access: not persisted` after a reboot means the SD-card grant was lost —
-  re-select the folder.
+  re-select the folder. On Linux the same line means the folder no longer
+  resolves (drive not connected, folder moved, portal access revoked); the
+  library you already indexed is kept, so re-selecting restores it.
 
 Please don't paste full private paths into public bug reports; the diagnostics
 above are designed so you don't have to.

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -5,7 +5,9 @@ Linux bundle inside `flatpak-builder`, install it, launch the real
 `io.github.thezupzup.linthra` app from the application menu, and get real,
 audible local and remote playback through a fully self-contained audio
 runtime, with Linthra's own icon on the launcher entry and AppStream metainfo
-for a software-centre listing. It is deliberately not the Flathub submission —
+for a software-centre listing, and let the user point Linthra at a music
+folder through the desktop portal without granting any host filesystem
+access. It is deliberately not the Flathub submission —
 the sandbox permissions are still open; see "What's deferred" below and the
 comments in `io.github.thezupzup.linthra.yml` itself.
 
@@ -218,6 +220,42 @@ commit SHA in `scripts/regenerate_flatpak_sources.sh` (`TOOL_COMMIT`, the
 `io.github.thezupzup.linthra.yml` and `generated/` from `flatpak-flutter.yml`
 and the current `pubspec.lock`. Diff the result before committing.
 
+## Local music folders
+
+Choosing a music folder (#438) needs **no** `finish-args` entry, and adding
+`--filesystem=host` or `--filesystem=home` would be the wrong fix for it.
+
+Linthra's Linux runner opens the folder chooser with GTK's
+`GtkFileChooserNative` (`../linux/runner/folder_picker_channel.cc`). GTK checks
+for `/.flatpak-info` itself and, inside a sandbox, routes that chooser to the
+**xdg-desktop-portal** `FileChooser` interface instead of drawing it in
+process. Every Flatpak may talk to the portal, so nothing has to be granted:
+
+* the chooser runs on the *host*, so it can browse the user's real home
+  directory while the sandbox still cannot;
+* only the folder the user actually picked comes back, exported through the
+  **document portal** (mounted for every Flatpak at `$XDG_RUNTIME_DIR/doc`) as
+  a path under Linthra's own document store;
+* that path is a real directory the `dart:io` scan walks unchanged, so the
+  scanner needs no Flatpak-specific branch and no hardcoded sandbox path;
+* the export persists, so the folder is still readable after a restart, and
+  revoking it (or unplugging the drive) makes the path stop resolving rather
+  than silently returning nothing — Linthra reports that as "select the folder
+  again" and leaves the indexed library alone.
+
+What the Flatpak deliberately does **not** get is everything else: unrelated
+host files stay invisible, which is the whole point of picking this route over
+a filesystem grant.
+
+`file_picker`, which the app uses on other desktops, cannot do this — its Linux
+implementation shells out to `zenity`/`qarma`/`kdialog`, and the sandbox
+contains none of them. It stays as the fallback for a build with no runner
+channel; native (non-Flatpak) Linux gets the ordinary in-process GTK dialog
+from the same code path.
+
+`scripts/check_linux_runner.py` holds the runner's channel name to the Dart
+side's, so the two cannot drift into a silent fallback.
+
 ## What's deferred
 
 Not in this manifest — each has its own issue:
@@ -228,12 +266,12 @@ Not in this manifest — each has its own issue:
   [Testing audio locally](#testing-audio-locally)); permanently granting
   Linthra network access for real provider use
   (Jellyfin/Navidrome-Subsonic/Plex) is #440's job, not this manifest's.
-* **Filesystem/portal permissions** (#438/#439), **Secret Service** (#441) —
-  no `--filesystem=host|home` or `--talk-name=org.freedesktop.secrets`.
-  Jellyfin/Subsonic/Plex session restore and secure-storage reads already
-  degrade to "not signed in" without them (`docs/linux-desktop.md` §"Secure
-  storage"). #433's local-audio validation likewise used a temporary,
-  non-committed filesystem grant rather than a committed one.
+* **The remaining filesystem-permission audit** (#439) and **Secret Service**
+  (#441) — no `--filesystem=host|home` or
+  `--talk-name=org.freedesktop.secrets`. Jellyfin/Subsonic/Plex session restore
+  and secure-storage reads already degrade to "not signed in" without them
+  (`docs/linux-desktop.md` §"Secure storage"). Picking a music folder no longer
+  needs a filesystem grant at all — see [Local music folders](#local-music-folders).
 * **Video codecs, hardware acceleration/hwaccel, subtitle-adjacent tuning
   beyond what libmpv/libass require to build** — Linthra is audio-only; the
   ffmpeg/mpv build stays scoped to the container/codec/protocol support

--- a/flatpak/flatpak-flutter.yml
+++ b/flatpak/flatpak-flutter.yml
@@ -51,6 +51,16 @@ finish-args:
   # and a PipeWire one — there is no separate "--socket=pipewire" finish-arg.
   - --socket=pulseaudio
   #
+  # Local music folders (#438) need nothing here on purpose. Linthra's Linux
+  # runner opens GTK's GtkFileChooserNative, which GTK routes to the
+  # xdg-desktop-portal FileChooser inside a sandbox — every app may talk to the
+  # portal, so no finish-arg grants it. The folder the user picks comes back
+  # through the document portal (already mounted for every Flatpak) as a path
+  # under the app's own document store, which is readable *because* the user
+  # chose it and stays readable across restarts. Nothing else on the host
+  # becomes visible, which is exactly what a --filesystem grant could not
+  # promise.
+  #
   # Deliberately withheld for issue #432, still withheld here (see
   # flatpak/README.md "What's deferred" for the reasoning):
   #   --share=network            (provider streaming: #440. #433 only proves
@@ -58,7 +68,9 @@ finish-args:
   #                                audio, using a temporary, non-committed
   #                                `flatpak override` for that validation —
   #                                see flatpak/README.md.)
-  #   --filesystem=host/home     (broad filesystem access: #438/#439)
+  #   --filesystem=host/home     (broad filesystem access. Not needed for the
+  #                                local library, per the portal note above;
+  #                                the remaining permission audit is #439.)
   #   --talk-name=org.freedesktop.secrets  (Secret Service: #441)
   # Their absence is safe: flutter_secure_storage/Jellyfin-Subsonic-Plex
   # session restore on Linux treats every read/write failure as "not signed

--- a/lib/core/services/folder_picker_service.dart
+++ b/lib/core/services/folder_picker_service.dart
@@ -14,3 +14,22 @@ abstract interface class FolderPickerService {
   /// Framework tree URI (Android).
   Future<String?> pickFolder();
 }
+
+/// Thrown by a [FolderPickerService] that could not offer a chooser at all on
+/// this build or platform — as opposed to returning `null`, which means the
+/// user was shown a chooser and cancelled.
+///
+/// The distinction matters where one platform has two chooser paths: on Linux
+/// the native GTK/portal chooser is the correct one, but it only exists in a
+/// build whose runner registered it, so [LinuxFolderPickerService] has to tell
+/// "no chooser here, try the plugin" apart from "the user said no" — falling
+/// back on a cancel would pop a second dialog in the user's face.
+class FolderPickerUnavailableException implements Exception {
+  const FolderPickerUnavailableException(this.reason);
+
+  /// Why no chooser was available, for logs. Never shown to the user.
+  final String reason;
+
+  @override
+  String toString() => 'FolderPickerUnavailableException: $reason';
+}

--- a/lib/core/services/linux_folder_picker_service.dart
+++ b/lib/core/services/linux_folder_picker_service.dart
@@ -1,0 +1,45 @@
+import 'file_picker_folder_picker_service.dart';
+import 'folder_picker_service.dart';
+import 'method_channel_linux_folder_picker.dart';
+
+/// The [FolderPickerService] Linux uses: the runner's GTK/portal chooser, with
+/// the `file_picker` chooser as a fallback.
+///
+/// The order is deliberate. [MethodChannelLinuxFolderPicker] is the chooser
+/// that works in *both* Linux builds — a plain GTK dialog natively, and the
+/// xdg-desktop-portal chooser inside the Flatpak, where `file_picker`'s
+/// `zenity`/`kdialog` binaries do not exist (#438). The plugin chooser is kept
+/// only for a build that has no such channel registered (a `flutter test` host,
+/// or an older runner), so nothing regresses if the native half is missing.
+///
+/// A cancel is never a fallback: only [FolderPickerUnavailableException] — "no
+/// chooser here" — moves on to the plugin, so cancelling never pops a second
+/// dialog.
+class LinuxFolderPickerService implements FolderPickerService {
+  const LinuxFolderPickerService({
+    FolderPickerService nativePicker = const MethodChannelLinuxFolderPicker(),
+    FolderPickerService fallbackPicker = const FilePickerFolderPickerService(),
+  })  : _nativePicker = nativePicker,
+        _fallbackPicker = fallbackPicker;
+
+  final FolderPickerService _nativePicker;
+  final FolderPickerService _fallbackPicker;
+
+  @override
+  Future<String?> pickFolder() async {
+    try {
+      return await _nativePicker.pickFolder();
+    } on FolderPickerUnavailableException {
+      // Fall through to the plugin chooser below.
+    }
+    try {
+      return await _fallbackPicker.pickFolder();
+    } catch (_) {
+      // `file_picker` throws a plain Exception on Linux when it can find no
+      // `zenity`/`qarma`/`kdialog` to shell out to. There is no chooser left to
+      // try, so this is "no folder chosen" rather than something to throw into
+      // the UI — the same outcome the user sees if they cancel.
+      return null;
+    }
+  }
+}

--- a/lib/core/services/method_channel_linux_folder_picker.dart
+++ b/lib/core/services/method_channel_linux_folder_picker.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/services.dart';
+
+import '../platform/host_platform.dart';
+import 'folder_picker_service.dart';
+import 'linux_music_directory.dart';
+
+/// A [FolderPickerService] that opens the desktop folder chooser through
+/// Linthra's own Linux runner channel (`linux/runner/folder_picker_channel.cc`)
+/// and returns the chosen folder's filesystem path.
+///
+/// This exists for the Flatpak (#438). The `file_picker` plugin's Linux
+/// implementation shells out to `zenity`/`qarma`/`kdialog`; none of those
+/// binaries exist inside the sandbox, so a Flatpak pick failed before any
+/// dialog appeared. The runner instead uses GTK's `GtkFileChooserNative`, which
+/// GTK routes to the **xdg-desktop-portal** FileChooser when the app is
+/// sandboxed and draws in-process otherwise — so one path serves both builds:
+///
+///  - Native Linux: the ordinary GTK folder dialog, returning a real path.
+///  - Flatpak: the portal runs the chooser on the host, and the folder the user
+///    picked comes back as a document-portal path (under `/run/user/…/doc/…`)
+///    that the sandbox may read. The user's explicit choice *is* the grant, so
+///    no `--filesystem=` permission is needed, and the grant persists across
+///    restarts for as long as the document store keeps it.
+///
+/// Off Linux, or on a build whose runner did not register the channel, it
+/// throws [FolderPickerUnavailableException] so [LinuxFolderPickerService] can
+/// fall back to the plugin chooser instead of reporting a cancel.
+class MethodChannelLinuxFolderPicker implements FolderPickerService {
+  const MethodChannelLinuxFolderPicker({
+    HostPlatform? host,
+    MethodChannel channel = _defaultChannel,
+    LinuxMusicDirectory suggestedDirectory = const LinuxMusicDirectory(),
+  })  : _host = host,
+        _channel = channel,
+        _suggestedDirectory = suggestedDirectory;
+
+  /// Mirrors `kChannelName` in `linux/runner/folder_picker_channel.cc`;
+  /// `scripts/check_linux_runner.py` holds the two to the same string.
+  static const String channelName =
+      'io.github.thezupzup.linthra/linux_folder_picker';
+
+  /// Mirrors `kPickFolderMethod` in the runner.
+  static const String pickFolderMethod = 'pickFolder';
+
+  /// The runner's "GTK could not give me a chooser" code — the one platform
+  /// error that means "fall back", rather than "no folder was chosen".
+  static const String chooserUnavailableCode = 'chooser_unavailable';
+
+  /// The chooser's title. Lives here, with the rest of the app's copy, rather
+  /// than in the runner.
+  static const String dialogTitle = 'Select your music folder';
+
+  static const MethodChannel _defaultChannel = MethodChannel(channelName);
+
+  final HostPlatform? _host;
+  final MethodChannel _channel;
+
+  /// The folder to open the chooser at — only ever a suggestion; see
+  /// [LinuxMusicDirectory].
+  final LinuxMusicDirectory _suggestedDirectory;
+
+  @override
+  Future<String?> pickFolder() async {
+    final HostPlatform host = _host ?? HostPlatform.current;
+    if (host != HostPlatform.linux) {
+      throw const FolderPickerUnavailableException(
+        'the GTK/portal chooser is only registered by the Linux runner',
+      );
+    }
+    try {
+      // Null means the user cancelled; the runner reports every other outcome
+      // as a platform error.
+      return await _channel.invokeMethod<String>(
+        pickFolderMethod,
+        <String, Object?>{
+          'title': dialogTitle,
+          'initialDirectory': await _suggestedDirectory.resolve(host: host),
+        },
+      );
+    } on MissingPluginException {
+      // A build whose runner predates the channel (or a test host). Let the
+      // caller fall back rather than leaving the user with no chooser.
+      throw const FolderPickerUnavailableException(
+        'the Linux runner did not register the folder picker channel',
+      );
+    } on PlatformException catch (error) {
+      if (error.code == chooserUnavailableCode) {
+        throw FolderPickerUnavailableException(
+          'the Linux runner could not open a chooser: ${error.code}',
+        );
+      }
+      // A pick already in flight, or a selection with no local path (a network
+      // location the scanner could not walk anyway). Treat as no selection
+      // rather than surfacing a raw platform error.
+      return null;
+    }
+  }
+}

--- a/lib/core/services/platform_folder_picker_service.dart
+++ b/lib/core/services/platform_folder_picker_service.dart
@@ -1,6 +1,7 @@
 import '../platform/host_platform.dart';
 import 'file_picker_folder_picker_service.dart';
 import 'folder_picker_service.dart';
+import 'linux_folder_picker_service.dart';
 import 'method_channel_saf_folder_picker.dart';
 
 /// The default [FolderPickerService]: routes folder selection to the chooser
@@ -8,17 +9,22 @@ import 'method_channel_saf_folder_picker.dart';
 ///
 /// On Android it uses [MethodChannelSafFolderPicker], which returns the picked
 /// `content://` tree URI with a persisted read grant — the scoped-storage-
-/// correct selection. Everywhere else (desktop, where the chooser returns a real
-/// filesystem path) it uses the `file_picker`-backed
-/// [FilePickerFolderPickerService]. This is the one place that knows about the
-/// platform split, mirroring [PlatformAudioFileScanner] on the scan side.
+/// correct selection. On Linux it uses [LinuxFolderPickerService], the runner's
+/// GTK chooser, which GTK routes through xdg-desktop-portal inside the Flatpak
+/// and draws in-process on a native build (#438). Everywhere else (the other
+/// desktops, where the chooser returns a real filesystem path) it uses the
+/// `file_picker`-backed [FilePickerFolderPickerService]. This is the one place
+/// that knows about the platform split, mirroring [PlatformAudioFileScanner] on
+/// the scan side.
 class PlatformFolderPickerService implements FolderPickerService {
   const PlatformFolderPickerService({
     HostPlatform? host,
     FolderPickerService androidPicker = const MethodChannelSafFolderPicker(),
+    FolderPickerService linuxPicker = const LinuxFolderPickerService(),
     FolderPickerService fallbackPicker = const FilePickerFolderPickerService(),
   })  : _host = host,
         _androidPicker = androidPicker,
+        _linuxPicker = linuxPicker,
         _fallbackPicker = fallbackPicker;
 
   /// The platform to route for. Null means "ask the real host", which is what
@@ -26,12 +32,17 @@ class PlatformFolderPickerService implements FolderPickerService {
   /// from one machine.
   final HostPlatform? _host;
   final FolderPickerService _androidPicker;
+  final FolderPickerService _linuxPicker;
   final FolderPickerService _fallbackPicker;
 
   @override
   Future<String?> pickFolder() {
-    if ((_host ?? HostPlatform.current).isAndroid) {
+    final HostPlatform host = _host ?? HostPlatform.current;
+    if (host.isAndroid) {
       return _androidPicker.pickFolder();
+    }
+    if (host == HostPlatform.linux) {
+      return _linuxPicker.pickFolder();
     }
     return _fallbackPicker.pickFolder();
   }

--- a/lib/core/sources/local/audio_file_scanner.dart
+++ b/lib/core/sources/local/audio_file_scanner.dart
@@ -19,7 +19,10 @@ import 'saf_tree_uri_resolver.dart';
 /// folder cannot be scanned.
 abstract interface class AudioFileScanner {
   /// Returns the absolute paths of every regular file under [folder], searched
-  /// recursively. Returns an empty list when the folder is missing.
+  /// recursively. Throws [FolderScanException] when the selected folder itself
+  /// cannot be opened — it is missing, or access to it was revoked — so a lost
+  /// folder surfaces as a recoverable error instead of an empty result that
+  /// would be persisted as "this folder has no music".
   Future<List<String>> listFiles(String folder);
 }
 
@@ -35,7 +38,19 @@ class IoAudioFileScanner implements AudioFileScanner {
   Future<List<String>> listFiles(String folder) async {
     final Directory root = Directory(folder);
     if (!await root.exists()) {
-      return const <String>[];
+      // Gone rather than unreadable: the drive was unmounted, the folder was
+      // moved or deleted, or — in the Flatpak — the portal document that
+      // exposed the user's chosen folder was revoked, which removes the path
+      // rather than making it unreadable. All of them are recoverable by
+      // reselecting, and none of them mean "there is no music here", so this
+      // must not return an empty list: that would be stored as a successful
+      // scan and wipe the catalog the user still has files for.
+      throw FolderScanException(
+        "Linthra couldn't find the selected folder. It may have been moved or "
+        'removed, the drive may not be connected, or access to it was '
+        'revoked. Try selecting the folder again.',
+        folder: folder,
+      );
     }
 
     // Walk one directory at a time (rather than `list(recursive: true)`) so a
@@ -68,9 +83,9 @@ class IoAudioFileScanner implements AudioFileScanner {
       } on FileSystemException {
         if (wasRoot) {
           throw FolderScanException(
-            "Linthra couldn't read the selected folder. Android may have "
-            'revoked access to it, or the storage was removed. Try selecting '
-            'the folder again.',
+            "Linthra couldn't read the selected folder. Access to it may have "
+            'been revoked, or the storage was removed. Try selecting the '
+            'folder again.',
             folder: folder,
           );
         }

--- a/lib/core/sources/local/local_scan_report.dart
+++ b/lib/core/sources/local/local_scan_report.dart
@@ -6,6 +6,13 @@ enum LocalScanError {
   /// Access Framework (revoked grant, unresolvable provider, unreadable path).
   safTraversal,
 
+  /// The selected folder itself could not be opened on a filesystem scan: it
+  /// is missing, unreadable, or (in the Flatpak) the portal document that
+  /// exposed it was revoked. Recoverable by reselecting the folder, and
+  /// deliberately distinct from [safTraversal] so a desktop report does not
+  /// read as an Android permission problem.
+  folderUnavailable,
+
   /// Any other unexpected scan failure (a `dart:io` fault, a plugin error).
   unexpected,
 }

--- a/lib/features/library/library_controller.dart
+++ b/lib/features/library/library_controller.dart
@@ -56,11 +56,16 @@ class LibraryController extends Notifier<LibraryState> {
       await _load();
     } on FolderScanException catch (error) {
       // The scanning layer already phrased a clear, secret-free message
-      // (unreachable SAF tree, unreadable scoped-storage path, …); show it.
+      // (unreachable SAF tree, unreadable scoped-storage path, a folder that
+      // is gone, …); show it. The catalog is deliberately left untouched: a
+      // folder Linthra cannot reach right now is a recoverable source state,
+      // not a reason to drop the tracks the user already has indexed.
       ref.read(localScanReportProvider.notifier).record(LocalScanReport.failure(
             folderSelected: folderPath.isNotEmpty,
             isContentUri: location.isContentUri,
-            error: LocalScanError.safTraversal,
+            error: location.isContentUri
+                ? LocalScanError.safTraversal
+                : LocalScanError.folderUnavailable,
           ));
       state = LibraryState.error(error.message);
     } catch (_) {

--- a/lib/features/library/library_providers.dart
+++ b/lib/features/library/library_providers.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/services/folder_picker_service.dart';
 import '../../core/services/platform_folder_picker_service.dart';
 import '../../core/sources/local/audio_file_scanner.dart';
+import '../../core/sources/local/directory_readability.dart';
 import '../../core/sources/local/local_metadata_reader.dart';
 import '../../core/sources/local/method_channel_saf_document_lister.dart';
 import '../../core/sources/local/method_channel_saf_permission_probe.dart';
@@ -51,6 +52,19 @@ final safPermissionProbeProvider = Provider<SafPermissionProbe>((ref) {
   return ref.watch(hostPlatformProvider).isAndroid
       ? const MethodChannelSafPermissionProbe()
       : const UnsupportedSafPermissionProbe();
+});
+
+/// The seam that answers whether a *filesystem* music folder can still be
+/// listed right now — the desktop half of the "did we lose access?" signal the
+/// SAF probe above answers on Android.
+///
+/// It is what tells a Flatpak whose portal document was revoked (the exported
+/// path simply disappears) apart from a folder that is genuinely empty, and it
+/// is equally the answer for an unplugged drive or a folder the user deleted on
+/// a native Linux build. Tests override it with a fake so neither case needs a
+/// real disk.
+final directoryReadabilityProvider = Provider<DirectoryReadability>((ref) {
+  return const IoDirectoryReadability();
 });
 
 /// The tag-reading seam used to enrich *filesystem* (desktop/Linux and

--- a/lib/features/settings/source/local_music_controller.dart
+++ b/lib/features/settings/source/local_music_controller.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/sources/local/folder_location.dart';
 import '../../../core/sources/local/local_music_source.dart';
+import '../../../data/repositories/host_platform_provider.dart';
 import '../../../data/repositories/music_library_repository_provider.dart';
 import '../../library/library_controller.dart';
 import '../../library/library_providers.dart';
@@ -135,20 +136,36 @@ final localMusicControllerProvider =
   LocalMusicController.new,
 );
 
-/// Whether Linthra still holds a persisted read grant for the selected
-/// `content://` folder — the removable-SD-card / lost-access signal shown on the
-/// Local music card. Re-evaluated whenever the selection changes.
+/// Whether Linthra can still reach the selected folder — the lost-access
+/// signal shown on the Local music card. Re-evaluated whenever the selection
+/// changes.
 ///
-/// Returns `null` when it doesn't apply (no folder, or a plain filesystem path)
-/// or can't be determined (off Android), so the card simply omits the line.
+/// Two storage kinds, one question:
+///  - an Android `content://` tree: does the app still hold the persisted SAF
+///    read grant (the removable-SD-card / revoked-permission case)?
+///  - a desktop filesystem path: can the folder still be listed? On a Flatpak
+///    that is the portal document exported for the folder the user chose;
+///    revoking it (or unplugging the drive, or deleting the folder) makes the
+///    path stop resolving, which is the same recoverable "select it again"
+///    state rather than an empty library (#438).
+///
+/// Returns `null` when it doesn't apply (no folder) or can't be determined (a
+/// filesystem path on a platform without a desktop chooser), so the card simply
+/// omits the line.
 final localFolderAccessProvider = FutureProvider<bool?>((ref) async {
   final String? folder =
       ref.watch(selectedFolderControllerProvider).valueOrNull;
   if (folder == null || folder.isEmpty) {
     return null;
   }
-  if (!FolderLocation.parse(folder).isContentUri) {
+  if (FolderLocation.parse(folder).isContentUri) {
+    return ref.read(safPermissionProbeProvider).hasPersistedPermission(folder);
+  }
+  // Desktop only: on Android a filesystem path is a legacy selection whose
+  // access story is scoped storage's, not this probe's, so it keeps reporting
+  // "can't tell" exactly as before.
+  if (!ref.watch(hostPlatformProvider).isDesktop) {
     return null;
   }
-  return ref.read(safPermissionProbeProvider).hasPersistedPermission(folder);
+  return ref.read(directoryReadabilityProvider).canList(folder);
 });

--- a/lib/features/settings/source/local_music_controller.dart
+++ b/lib/features/settings/source/local_music_controller.dart
@@ -155,6 +155,14 @@ final localMusicControllerProvider =
 final localFolderAccessProvider = FutureProvider<bool?>((ref) async {
   final String? folder =
       ref.watch(selectedFolderControllerProvider).valueOrNull;
+  // Re-probed on every recorded scan, not only when the *selection* changes.
+  // Access is lost while the app is running — a drive unplugged, a portal
+  // document revoked, a folder deleted — and the selection does not change when
+  // it happens, so a cached "yes" would outlive the truth and leave both cards
+  // showing a healthy folder right after a rescan failed on it. Every scan path
+  // (this card and the Library empty state) records through this provider, so
+  // watching it is what makes a rescan the natural way to re-check.
+  ref.watch(localScanReportProvider);
   if (folder == null || folder.isEmpty) {
     return null;
   }

--- a/lib/features/settings/source/local_music_settings_section.dart
+++ b/lib/features/settings/source/local_music_settings_section.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../app/dimens.dart';
+import '../../../core/platform/host_platform.dart';
 import '../../../core/sources/local/folder_location.dart';
 import '../../../core/sources/local/local_scan_report.dart';
+import '../../../data/repositories/host_platform_provider.dart';
 import '../../library/local_scan_report_provider.dart';
 import '../../library/selected_folder_controller.dart';
 import 'local_music_controller.dart';
@@ -38,6 +40,7 @@ class LocalMusicSettingsSection extends ConsumerWidget {
         ref.watch(localMusicControllerProvider);
     final bool? persisted = ref.watch(localFolderAccessProvider).valueOrNull;
     final bool hasFolder = folder != null && folder.isNotEmpty;
+    final HostPlatform host = ref.watch(hostPlatformProvider);
 
     final LocalMusicController controller =
         ref.read(localMusicControllerProvider.notifier);
@@ -58,9 +61,7 @@ class LocalMusicSettingsSection extends ConsumerWidget {
             ),
             const SizedBox(height: AppSpacing.xs),
             Text(
-              'Play music from a folder on this device or an SD card. Linthra '
-              "reads it through Android's folder access — it needs no broad "
-              'storage permission, and your files are never moved or copied.',
+              _blurbFor(host),
               style: theme.textTheme.bodySmall?.copyWith(color: muted),
             ),
             const SizedBox(height: AppSpacing.md),
@@ -109,6 +110,23 @@ class LocalMusicSettingsSection extends ConsumerWidget {
   }
 }
 
+/// How the folder gets read, in the user's terms. The two platforms grant
+/// access in genuinely different ways — Android's folder access (SAF) and the
+/// desktop chooser, which inside a Flatpak is the system's file portal — and
+/// both are worth stating, because in both cases the point is the same: only
+/// the folder the user picked, and no broad storage permission.
+String _blurbFor(HostPlatform host) {
+  if (host.isAndroid) {
+    return 'Play music from a folder on this device or an SD card. Linthra '
+        "reads it through Android's folder access — it needs no broad storage "
+        'permission, and your files are never moved or copied.';
+  }
+  return 'Play music from a folder on this computer or an external drive. '
+      'Linthra reads only the folder you choose in the system file chooser — '
+      'it needs no broad filesystem permission, and your files are never '
+      'moved or copied.';
+}
+
 /// The selected-folder summary: which folder, whether access is still held, and
 /// what the last scan saw.
 class _SelectedFolderView extends StatelessWidget {
@@ -147,7 +165,8 @@ class _SelectedFolderView extends StatelessWidget {
         if (persisted == false) ...[
           const SizedBox(height: AppSpacing.xs),
           Text(
-            'Access to this folder was lost. Select it again to restore it.',
+            'Linthra can no longer reach this folder. Select it again to '
+            'restore access — your library stays as it is until you do.',
             style: theme.textTheme.bodySmall
                 ?.copyWith(color: theme.colorScheme.error),
           ),

--- a/lib/features/settings/source/local_music_settings_section.dart
+++ b/lib/features/settings/source/local_music_settings_section.dart
@@ -70,6 +70,7 @@ class LocalMusicSettingsSection extends ConsumerWidget {
                 folderLabel: FolderLocation.parse(folder).displayLabel,
                 persisted: persisted,
                 report: report,
+                host: host,
               )
             else
               Text(
@@ -134,11 +135,15 @@ class _SelectedFolderView extends StatelessWidget {
     required this.folderLabel,
     required this.persisted,
     required this.report,
+    required this.host,
   });
 
   final String folderLabel;
   final bool? persisted;
   final LocalScanReport? report;
+
+  /// Which platform's folder chooser the recovery hint should name.
+  final HostPlatform host;
 
   @override
   Widget build(BuildContext context) {
@@ -173,7 +178,7 @@ class _SelectedFolderView extends StatelessWidget {
         ],
         if (report != null) ...[
           const SizedBox(height: AppSpacing.sm),
-          _ScanSummary(report: report!),
+          _ScanSummary(report: report!, host: host),
         ],
       ],
     );
@@ -188,9 +193,12 @@ class _SelectedFolderView extends StatelessWidget {
 /// only booleans and counts (never a path, file name, or raw error), so nothing
 /// private about the user's library can reach the card.
 class _ScanSummary extends StatelessWidget {
-  const _ScanSummary({required this.report});
+  const _ScanSummary({required this.report, required this.host});
 
   final LocalScanReport report;
+
+  /// The platform whose folder chooser the hint points the user back to.
+  final HostPlatform host;
 
   @override
   Widget build(BuildContext context) {
@@ -199,7 +207,7 @@ class _ScanSummary extends StatelessWidget {
     // A scan that threw produced no trustworthy counts, so the breakdown is
     // dropped and only the status + hint are shown.
     final String? counts = report.hadError ? null : _counts(report);
-    final String? hint = _hint(report);
+    final String? hint = _hint(report, host);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -255,10 +263,11 @@ class _ScanSummary extends StatelessWidget {
   }
 
   /// A calm, non-blaming next step when the scan imported nothing. Two shapes: a
-  /// likely access problem (the SD-card / lost-grant case) versus a folder that
-  /// simply held no recognized audio. Both point at re-picking the folder with
-  /// the Android chooser; neither faults the user.
-  static String? _hint(LocalScanReport report) {
+  /// likely access problem (the SD-card / lost-grant / unreachable-folder case)
+  /// versus a folder that simply held no recognized audio. Both point at
+  /// re-picking the folder in the chooser the user actually has; neither faults
+  /// the user.
+  static String? _hint(LocalScanReport report, HostPlatform host) {
     if (report.importedTracks > 0) {
       return null;
     }
@@ -269,12 +278,23 @@ class _ScanSummary extends StatelessWidget {
       final String sdNote =
           report.isContentUri ? ' — common with SD cards' : '';
       return "Linthra couldn't read this folder$sdNote. Select it again with "
-          "Android's folder chooser to restore access.";
+          '${_chooserName(host)} to restore access.';
     }
     return "This folder doesn't seem to contain audio Linthra recognizes. Check "
         'that it has supported audio files (like MP3, M4A, FLAC, or OGG), or '
-        "select the folder again with Android's folder chooser.";
+        'select the folder again with ${_chooserName(host)}.';
   }
+
+  /// What to call the chooser the user re-picks the folder in.
+  ///
+  /// Android's is the system folder chooser (SAF), and saying so is the
+  /// clearest phrasing there. On a desktop it is the system's own chooser —
+  /// inside the Flatpak, the xdg-desktop-portal one — so naming Android's would
+  /// send the user looking for something that is not on their machine. This
+  /// keys off the platform rather than the report's `isContentUri`, which is a
+  /// storage kind: a legacy filesystem selection on Android is still Android.
+  static String _chooserName(HostPlatform host) =>
+      host.isAndroid ? "Android's folder chooser" : 'the system folder chooser';
 }
 
 /// One line of calm guidance (info icon + muted text) shown when a scan needs a

--- a/linux/runner/CMakeLists.txt
+++ b/linux/runner/CMakeLists.txt
@@ -9,6 +9,7 @@ project(runner LANGUAGES CXX)
 add_executable(${BINARY_NAME}
   "main.cc"
   "my_application.cc"
+  "folder_picker_channel.cc"
   "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
 )
 

--- a/linux/runner/folder_picker_channel.cc
+++ b/linux/runner/folder_picker_channel.cc
@@ -1,0 +1,183 @@
+#include "folder_picker_channel.h"
+
+#include <cstring>
+
+// The channel and method names Dart's MethodChannelLinuxFolderPicker uses.
+// scripts/check_linux_runner.py holds the two sides to the same strings, so a
+// rename on one side fails a check instead of silently making every pick look
+// like "no chooser available".
+static constexpr const char* kChannelName =
+    "io.github.thezupzup.linthra/linux_folder_picker";
+static constexpr const char* kPickFolderMethod = "pickFolder";
+static constexpr const char* kTitleArgument = "title";
+static constexpr const char* kInitialDirectoryArgument = "initialDirectory";
+
+// Returned when GTK could not create a chooser at all. Dart treats this one
+// code (and a missing channel) as "no native chooser here" and falls back to
+// the plugin chooser; every other error is just "no folder chosen".
+static constexpr const char* kChooserUnavailableError = "chooser_unavailable";
+// A second pick while one is already open. Refused rather than stacking two
+// dialogs (or, under the portal, two host-side requests).
+static constexpr const char* kPickInProgressError = "pick_in_progress";
+// The user picked something that is not a local directory — a network share
+// or a virtual location a `dart:io` scan cannot walk.
+static constexpr const char* kUnsupportedLocationError = "unsupported_location";
+
+// Only used if Dart sends no title; the user-facing string lives with the rest
+// of the app's copy, on the Dart side.
+static constexpr const char* kDefaultTitle = "Select a folder";
+
+struct _FolderPickerChannel {
+  FlMethodChannel* channel;
+  GtkWindow* window;
+  // The chooser currently on screen, and the call it will answer. Both null
+  // when no pick is in flight; they are only ever set and cleared together.
+  GtkFileChooserNative* chooser;
+  FlMethodCall* pending_call;
+};
+
+static void respond_error(FlMethodCall* method_call, const char* code,
+                          const char* message) {
+  g_autoptr(FlMethodResponse) response =
+      FL_METHOD_RESPONSE(fl_method_error_response_new(code, message, nullptr));
+  g_autoptr(GError) error = nullptr;
+  if (!fl_method_call_respond(method_call, response, &error)) {
+    g_warning("Failed to send folder picker error: %s", error->message);
+  }
+}
+
+// Answers the pending call with the chosen path (or null for a cancel) and
+// disposes of the chooser.
+static void folder_picker_response_cb(GtkNativeDialog* dialog, gint response_id,
+                                      gpointer user_data) {
+  FolderPickerChannel* self = static_cast<FolderPickerChannel*>(user_data);
+  g_autoptr(FlMethodCall) method_call = self->pending_call;
+  self->pending_call = nullptr;
+
+  g_autofree gchar* path = nullptr;
+  if (response_id == GTK_RESPONSE_ACCEPT) {
+    // Inside a Flatpak this is the document-portal path the portal exported
+    // for the folder the user chose on the host, which is exactly what the
+    // sandbox is allowed to read; on a native build it is the folder itself.
+    // Either way it is a real path, so nothing downstream has to know which
+    // build it is running in.
+    path = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
+  }
+
+  if (method_call != nullptr) {
+    if (response_id == GTK_RESPONSE_ACCEPT && path == nullptr) {
+      // Accepted, but the selection has no local path (a gvfs/network
+      // location). Report it rather than passing back a path the scanner
+      // would fail on.
+      respond_error(method_call, kUnsupportedLocationError,
+                    "The selected folder is not a local directory.");
+    } else {
+      g_autoptr(FlValue) result =
+          path != nullptr ? fl_value_new_string(path) : fl_value_new_null();
+      g_autoptr(GError) error = nullptr;
+      if (!fl_method_call_respond_success(method_call, result, &error)) {
+        g_warning("Failed to send folder picker result: %s", error->message);
+      }
+    }
+  }
+
+  gtk_native_dialog_destroy(GTK_NATIVE_DIALOG(dialog));
+  g_clear_object(&self->chooser);
+}
+
+static void folder_picker_method_call_cb(FlMethodChannel* channel,
+                                         FlMethodCall* method_call,
+                                         gpointer user_data) {
+  FolderPickerChannel* self = static_cast<FolderPickerChannel*>(user_data);
+
+  if (g_strcmp0(fl_method_call_get_name(method_call), kPickFolderMethod) != 0) {
+    g_autoptr(FlMethodResponse) response =
+        FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
+    g_autoptr(GError) error = nullptr;
+    if (!fl_method_call_respond(method_call, response, &error)) {
+      g_warning("Failed to respond to folder picker call: %s", error->message);
+    }
+    return;
+  }
+
+  if (self->pending_call != nullptr) {
+    respond_error(method_call, kPickInProgressError,
+                  "A folder chooser is already open.");
+    return;
+  }
+
+  const gchar* title = kDefaultTitle;
+  const gchar* initial_directory = nullptr;
+  FlValue* args = fl_method_call_get_args(method_call);
+  if (args != nullptr && fl_value_get_type(args) == FL_VALUE_TYPE_MAP) {
+    FlValue* value = fl_value_lookup_string(args, kTitleArgument);
+    if (value != nullptr && fl_value_get_type(value) == FL_VALUE_TYPE_STRING) {
+      title = fl_value_get_string(value);
+    }
+    value = fl_value_lookup_string(args, kInitialDirectoryArgument);
+    if (value != nullptr && fl_value_get_type(value) == FL_VALUE_TYPE_STRING) {
+      initial_directory = fl_value_get_string(value);
+    }
+  }
+
+  // GtkFileChooserNative, not GtkFileChooserDialog: this is the widget GTK
+  // redirects to the xdg-desktop-portal FileChooser when the app is sandboxed
+  // (it checks for /.flatpak-info itself), and draws in-process otherwise.
+  GtkFileChooserNative* chooser = gtk_file_chooser_native_new(
+      title, self->window, GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, nullptr,
+      nullptr);
+  if (chooser == nullptr) {
+    respond_error(method_call, kChooserUnavailableError,
+                  "Could not create a folder chooser.");
+    return;
+  }
+  gtk_native_dialog_set_modal(GTK_NATIVE_DIALOG(chooser), TRUE);
+  if (initial_directory != nullptr && initial_directory[0] != '\0') {
+    // Only ever a starting point — the user can navigate anywhere. Under the
+    // portal the host-side chooser resolves it, so a path that does not exist
+    // in this sandbox is not an error, just an unused suggestion.
+    gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser),
+                                        initial_directory);
+  }
+
+  self->chooser = chooser;
+  self->pending_call = FL_METHOD_CALL(g_object_ref(method_call));
+  g_signal_connect(chooser, "response", G_CALLBACK(folder_picker_response_cb),
+                   self);
+  // Shown, not run: gtk_native_dialog_run() would spin a nested main loop on
+  // the platform thread the engine dispatches this call on. The response
+  // signal answers the call instead.
+  gtk_native_dialog_show(GTK_NATIVE_DIALOG(chooser));
+}
+
+FolderPickerChannel* folder_picker_channel_new(FlView* view,
+                                               GtkWindow* window) {
+  FolderPickerChannel* self = g_new0(FolderPickerChannel, 1);
+  self->window = window;
+
+  g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
+  FlEngine* engine = fl_view_get_engine(view);
+  self->channel = fl_method_channel_new(fl_engine_get_binary_messenger(engine),
+                                        kChannelName, FL_METHOD_CODEC(codec));
+  fl_method_channel_set_method_call_handler(
+      self->channel, folder_picker_method_call_cb, self, nullptr);
+  return self;
+}
+
+void folder_picker_channel_free(FolderPickerChannel* self) {
+  if (self == nullptr) {
+    return;
+  }
+  if (self->pending_call != nullptr) {
+    g_autoptr(FlMethodCall) method_call = self->pending_call;
+    self->pending_call = nullptr;
+    respond_error(method_call, kChooserUnavailableError,
+                  "The folder chooser was closed.");
+  }
+  if (self->chooser != nullptr) {
+    gtk_native_dialog_destroy(GTK_NATIVE_DIALOG(self->chooser));
+    g_clear_object(&self->chooser);
+  }
+  g_clear_object(&self->channel);
+  g_free(self);
+}

--- a/linux/runner/folder_picker_channel.h
+++ b/linux/runner/folder_picker_channel.h
@@ -1,0 +1,36 @@
+#ifndef RUNNER_FOLDER_PICKER_CHANNEL_H_
+#define RUNNER_FOLDER_PICKER_CHANNEL_H_
+
+#include <flutter_linux/flutter_linux.h>
+#include <gtk/gtk.h>
+
+G_BEGIN_DECLS
+
+// The native half of Linthra's Linux folder chooser (issue #438).
+//
+// Dart's `MethodChannelLinuxFolderPicker` asks this channel for a music folder
+// and gets back a filesystem path the `dart:io` scanner can walk, or null when
+// the user cancelled.
+//
+// Why the runner and not a plugin: `file_picker` on Linux shells out to
+// `zenity`/`qarma`/`kdialog`, none of which exist inside the Flatpak sandbox,
+// so folder selection there fails before a dialog ever appears. GTK's
+// `GtkFileChooserNative` is the supported path for both builds at once — it
+// opens the normal GTK dialog on a native build, and inside a sandbox GTK
+// routes it to the xdg-desktop-portal FileChooser, which runs the picker on
+// the host and hands back a document-portal path the sandbox may read. That
+// needs no filesystem finish-arg: the user's explicit choice is the grant.
+typedef struct _FolderPickerChannel FolderPickerChannel;
+
+// Registers the folder-picker channel on `view`'s engine, parenting the
+// chooser on `window` so it opens modal to the app (and, under the portal, is
+// correctly associated with Linthra's window). Never returns NULL.
+FolderPickerChannel* folder_picker_channel_new(FlView* view, GtkWindow* window);
+
+// Tears the channel down, answering an in-flight pick (if any) so the Dart
+// side never waits forever on a chooser that is going away.
+void folder_picker_channel_free(FolderPickerChannel* self);
+
+G_END_DECLS
+
+#endif  // RUNNER_FOLDER_PICKER_CHANNEL_H_

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -6,6 +6,7 @@
 #endif
 
 #include "flutter/generated_plugin_registrant.h"
+#include "folder_picker_channel.h"
 
 // The user-visible application name. Kept as one constant so the header bar,
 // the fallback title bar, and anything added later can never drift apart — and
@@ -27,6 +28,10 @@ static constexpr int kMinimumWindowHeight = 600;
 struct _MyApplication {
   GtkApplication parent_instance;
   char** dart_entrypoint_arguments;
+  // The GTK/portal folder chooser Dart asks for a music folder (#438). Owned
+  // here because it needs the application's own window as the dialog parent,
+  // which a plugin registrant does not have.
+  FolderPickerChannel* folder_picker;
 };
 
 G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
@@ -102,6 +107,13 @@ static void my_application_activate(GApplication* application) {
 
   fl_register_plugins(FL_PLUGIN_REGISTRY(view));
 
+  // Registered alongside the plugins, on the same engine: the folder chooser
+  // is Linthra's own channel rather than a plugin, so that a Flatpak build
+  // gets the xdg-desktop-portal chooser instead of `file_picker`'s
+  // zenity/kdialog, which the sandbox does not contain. See
+  // folder_picker_channel.h.
+  self->folder_picker = folder_picker_channel_new(view, window);
+
   gtk_widget_grab_focus(GTK_WIDGET(view));
 }
 
@@ -148,6 +160,7 @@ static void my_application_shutdown(GApplication* application) {
 static void my_application_dispose(GObject* object) {
   MyApplication* self = MY_APPLICATION(object);
   g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
+  g_clear_pointer(&self->folder_picker, folder_picker_channel_free);
   G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
 }
 

--- a/scripts/check_linux_runner.py
+++ b/scripts/check_linux_runner.py
@@ -41,6 +41,14 @@ precisely the name `Icon=` asks for, and that source is itself checked for the
 two things that would make it unusable inside a sandbox: an absolute host path,
 or a reference to a file it does not carry.
 
+It also checks the one runner<->Dart contract that is a pair of strings and
+nothing else: the folder-picker method channel (#438). The runner answers on
+`linux/runner/folder_picker_channel.cc`'s channel name and Dart calls
+`MethodChannelLinuxFolderPicker.channelName`; if those drift, or the source
+file stops being compiled into the runner, nothing fails to build — every pick
+just reports "no chooser here" and silently falls back to `file_picker`, which
+inside the Flatpak has no `zenity`/`kdialog` to run.
+
 It also checks two things that are about *how* the runner builds rather than
 what it is called:
 
@@ -73,6 +81,11 @@ from xml.etree import ElementTree
 # Paths this script reads, all relative to the repository root.
 CMAKELISTS = Path("linux") / "CMakeLists.txt"
 MY_APPLICATION = Path("linux") / "runner" / "my_application.cc"
+RUNNER_CMAKELISTS = Path("linux") / "runner" / "CMakeLists.txt"
+FOLDER_PICKER_CHANNEL_SOURCE = Path("linux") / "runner" / "folder_picker_channel.cc"
+FOLDER_PICKER_DART = (
+    Path("lib") / "core" / "services" / "method_channel_linux_folder_picker.dart"
+)
 PUBSPEC = Path("pubspec.yaml")
 APP_INFO = Path("lib") / "core" / "app_info.dart"
 BUILD_GRADLE = Path("android") / "app" / "build.gradle"
@@ -126,6 +139,13 @@ DESKTOP_ENTRY_GROUP = "Desktop Entry"
 # The CMake variable linux/CMakeLists.txt uses to accept an already-unpacked
 # SQLite amalgamation instead of downloading one. See docs/linux-desktop.md.
 SQLITE_SOURCE_VARIABLE = "LINTHRA_SQLITE3_SOURCE_DIR"
+
+# The folder-picker channel (#438): one name on each side of the same wire,
+# plus the method the two agree on.
+FOLDER_PICKER_NATIVE_CHANNEL = r'kChannelName\s*=\s*\n?\s*"([^"]+)"'
+FOLDER_PICKER_NATIVE_METHOD = r'kPickFolderMethod\s*=\s*"([^"]+)"'
+FOLDER_PICKER_DART_CHANNEL = r"String channelName\s*=\s*\n?\s*'([^']+)'"
+FOLDER_PICKER_DART_METHOD = r"String pickFolderMethod\s*=\s*'([^']+)'"
 
 SECURE_STORAGE_TARGET = "flutter_secure_storage_linux_plugin"
 SECURE_STORAGE_WARNING_EXCEPTION = "-Wno-error=deprecated-literal-operator"
@@ -434,6 +454,57 @@ def icon_source_problems(root: Path) -> list[str]:
     return problems
 
 
+def folder_picker_problems(root: Path) -> list[str]:
+    """Disagreements between the runner's folder-picker channel and Dart's.
+
+    The channel is how a Flatpak build reaches the xdg-desktop-portal folder
+    chooser instead of `file_picker`'s zenity/kdialog, which the sandbox does
+    not contain. A mismatched name still compiles and still runs; it just never
+    answers, and Dart's fallback then finds no chooser at all inside the
+    sandbox.
+    """
+    problems: list[str] = []
+
+    runner_cmakelists = _read(root, RUNNER_CMAKELISTS)
+    if FOLDER_PICKER_CHANNEL_SOURCE.name not in runner_cmakelists:
+        problems.append(
+            f"{RUNNER_CMAKELISTS} does not compile "
+            f"{FOLDER_PICKER_CHANNEL_SOURCE.name}, so the runner registers no "
+            "folder-picker channel"
+        )
+
+    native = _read(root, FOLDER_PICKER_CHANNEL_SOURCE)
+    dart = _read(root, FOLDER_PICKER_DART)
+    for what, native_pattern, dart_pattern in (
+        ("channel name", FOLDER_PICKER_NATIVE_CHANNEL, FOLDER_PICKER_DART_CHANNEL),
+        ("method name", FOLDER_PICKER_NATIVE_METHOD, FOLDER_PICKER_DART_METHOD),
+    ):
+        native_value = _extract(
+            native,
+            native_pattern,
+            f"the folder picker {what}",
+            FOLDER_PICKER_CHANNEL_SOURCE,
+        )
+        dart_value = _extract(
+            dart, dart_pattern, f"the folder picker {what}", FOLDER_PICKER_DART
+        )
+        if native_value != dart_value:
+            problems.append(
+                f"folder picker {what} is {native_value!r} in "
+                f"{FOLDER_PICKER_CHANNEL_SOURCE} but {dart_value!r} in "
+                f"{FOLDER_PICKER_DART}"
+            )
+
+    # my_application.cc has to actually register it; a compiled-but-unreferenced
+    # channel is the same silence.
+    if "folder_picker_channel_new" not in _read(root, MY_APPLICATION):
+        problems.append(
+            f"{MY_APPLICATION} never calls folder_picker_channel_new(), so the "
+            "folder-picker channel is never registered on the engine"
+        )
+    return problems
+
+
 def absolute_paths_under_linux(root: Path) -> list[str]:
     """Absolute host paths hardcoded in the committed Linux build files.
 
@@ -494,6 +565,10 @@ def check(root: Path) -> list[str]:
     # what connects it to a file the built Flatpak actually contains.
     problems.extend(icon_install_problems(root))
     problems.extend(icon_source_problems(root))
+
+    # The folder-picker channel (#438): two strings that have to agree, and a
+    # source file that has to be compiled and registered.
+    problems.extend(folder_picker_problems(root))
 
     # Window metrics: a minimum larger than the default would open the window
     # already clamped, which reads as the app ignoring its own default.

--- a/test/core/services/linux_folder_picker_service_test.dart
+++ b/test/core/services/linux_folder_picker_service_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/services/folder_picker_service.dart';
+import 'package:linthra/core/services/linux_folder_picker_service.dart';
+
+/// Answers with a canned result, so the routing between the two Linux choosers
+/// can be asserted without a real dialog.
+class _StubPicker implements FolderPickerService {
+  _StubPicker.answers(this.answer) : error = null;
+  _StubPicker.throws(this.error) : answer = null;
+
+  final String? answer;
+  final Object? error;
+  int calls = 0;
+
+  @override
+  Future<String?> pickFolder() async {
+    calls++;
+    if (error != null) {
+      throw error!;
+    }
+    return answer;
+  }
+}
+
+void main() {
+  group('LinuxFolderPickerService', () {
+    test('uses the runner GTK/portal chooser when it is there', () async {
+      final native = _StubPicker.answers('/home/me/Music');
+      final fallback = _StubPicker.answers('/should/not/be/used');
+
+      final result = await LinuxFolderPickerService(
+        nativePicker: native,
+        fallbackPicker: fallback,
+      ).pickFolder();
+
+      expect(result, '/home/me/Music');
+      expect(native.calls, 1);
+      expect(fallback.calls, 0);
+    });
+
+    test('a cancelled native pick is a cancel, not a reason to fall back',
+        () async {
+      // Falling back here would pop a second dialog in the face of a user who
+      // just dismissed the first one.
+      final native = _StubPicker.answers(null);
+      final fallback = _StubPicker.answers('/home/me/Music');
+
+      final result = await LinuxFolderPickerService(
+        nativePicker: native,
+        fallbackPicker: fallback,
+      ).pickFolder();
+
+      expect(result, isNull);
+      expect(fallback.calls, 0);
+    });
+
+    test('falls back to the plugin chooser when no native chooser exists',
+        () async {
+      // A build whose runner never registered the channel (a test host, an
+      // older native build) must still be able to pick a folder.
+      final native = _StubPicker.throws(
+        const FolderPickerUnavailableException('no channel'),
+      );
+      final fallback = _StubPicker.answers('/home/me/Music');
+
+      final result = await LinuxFolderPickerService(
+        nativePicker: native,
+        fallbackPicker: fallback,
+      ).pickFolder();
+
+      expect(result, '/home/me/Music');
+      expect(fallback.calls, 1);
+    });
+
+    test('reports no selection when the fallback chooser cannot run either',
+        () async {
+      // `file_picker` throws when it finds no zenity/qarma/kdialog to shell out
+      // to — the sandbox case. There is no chooser left to try, so this is
+      // "nothing chosen" rather than a raw exception thrown into the UI.
+      final native = _StubPicker.throws(
+        const FolderPickerUnavailableException('no channel'),
+      );
+      final fallback = _StubPicker.throws(
+        Exception("Couldn't find the executable zenity in your path"),
+      );
+
+      final result = await LinuxFolderPickerService(
+        nativePicker: native,
+        fallbackPicker: fallback,
+      ).pickFolder();
+
+      expect(result, isNull);
+    });
+  });
+}

--- a/test/core/services/method_channel_linux_folder_picker_test.dart
+++ b/test/core/services/method_channel_linux_folder_picker_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/core/services/folder_picker_service.dart';
+import 'package:linthra/core/services/linux_music_directory.dart';
+import 'package:linthra/core/services/method_channel_linux_folder_picker.dart';
+
+/// A fixed suggestion, so the argument the chooser is opened at is assertable
+/// without reading the machine's real `user-dirs.dirs`.
+class _FixedMusicDirectory implements LinuxMusicDirectory {
+  const _FixedMusicDirectory(this.path);
+
+  final String? path;
+
+  @override
+  Future<String?> resolve({
+    HostPlatform? host,
+    Map<String, String>? environment,
+  }) async =>
+      path;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const MethodChannel channel =
+      MethodChannel(MethodChannelLinuxFolderPicker.channelName);
+
+  /// Installs a handler for the runner's channel and records what Dart sent.
+  List<MethodCall> handleWith(Future<Object?> Function(MethodCall) handler) {
+    final List<MethodCall> calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall call) async {
+      calls.add(call);
+      return handler(call);
+    });
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+    return calls;
+  }
+
+  MethodChannelLinuxFolderPicker picker({
+    HostPlatform host = HostPlatform.linux,
+    String? suggested = '/home/me/Music',
+  }) {
+    return MethodChannelLinuxFolderPicker(
+      host: host,
+      suggestedDirectory: _FixedMusicDirectory(suggested),
+    );
+  }
+
+  group('MethodChannelLinuxFolderPicker', () {
+    test('returns the path the runner chose, and suggests a starting folder',
+        () async {
+      final List<MethodCall> calls =
+          handleWith((_) async => '/home/me/Music/Albums');
+
+      expect(await picker().pickFolder(), '/home/me/Music/Albums');
+      expect(calls, hasLength(1));
+      expect(
+          calls.single.method, MethodChannelLinuxFolderPicker.pickFolderMethod);
+      final Map<Object?, Object?> arguments =
+          calls.single.arguments as Map<Object?, Object?>;
+      expect(arguments['title'], MethodChannelLinuxFolderPicker.dialogTitle);
+      expect(arguments['initialDirectory'], '/home/me/Music');
+    });
+
+    test('passes no starting folder when there is nothing to suggest',
+        () async {
+      // LinuxMusicDirectory fails safe to null; the chooser then opens wherever
+      // the desktop (or the portal) would open it by default.
+      final List<MethodCall> calls = handleWith((_) async => null);
+
+      await picker(suggested: null).pickFolder();
+
+      final Map<Object?, Object?> arguments =
+          calls.single.arguments as Map<Object?, Object?>;
+      expect(arguments['initialDirectory'], isNull);
+    });
+
+    test('returns null when the user cancels', () async {
+      handleWith((_) async => null);
+
+      expect(await picker().pickFolder(), isNull);
+    });
+
+    test('reports "no chooser here" off Linux, without touching the channel',
+        () async {
+      // Asserted with an injected host so the branch is reachable from any
+      // machine. Nothing is sent: the channel only exists in the Linux runner.
+      final List<MethodCall> calls = handleWith((_) async => '/should/not/run');
+
+      await expectLater(
+        picker(host: HostPlatform.android).pickFolder(),
+        throwsA(isA<FolderPickerUnavailableException>()),
+      );
+      expect(calls, isEmpty);
+    });
+
+    test('reports "no chooser here" when the runner registered no handler',
+        () async {
+      // No mock handler installed: the platform channel answers with
+      // MissingPluginException, which is an older/other runner, not a cancel.
+      await expectLater(
+        picker().pickFolder(),
+        throwsA(isA<FolderPickerUnavailableException>()),
+      );
+    });
+
+    test('reports "no chooser here" when GTK could not open a chooser',
+        () async {
+      handleWith((_) async {
+        throw PlatformException(
+          code: MethodChannelLinuxFolderPicker.chooserUnavailableCode,
+        );
+      });
+
+      await expectLater(
+        picker().pickFolder(),
+        throwsA(isA<FolderPickerUnavailableException>()),
+      );
+    });
+
+    test('treats any other platform error as no selection', () async {
+      // A pick already in flight, or a selection with no local path. There is
+      // nothing to fall back to and nothing to scan, so the caller sees the
+      // same "nothing chosen" it sees for a cancel.
+      handleWith((_) async {
+        throw PlatformException(code: 'pick_in_progress');
+      });
+
+      expect(await picker().pickFolder(), isNull);
+    });
+  });
+}

--- a/test/core/services/platform_folder_picker_service_test.dart
+++ b/test/core/services/platform_folder_picker_service_test.dart
@@ -22,14 +22,15 @@ class _RecordingPicker implements FolderPickerService {
 
 void main() {
   group('PlatformFolderPickerService', () {
-    test('off Android, delegates to the fallback (file_picker) chooser',
-        () async {
-      // The unit-test host is never Android, so the SAF picker must not run and
-      // the filesystem fallback handles the pick.
+    test('off Android, never runs the SAF picker', () async {
+      // The unit-test host is never Android, so the SAF picker must not run;
+      // one of the desktop choosers handles the pick.
       final android = _RecordingPicker('content://should-not-be-used');
+      final linux = _RecordingPicker('/home/me/Music');
       final fallback = _RecordingPicker('/home/me/Music');
       final service = PlatformFolderPickerService(
         androidPicker: android,
+        linuxPicker: linux,
         fallbackPicker: fallback,
       );
 
@@ -37,8 +38,8 @@ void main() {
 
       expect(Platform.isAndroid, isFalse, reason: 'precondition for this host');
       expect(result, '/home/me/Music');
-      expect(fallback.calls, 1);
       expect(android.calls, 0);
+      expect(linux.calls + fallback.calls, 1);
     });
 
     test('on Android, delegates to the SAF picker', () async {
@@ -46,10 +47,12 @@ void main() {
       // half of the split is covered from any machine — including the Linux CI
       // runner, where it would otherwise be untestable.
       final android = _RecordingPicker('content://tree/primary%3AMusic');
-      final fallback = _RecordingPicker('/home/me/Music');
+      final linux = _RecordingPicker('/should/not/be/used');
+      final fallback = _RecordingPicker('/should/not/be/used');
       final service = PlatformFolderPickerService(
         host: HostPlatform.android,
         androidPicker: android,
+        linuxPicker: linux,
         fallbackPicker: fallback,
       );
 
@@ -57,21 +60,47 @@ void main() {
 
       expect(result, 'content://tree/primary%3AMusic');
       expect(android.calls, 1);
+      expect(linux.calls, 0);
       expect(fallback.calls, 0);
     });
 
-    test('on Linux, delegates to the filesystem chooser', () async {
+    test('on Linux, delegates to the GTK/portal chooser', () async {
+      // Not the `file_picker` fallback: that one shells out to
+      // zenity/qarma/kdialog, none of which exist inside the Flatpak sandbox
+      // (#438).
       final android = _RecordingPicker('content://should-not-be-used');
-      final fallback = _RecordingPicker('/home/me/Music');
+      final linux = _RecordingPicker('/home/me/Music');
+      final fallback = _RecordingPicker('/should/not/be/used');
       final service = PlatformFolderPickerService(
         host: HostPlatform.linux,
         androidPicker: android,
+        linuxPicker: linux,
         fallbackPicker: fallback,
       );
 
       expect(await service.pickFolder(), '/home/me/Music');
+      expect(linux.calls, 1);
       expect(android.calls, 0);
+      expect(fallback.calls, 0);
+    });
+
+    test('on another desktop, delegates to the file_picker chooser', () async {
+      // macOS/Windows are not targets yet, but they must not fall into the
+      // Linux-only channel if someone builds them.
+      final android = _RecordingPicker('content://should-not-be-used');
+      final linux = _RecordingPicker('/should/not/be/used');
+      final fallback = _RecordingPicker(r'C:\Users\me\Music');
+      final service = PlatformFolderPickerService(
+        host: HostPlatform.windows,
+        androidPicker: android,
+        linuxPicker: linux,
+        fallbackPicker: fallback,
+      );
+
+      expect(await service.pickFolder(), r'C:\Users\me\Music');
       expect(fallback.calls, 1);
+      expect(linux.calls, 0);
+      expect(android.calls, 0);
     });
 
     test('an explicit host never disagrees with the real host on this machine',
@@ -79,16 +108,19 @@ void main() {
       // Guards the injection itself: passing the actual platform must behave
       // identically to passing nothing.
       final android = _RecordingPicker('content://should-not-be-used');
+      final linux = _RecordingPicker('/home/me/Music');
       final fallback = _RecordingPicker('/home/me/Music');
 
       expect(
         await PlatformFolderPickerService(
           host: HostPlatform.current,
           androidPicker: android,
+          linuxPicker: linux,
           fallbackPicker: fallback,
         ).pickFolder(),
         await PlatformFolderPickerService(
           androidPicker: android,
+          linuxPicker: linux,
           fallbackPicker: fallback,
         ).pickFolder(),
       );

--- a/test/core/sources/local/audio_file_scanner_test.dart
+++ b/test/core/sources/local/audio_file_scanner_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/sources/local/audio_file_scanner.dart';
+import 'package:linthra/core/sources/local/folder_scan_exception.dart';
 
 void main() {
   group('IoAudioFileScanner', () {
@@ -53,10 +54,26 @@ void main() {
       expect(files.any((path) => path.endsWith('deep.ogg')), isTrue);
     });
 
-    test('returns an empty list for a folder that does not exist', () async {
+    test('raises a recoverable scan error for a folder that is gone', () async {
+      // A selected folder that no longer resolves — unmounted drive, deleted
+      // folder, or a revoked Flatpak portal document — must not look like a
+      // successful scan of an empty folder: that result would be persisted and
+      // would wipe a catalog the user's files are still behind.
       const scanner = IoAudioFileScanner();
-      final files = await scanner.listFiles('${root.path}/missing');
-      expect(files, isEmpty);
+
+      await expectLater(
+        scanner.listFiles('${root.path}/missing'),
+        throwsA(
+          isA<FolderScanException>().having(
+            (error) => error.message,
+            'message',
+            allOf(
+              contains("couldn't find the selected folder"),
+              contains('selecting the folder again'),
+            ),
+          ),
+        ),
+      );
     });
   });
 }

--- a/test/features/library/library_controller_test.dart
+++ b/test/features/library/library_controller_test.dart
@@ -5,12 +5,15 @@ import 'package:linthra/core/repositories/music_library_repository.dart';
 import 'package:linthra/core/sources/local/audio_file_scanner.dart';
 import 'package:linthra/core/sources/local/directory_readability.dart';
 import 'package:linthra/core/sources/local/folder_scan_exception.dart';
+import 'package:linthra/core/sources/local/local_scan_diagnostics.dart';
+import 'package:linthra/core/sources/local/local_scan_report.dart';
 import 'package:linthra/core/sources/local/saf_document_lister.dart';
 import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
 import 'package:linthra/data/repositories/music_library_repository_provider.dart';
 import 'package:linthra/features/library/library_controller.dart';
 import 'package:linthra/features/library/library_providers.dart';
 import 'package:linthra/features/library/library_state.dart';
+import 'package:linthra/features/library/local_scan_report_provider.dart';
 
 import '../../core/sources/local/fake_saf_document_lister.dart';
 import 'fake_audio_file_scanner.dart';
@@ -294,6 +297,45 @@ void main() {
       final state = container.read(libraryControllerProvider);
       expect(state.status, LibraryStatus.error);
       expect(state.errorMessage, contains('not letting it read'));
+    });
+
+    test('a folder Linthra can no longer reach keeps the catalog intact',
+        () async {
+      // The recoverable-source case (#438/#414): a selected folder that has
+      // gone away — an unplugged drive, a deleted folder, a revoked Flatpak
+      // portal document — must leave the already-indexed tracks alone. Wiping
+      // them would turn a "reselect the folder" problem into a lost library.
+      // The scan report recorder is a process-wide static; keep this test's
+      // report from leaking into the next one.
+      addTearDown(LocalScanDiagnostics.reset);
+      final repository = InMemoryMusicLibraryRepository();
+      await repository.upsertCatalog(
+        sourceId: 'local',
+        tracks: <Track>[_track('a'), _track('b')],
+        albums: const [],
+        artists: const [],
+      );
+      final container = _scanContainer(
+        repository: repository,
+        scanner: FakeAudioFileScanner(
+          error: const FolderScanException(
+            "Linthra couldn't find the selected folder.",
+          ),
+        ),
+      );
+
+      await container
+          .read(libraryControllerProvider.notifier)
+          .scanFolder('/home/me/Music');
+
+      final state = container.read(libraryControllerProvider);
+      expect(state.status, LibraryStatus.error);
+      expect(await repository.getAllTracks(), hasLength(2));
+      // Recorded as a folder-availability failure, not as an Android SAF one,
+      // so a desktop diagnostics report says what actually happened.
+      final report = container.read(localScanReportProvider);
+      expect(report?.error, LocalScanError.folderUnavailable);
+      expect(report?.isContentUri, isFalse);
     });
   });
 }

--- a/test/features/settings/source/local_music_controller_test.dart
+++ b/test/features/settings/source/local_music_controller_test.dart
@@ -1,6 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/core/sources/local/audio_file_scanner.dart';
+import 'package:linthra/core/sources/local/directory_readability.dart';
+import 'package:linthra/core/sources/local/folder_scan_exception.dart';
 import 'package:linthra/core/sources/local/local_scan_diagnostics.dart';
+import 'package:linthra/core/sources/local/local_scan_report.dart';
+import 'package:linthra/data/repositories/host_platform_provider.dart';
 import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
 import 'package:linthra/data/repositories/in_memory_selected_music_folder_repository.dart';
 import 'package:linthra/data/repositories/music_library_repository_provider.dart';
@@ -12,6 +18,34 @@ import 'package:linthra/features/settings/source/local_music_controller.dart';
 
 import '../../library/fake_audio_file_scanner.dart';
 import '../../library/fake_folder_picker_service.dart';
+
+/// A scanner whose answer can change between scans, so one test can walk a
+/// folder that is readable and then lose it.
+class _MutableScanner implements AudioFileScanner {
+  _MutableScanner({this.files = const <String>[]});
+
+  List<String> files;
+  Object? error;
+
+  @override
+  Future<List<String>> listFiles(String folder) async {
+    final Object? failure = error;
+    if (failure != null) {
+      throw failure;
+    }
+    return files;
+  }
+}
+
+/// The desktop access probe, likewise flippable mid-test.
+class _MutableReadability implements DirectoryReadability {
+  _MutableReadability(this.readable);
+
+  bool readable;
+
+  @override
+  Future<bool> canList(String path) async => readable;
+}
 
 ProviderContainer _container({
   required FakeFolderPickerService picker,
@@ -36,6 +70,49 @@ void main() {
   tearDown(LocalScanDiagnostics.reset);
 
   group('LocalMusicController', () {
+    test('losing access to a desktop folder is noticed on the next scan',
+        () async {
+      // Access is lost while the app runs — a drive unplugged, a Flatpak portal
+      // document revoked — and the *selection* never changes when that happens.
+      // A rescan is the user's natural way to find out, so the access line has
+      // to be re-probed then rather than staying on the answer cached when the
+      // folder was first picked.
+      final scanner = _MutableScanner(files: const <String>['/music/a.mp3']);
+      final readability = _MutableReadability(true);
+      final container = ProviderContainer(
+        overrides: [
+          folderPickerServiceProvider
+              .overrideWithValue(FakeFolderPickerService(folder: '/music')),
+          selectedMusicFolderRepositoryProvider
+              .overrideWithValue(InMemorySelectedMusicFolderRepository()),
+          musicLibraryRepositoryProvider
+              .overrideWithValue(InMemoryMusicLibraryRepository()),
+          audioFileScannerProvider.overrideWithValue(scanner),
+          directoryReadabilityProvider.overrideWithValue(readability),
+          hostPlatformProvider.overrideWithValue(HostPlatform.linux),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(localMusicControllerProvider.notifier).pickFolder();
+      expect(await container.read(localFolderAccessProvider.future), isTrue);
+
+      // The folder goes away, then the user hits Rescan.
+      readability.readable = false;
+      scanner.error = const FolderScanException(
+        "Linthra couldn't find the selected folder.",
+      );
+      await container.read(localMusicControllerProvider.notifier).rescan();
+
+      expect(
+        container.read(localScanReportProvider)?.error,
+        LocalScanError.folderUnavailable,
+      );
+      // The card's lost-access line now shows, instead of the folder still
+      // reading as healthy.
+      expect(await container.read(localFolderAccessProvider.future), isFalse);
+    });
+
     test('pickFolder scans the chosen folder and imports its audio', () async {
       final libraryRepo = InMemoryMusicLibraryRepository();
       final container = _container(

--- a/test/features/settings/source/local_music_settings_section_test.dart
+++ b/test/features/settings/source/local_music_settings_section_test.dart
@@ -1,11 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/core/sources/local/directory_readability.dart';
 import 'package:linthra/core/sources/local/local_scan_diagnostics.dart';
 import 'package:linthra/core/sources/local/local_scan_report.dart';
+import 'package:linthra/data/repositories/host_platform_provider.dart';
 import 'package:linthra/data/repositories/in_memory_selected_music_folder_repository.dart';
 import 'package:linthra/data/repositories/selected_music_folder_repository_provider.dart';
+import 'package:linthra/features/library/library_providers.dart';
 import 'package:linthra/features/settings/source/local_music_settings_section.dart';
+
+/// Reports one fixed answer for "can this folder still be listed?", standing in
+/// for the real `dart:io` probe so the desktop lost-access state can be driven
+/// without a disk.
+class _FixedReadability implements DirectoryReadability {
+  const _FixedReadability(this.readable);
+
+  final bool readable;
+
+  @override
+  Future<bool> canList(String path) async => readable;
+}
 
 const String _safFolder =
     'content://com.android.externalstorage.documents/tree/primary%3AMusic';
@@ -14,6 +30,8 @@ Future<void> _pump(
   WidgetTester tester, {
   String? initialFolder,
   LocalScanReport? report,
+  HostPlatform? host,
+  DirectoryReadability? readability,
 }) async {
   // The card reads the last scan reactively from localScanReportProvider, which
   // seeds itself from LocalScanDiagnostics.last — so recording here is how a
@@ -27,6 +45,9 @@ Future<void> _pump(
         selectedMusicFolderRepositoryProvider.overrideWithValue(
           InMemorySelectedMusicFolderRepository(initialFolder: initialFolder),
         ),
+        if (host != null) hostPlatformProvider.overrideWithValue(host),
+        if (readability != null)
+          directoryReadabilityProvider.overrideWithValue(readability),
       ],
       child: const MaterialApp(
         home: Scaffold(body: LocalMusicSettingsSection()),
@@ -43,6 +64,63 @@ void main() {
   tearDown(LocalScanDiagnostics.reset);
 
   group('LocalMusicSettingsSection', () {
+    testWidgets('on Linux, a folder Linthra cannot reach says so', (
+      tester,
+    ) async {
+      // The Flatpak/desktop half of the lost-access state (#438): the portal
+      // document was revoked, the drive was unplugged, or the folder is gone.
+      // The card has to say that plainly, and promise the library is still
+      // there, instead of quietly showing an empty local source.
+      await _pump(
+        tester,
+        initialFolder: '/home/me/Music',
+        host: HostPlatform.linux,
+        readability: const _FixedReadability(false),
+      );
+
+      expect(
+        find.textContaining('Linthra can no longer reach this folder'),
+        findsOneWidget,
+      );
+      // Recoverable, not destructive: reselecting is the fix, and the actions
+      // to do it are still on the card.
+      expect(find.text('Change'), findsOneWidget);
+      expect(find.text('Forget folder'), findsOneWidget);
+    });
+
+    testWidgets('on Linux, a reachable folder says nothing about access', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        initialFolder: '/home/me/Music',
+        host: HostPlatform.linux,
+        readability: const _FixedReadability(true),
+      );
+
+      expect(find.text('/home/me/Music'), findsOneWidget);
+      expect(
+        find.textContaining('Linthra can no longer reach this folder'),
+        findsNothing,
+      );
+    });
+
+    testWidgets('on Linux, the blurb describes the desktop file chooser', (
+      tester,
+    ) async {
+      // The Android copy ("Android's folder access") is wrong on a desktop,
+      // where the same promise — only the folder you chose, no broad
+      // permission — is kept by the system file chooser (the portal, in a
+      // Flatpak).
+      await _pump(tester, host: HostPlatform.linux);
+
+      expect(
+        find.textContaining('the system file chooser'),
+        findsOneWidget,
+      );
+      expect(find.textContaining("Android's folder access"), findsNothing);
+    });
+
     testWidgets('with no folder, invites the user to select one',
         (tester) async {
       await _pump(tester);

--- a/test/features/settings/source/local_music_settings_section_test.dart
+++ b/test/features/settings/source/local_music_settings_section_test.dart
@@ -203,6 +203,9 @@ void main() {
         'without blaming the user', (tester) async {
       await _pump(
         tester,
+        // A SAF folder is an Android selection, and the hint names Android's
+        // chooser — asserted with an injected host so it holds on any machine.
+        host: HostPlatform.android,
         initialFolder: _safFolder,
         report: const LocalScanReport(
           folderSelected: true,
@@ -245,10 +248,71 @@ void main() {
       expect(find.textContaining('restore access'), findsOneWidget);
     });
 
+    testWidgets(
+        'on Linux, an unreadable folder points at the system chooser, not '
+        "Android's", (tester) async {
+      // The Flatpak case this has to get right: a portal folder that was
+      // revoked or unplugged. Access is reported as fine here so the only
+      // recovery text on screen is the scan hint itself.
+      await _pump(
+        tester,
+        host: HostPlatform.linux,
+        readability: const _FixedReadability(true),
+        initialFolder: '/home/me/Music',
+        report: const LocalScanReport.failure(
+          folderSelected: true,
+          isContentUri: false,
+          error: LocalScanError.folderUnavailable,
+        ),
+      );
+
+      expect(find.textContaining("Android's folder chooser"), findsNothing);
+      // Still a clear way back: reselect the folder in the chooser Linux has.
+      expect(find.textContaining("couldn't read this folder"), findsOneWidget);
+      expect(
+          find.textContaining('Select it again with the system folder '
+              'chooser'),
+          findsOneWidget);
+      expect(find.textContaining('restore access'), findsOneWidget);
+      // The SD-card aside is an Android storage note; a desktop path is not it.
+      expect(find.textContaining('SD cards'), findsNothing);
+    });
+
+    testWidgets(
+        'on Linux, an empty scan suggests reselecting in the system chooser',
+        (tester) async {
+      await _pump(
+        tester,
+        host: HostPlatform.linux,
+        readability: const _FixedReadability(true),
+        initialFolder: '/home/me/Music',
+        report: const LocalScanReport(
+          folderSelected: true,
+          isContentUri: false,
+          filesVisited: 5,
+          audioCandidates: 0,
+          importedTracks: 0,
+          skippedUnsupported: 5,
+          readFailures: 0,
+        ),
+      );
+
+      expect(find.textContaining("Android's folder chooser"), findsNothing);
+      expect(find.textContaining('supported audio files'), findsOneWidget);
+      expect(
+        find.textContaining(
+          'select the folder again with the system folder chooser',
+        ),
+        findsOneWidget,
+      );
+    });
+
     testWidgets('a failed scan shows a gentle status and a reselect hint',
         (tester) async {
       await _pump(
         tester,
+        // A SAF selection, so the Android wording is the right one here.
+        host: HostPlatform.android,
         initialFolder: _safFolder,
         report: const LocalScanReport.failure(
           folderSelected: true,

--- a/test/tooling/check_linux_runner_test.py
+++ b/test/tooling/check_linux_runner_test.py
@@ -79,12 +79,49 @@ endif()
 MY_APPLICATION = """\
 #include "my_application.h"
 
+#include "folder_picker_channel.h"
+
 static constexpr const char* kApplicationName = "{display_name}";
 static constexpr int kDefaultWindowWidth = 1180;
 static constexpr int kDefaultWindowHeight = 780;
 static constexpr int kMinimumWindowWidth = 420;
 static constexpr int kMinimumWindowHeight = 600;
+
+static void activate() {{
+  self->folder_picker = folder_picker_channel_new(view, window);
+}}
 """
+
+# The runner's own build file, which has to compile the folder-picker source
+# (#438) for the channel to exist at all.
+RUNNER_CMAKELISTS = """\
+add_executable(${{BINARY_NAME}}
+  "main.cc"
+  "my_application.cc"
+  "folder_picker_channel.cc"
+)
+"""
+
+# The two halves of the folder-picker channel, reduced to the strings the
+# checker compares. A rename on either side is invisible at build time and
+# turns every pick into a silent fallback, which inside the Flatpak means no
+# chooser at all.
+FOLDER_PICKER_CHANNEL = """\
+static constexpr const char* kChannelName =
+    "{channel}";
+static constexpr const char* kPickFolderMethod = "{method}";
+"""
+
+FOLDER_PICKER_DART = """\
+class MethodChannelLinuxFolderPicker implements FolderPickerService {{
+  static const String channelName =
+      '{channel}';
+  static const String pickFolderMethod = '{method}';
+}}
+"""
+
+FOLDER_PICKER_CHANNEL_NAME = f"{APP_ID}/linux_folder_picker"
+FOLDER_PICKER_METHOD_NAME = "pickFolder"
 
 BUILD_GRADLE = """\
 android {{
@@ -197,6 +234,9 @@ def build_checkout(
     flatpak_manifest: str | None = None,
     icon_svg: str | None = None,
     write_icon: bool = True,
+    runner_cmakelists: str | None = None,
+    folder_picker_channel: str | None = None,
+    folder_picker_dart: str | None = None,
 ) -> Path:
     """Write a minimal, internally consistent checkout the checker can read."""
     (directory / "linux" / "runner").mkdir(parents=True, exist_ok=True)
@@ -205,6 +245,7 @@ def build_checkout(
     (directory / "tool" / "branding").mkdir(parents=True, exist_ok=True)
     (directory / "android" / "app").mkdir(parents=True, exist_ok=True)
     (directory / "lib" / "core").mkdir(parents=True, exist_ok=True)
+    (directory / "lib" / "core" / "services").mkdir(parents=True, exist_ok=True)
 
     (directory / "linux" / "CMakeLists.txt").write_text(
         cmakelists
@@ -216,6 +257,30 @@ def build_checkout(
         my_application
         if my_application is not None
         else MY_APPLICATION.format(display_name=DISPLAY_NAME),
+        encoding="utf-8",
+    )
+    runner = directory / "linux" / "runner"
+    (runner / "CMakeLists.txt").write_text(
+        runner_cmakelists if runner_cmakelists is not None else RUNNER_CMAKELISTS,
+        encoding="utf-8",
+    )
+    (runner / "folder_picker_channel.cc").write_text(
+        folder_picker_channel
+        if folder_picker_channel is not None
+        else FOLDER_PICKER_CHANNEL.format(
+            channel=FOLDER_PICKER_CHANNEL_NAME, method=FOLDER_PICKER_METHOD_NAME
+        ),
+        encoding="utf-8",
+    )
+    (
+        directory / "lib" / "core" / "services"
+        / "method_channel_linux_folder_picker.dart"
+    ).write_text(
+        folder_picker_dart
+        if folder_picker_dart is not None
+        else FOLDER_PICKER_DART.format(
+            channel=FOLDER_PICKER_CHANNEL_NAME, method=FOLDER_PICKER_METHOD_NAME
+        ),
         encoding="utf-8",
     )
     (directory / "android" / "app" / "build.gradle").write_text(
@@ -645,6 +710,69 @@ class WindowMetricsTest(CheckoutCase):
             .replace("kMinimumWindowHeight = 600", "kMinimumWindowHeight = 780"),
         )
         self.assertEqual(checker.check(self.root), [])
+
+
+class FolderPickerChannelTest(CheckoutCase):
+    """The runner<->Dart folder-picker contract (#438).
+
+    Every failure here is silent at build time: the app still compiles, the
+    chooser just never answers and Dart falls back to `file_picker`, which
+    inside the Flatpak has no zenity/kdialog to run. So the only thing that
+    catches it before a user does is this comparison.
+    """
+
+    def test_a_renamed_channel_on_the_dart_side_is_caught(self) -> None:
+        build_checkout(
+            self.root,
+            folder_picker_dart=FOLDER_PICKER_DART.format(
+                channel="io.example.app/renamed",
+                method=FOLDER_PICKER_METHOD_NAME,
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("channel name", problems[0])
+        self.assertIn("io.example.app/renamed", problems[0])
+
+    def test_a_renamed_method_on_the_native_side_is_caught(self) -> None:
+        build_checkout(
+            self.root,
+            folder_picker_channel=FOLDER_PICKER_CHANNEL.format(
+                channel=FOLDER_PICKER_CHANNEL_NAME, method="chooseFolder"
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("method name", problems[0])
+        self.assertIn("chooseFolder", problems[0])
+
+    def test_dropping_the_source_from_the_runner_build_is_caught(self) -> None:
+        # What a `flutter create` regeneration of linux/ would do: restore the
+        # template's source list and leave the channel uncompiled.
+        build_checkout(
+            self.root,
+            runner_cmakelists=RUNNER_CMAKELISTS.replace(
+                '  "folder_picker_channel.cc"\n', ""
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("folder_picker_channel.cc", problems[0])
+
+    def test_never_registering_the_channel_is_caught(self) -> None:
+        # Compiled but never wired to the engine is the same silence.
+        build_checkout(
+            self.root,
+            my_application=MY_APPLICATION.format(
+                display_name=DISPLAY_NAME
+            ).replace(
+                "self->folder_picker = folder_picker_channel_new(view, window);",
+                "// no folder picker here",
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("folder_picker_channel_new", problems[0])
 
 
 class OfflineBuildSeamTest(CheckoutCase):


### PR DESCRIPTION
Closes #438.

## The problem

In the Flatpak, picking a music folder failed before a dialog ever appeared. `file_picker`'s Linux implementation shells out to `zenity`/`qarma`/`kdialog`, and the sandbox contains none of them. Granting `--filesystem=host` or `--filesystem=home` would have "fixed" it by handing Linthra the user's whole home directory, which is the opposite of what #438 asks for.

## What this does

Linthra's Linux runner now registers its own folder-picker method channel (`linux/runner/folder_picker_channel.cc`) backed by GTK's `GtkFileChooserNative`. GTK checks for `/.flatpak-info` itself, so the same widget:

* draws the ordinary in-process GTK dialog on a native build, and
* routes to the **xdg-desktop-portal** `FileChooser` inside the Flatpak, where the chooser runs on the host.

Only the folder the user picked comes back, exported through the document portal as a real path. The `dart:io` scan walks it unchanged, so there is no Flatpak branch in the scanner and no hardcoded sandbox path anywhere. Nothing was added to `finish-args`: talking to the portal needs no grant, and the document export persists across restarts, so the folder still scans after a relaunch.

Dart side:

* `MethodChannelLinuxFolderPicker` calls the channel, and tells "the user cancelled" (null) apart from "there is no chooser here" (a typed `FolderPickerUnavailableException`).
* `LinuxFolderPickerService` composes that with `file_picker` as a fallback for a build whose runner never registered the channel. A cancel never falls back, so dismissing the dialog cannot pop a second one.
* `PlatformFolderPickerService` routes Linux to it. Android and the other desktops are untouched.

## Losing access is recoverable, not destructive

A selected root that no longer resolves (unplugged drive, deleted folder, revoked portal document) used to come back as an empty listing, which was persisted as a successful "no music" scan and wiped the local catalog. `IoAudioFileScanner` now raises a `FolderScanException` for that case, recorded as a new `LocalScanError.folderUnavailable`, and the library controller leaves the indexed tracks alone. The Local music card says the folder can no longer be reached and offers reselect, driven by a readability probe for filesystem folders alongside the existing SAF grant probe on Android.

Two follow-ups landed on review feedback:

* **86ba7c7** — the access probe re-runs on every recorded scan, not only when the selection changes. Access is lost while the app is running and the selection does not change when that happens, so a cached "yes" would have outlived the truth and left both cards showing a healthy folder right after a rescan failed on it. Watching the scan report covers both scan paths and makes Rescan the natural way to re-check.
* **d539417** — the card's copy is platform-correct throughout. The main blurb and the scan recap's recovery hint both named "Android's folder chooser", which on Linux points the user at something their machine does not have. The hint now names Android's chooser on Android and the system folder chooser elsewhere, keyed off the platform rather than the report's `isContentUri` (a storage kind: a legacy filesystem selection on Android is still Android).

## Scope

* No new Flatpak permissions, and `--filesystem=host|home` stays out of the manifest. Only comments changed in `flatpak-flutter.yml`, so the generated manifest needs no regeneration.
* Android SAF selection, scanning and grant handling are unchanged, copy included.
* Native non-Flatpak Linux keeps working through the same code path (plain GTK dialog).

## Tests and checks

* New: `method_channel_linux_folder_picker_test.dart`, `linux_folder_picker_service_test.dart`; updated routing, scanner, library-controller and Local music card tests (catalog survives a lost folder; the card reports it).
* Both follow-ups have regression tests that fail against the old code: the access-staleness one drives the real flow (pick a readable folder, flip it unreachable, rescan) and got a stale `true`; the two Linux wording ones assert the Android chooser is never named on Linux while a clear reselect message still is.
* `scripts/check_linux_runner.py` now holds the runner's channel and method names to the Dart side's and checks the source is compiled and registered, because every drift there is silent at build time. Four new cases in `test/tooling/check_linux_runner_test.py`.
* `./scripts/verify_linux.sh` passes: `dart format`, `flutter analyze` (no issues), `flutter test` (3899 passing), runner config check, runner tooling tests (53 passing). `ruff check`/`ruff format --check` clean on `scripts tool tools`.
* `flutter build linux --release` could **not** run in the authoring environment: `sqlite3_flutter_libs` fetches the SQLite amalgamation from sqlite.org at configure time and egress to it is blocked there (the `LINTHRA_SQLITE3_SOURCE_DIR` seam needs a local copy there was no way to obtain). Both runner sources were compiled instead with `clang++ -Wall -Werror` against the real `flutter_linux` and GTK 3 headers. CI's **Build Linux desktop** job covers the full build and link.
* Not verified anywhere yet: an actual `flatpak-builder` run and a real portal pick. `docs/flatpak-development.md` gains the manual pass for it, including checking the export with `flatpak documents` and revoking it with `flatpak document-unexport` to see the recoverable state.

## Docs

`flatpak/README.md` (new "Local music folders" section explaining why no filesystem grant is needed), `docs/flatpak-development.md`, `docs/linux-desktop.md` (parity rows and the seam table), `docs/local-music.md` (a Linux section, plus the diagnostics lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGgu5TnGAtdFfrm5tMGdii