### PR TITLE
fix(flatpak): allow configured server networking

### DIFF
--- a/docs/flatpak-development.md
+++ b/docs/flatpak-development.md
@@ -21,8 +21,9 @@ Three docs, three jobs:
 > The committed manifest builds, installs and launches the real app with
 > working audio, and installs a desktop entry, Linthra's own icon, and AppStream
 > metainfo so the app appears in the application menu and in software centres.
-> It is not the Flathub submission: there is no network or Secret Service
-> access, and no filesystem grant beyond the folders the user picks through
+> It is not the Flathub submission: normal network access is enabled for
+> configured self-hosted servers, but there is no Secret Service access and no
+> filesystem grant beyond the folders the user picks through
 > the desktop portal.
 > See [What the sandbox allows today](#what-the-sandbox-allows-today).
 
@@ -292,14 +293,19 @@ flatpak override --user --show io.github.thezupzup.linthra
 The committed manifest grants exactly:
 
 ```
---socket=wayland  --socket=fallback-x11  --share=ipc
+--socket=wayland  --socket=fallback-x11  --share=ipc  --share=network
 --device=dri      --socket=pulseaudio
 ```
 
-So these are **expected**, not bugs, and not worth debugging:
+`--share=network` is the minimum Flatpak capability for Linthra's existing
+HTTP(S) clients to reach configured Jellyfin, Navidrome/Subsonic, and Plex
+endpoints. It enables ordinary network destinations—including LAN addresses,
+hostnames, valid HTTPS endpoints, and remote/tunnel URLs—but exposes no host
+files and grants no D-Bus API. Discovery (mDNS/SSDP/broadcast) is separate and
+is not enabled by this change.
 
-* Jellyfin, Navidrome/Subsonic and Plex cannot reach a server — there is no
-  `--share=network` yet ([#440](https://github.com/TheZupZup/Linthra/issues/440)).
+The following are **expected**, not bugs, and not worth debugging:
+
 * Unrelated host files are invisible — there is no `--filesystem=` grant
   ([#439](https://github.com/TheZupZup/Linthra/issues/439) is the remaining
   permission audit). Picking a **music folder** does work, and needs no grant:
@@ -329,19 +335,15 @@ So these are **expected**, not bugs, and not worth debugging:
   icon after that is usually caching: log out and back in, or run
   `gtk4-update-icon-cache -f ~/.local/share/flatpak/exports/share/icons/hicolor`.
 
-To exercise those paths anyway, pass the permission to `flatpak run` for a
-single launch — it applies to that invocation only, so there is nothing to
-revoke and nothing left behind:
+Do not add filesystem or D-Bus permissions to test networking. For a deliberate
+one-shot failure test, remove the packaged network share only for that launch:
 
 ```bash
-flatpak run --filesystem=/path/to/test-music:ro io.github.thezupzup.linthra
-flatpak run --share=network io.github.thezupzup.linthra
+flatpak run --unshare=network io.github.thezupzup.linthra
 ```
 
-Use that rather than `flatpak override`, whose grants persist and cannot be
-cleanly undone — see
-[`flatpak/README.md`](../flatpak/README.md#testing-audio-locally). Never commit
-either permission to the manifest.
+Use this rather than `flatpak override`, whose grants persist and can obscure
+what the manifest actually provides.
 
 ## Smoke testing
 
@@ -370,12 +372,17 @@ Until #445/#446 land, the manual pass for a packaging change is:
 2. `flatpak run io.github.thezupzup.linthra` → the window opens and renders.
    A missing bundled library shows up here, as a startup failure before the
    first frame.
-3. Play audio with a one-shot permission —
-   `flatpak run --filesystem=/path/to/test-music:ro io.github.thezupzup.linthra`,
-   or `--share=network` for a stream, per
-   [`flatpak/README.md`](../flatpak/README.md#testing-audio-locally). It lasts
-   for that launch only.
-4. Local music without any grant: launch plainly
+3. Test a configured LAN server: enter its direct address (for example
+   `http://192.168.1.20:8096`) in the Jellyfin, Navidrome/Subsonic, or Plex
+   connection UI, sign in, sync, and play a track. Repeat with its hostname.
+4. Test a real remote `https://` endpoint (or tunnel URL) the same way. Use a
+   valid certificate; never weaken TLS verification for this test.
+5. Test recovery: stop the server or launch once with
+   `flatpak run --unshare=network io.github.thezupzup.linthra`. A retry should
+   use Linthra's existing configured-but-unreachable/offline provider state,
+   the app and cached playback should remain usable, and a normal relaunch
+   after restoring connectivity should recover.
+6. Local music without any grant: launch plainly
    (`flatpak run io.github.thezupzup.linthra`), then Settings ▸ Local music ▸
    *Select a folder*. The system's own folder chooser opens (the portal, run on
    the host), and the folder you pick scans. Check that it really went through
@@ -391,6 +398,6 @@ Until #445/#446 land, the manual pass for a packaging change is:
    the same folder still scans. `flatpak document-unexport /path/to/test-music`
    on the host revokes it, after which Linthra says the folder can no longer be
    reached and keeps the library it already indexed instead of emptying it.
-5. `flatpak info --show-permissions io.github.thezupzup.linthra` → still only
-   the five finish-args listed above, i.e. you did not widen the sandbox by
-   accident.
+7. `flatpak info --show-permissions io.github.thezupzup.linthra` → shows
+   `shared=network;ipc;` and still only the six finish-args listed above, i.e.
+   you did not widen the sandbox by accident.

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -8,8 +8,8 @@ runtime, with Linthra's own icon on the launcher entry and AppStream metainfo
 for a software-centre listing, and let the user point Linthra at a music
 folder through the desktop portal without granting any host filesystem
 access. It is deliberately not the Flathub submission —
-the sandbox permissions are still open; see "What's deferred" below and the
-comments in `io.github.thezupzup.linthra.yml` itself.
+some sandbox permissions are still deferred; see "What's deferred" below and
+the comments in `io.github.thezupzup.linthra.yml` itself.
 
 ## Audio runtime
 
@@ -123,9 +123,8 @@ type="desktop-id">` and `<icon type="stock">` point at the desktop entry and
 icon already installed under that id. Screenshots are omitted until there are
 Linux captures; Android shots would misrepresent the desktop window.
 
-The description only covers local playback. Server streaming (Jellyfin /
-Navidrome / Subsonic / Plex) stays out until the Flatpak has network
-permission (#440).
+The description covers local playback. The sandbox also permits normal network
+connections for user-configured Jellyfin, Navidrome/Subsonic, and Plex servers.
 
 ## Files here
 
@@ -167,42 +166,50 @@ Nothing above needs network access during the actual sandboxed build —
 the Flutter SDK module, the ffmpeg/libplacebo/libass/mpv archives) happens
 before the sandbox is entered, exactly like any other Flatpak module.
 
-## Testing audio locally
+## Network access and endpoint validation
 
-The committed manifest grants `--socket=pulseaudio` but no filesystem or
-network access, matching #438/#439/#440's scope. To manually verify playback
-of your own local files or a real remote stream, pass the extra permission to
-`flatpak run` itself. Options given there apply to that one invocation only,
-so there is nothing to revoke afterwards and nothing is left behind:
+The committed manifest grants exactly `--share=network` for networking. Flatpak
+otherwise gives an application no network namespace access, so this is the
+minimum capability that lets Linthra's existing HTTP clients connect to a
+user-configured Jellyfin, Navidrome/Subsonic, or Plex server. It covers ordinary
+IPv4/IPv6 sockets: direct LAN addresses, DNS hostnames, HTTPS, and remote or
+tunnel endpoints all behave as normal network destinations.
 
-```bash
-# Local file: read-only access to a directory with a test track, for this
-# launch only. Play it from within the app.
-flatpak run --filesystem=/path/to/test-music:ro io.github.thezupzup.linthra
+This grant does **not** expose arbitrary host files and adds no D-Bus access.
+There is still no `--filesystem=host`, `--filesystem=home`, broad D-Bus grant,
+or Secret Service permission. It also does not add mDNS, SSDP, or broadcast
+discovery behavior: issue #440 covers endpoints the user configured directly;
+provider discovery remains separate.
 
-# Remote HTTP(S) stream: same idea with network instead.
-flatpak run --share=network io.github.thezupzup.linthra
-```
+After building and installing the Flatpak, validate a LAN endpoint by entering
+its direct address (for example `http://192.168.1.20:8096`) in the matching
+provider's connection screen, signing in, syncing, and playing a track. Repeat
+with a hostname if the server has one. Validate a remote endpoint by entering a
+real `https://` hostname (including a tunnel URL if that is how the server is
+normally exposed), then sign in, sync, and play a track. Do not disable TLS or
+certificate verification: use the same valid endpoint that native Linthra uses.
 
-Do **not** use `flatpak override` for this. Its grants are persistent, and the
-apparent undo is not one: `--nofilesystem=…`/`--unshare=network` record a
-*negative* override on top of the grant rather than deleting it, so the app
-keeps leftover permission state either way. `--reset` is worse — it wipes
-*every* persistent override you have for this app, including unrelated ones
-you set yourself. A one-shot `flatpak run` permission avoids the whole problem.
+Verify recoverable failure behavior without changing the manifest:
 
-Never add these permissions to `io.github.thezupzup.linthra.yml` either: a
-committed grant is #440's (network) and #438/#439's (filesystem) decision, not
-a testing convenience. The package itself is unchanged by the runs above, and
-stays that way:
+1. While connected, note that the provider is available and its tracks play.
+2. Stop the test server, disconnect the network, or run a one-shot denial with
+   `flatpak run --unshare=network io.github.thezupzup.linthra`.
+3. Retry the provider operation. Linthra should report its existing configured
+   but unreachable/offline provider state; the app must remain usable and any
+   cached track must remain playable.
+4. Restore the server/network, launch normally, and retry. The provider should
+   become available again through the existing reachability recovery path.
+
+Inspect the installed package rather than relying on the source file:
 
 ```bash
 flatpak info --show-permissions io.github.thezupzup.linthra
-# Still only the manifest's finish-args — a permission passed to `flatpak run`
-# never appears here.
+flatpak override --user --show io.github.thezupzup.linthra
 ```
 
-Automated audio smoke coverage is #446's job, not this file's.
+The first command should show `shared=network;ipc;` (alongside the existing
+windowing, GPU, and audio grants), and no filesystem or D-Bus permission. The
+second reveals persistent local overrides that could invalidate the test.
 
 ## Regenerating the pinned sources
 
@@ -260,12 +267,6 @@ side's, so the two cannot drift into a silent fallback.
 
 Not in this manifest — each has its own issue:
 
-* **Provider network access** (#440) — no permanent `--share=network`.
-  #433 proved the bundled ffmpeg/libmpv can decode HTTP(S) audio using only a
-  temporary, non-committed grant for that validation (see
-  [Testing audio locally](#testing-audio-locally)); permanently granting
-  Linthra network access for real provider use
-  (Jellyfin/Navidrome-Subsonic/Plex) is #440's job, not this manifest's.
 * **The remaining filesystem-permission audit** (#439) and **Secret Service**
   (#441) — no `--filesystem=host|home` or
   `--talk-name=org.freedesktop.secrets`. Jellyfin/Subsonic/Plex session restore

--- a/flatpak/flatpak-flutter.yml
+++ b/flatpak/flatpak-flutter.yml
@@ -50,6 +50,13 @@ finish-args:
   # so --socket=pulseaudio is what reaches both a native PulseAudio session
   # and a PipeWire one — there is no separate "--socket=pipewire" finish-arg.
   - --socket=pulseaudio
+  # User-configured Jellyfin, Navidrome/Subsonic and Plex servers are ordinary
+  # HTTP(S) destinations. Flatpak disables all networking unless this single
+  # capability is granted; --share=network enables normal sockets (including
+  # LAN addresses, DNS hostnames and remote/tunnel endpoints) without exposing
+  # host files or adding a D-Bus permission. Provider discovery remains out of
+  # scope: direct configured endpoints need no discovery-specific grant.
+  - --share=network
   #
   # Local music folders (#438) need nothing here on purpose. Linthra's Linux
   # runner opens GTK's GtkFileChooserNative, which GTK routes to the
@@ -63,11 +70,6 @@ finish-args:
   #
   # Deliberately withheld for issue #432, still withheld here (see
   # flatpak/README.md "What's deferred" for the reasoning):
-  #   --share=network            (provider streaming: #440. #433 only proves
-  #                                the bundled runtime *can* play HTTP(S)
-  #                                audio, using a temporary, non-committed
-  #                                `flatpak override` for that validation —
-  #                                see flatpak/README.md.)
   #   --filesystem=host/home     (broad filesystem access. Not needed for the
   #                                local library, per the portal note above;
   #                                the remaining permission audit is #439.)

--- a/flatpak/io.github.thezupzup.linthra.yml
+++ b/flatpak/io.github.thezupzup.linthra.yml
@@ -19,6 +19,7 @@ finish-args:
   - --share=ipc
   - --device=dri
   - --socket=pulseaudio
+  - --share=network
 modules:
   - name: ffmpeg
     cleanup:

--- a/scripts/check_linux_runner.py
+++ b/scripts/check_linux_runner.py
@@ -407,9 +407,7 @@ def flatpak_permission_problems(root: Path) -> list[str]:
                 )
                 continue
             try:
-                values = shlex.split(
-                    stripped[1:].strip(), comments=True, posix=True
-                )
+                values = shlex.split(stripped[1:].strip(), comments=True, posix=True)
             except ValueError as error:
                 problems.append(
                     f"{manifest} finish-args contains an invalid scalar "

--- a/scripts/check_linux_runner.py
+++ b/scripts/check_linux_runner.py
@@ -74,6 +74,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import shlex
 import sys
 from pathlib import Path
 from xml.etree import ElementTree
@@ -398,9 +399,30 @@ def flatpak_permission_problems(root: Path) -> list[str]:
             if not line[0].isspace():
                 break
 
-            item = re.fullmatch(r"\s+-\s+(--[^\s#]+)(?:\s+#.*)?\s*", line)
-            if item is not None:
-                actual.add(item.group(1))
+            stripped = line.strip()
+            if not stripped.startswith("-"):
+                problems.append(
+                    f"{manifest} finish-args contains an unrecognised line: "
+                    f"{stripped!r}"
+                )
+                continue
+            try:
+                values = shlex.split(
+                    stripped[1:].strip(), comments=True, posix=True
+                )
+            except ValueError as error:
+                problems.append(
+                    f"{manifest} finish-args contains an invalid scalar "
+                    f"{stripped!r}: {error}"
+                )
+                continue
+            if len(values) != 1:
+                problems.append(
+                    f"{manifest} finish-args entry {stripped!r} does not resolve "
+                    "to exactly one scalar"
+                )
+                continue
+            actual.add(values[0])
 
         missing = EXPECTED_FLATPAK_FINISH_ARGS - actual
         unexpected = actual - EXPECTED_FLATPAK_FINISH_ARGS

--- a/scripts/check_linux_runner.py
+++ b/scripts/check_linux_runner.py
@@ -382,16 +382,26 @@ def flatpak_permission_problems(root: Path) -> list[str]:
     manifests = (FLATPAK_TEMPLATE, FLATPAK_DIR / f"{app_id}.yml")
 
     for manifest in manifests:
-        text = _read(root, manifest)
-        match = re.search(r"(?m)^finish-args:\s*\n((?:[ \t]+.*\n)*)", text)
-        actual = (
-            {
-                item.group(1)
-                for item in re.finditer(r"(?m)^\s+-\s+(--\S+)\s*$", match.group(1))
-            }
-            if match is not None
-            else set()
-        )
+        actual: set[str] = set()
+        in_finish_args = False
+        for line in _read(root, manifest).splitlines():
+            if not in_finish_args:
+                in_finish_args = (
+                    re.fullmatch(r"finish-args\s*:\s*(?:#.*)?", line) is not None
+                )
+                continue
+
+            # Blank lines and comments are harmless within a YAML block. The
+            # next unindented mapping key ends finish-args.
+            if not line.strip() or line.lstrip().startswith("#"):
+                continue
+            if not line[0].isspace():
+                break
+
+            item = re.fullmatch(r"\s+-\s+(--[^\s#]+)(?:\s+#.*)?\s*", line)
+            if item is not None:
+                actual.add(item.group(1))
+
         missing = EXPECTED_FLATPAK_FINISH_ARGS - actual
         unexpected = actual - EXPECTED_FLATPAK_FINISH_ARGS
         if missing:

--- a/scripts/check_linux_runner.py
+++ b/scripts/check_linux_runner.py
@@ -96,6 +96,19 @@ PACKAGING_DIR = Path("linux") / "packaging"
 FLATPAK_DIR = Path("flatpak")
 FLATPAK_TEMPLATE = FLATPAK_DIR / "flatpak-flutter.yml"
 
+# The complete sandbox surface approved for the current Flatpak. Keeping an
+# exact allow-list (rather than checking only for --share=network) makes this a
+# regression guard against solving provider access with a filesystem or D-Bus
+# grant. Both the authoritative template and generated manifest are checked.
+EXPECTED_FLATPAK_FINISH_ARGS = {
+    "--socket=wayland",
+    "--socket=fallback-x11",
+    "--share=ipc",
+    "--device=dri",
+    "--socket=pulseaudio",
+    "--share=network",
+}
+
 # Where a Flatpak's desktop entry has to land: flatpak-builder exports what it
 # finds in this directory at `finish` time and nothing from anywhere else.
 DESKTOP_ENTRY_INSTALL_DIR = "/app/share/applications"
@@ -362,6 +375,37 @@ def desktop_entry_install_problems(root: Path) -> list[str]:
     return problems
 
 
+def flatpak_permission_problems(root: Path) -> list[str]:
+    """Missing, unexpected, or unsynchronised Flatpak finish arguments."""
+    problems: list[str] = []
+    app_id = android_application_id(root)
+    manifests = (FLATPAK_TEMPLATE, FLATPAK_DIR / f"{app_id}.yml")
+
+    for manifest in manifests:
+        text = _read(root, manifest)
+        match = re.search(r"(?m)^finish-args:\s*\n((?:[ \t]+.*\n)*)", text)
+        actual = (
+            {
+                item.group(1)
+                for item in re.finditer(r"(?m)^\s+-\s+(--\S+)\s*$", match.group(1))
+            }
+            if match is not None
+            else set()
+        )
+        missing = EXPECTED_FLATPAK_FINISH_ARGS - actual
+        unexpected = actual - EXPECTED_FLATPAK_FINISH_ARGS
+        if missing:
+            problems.append(
+                f"{manifest} finish-args missing {', '.join(sorted(missing))}"
+            )
+        if unexpected:
+            problems.append(
+                f"{manifest} finish-args contain unrelated permission(s): "
+                f"{', '.join(sorted(unexpected))}"
+            )
+    return problems
+
+
 def icon_install_problems(root: Path) -> list[str]:
     """Disagreements between the desktop entry's `Icon=` and the installed icon.
 
@@ -560,6 +604,7 @@ def check(root: Path) -> list[str]:
     # runner that drifts is reported once rather than twice.
     problems.extend(desktop_entry_problems(root))
     problems.extend(desktop_entry_install_problems(root))
+    problems.extend(flatpak_permission_problems(root))
 
     # The application icon (#436): `Icon=` above is only a name, so this is
     # what connects it to a file the built Flatpak actually contains.

--- a/test/tooling/check_linux_runner_quoted_permissions_test.py
+++ b/test/tooling/check_linux_runner_quoted_permissions_test.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Regression tests for quoted Flatpak finish-args in the Linux checker."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import check_linux_runner as checker  # noqa: E402
+
+
+APP_ID = "io.example.app"
+
+
+def _manifest(*, extra: str | None = None, quoted_network: bool = False) -> str:
+    lines = ["app-id: io.example.app", "finish-args:"]
+    for permission in sorted(checker.EXPECTED_FLATPAK_FINISH_ARGS):
+        if permission == "--share=network" and quoted_network:
+            lines.append('  - "--share=network" # configured providers')
+        else:
+            lines.append(f"  - {permission}")
+    if extra is not None:
+        lines.append(f"  - {extra}")
+    lines.extend(("modules:", "  []", ""))
+    return "\n".join(lines)
+
+
+def _root_with_manifests(template: str, generated: str) -> tempfile.TemporaryDirectory:
+    temporary = tempfile.TemporaryDirectory()
+    root = Path(temporary.name)
+    (root / "android" / "app").mkdir(parents=True)
+    (root / "flatpak").mkdir(parents=True)
+    (root / "android" / "app" / "build.gradle").write_text(
+        f'android {{\n  defaultConfig {{\n    applicationId = "{APP_ID}"\n  }}\n}}\n',
+        encoding="utf-8",
+    )
+    (root / "flatpak" / "flatpak-flutter.yml").write_text(
+        template, encoding="utf-8"
+    )
+    (root / "flatpak" / f"{APP_ID}.yml").write_text(generated, encoding="utf-8")
+    temporary.root = root  # type: ignore[attr-defined]
+    return temporary
+
+
+class QuotedFlatpakPermissionTest(unittest.TestCase):
+    def test_double_quoted_filesystem_permission_is_caught(self) -> None:
+        normal = _manifest()
+        temporary = _root_with_manifests(
+            normal,
+            _manifest(extra='"--filesystem=host"'),
+        )
+        self.addCleanup(temporary.cleanup)
+
+        problems = checker.flatpak_permission_problems(temporary.root)  # type: ignore[attr-defined]
+
+        self.assertEqual(len(problems), 1)
+        self.assertIn("--filesystem=host", problems[0])
+        self.assertIn(f"flatpak/{APP_ID}.yml", problems[0])
+
+    def test_single_quoted_dbus_permission_with_comment_is_caught(self) -> None:
+        normal = _manifest()
+        temporary = _root_with_manifests(
+            normal,
+            _manifest(extra="'--talk-name=org.example.Service' # comment"),
+        )
+        self.addCleanup(temporary.cleanup)
+
+        problems = checker.flatpak_permission_problems(temporary.root)  # type: ignore[attr-defined]
+
+        self.assertEqual(len(problems), 1)
+        self.assertIn("--talk-name=org.example.Service", problems[0])
+
+    def test_allowed_quoted_permission_with_comment_is_recognised(self) -> None:
+        quoted = _manifest(quoted_network=True)
+        temporary = _root_with_manifests(quoted, quoted)
+        self.addCleanup(temporary.cleanup)
+
+        self.assertEqual(
+            checker.flatpak_permission_problems(temporary.root),  # type: ignore[attr-defined]
+            [],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/tooling/check_linux_runner_quoted_permissions_test.py
+++ b/test/tooling/check_linux_runner_quoted_permissions_test.py
@@ -30,7 +30,10 @@ def _manifest(*, extra: str | None = None, quoted_network: bool = False) -> str:
     return "\n".join(lines)
 
 
-def _root_with_manifests(template: str, generated: str) -> tempfile.TemporaryDirectory:
+def _root_with_manifests(
+    template: str,
+    generated: str,
+) -> tuple[tempfile.TemporaryDirectory, Path]:
     temporary = tempfile.TemporaryDirectory()
     root = Path(temporary.name)
     (root / "android" / "app").mkdir(parents=True)
@@ -40,23 +43,26 @@ def _root_with_manifests(template: str, generated: str) -> tempfile.TemporaryDir
         encoding="utf-8",
     )
     (root / "flatpak" / "flatpak-flutter.yml").write_text(
-        template, encoding="utf-8"
+        template,
+        encoding="utf-8",
     )
-    (root / "flatpak" / f"{APP_ID}.yml").write_text(generated, encoding="utf-8")
-    temporary.root = root  # type: ignore[attr-defined]
-    return temporary
+    (root / "flatpak" / f"{APP_ID}.yml").write_text(
+        generated,
+        encoding="utf-8",
+    )
+    return temporary, root
 
 
 class QuotedFlatpakPermissionTest(unittest.TestCase):
     def test_double_quoted_filesystem_permission_is_caught(self) -> None:
         normal = _manifest()
-        temporary = _root_with_manifests(
+        temporary, root = _root_with_manifests(
             normal,
             _manifest(extra='"--filesystem=host"'),
         )
         self.addCleanup(temporary.cleanup)
 
-        problems = checker.flatpak_permission_problems(temporary.root)  # type: ignore[attr-defined]
+        problems = checker.flatpak_permission_problems(root)
 
         self.assertEqual(len(problems), 1)
         self.assertIn("--filesystem=host", problems[0])
@@ -64,26 +70,23 @@ class QuotedFlatpakPermissionTest(unittest.TestCase):
 
     def test_single_quoted_dbus_permission_with_comment_is_caught(self) -> None:
         normal = _manifest()
-        temporary = _root_with_manifests(
+        temporary, root = _root_with_manifests(
             normal,
             _manifest(extra="'--talk-name=org.example.Service' # comment"),
         )
         self.addCleanup(temporary.cleanup)
 
-        problems = checker.flatpak_permission_problems(temporary.root)  # type: ignore[attr-defined]
+        problems = checker.flatpak_permission_problems(root)
 
         self.assertEqual(len(problems), 1)
         self.assertIn("--talk-name=org.example.Service", problems[0])
 
     def test_allowed_quoted_permission_with_comment_is_recognised(self) -> None:
         quoted = _manifest(quoted_network=True)
-        temporary = _root_with_manifests(quoted, quoted)
+        temporary, root = _root_with_manifests(quoted, quoted)
         self.addCleanup(temporary.cleanup)
 
-        self.assertEqual(
-            checker.flatpak_permission_problems(temporary.root),  # type: ignore[attr-defined]
-            [],
-        )
+        self.assertEqual(checker.flatpak_permission_problems(root), [])
 
 
 if __name__ == "__main__":

--- a/test/tooling/check_linux_runner_test.py
+++ b/test/tooling/check_linux_runner_test.py
@@ -545,10 +545,10 @@ class FlatpakPermissionTest(CheckoutCase):
         self.assertIn(f"flatpak/{APP_ID}.yml", problems[0])
         self.assertIn("--share=network", problems[0])
 
-    def test_unrelated_filesystem_permission_is_caught(self) -> None:
+    def test_unrelated_commented_filesystem_permission_is_caught(self) -> None:
         manifest = FLATPAK_MANIFEST.format(app_id=APP_ID, binary=BINARY).replace(
             "  - --share=network\n",
-            "  - --share=network\n  - --filesystem=host\n",
+            "  - --share=network\n  - --filesystem=host # comment\n",
         )
         build_checkout(self.root, flatpak_manifest=manifest)
         problems = checker.check(self.root)
@@ -556,15 +556,23 @@ class FlatpakPermissionTest(CheckoutCase):
         self.assertIn("unrelated permission", problems[0])
         self.assertIn("--filesystem=host", problems[0])
 
-    def test_unrelated_dbus_permission_is_caught(self) -> None:
+    def test_unrelated_commented_dbus_permission_is_caught(self) -> None:
         manifest = FLATPAK_MANIFEST.format(app_id=APP_ID, binary=BINARY).replace(
             "  - --share=network\n",
-            "  - --share=network\n  - --talk-name=org.example.Service\n",
+            "  - --share=network\n  - --talk-name=org.example.Service # comment\n",
         )
         build_checkout(self.root, flatpak_manifest=manifest)
         problems = checker.check(self.root)
         self.assertEqual(len(problems), 1)
         self.assertIn("--talk-name=org.example.Service", problems[0])
+
+    def test_allowed_permission_with_inline_comment_is_recognised(self) -> None:
+        manifest = FLATPAK_MANIFEST.format(app_id=APP_ID, binary=BINARY).replace(
+            "  - --share=network\n",
+            "  - --share=network # configured providers\n",
+        )
+        build_checkout(self.root, flatpak_manifest=manifest)
+        self.assertEqual(checker.check(self.root), [])
 
 
 class IconInstallTest(CheckoutCase):

--- a/test/tooling/check_linux_runner_test.py
+++ b/test/tooling/check_linux_runner_test.py
@@ -182,6 +182,13 @@ ICON_SVG = """\
 FLATPAK_MANIFEST = """\
 app-id: {app_id}
 command: {binary}
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+  - --socket=pulseaudio
+  - --share=network
 modules:
   - name: {binary}
     buildsystem: simple
@@ -273,7 +280,10 @@ def build_checkout(
         encoding="utf-8",
     )
     (
-        directory / "lib" / "core" / "services"
+        directory
+        / "lib"
+        / "core"
+        / "services"
         / "method_channel_linux_folder_picker.dart"
     ).write_text(
         folder_picker_dart
@@ -522,6 +532,41 @@ class DesktopEntryInstallTest(CheckoutCase):
         self.assertIn("no desktop entry to export", problems[0])
 
 
+class FlatpakPermissionTest(CheckoutCase):
+    def test_generated_manifest_without_network_is_caught(self) -> None:
+        build_checkout(
+            self.root,
+            flatpak_manifest=FLATPAK_MANIFEST.format(
+                app_id=APP_ID, binary=BINARY
+            ).replace("  - --share=network\n", ""),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn(f"flatpak/{APP_ID}.yml", problems[0])
+        self.assertIn("--share=network", problems[0])
+
+    def test_unrelated_filesystem_permission_is_caught(self) -> None:
+        manifest = FLATPAK_MANIFEST.format(app_id=APP_ID, binary=BINARY).replace(
+            "  - --share=network\n",
+            "  - --share=network\n  - --filesystem=host\n",
+        )
+        build_checkout(self.root, flatpak_manifest=manifest)
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("unrelated permission", problems[0])
+        self.assertIn("--filesystem=host", problems[0])
+
+    def test_unrelated_dbus_permission_is_caught(self) -> None:
+        manifest = FLATPAK_MANIFEST.format(app_id=APP_ID, binary=BINARY).replace(
+            "  - --share=network\n",
+            "  - --share=network\n  - --talk-name=org.example.Service\n",
+        )
+        build_checkout(self.root, flatpak_manifest=manifest)
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("--talk-name=org.example.Service", problems[0])
+
+
 class IconInstallTest(CheckoutCase):
     """The desktop entry's `Icon=` and the installed icon file, held together.
 
@@ -763,9 +808,7 @@ class FolderPickerChannelTest(CheckoutCase):
         # Compiled but never wired to the engine is the same silence.
         build_checkout(
             self.root,
-            my_application=MY_APPLICATION.format(
-                display_name=DISPLAY_NAME
-            ).replace(
+            my_application=MY_APPLICATION.format(display_name=DISPLAY_NAME).replace(
                 "self->folder_picker = folder_picker_channel_new(view, window);",
                 "// no folder picker here",
             ),
@@ -883,7 +926,6 @@ class MissingFileTest(CheckoutCase):
 
 
 class RealRepositoryTest(unittest.TestCase):
-
     def test_the_committed_linux_runner_is_consistent(self) -> None:
         self.assertEqual(checker.check(ROOT), [])
 
@@ -901,9 +943,7 @@ class RealRepositoryTest(unittest.TestCase):
         # Stated explicitly because it is the whole point of #436: the file
         # the Flatpak installs answers to the name the launcher looks up.
         icon_name = checker.desktop_entry(ROOT)["Icon"]
-        installed = (
-            f"{checker.ICON_INSTALL_DIR}/{icon_name}{checker.ICON_EXTENSION}"
-        )
+        installed = f"{checker.ICON_INSTALL_DIR}/{icon_name}{checker.ICON_EXTENSION}"
         self.assertEqual(
             installed,
             "/app/share/icons/hicolor/scalable/apps/"


### PR DESCRIPTION
### Motivation

- Users cannot reach self-hosted Jellyfin, Navidrome/Subsonic and Plex servers from the Flatpak because the sandbox disallows networking by default (#440).
- The goal is to enable normal HTTP(S)/LAN networking for user-configured endpoints while adding no unrelated capability or filesystem/DBus grants.
- Keep all existing recoverable provider reachability/error semantics and avoid changing provider discovery behavior.

### Description

- Added the minimal Flatpak finish-arg `--share=network` to the authoritative manifest `flatpak/flatpak-flutter.yml` and regenerated the built manifest `flatpak/io.github.thezupzup.linthra.yml` so the packaged Flatpak exposes normal network sockets to the app.
- Extended `scripts/check_linux_runner.py` with an allow-list (`EXPECTED_FLATPAK_FINISH_ARGS`) and a `flatpak_permission_problems` check that validates both the hand-authored template and the generated manifest for the expected finish-args and rejects unrelated permissions like `--filesystem=host` or extra `--talk-name` DBus grants.
- Added focused tests in `test/tooling/check_linux_runner_test.py` to assert missing `--share=network`, and to detect accidental filesystem or D-Bus finish-args being introduced into a manifest.
- Updated `flatpak/README.md` and `docs/flatpak-development.md` to explain why `--share=network` is needed, the exact security boundary it provides, manual LAN/hostname/HTTPS/tunnel validation steps, and how to verify installed Flatpak permissions.

### Testing

- Regenerated pinned Flatpak outputs with `./scripts/regenerate_flatpak_sources.sh` and confirmed the generated manifest was updated successfully and stable across a second regen.
- Ran the packaging checker tests with `python3 test/tooling/check_linux_runner_test.py` which passed (all added Flatpak permission tests succeeded) and ran `python3 scripts/check_linux_runner.py` which reported no unexpected issues on the repository state.
- Ran repository tooling and linters: `ruff check`/`ruff format` passed and Python unit test suite runs completed (`python3 -m unittest discover -s test/tooling -p '*_test.py'` passed with skipped tests as expected).
- Environment limitations prevented executing full Flatpak and Flutter smoke runs: `flatpak`, `flatpak-builder`, `flutter` and the Dart SDK were not available here, so end-to-end Flatpak build and live network smoke tests could not be performed in this environment and must be validated manually (docs include manual test steps).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a981530e054832dabee4ec85fa5413b)