### PR TITLE
feat(flatpak): make secure credential storage work in the sandbox (#441)

### DIFF
--- a/docs/flatpak-development.md
+++ b/docs/flatpak-development.md
@@ -22,9 +22,9 @@ Three docs, three jobs:
 > working audio, and installs a desktop entry, Linthra's own icon, and AppStream
 > metainfo so the app appears in the application menu and in software centres.
 > It is not the Flathub submission: normal network access is enabled for
-> configured self-hosted servers, but there is no Secret Service access and no
-> filesystem grant beyond the folders the user picks through
-> the desktop portal.
+> configured self-hosted servers and provider credentials are kept in the
+> desktop keyring through the Secret Service, but there is no filesystem grant
+> beyond the folders the user picks through the desktop portal.
 > See [What the sandbox allows today](#what-the-sandbox-allows-today).
 
 All commands are relative to the repository. Run them from the repository root
@@ -43,7 +43,7 @@ packages for one expecting them to help the other.
 | Build | `flutter build linux --release` | `flatpak run org.flatpak.Builder …` (below) |
 | Run | `./build/linux/x64/release/bundle/linthra` | `flatpak run io.github.thezupzup.linthra` |
 | App data | `~/.local/share/` and `~/.config/` | `~/.var/app/io.github.thezupzup.linthra/` |
-| Credentials | host Secret Service (encrypted) | not granted yet — sessions degrade to "not signed in" |
+| Credentials | host Secret Service (encrypted) | same Secret Service, reached with one D-Bus name grant ([Secure credential storage](#secure-credential-storage)) |
 | Automated checks | `./scripts/verify_linux.sh` | manual today — see [Smoke testing](#smoke-testing) |
 
 A libmpv-related failure in one says nothing about the other: the Flatpak
@@ -294,15 +294,23 @@ The committed manifest grants exactly:
 
 ```
 --socket=wayland  --socket=fallback-x11  --share=ipc  --share=network
---device=dri      --socket=pulseaudio
+--device=dri      --socket=pulseaudio    --talk-name=org.freedesktop.secrets
 ```
 
 `--share=network` is the minimum Flatpak capability for Linthra's existing
 HTTP(S) clients to reach configured Jellyfin, Navidrome/Subsonic, and Plex
-endpoints. It enables ordinary network destinations—including LAN addresses,
-hostnames, valid HTTPS endpoints, and remote/tunnel URLs—but exposes no host
-files and grants no D-Bus API. Discovery (mDNS/SSDP/broadcast) is separate and
-is not enabled by this change.
+endpoints. It enables ordinary network destinations (LAN addresses, hostnames,
+valid HTTPS endpoints, and remote/tunnel URLs) but exposes no host files and
+grants no D-Bus API. Discovery (mDNS/SSDP/broadcast) is separate and is not
+enabled by this change.
+
+`--talk-name=org.freedesktop.secrets` is the whole of the manifest's D-Bus
+surface: permission to talk (not own) to the one session-bus name libsecret
+connects to for the Secret Service, and nothing else. It is what makes saved
+Jellyfin/Navidrome/Plex credentials work inside the sandbox on a host whose
+portal has no Secret implementation. See
+[Secure credential storage](#secure-credential-storage) for the full
+reasoning, what is stored, and how to test it.
 
 The following are **expected**, not bugs, and not worth debugging:
 
@@ -312,9 +320,13 @@ The following are **expected**, not bugs, and not worth debugging:
   the chooser goes through xdg-desktop-portal and the folder comes back through
   the document portal ([#438](https://github.com/TheZupZup/Linthra/issues/438),
   see [`flatpak/README.md`](../flatpak/README.md#local-music-folders)).
-* Saved sessions come back as "not signed in" — no Secret Service access yet
-  ([#441](https://github.com/TheZupZup/Linthra/issues/441)). Linthra treats
-  that as signed-out and keeps running; it never falls back to plaintext.
+* Saved sessions come back signed in
+  ([#441](https://github.com/TheZupZup/Linthra/issues/441)), because
+  credentials go to the platform keyring like they do natively. What is *not*
+  a bug: a locked or missing keyring produces a visible storage error and
+  leaves the providers signed out. Linthra never falls back to plaintext, and
+  it never writes a credential to a file. See
+  [Secure credential storage](#secure-credential-storage).
 * Linthra is in the application menu now
   ([#434](https://github.com/TheZupZup/Linthra/issues/434)) with its own icon
   ([#436](https://github.com/TheZupZup/Linthra/issues/436)) and an AppStream
@@ -344,6 +356,98 @@ flatpak run --unshare=network io.github.thezupzup.linthra
 
 Use this rather than `flatpak override`, whose grants persist and can obscure
 what the manifest actually provides.
+
+## Secure credential storage
+
+Provider credentials go where they go natively: the platform keyring. The
+manifest's one D-Bus grant is what reaches it from inside the sandbox.
+
+```
+--talk-name=org.freedesktop.secrets
+```
+
+`flutter_secure_storage_linux` is a thin libsecret wrapper, and libsecret picks
+its backend at runtime: inside a sandbox it prefers its portal-backed encrypted
+file backend when xdg-desktop-portal answers `org.freedesktop.portal.Secret`
+(the usual GNOME case, no finish-arg needed), and otherwise falls back to the
+Secret Service backend, which connects to the session-bus name above. Granting
+that one name is what makes the fallback path work, and it is the narrowest
+grant that does: talk, not own, to one exact well-known name.
+[`flatpak/README.md`](../flatpak/README.md#secure-credential-storage) has the
+full derivation, the table of what each provider stores, and why no wider D-Bus
+or filesystem permission was added.
+
+Three things are worth knowing while debugging:
+
+* **Nothing is stored in the clear, ever.** One class,
+  `SecureSessionStorage`, is the app's only caller of `flutter_secure_storage`,
+  and it has no fallback: a failed write stores nothing anywhere else, and a
+  failed read is an error rather than a silent "not signed in".
+* **Keyring failures are visible.** Missing, locked and denied are surfaced as
+  recoverable sign-in/storage errors on the provider's settings card. The
+  message never carries a token, a password, or the platform's own error text.
+* **Never print a secret while debugging this.** `secret-tool search` shows
+  attributes, which is all you need; `secret-tool lookup` prints the secret
+  itself, so do not use it here.
+
+### Manual test: save, read, restart, delete
+
+1. Launch, then sign in to Jellyfin, Navidrome/Subsonic and Plex.
+2. Confirm where it landed. On a host using the Secret Service backend (no
+   Secret portal, e.g. a KDE session) the plugin's item is labelled
+   `io.github.thezupzup.linthra/FlutterSecureStorage` with the attribute
+   `account=io.github.thezupzup.linthra.secureStorage`:
+
+   ```bash
+   secret-tool search account io.github.thezupzup.linthra.secureStorage
+   ```
+
+   It shows in Seahorse ("Passwords and Keys") or KWalletManager too. On a host
+   using the portal file backend (the usual GNOME case) `secret-tool search`
+   finds nothing and the item is in the app's own encrypted
+   `~/.var/app/io.github.thezupzup.linthra/data/keyrings/default.keyring`
+   instead. Both are correct; see
+   [`flatpak/README.md`](../flatpak/README.md#secure-credential-storage).
+3. Quit and relaunch (`flatpak run io.github.thezupzup.linthra`). All three
+   providers come back signed in with no re-entry, and a track streams.
+4. Sign out of each. The cards return to signed-out and the keyring item is
+   gone from `secret-tool search` and from Seahorse/KWalletManager.
+5. Nothing in the clear:
+
+   ```bash
+   grep -rIl "your-test-token" ~/.var/app/io.github.thezupzup.linthra/ || \
+     echo "no plaintext credential"
+   ```
+
+   The file backend's `data/keyrings/default.keyring`, on hosts where that is
+   the path in use, is ciphertext and does not match.
+
+### Manual test: locked or unavailable service
+
+1. **Locked.** Lock the keyring on the host and sign in:
+
+   ```bash
+   secret-tool lock --collection='login'   # GNOME/gnome-keyring
+   ```
+
+   KDE: close the wallet in KWalletManager. Expect a visible "Couldn't save
+   your … sign-in on this device. Unlock your keyring and try again.", the app
+   still usable, and no crash. Unlock, retry, and the sign-in completes.
+2. **Unavailable.** Withhold the grant for one launch:
+
+   ```bash
+   flatpak run --no-talk-name=org.freedesktop.secrets io.github.thezupzup.linthra
+   ```
+
+   On a host using the Secret Service backend: saved sessions report a restore
+   error, a new sign-in reports the storage failure, nothing is written
+   anywhere else, and a normal relaunch recovers with credentials intact. On a
+   host whose portal provides the Secret implementation, libsecret uses the
+   portal-backed file backend and this launch behaves normally. That difference
+   between GNOME and KDE-style hosts is expected, not a failure.
+3. **No keyring at all.** In a bare session with no Secret Service and no
+   portal Secret implementation, expect the same recoverable errors as (2),
+   with the app fully usable for local music.
 
 ## Smoke testing
 
@@ -398,6 +502,12 @@ Until #445/#446 land, the manual pass for a packaging change is:
    the same folder still scans. `flatpak document-unexport /path/to/test-music`
    on the host revokes it, after which Linthra says the folder can no longer be
    reached and keeps the library it already indexed instead of emptying it.
-7. `flatpak info --show-permissions io.github.thezupzup.linthra` → shows
-   `shared=network;ipc;` and still only the six finish-args listed above, i.e.
-   you did not widen the sandbox by accident.
+7. Credentials: sign in, restart, and sign out as described in
+   [Secure credential storage](#secure-credential-storage), including one
+   locked-keyring pass. Sessions survive the restart, sign-out clears the
+   keyring item, and a locked keyring produces a visible error rather than a
+   crash or a silent loss.
+8. `flatpak info --show-permissions io.github.thezupzup.linthra` → shows
+   `shared=network;ipc;`, no `filesystems=` line, and a `[Session Bus Policy]`
+   section whose only entry is `org.freedesktop.secrets=talk`, i.e. still just
+   the seven finish-args listed above and no sandbox widened by accident.

--- a/docs/flatpak-development.md
+++ b/docs/flatpak-development.md
@@ -22,9 +22,10 @@ Three docs, three jobs:
 > working audio, and installs a desktop entry, Linthra's own icon, and AppStream
 > metainfo so the app appears in the application menu and in software centres.
 > It is not the Flathub submission: normal network access is enabled for
-> configured self-hosted servers and provider credentials are kept in the
-> desktop keyring through the Secret Service, but there is no filesystem grant
-> beyond the folders the user picks through the desktop portal.
+> configured self-hosted servers, provider credentials go to platform secure
+> storage through the desktop's Secret portal (no permission needed), and there
+> is no filesystem grant beyond the folders the user picks through the desktop
+> portal.
 > See [What the sandbox allows today](#what-the-sandbox-allows-today).
 
 All commands are relative to the repository. Run them from the repository root
@@ -43,7 +44,7 @@ packages for one expecting them to help the other.
 | Build | `flutter build linux --release` | `flatpak run org.flatpak.Builder …` (below) |
 | Run | `./build/linux/x64/release/bundle/linthra` | `flatpak run io.github.thezupzup.linthra` |
 | App data | `~/.local/share/` and `~/.config/` | `~/.var/app/io.github.thezupzup.linthra/` |
-| Credentials | host Secret Service (encrypted) | same Secret Service, reached with one D-Bus name grant ([Secure credential storage](#secure-credential-storage)) |
+| Credentials | host Secret Service (encrypted) | libsecret's portal-keyed encrypted store, no permission ([Secure credential storage](#secure-credential-storage)) |
 | Automated checks | `./scripts/verify_linux.sh` | manual today — see [Smoke testing](#smoke-testing) |
 
 A libmpv-related failure in one says nothing about the other: the Flatpak
@@ -294,7 +295,7 @@ The committed manifest grants exactly:
 
 ```
 --socket=wayland  --socket=fallback-x11  --share=ipc  --share=network
---device=dri      --socket=pulseaudio    --talk-name=org.freedesktop.secrets
+--device=dri      --socket=pulseaudio
 ```
 
 `--share=network` is the minimum Flatpak capability for Linthra's existing
@@ -304,13 +305,11 @@ valid HTTPS endpoints, and remote/tunnel URLs) but exposes no host files and
 grants no D-Bus API. Discovery (mDNS/SSDP/broadcast) is separate and is not
 enabled by this change.
 
-`--talk-name=org.freedesktop.secrets` is the whole of the manifest's D-Bus
-surface: permission to talk (not own) to the one session-bus name libsecret
-connects to for the Secret Service, and nothing else. It is what makes saved
-Jellyfin/Navidrome/Plex credentials work inside the sandbox on a host whose
-portal has no Secret implementation. See
-[Secure credential storage](#secure-credential-storage) for the full
-reasoning, what is stored, and how to test it.
+There is **no D-Bus permission at all**, credential storage included: secure
+storage reaches the platform keyring through the xdg-desktop-portal Secret
+portal, which every Flatpak may use without a finish-arg. See
+[Secure credential storage](#secure-credential-storage) for why, what is
+stored, and how to test it.
 
 The following are **expected**, not bugs, and not worth debugging:
 
@@ -321,11 +320,13 @@ The following are **expected**, not bugs, and not worth debugging:
   the document portal ([#438](https://github.com/TheZupZup/Linthra/issues/438),
   see [`flatpak/README.md`](../flatpak/README.md#local-music-folders)).
 * Saved sessions come back signed in
-  ([#441](https://github.com/TheZupZup/Linthra/issues/441)), because
-  credentials go to the platform keyring like they do natively. What is *not*
-  a bug: a locked or missing keyring produces a visible storage error and
-  leaves the providers signed out. Linthra never falls back to plaintext, and
-  it never writes a credential to a file. See
+  ([#441](https://github.com/TheZupZup/Linthra/issues/441)), through the
+  Secret portal rather than a D-Bus grant. Two things that are *not* bugs:
+  `secret-tool` on the host does not list Linthra's item (on the portal path
+  it lives in libsecret's own encrypted file, not the host keyring's
+  collection), and a locked or unavailable keyring produces a visible storage
+  error with the providers signed out. Linthra itself never falls back to a
+  file or to plaintext. See
   [Secure credential storage](#secure-credential-storage).
 * Linthra is in the application menu now
   ([#434](https://github.com/TheZupZup/Linthra/issues/434)) with its own icon
@@ -359,31 +360,35 @@ what the manifest actually provides.
 
 ## Secure credential storage
 
-Provider credentials go where they go natively: the platform keyring. The
-manifest's one D-Bus grant is what reaches it from inside the sandbox.
-
-```
---talk-name=org.freedesktop.secrets
-```
+Provider credentials go to platform secure storage, and the sandbox needs **no
+finish-arg** for it.
 
 `flutter_secure_storage_linux` is a thin libsecret wrapper, and libsecret picks
-its backend at runtime: inside a sandbox it prefers its portal-backed encrypted
-file backend when xdg-desktop-portal answers `org.freedesktop.portal.Secret`
-(the usual GNOME case, no finish-arg needed), and otherwise falls back to the
-Secret Service backend, which connects to the session-bus name above. Granting
-that one name is what makes the fallback path work, and it is the narrowest
-grant that does: talk, not own, to one exact well-known name.
+its backend at runtime: inside a sandbox it uses its own encrypted file
+backend, keyed by a master secret from xdg-desktop-portal's
+`org.freedesktop.portal.Secret`, whenever the desktop provides that portal.
+GNOME does (gnome-keyring) and KDE Plasma 6 does (KWallet's `ksecretd`), so on
+both the credential path is a portal every Flatpak may use, and
+`--talk-name=org.freedesktop.secrets` is not shipped.
 [`flatpak/README.md`](../flatpak/README.md#secure-credential-storage) has the
-full derivation, the table of what each provider stores, and why no wider D-Bus
-or filesystem permission was added.
+full derivation, the source references, the table of what each provider
+stores, and the user-side override for hosts with no Secret portal backend.
 
-Three things are worth knowing while debugging:
+Four things worth knowing while debugging:
 
-* **Nothing is stored in the clear, ever.** One class,
-  `SecureSessionStorage`, is the app's only caller of `flutter_secure_storage`,
-  and it has no fallback: a failed write stores nothing anywhere else, and a
-  failed read is an error rather than a silent "not signed in".
-* **Keyring failures are visible.** Missing, locked and denied are surfaced as
+* **Where the bytes are.** On the portal path they are in libsecret's
+  gcrypt-encrypted
+  `~/.var/app/io.github.thezupzup.linthra/data/keyrings/default.keyring`, not
+  in the host keyring's own collection, so `secret-tool` on the host will not
+  list them. That file is ciphertext libsecret writes and reads; Linthra never
+  opens it.
+* **Linthra has no fallback.** `SecureSessionStorage` is the single wrapper the
+  Jellyfin, Navidrome/Subsonic and Plex session stores use, and it has no
+  alternative path: a failed write stores nothing in preferences, SQLite, the
+  cache or any file, and a failed read is an error rather than a silent "not
+  signed in". (The GitHub Sponsors token store calls `flutter_secure_storage`
+  directly; it holds no provider credential and is outside #441.)
+* **Storage failures are visible.** Missing, locked and denied surface as
   recoverable sign-in/storage errors on the provider's settings card. The
   message never carries a token, a password, or the platform's own error text.
 * **Never print a secret while debugging this.** `secret-tool search` shows
@@ -393,61 +398,61 @@ Three things are worth knowing while debugging:
 ### Manual test: save, read, restart, delete
 
 1. Launch, then sign in to Jellyfin, Navidrome/Subsonic and Plex.
-2. Confirm where it landed. On a host using the Secret Service backend (no
-   Secret portal, e.g. a KDE session) the plugin's item is labelled
-   `io.github.thezupzup.linthra/FlutterSecureStorage` with the attribute
-   `account=io.github.thezupzup.linthra.secureStorage`:
+2. Confirm where it landed. On a GNOME or Plasma 6 host (Secret portal
+   present):
+
+   ```bash
+   ls -l ~/.var/app/io.github.thezupzup.linthra/data/keyrings/
+   ```
+
+   `default.keyring` exists and is ciphertext. On a host using the Secret
+   Service backend instead, the item shows up in the host keyring:
 
    ```bash
    secret-tool search account io.github.thezupzup.linthra.secureStorage
    ```
 
-   It shows in Seahorse ("Passwords and Keys") or KWalletManager too. On a host
-   using the portal file backend (the usual GNOME case) `secret-tool search`
-   finds nothing and the item is in the app's own encrypted
-   `~/.var/app/io.github.thezupzup.linthra/data/keyrings/default.keyring`
-   instead. Both are correct; see
-   [`flatpak/README.md`](../flatpak/README.md#secure-credential-storage).
+   Either result is correct; which one you get tells you which backend
+   libsecret chose.
 3. Quit and relaunch (`flatpak run io.github.thezupzup.linthra`). All three
    providers come back signed in with no re-entry, and a track streams.
-4. Sign out of each. The cards return to signed-out and the keyring item is
-   gone from `secret-tool search` and from Seahorse/KWalletManager.
-5. Nothing in the clear:
+4. Sign out of each. The cards return to signed-out and the stored entry is
+   gone.
+5. Nothing readable anywhere in app data:
 
    ```bash
    grep -rIl "your-test-token" ~/.var/app/io.github.thezupzup.linthra/ || \
-     echo "no plaintext credential"
+     echo "no readable credential anywhere in app data"
    ```
 
-   The file backend's `data/keyrings/default.keyring`, on hosts where that is
-   the path in use, is ciphertext and does not match.
+### Manual test: locked or unavailable secure storage
 
-### Manual test: locked or unavailable service
-
-1. **Locked.** Lock the keyring on the host and sign in:
+1. **Locked.** Lock the host keyring and sign in:
 
    ```bash
    secret-tool lock --collection='login'   # GNOME/gnome-keyring
    ```
 
-   KDE: close the wallet in KWalletManager. Expect a visible "Couldn't save
+   KDE: close the wallet in KWalletManager. The portal cannot hand over the
+   master secret against a locked keyring, so expect a visible "Couldn't save
    your … sign-in on this device. Unlock your keyring and try again.", the app
    still usable, and no crash. Unlock, retry, and the sign-in completes.
-2. **Unavailable.** Withhold the grant for one launch:
+2. **Unavailable.** Use a session with neither a Secret portal backend nor a
+   reachable Secret Service (a bare window manager with no keyring daemon).
+   Saved sessions report a restore error, a new sign-in reports the storage
+   failure, nothing is written anywhere else, local music keeps working, and
+   returning to a normal session recovers with credentials intact.
+3. **The Secret Service fallback**, if you want to exercise it on such a host:
+   grant the name for your own install only, then sign in again.
 
    ```bash
-   flatpak run --no-talk-name=org.freedesktop.secrets io.github.thezupzup.linthra
+   flatpak override --user --talk-name=org.freedesktop.secrets \
+     io.github.thezupzup.linthra
+   flatpak override --user --reset io.github.thezupzup.linthra   # undo
    ```
 
-   On a host using the Secret Service backend: saved sessions report a restore
-   error, a new sign-in reports the storage failure, nothing is written
-   anywhere else, and a normal relaunch recovers with credentials intact. On a
-   host whose portal provides the Secret implementation, libsecret uses the
-   portal-backed file backend and this launch behaves normally. That difference
-   between GNOME and KDE-style hosts is expected, not a failure.
-3. **No keyring at all.** In a bare session with no Secret Service and no
-   portal Secret implementation, expect the same recoverable errors as (2),
-   with the app fully usable for local music.
+   This is a user-side choice, not something the manifest ships, so remember to
+   reset it before testing anything else about the packaged permissions.
 
 ## Smoke testing
 
@@ -508,6 +513,8 @@ Until #445/#446 land, the manual pass for a packaging change is:
    keyring item, and a locked keyring produces a visible error rather than a
    crash or a silent loss.
 8. `flatpak info --show-permissions io.github.thezupzup.linthra` → shows
-   `shared=network;ipc;`, no `filesystems=` line, and a `[Session Bus Policy]`
-   section whose only entry is `org.freedesktop.secrets=talk`, i.e. still just
-   the seven finish-args listed above and no sandbox widened by accident.
+   `shared=network;ipc;`, no `filesystems=` line and no `[Session Bus Policy]`
+   section, i.e. still just the six finish-args listed above and no sandbox
+   widened by accident. `flatpak override --user --show` should be empty too:
+   a leftover Secret Service override from the fallback test would mask what
+   the manifest actually provides.

--- a/docs/flatpak-development.md
+++ b/docs/flatpak-development.md
@@ -430,9 +430,14 @@ Four things worth knowing while debugging:
 1. **Locked.** Lock the host keyring and sign in:
 
    ```bash
-   secret-tool lock --collection='login'   # GNOME/gnome-keyring
+   # GNOME/gnome-keyring, libsecret 0.20.5+. Locks the default collection;
+   # a bare `secret-tool lock` locks every collection instead.
+   secret-tool lock --collection=default
    ```
 
+   `--collection` takes a full D-Bus path or the literal `default` alias, not
+   a wallet name like `login` (libsecret's `get_collection_path()` rejects
+   that). Seahorse does the same thing: right-click the login keyring, *Lock*.
    KDE: close the wallet in KWalletManager. The portal cannot hand over the
    master secret against a locked keyring, so expect a visible "Couldn't save
    your … sign-in on this device. Unlock your keyring and try again.", the app

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -149,15 +149,34 @@ place your other desktop apps keep credentials — instead of Android's Keystore
 Jellyfin, Subsonic/Navidrome and Plex sessions are encrypted at rest on Linux
 exactly as they are on Android.
 
-Two runtime facts worth knowing:
+What is stored: one entry per provider (`jellyfin_session_v1`,
+`subsonic_session_v1`, `plex_session_v1`), each the JSON of a session object.
+Passwords are never among them: Jellyfin exchanges one for an access token,
+Subsonic derives a salt+token pair and discards it, Plex is token-based from
+the start.
+
+Three runtime facts worth knowing:
 
 * A Secret Service provider must be running and **unlocked**. On a normal
-  desktop session the login keyring is unlocked at login and nothing is asked of
-  you. On a bare window manager with no keyring daemon, reads and writes fail —
-  Linthra treats that as "not signed in" and keeps running. It never writes
-  credentials anywhere else.
+  desktop session the login keyring is unlocked at login and nothing is asked
+  of you. On a bare window manager with no keyring daemon, or with the keyring
+  locked, reads and writes fail.
+* A failure is reported, not swallowed. All three stores go through one class,
+  `SecureSessionStorage` (`lib/data/repositories/secure_session_storage.dart`),
+  which turns a platform failure into a typed `SecureStorageException`
+  (unavailable, locked, denied, unknown) carrying nothing from the platform
+  error, so a token cannot reach a log or a diagnostics report through it. The
+  provider settings cards turn that into a recoverable message ("Couldn't save
+  your Jellyfin sign-in on this device. Unlock your keyring and try again."),
+  the app stays usable, and a session that could not be saved is not adopted:
+  it would look signed in until the next launch and then be gone.
 * Credential storage was not weakened to make Linux work, and there is no
-  plaintext fallback on any platform.
+  plaintext fallback on any platform. A failed write stores nothing in
+  preferences, the database, the cache, or a file.
+
+The Flatpak reaches the same Secret Service with a single D-Bus grant,
+`--talk-name=org.freedesktop.secrets`; see
+[flatpak-development.md](./flatpak-development.md#secure-credential-storage).
 
 ## Audio playback
 
@@ -365,8 +384,9 @@ launches with working audio, and installs the desktop entry
 native package rather than Flatpak-only) together with Linthra's scalable icon
 under `share/icons/hicolor/scalable/apps/io.github.thezupzup.linthra.svg` and
 AppStream metainfo under
-`linux/packaging/io.github.thezupzup.linthra.metainfo.xml`;
-the network/filesystem/Secret Service permissions are still open sub-issues.
+`linux/packaging/io.github.thezupzup.linthra.metainfo.xml`; networking and
+Secret Service access are granted with one narrow permission each, and the
+remaining filesystem-permission audit is still an open sub-issue.
 None of it changes the native build on this page.
 
 Decisions already taken with that destination in mind:

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -161,21 +161,27 @@ Three runtime facts worth knowing:
   desktop session the login keyring is unlocked at login and nothing is asked
   of you. On a bare window manager with no keyring daemon, or with the keyring
   locked, reads and writes fail.
-* A failure is reported, not swallowed. All three stores go through one class,
-  `SecureSessionStorage` (`lib/data/repositories/secure_session_storage.dart`),
-  which turns a platform failure into a typed `SecureStorageException`
-  (unavailable, locked, denied, unknown) carrying nothing from the platform
-  error, so a token cannot reach a log or a diagnostics report through it. The
-  provider settings cards turn that into a recoverable message ("Couldn't save
-  your Jellyfin sign-in on this device. Unlock your keyring and try again."),
-  the app stays usable, and a session that could not be saved is not adopted:
-  it would look signed in until the next launch and then be gone.
-* Credential storage was not weakened to make Linux work, and there is no
+* A failure is reported, not swallowed. The three provider stores go through
+  one wrapper, `SecureSessionStorage`
+  (`lib/data/repositories/secure_session_storage.dart`), which turns a platform
+  failure into a typed `SecureStorageException` (unavailable, locked, denied,
+  unknown) carrying nothing from the platform error, so a token cannot reach a
+  log or a diagnostics report through it. The provider settings cards turn that
+  into a recoverable message ("Couldn't save your Jellyfin sign-in on this
+  device. Unlock your keyring and try again."), the app stays usable, and a
+  session that could not be saved is not adopted: it would look signed in until
+  the next launch and then be gone.
+* Credential storage was not weakened to make Linux work, and Linthra has no
   plaintext fallback on any platform. A failed write stores nothing in
-  preferences, the database, the cache, or a file.
+  preferences, the database, the cache, or any file Linthra writes.
 
-The Flatpak reaches the same Secret Service with a single D-Bus grant,
-`--talk-name=org.freedesktop.secrets`; see
+In the **Flatpak** the same plugin reaches secure storage differently, and
+without any D-Bus permission: libsecret detects the sandbox and, when the
+desktop provides the xdg-desktop-portal Secret portal (GNOME via gnome-keyring,
+KDE Plasma 6 via KWallet's `ksecretd`), keeps its own gcrypt-encrypted store
+under the app's data directory with the master secret handed over by that
+portal. Encrypted at rest either way, and libsecret's storage in both cases,
+just not the shared keyring collection this page's native build uses. See
 [flatpak-development.md](./flatpak-development.md#secure-credential-storage).
 
 ## Audio playback
@@ -384,9 +390,10 @@ launches with working audio, and installs the desktop entry
 native package rather than Flatpak-only) together with Linthra's scalable icon
 under `share/icons/hicolor/scalable/apps/io.github.thezupzup.linthra.svg` and
 AppStream metainfo under
-`linux/packaging/io.github.thezupzup.linthra.metainfo.xml`; networking and
-Secret Service access are granted with one narrow permission each, and the
-remaining filesystem-permission audit is still an open sub-issue.
+`linux/packaging/io.github.thezupzup.linthra.metainfo.xml`; networking is
+granted with one narrow permission, secure storage needs none (it goes through
+the desktop's Secret portal), and the remaining filesystem-permission audit is
+still an open sub-issue.
 None of it changes the native build on this page.
 
 Decisions already taken with that destination in mind:

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -7,8 +7,8 @@ audible local and remote playback through a fully self-contained audio
 runtime, with Linthra's own icon on the launcher entry and AppStream metainfo
 for a software-centre listing, and let the user point Linthra at a music
 folder through the desktop portal without granting any host filesystem
-access, and keep provider credentials in the desktop keyring through the
-Secret Service. It is deliberately not the Flathub submission:
+access, and keep provider credentials in platform secure storage through the
+desktop's Secret portal. It is deliberately not the Flathub submission:
 some sandbox permissions are still deferred; see "What's deferred" below and
 the comments in `io.github.thezupzup.linthra.yml` itself.
 
@@ -176,13 +176,12 @@ user-configured Jellyfin, Navidrome/Subsonic, or Plex server. It covers ordinary
 IPv4/IPv6 sockets: direct LAN addresses, DNS hostnames, HTTPS, and remote or
 tunnel endpoints all behave as normal network destinations.
 
-This grant does **not** expose arbitrary host files and adds no D-Bus access
-of its own. There is still no `--filesystem=host`, `--filesystem=home`, or
-broad D-Bus grant; the manifest's only D-Bus entry is the single Secret Service
-name covered in [Secure credential storage](#secure-credential-storage), which
-networking neither needs nor affects. It also does not add mDNS, SSDP, or
-broadcast discovery behavior: issue #440 covers endpoints the user configured
-directly; provider discovery remains separate.
+This grant does **not** expose arbitrary host files and adds no D-Bus access.
+There is still no `--filesystem=host`, `--filesystem=home`, or D-Bus
+permission of any kind: credential storage needs none either, see
+[Secure credential storage](#secure-credential-storage). It also does not add
+mDNS, SSDP, or broadcast discovery behavior: issue #440 covers endpoints the
+user configured directly; provider discovery remains separate.
 
 After building and installing the Flatpak, validate a LAN endpoint by entering
 its direct address (for example `http://192.168.1.20:8096`) in the matching
@@ -212,50 +211,71 @@ flatpak override --user --show io.github.thezupzup.linthra
 
 The first command prints the installed metadata: `shared=network;ipc;`
 (alongside the existing windowing, GPU, and audio grants), no `filesystems=`
-line at all, and a `[Session Bus Policy]` section whose only entry is
-`org.freedesktop.secrets=talk`. The second reveals persistent local overrides
-that could invalidate the test.
+line at all, and no `[Session Bus Policy]` section. The second reveals
+persistent local overrides that could invalidate the test.
 
 ## Secure credential storage
 
-The committed manifest grants exactly one D-Bus permission for credentials
-(#441):
+Provider credentials (#441) go to platform secure storage, and the sandbox
+needs **no finish-args at all** for it: the path in is a portal, exactly as it
+is for local music folders.
 
-```
---talk-name=org.freedesktop.secrets
-```
+### Why no permission
 
-**Why that name, and why only that one.** `flutter_secure_storage`'s Linux
-implementation (`flutter_secure_storage_linux` 1.2.3) has no store of its own:
-it calls libsecret's `secret_password_storev_sync` / `secret_password_lookupv_sync`
-and nothing else. libsecret decides at runtime how to satisfy those calls
+`flutter_secure_storage`'s Linux implementation
+(`flutter_secure_storage_linux` 1.2.3) has no store of its own: it calls
+libsecret's `secret_password_storev_sync` / `secret_password_lookupv_sync` and
+nothing else. libsecret chooses its own backend at runtime
 (`secret-backend.c`, `backend_get_impl_type`):
 
-* Inside a sandbox (`/.flatpak-info` present) it first asks
-  xdg-desktop-portal for `org.freedesktop.portal.Secret` version 1. If that
-  answers, libsecret uses its **file backend**: a gcrypt-encrypted file under
-  the app's own data directory whose master key comes from the portal, which in
-  turn gets it from the host's keyring. Every Flatpak may talk to the portal,
-  so that path needs no finish-arg. This is the usual case on GNOME, where
-  gnome-keyring provides the portal implementation.
-* If the portal has no Secret implementation (or reports a different version),
-  libsecret falls back to its **Secret Service backend** and connects to the
-  session-bus name `org.freedesktop.secrets` (`SECRET_SERVICE_BUS_NAME` in
-  libsecret's own headers). A Flatpak's D-Bus proxy hides names the manifest
-  does not grant, so without this line every credential read and write inside
-  the sandbox fails on such a host. KDE/kwallet sessions are the common case.
+* If `/.flatpak-info` exists **and** xdg-desktop-portal answers
+  `org.freedesktop.portal.Secret` version 1, libsecret uses its **file
+  backend**: a gcrypt-encrypted store under the app's own data directory whose
+  master secret is handed over by the portal, which gets it from the host's
+  keyring. Every Flatpak may talk to the portal, so nothing grants this.
+* Otherwise it falls back to the **Secret Service backend** and connects to the
+  session-bus name `org.freedesktop.secrets`, which the sandbox's D-Bus proxy
+  hides unless a manifest grants it.
 
-`--talk-name` is the narrowest grant that covers the second path: permission to
-*talk* (not own) to exactly one well-known name on the session bus. Everything
-wider was rejected deliberately, and `scripts/check_linux_runner.py` fails the
-build if any of it reappears: `--socket=session-bus`, any
-`--talk-name=org.freedesktop.*` or `…secrets.*` wildcard,
-`--own-name=org.freedesktop.secrets`, and the same name on the system bus. No
-filesystem grant was added either; nothing in the credential path opens a file.
+The portal is exported only when the desktop ships a backend implementing
+`org.freedesktop.impl.portal.Secret` (xdg-desktop-portal's
+`desktop-portal/secret.c`, `init_secret`: with no impl configured the
+interface is never exported). Both desktops this package targets ship one:
 
-**What is stored there.** One entry per provider, each the JSON of a session
-object, written by the three secure stores in
-`../lib/data/repositories/`:
+| Desktop | Secret portal backend |
+| --- | --- |
+| GNOME | gnome-keyring (`daemon/dbus/gkd-secret-portal.c`) |
+| KDE Plasma 6 | KWallet's `ksecretd` (`src/runtime/ksecretd/kwalletportalsecrets.cpp`), which installs `org.freedesktop.impl.portal.desktop.kwallet.service` and `kwallet.portal` |
+
+KDE's backend is KF6-only; the KF5 `kwalletd` had none, which is where the
+older "Flatpak apps can't use KWallet" reports come from. And
+`org.gnome.Platform//50` carries libsecret 0.21.7 built with libgcrypt
+(freedesktop-sdk 25.08 `elements/components/libsecret.bst`), so the file
+backend is compiled in and the sandbox detection above is live.
+
+So `--talk-name=org.freedesktop.secrets` is **not** granted. It would be dead
+weight on both supported desktops, and `scripts/check_linux_runner.py` now
+rejects it, along with `--socket=session-bus`, any `org.freedesktop.*` or
+`…secrets.*` wildcard, `--own-name`, and the system-bus forms. The manifest
+has no D-Bus permission of any kind, and no filesystem grant either.
+
+**On a host with no Secret portal backend** (a KF5-era KDE, a bare window
+manager running only a Secret Service daemon), libsecret falls back to the bus
+name, the proxy hides it, and Linthra reports a recoverable storage error and
+stays signed out. It never falls back to storage of its own. A user who wants
+that fallback can grant it for their own install, which is their decision
+rather than a permission on every install:
+
+```bash
+flatpak override --user --talk-name=org.freedesktop.secrets \
+  io.github.thezupzup.linthra
+```
+
+### What is stored, and where
+
+One entry per provider, each the JSON of a session object, written by the three
+secure stores in `../lib/data/repositories/` through the single
+`SecureSessionStorage` wrapper:
 
 | Key | Provider | Contents |
 | --- | --- | --- |
@@ -268,20 +288,45 @@ Subsonic derives a salt+token pair and discards it, Plex is token-based from
 the start. Everything else (library rows, preferences, playback state) stays in
 SQLite and preferences and holds no secret.
 
-**No plaintext fallback.** All three stores go through one class,
-`SecureSessionStorage`, which is the only thing in the app that touches
-`flutter_secure_storage`. It has no alternative path: if the platform store
-cannot take a value, the write fails and nothing is written to preferences, the
-database, the cache, or a file, and a read that fails is an error rather than a
-silent "no session". Failures are translated into a typed
-`SecureStorageException` carrying only an operation and a cause (unavailable,
-locked, denied, unknown), never the platform error text, the key, or the
-value, so a keyring problem cannot leak a token into a log, a diagnostics
-report, or a crash report. Jellyfin, Navidrome/Subsonic and Plex each turn that
-into a visible, recoverable message: "Couldn't save your … sign-in on this
-device. Unlock your keyring and try again." A session that could not be saved
-is not adopted, because it would look signed in until the next launch and then
-be gone.
+Where the bytes land depends on which libsecret backend is in use, and both are
+encrypted at rest:
+
+* **Portal file backend** (the path inside this Flatpak on GNOME and Plasma 6):
+  libsecret's own gcrypt-encrypted
+  `~/.var/app/io.github.thezupzup.linthra/data/keyrings/default.keyring`,
+  unlockable only with the master secret the Secret portal hands over from the
+  host keyring. It is ciphertext written and read by libsecret; Linthra never
+  opens it.
+* **Secret Service backend** (native Linthra, and a sandbox with the name
+  granted by user override): items in the desktop keyring itself, labelled
+  `io.github.thezupzup.linthra/FlutterSecureStorage` with the attribute
+  `account=io.github.thezupzup.linthra.secureStorage`.
+
+### What "no plaintext fallback" means precisely
+
+* **Linthra** has no plaintext or custom file fallback. It writes credentials
+  through `SecureSessionStorage` and nowhere else.
+* Secrets never go to `shared_preferences`, SQLite, the app cache, a log, a
+  diagnostics report, an exception, or any file Linthra writes.
+* **libsecret** may legitimately use its own encrypted, portal-keyed file
+  backend. That is the platform's storage, not a Linthra fallback, and it is
+  ciphertext, not plaintext.
+* When neither libsecret backend can store the value, the write fails and
+  nothing is written anywhere.
+
+`SecureSessionStorage` is the single wrapper the Jellyfin, Navidrome/Subsonic
+and Plex session stores use. (The GitHub Sponsors token store calls
+`flutter_secure_storage` directly; it holds no provider credential and is
+outside #441.) It has no alternative path: a failed write stores nothing, and a
+failed read is an error rather than a silent "no session" that would look like
+a clean sign-out. Failures become a typed `SecureStorageException` carrying
+only an operation and a cause (unavailable, locked, denied, unknown), never the
+platform error text, the key, or the value, so a storage problem cannot leak a
+token into a log or a crash report. Jellyfin, Navidrome/Subsonic and Plex each
+turn that into a visible, recoverable message ("Couldn't save your … sign-in on
+this device. Unlock your keyring and try again."), and a session that could not
+be saved is not adopted, because it would look signed in until the next launch
+and then be gone.
 
 `test/data/repositories/secure_session_storage_test.dart` drives the real
 plugin channel (`plugins.it_nomads.com/flutter_secure_storage`) with the exact
@@ -295,72 +340,49 @@ Save, read after restart, delete:
 
 1. Build, install and launch (above). Sign in to Jellyfin, Navidrome/Subsonic
    and Plex.
-2. Confirm on the host where the credential landed. Which of libsecret's two
-   backends is in use decides what you will see, and both are correct:
+2. Confirm which backend is in play, since that decides where to look. On a
+   GNOME or Plasma 6 host with the Secret portal, expect the encrypted file:
 
-   * **Secret Service backend** (no Secret portal on the host, e.g. a KDE
-     session): the plugin's item is labelled
-     `io.github.thezupzup.linthra/FlutterSecureStorage` with the attribute
-     `account=io.github.thezupzup.linthra.secureStorage`, and shows up in the
-     host keyring:
+   ```bash
+   ls -l ~/.var/app/io.github.thezupzup.linthra/data/keyrings/
+   ```
 
-     ```bash
-     secret-tool search account io.github.thezupzup.linthra.secureStorage
-     ```
-
-     GNOME users see the same item in Seahorse ("Passwords and Keys"), KDE
-     users in KWalletManager.
-   * **Portal file backend** (the usual GNOME case): `secret-tool search` finds
-     nothing, because the item is in the app's own encrypted
-     `~/.var/app/io.github.thezupzup.linthra/data/keyrings/default.keyring`,
-     whose key comes from the portal. That file is ciphertext; step 5 checks it
-     holds no readable credential.
-
-   Either way, do not print the secret: `secret-tool search` shows attributes,
-   which is what you are checking, while `secret-tool lookup` would print the
-   value itself.
+   `secret-tool search account io.github.thezupzup.linthra.secureStorage` will
+   find nothing there, which is correct: the item is in that file, not in the
+   host keyring's own collection. On a host using the Secret Service backend
+   the reverse holds, and the item shows in Seahorse or KWalletManager. Do not
+   print the secret: `secret-tool search` shows attributes, which is what you
+   are checking, while `secret-tool lookup` would print the value.
 3. Quit and relaunch: `flatpak run io.github.thezupzup.linthra`. All three
-   providers should come back signed in, without re-entering anything, and a
-   track should stream.
+   providers come back signed in, without re-entering anything, and a track
+   streams.
 4. Sign out of each provider. The card returns to the signed-out state and the
-   keyring entry is gone (`secret-tool search …` no longer lists it, and the
-   entry disappears from Seahorse/KWalletManager).
-5. Check that nothing was written in the clear. There must be no credential in
-   the app's own data:
+   entry is gone (the keyring file no longer holds it; on the Secret Service
+   path it disappears from Seahorse/KWalletManager).
+5. Check nothing readable was written. The keyring file is ciphertext, so a
+   grep for the token must not match it or anything else:
 
    ```bash
    grep -rIl "your-test-token" ~/.var/app/io.github.thezupzup.linthra/ || \
-     echo "no plaintext credential"
+     echo "no readable credential anywhere in app data"
    ```
 
-   (The encrypted file backend's `data/keyrings/default.keyring`, when that
-   path is the one in use, is ciphertext and will not match.)
+Locked or unavailable secure storage:
 
-Locked or unavailable service:
-
-1. **Locked.** Lock the keyring on the host (`gnome-keyring` users:
-   `secret-tool lock --collection='login'`; KDE users: close the wallet in
-   KWalletManager), then launch Linthra and sign in. Expect a visible
-   "Couldn't save your … sign-in on this device. Unlock your keyring and try
-   again.", the app still usable, and no crash. Unlock and retry: the sign-in
-   completes.
-2. **Unavailable.** Launch once with the grant withheld:
-
-   ```bash
-   flatpak run --no-talk-name=org.freedesktop.secrets io.github.thezupzup.linthra
-   ```
-
-   On a host that was using the Secret Service backend, saved sessions come
-   back as a restore error ("Couldn't restore your saved … sign-in from this
-   device."), signing in reports the storage failure, and nothing is written
-   anywhere else. A normal `flatpak run` afterwards recovers with the
-   credentials intact. On a host whose portal provides the Secret
-   implementation, libsecret uses the portal-backed file backend and this
-   launch behaves normally, which is the expected difference between the two
-   paths, not a failed test.
-
-Use one-shot `flatpak run` flags rather than `flatpak override`: overrides
-persist and then hide what the manifest actually grants.
+1. **Locked.** Lock the host keyring (`secret-tool lock --collection='login'`
+   on gnome-keyring; close the wallet in KWalletManager on KDE), then launch
+   and sign in. The portal's `RetrieveSecret` cannot complete against a locked
+   keyring, so expect a visible "Couldn't save your … sign-in on this device.
+   Unlock your keyring and try again.", the app still usable, and no crash.
+   Unlock, retry, and the sign-in completes.
+2. **Unavailable.** Use a session with neither a Secret portal backend nor a
+   reachable Secret Service (a bare window manager with no keyring daemon is
+   the easy case). Saved sessions report a restore error, signing in reports
+   the storage failure, nothing is written anywhere else, and local music keeps
+   working. Returning to a normal session recovers with credentials intact.
+3. There is no `--no-talk-name` test any more, because nothing is granted to
+   withhold. To exercise the Secret Service fallback deliberately, add the
+   override above on a portal-less host and confirm sign-in then succeeds.
 
 ## Regenerating the pinned sources
 

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -369,12 +369,16 @@ Save, read after restart, delete:
 
 Locked or unavailable secure storage:
 
-1. **Locked.** Lock the host keyring (`secret-tool lock --collection='login'`
-   on gnome-keyring; close the wallet in KWalletManager on KDE), then launch
-   and sign in. The portal's `RetrieveSecret` cannot complete against a locked
-   keyring, so expect a visible "Couldn't save your … sign-in on this device.
-   Unlock your keyring and try again.", the app still usable, and no crash.
-   Unlock, retry, and the sign-in completes.
+1. **Locked.** Lock the host keyring, then launch and sign in. On
+   gnome-keyring that is `secret-tool lock --collection=default` (libsecret
+   0.20.5+; `--collection` wants a full D-Bus path or the literal `default`
+   alias, not a wallet name, and a bare `secret-tool lock` locks every
+   collection), or right-click the login keyring in Seahorse and choose
+   *Lock*. On KDE, close the wallet in KWalletManager. The portal's
+   `RetrieveSecret` cannot complete against a locked keyring, so expect a
+   visible "Couldn't save your … sign-in on this device. Unlock your keyring
+   and try again.", the app still usable, and no crash. Unlock, retry, and the
+   sign-in completes.
 2. **Unavailable.** Use a session with neither a Secret portal backend nor a
    reachable Secret Service (a bare window manager with no keyring daemon is
    the easy case). Saved sessions report a restore error, signing in reports

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -7,7 +7,8 @@ audible local and remote playback through a fully self-contained audio
 runtime, with Linthra's own icon on the launcher entry and AppStream metainfo
 for a software-centre listing, and let the user point Linthra at a music
 folder through the desktop portal without granting any host filesystem
-access. It is deliberately not the Flathub submission —
+access, and keep provider credentials in the desktop keyring through the
+Secret Service. It is deliberately not the Flathub submission:
 some sandbox permissions are still deferred; see "What's deferred" below and
 the comments in `io.github.thezupzup.linthra.yml` itself.
 
@@ -175,11 +176,13 @@ user-configured Jellyfin, Navidrome/Subsonic, or Plex server. It covers ordinary
 IPv4/IPv6 sockets: direct LAN addresses, DNS hostnames, HTTPS, and remote or
 tunnel endpoints all behave as normal network destinations.
 
-This grant does **not** expose arbitrary host files and adds no D-Bus access.
-There is still no `--filesystem=host`, `--filesystem=home`, broad D-Bus grant,
-or Secret Service permission. It also does not add mDNS, SSDP, or broadcast
-discovery behavior: issue #440 covers endpoints the user configured directly;
-provider discovery remains separate.
+This grant does **not** expose arbitrary host files and adds no D-Bus access
+of its own. There is still no `--filesystem=host`, `--filesystem=home`, or
+broad D-Bus grant; the manifest's only D-Bus entry is the single Secret Service
+name covered in [Secure credential storage](#secure-credential-storage), which
+networking neither needs nor affects. It also does not add mDNS, SSDP, or
+broadcast discovery behavior: issue #440 covers endpoints the user configured
+directly; provider discovery remains separate.
 
 After building and installing the Flatpak, validate a LAN endpoint by entering
 its direct address (for example `http://192.168.1.20:8096`) in the matching
@@ -207,9 +210,157 @@ flatpak info --show-permissions io.github.thezupzup.linthra
 flatpak override --user --show io.github.thezupzup.linthra
 ```
 
-The first command should show `shared=network;ipc;` (alongside the existing
-windowing, GPU, and audio grants), and no filesystem or D-Bus permission. The
-second reveals persistent local overrides that could invalidate the test.
+The first command prints the installed metadata: `shared=network;ipc;`
+(alongside the existing windowing, GPU, and audio grants), no `filesystems=`
+line at all, and a `[Session Bus Policy]` section whose only entry is
+`org.freedesktop.secrets=talk`. The second reveals persistent local overrides
+that could invalidate the test.
+
+## Secure credential storage
+
+The committed manifest grants exactly one D-Bus permission for credentials
+(#441):
+
+```
+--talk-name=org.freedesktop.secrets
+```
+
+**Why that name, and why only that one.** `flutter_secure_storage`'s Linux
+implementation (`flutter_secure_storage_linux` 1.2.3) has no store of its own:
+it calls libsecret's `secret_password_storev_sync` / `secret_password_lookupv_sync`
+and nothing else. libsecret decides at runtime how to satisfy those calls
+(`secret-backend.c`, `backend_get_impl_type`):
+
+* Inside a sandbox (`/.flatpak-info` present) it first asks
+  xdg-desktop-portal for `org.freedesktop.portal.Secret` version 1. If that
+  answers, libsecret uses its **file backend**: a gcrypt-encrypted file under
+  the app's own data directory whose master key comes from the portal, which in
+  turn gets it from the host's keyring. Every Flatpak may talk to the portal,
+  so that path needs no finish-arg. This is the usual case on GNOME, where
+  gnome-keyring provides the portal implementation.
+* If the portal has no Secret implementation (or reports a different version),
+  libsecret falls back to its **Secret Service backend** and connects to the
+  session-bus name `org.freedesktop.secrets` (`SECRET_SERVICE_BUS_NAME` in
+  libsecret's own headers). A Flatpak's D-Bus proxy hides names the manifest
+  does not grant, so without this line every credential read and write inside
+  the sandbox fails on such a host. KDE/kwallet sessions are the common case.
+
+`--talk-name` is the narrowest grant that covers the second path: permission to
+*talk* (not own) to exactly one well-known name on the session bus. Everything
+wider was rejected deliberately, and `scripts/check_linux_runner.py` fails the
+build if any of it reappears: `--socket=session-bus`, any
+`--talk-name=org.freedesktop.*` or `…secrets.*` wildcard,
+`--own-name=org.freedesktop.secrets`, and the same name on the system bus. No
+filesystem grant was added either; nothing in the credential path opens a file.
+
+**What is stored there.** One entry per provider, each the JSON of a session
+object, written by the three secure stores in
+`../lib/data/repositories/`:
+
+| Key | Provider | Contents |
+| --- | --- | --- |
+| `jellyfin_session_v1` | Jellyfin | server URL, user id/name, access token, device id |
+| `subsonic_session_v1` | Navidrome/Subsonic | server URL, username, salt, derived token |
+| `plex_session_v1` | Plex | server URL, machine identifier, token, selected library keys |
+
+Passwords are never stored: Jellyfin exchanges one for an access token,
+Subsonic derives a salt+token pair and discards it, Plex is token-based from
+the start. Everything else (library rows, preferences, playback state) stays in
+SQLite and preferences and holds no secret.
+
+**No plaintext fallback.** All three stores go through one class,
+`SecureSessionStorage`, which is the only thing in the app that touches
+`flutter_secure_storage`. It has no alternative path: if the platform store
+cannot take a value, the write fails and nothing is written to preferences, the
+database, the cache, or a file, and a read that fails is an error rather than a
+silent "no session". Failures are translated into a typed
+`SecureStorageException` carrying only an operation and a cause (unavailable,
+locked, denied, unknown), never the platform error text, the key, or the
+value, so a keyring problem cannot leak a token into a log, a diagnostics
+report, or a crash report. Jellyfin, Navidrome/Subsonic and Plex each turn that
+into a visible, recoverable message: "Couldn't save your … sign-in on this
+device. Unlock your keyring and try again." A session that could not be saved
+is not adopted, because it would look signed in until the next launch and then
+be gone.
+
+`test/data/repositories/secure_session_storage_test.dart` drives the real
+plugin channel (`plugins.it_nomads.com/flutter_secure_storage`) with the exact
+`PlatformException`s the Linux plugin raises, and covers save, read after a
+restart, delete, the missing/locked/denied service, and the absence of any
+fallback write.
+
+### Testing it in the sandbox
+
+Save, read after restart, delete:
+
+1. Build, install and launch (above). Sign in to Jellyfin, Navidrome/Subsonic
+   and Plex.
+2. Confirm on the host where the credential landed. Which of libsecret's two
+   backends is in use decides what you will see, and both are correct:
+
+   * **Secret Service backend** (no Secret portal on the host, e.g. a KDE
+     session): the plugin's item is labelled
+     `io.github.thezupzup.linthra/FlutterSecureStorage` with the attribute
+     `account=io.github.thezupzup.linthra.secureStorage`, and shows up in the
+     host keyring:
+
+     ```bash
+     secret-tool search account io.github.thezupzup.linthra.secureStorage
+     ```
+
+     GNOME users see the same item in Seahorse ("Passwords and Keys"), KDE
+     users in KWalletManager.
+   * **Portal file backend** (the usual GNOME case): `secret-tool search` finds
+     nothing, because the item is in the app's own encrypted
+     `~/.var/app/io.github.thezupzup.linthra/data/keyrings/default.keyring`,
+     whose key comes from the portal. That file is ciphertext; step 5 checks it
+     holds no readable credential.
+
+   Either way, do not print the secret: `secret-tool search` shows attributes,
+   which is what you are checking, while `secret-tool lookup` would print the
+   value itself.
+3. Quit and relaunch: `flatpak run io.github.thezupzup.linthra`. All three
+   providers should come back signed in, without re-entering anything, and a
+   track should stream.
+4. Sign out of each provider. The card returns to the signed-out state and the
+   keyring entry is gone (`secret-tool search …` no longer lists it, and the
+   entry disappears from Seahorse/KWalletManager).
+5. Check that nothing was written in the clear. There must be no credential in
+   the app's own data:
+
+   ```bash
+   grep -rIl "your-test-token" ~/.var/app/io.github.thezupzup.linthra/ || \
+     echo "no plaintext credential"
+   ```
+
+   (The encrypted file backend's `data/keyrings/default.keyring`, when that
+   path is the one in use, is ciphertext and will not match.)
+
+Locked or unavailable service:
+
+1. **Locked.** Lock the keyring on the host (`gnome-keyring` users:
+   `secret-tool lock --collection='login'`; KDE users: close the wallet in
+   KWalletManager), then launch Linthra and sign in. Expect a visible
+   "Couldn't save your … sign-in on this device. Unlock your keyring and try
+   again.", the app still usable, and no crash. Unlock and retry: the sign-in
+   completes.
+2. **Unavailable.** Launch once with the grant withheld:
+
+   ```bash
+   flatpak run --no-talk-name=org.freedesktop.secrets io.github.thezupzup.linthra
+   ```
+
+   On a host that was using the Secret Service backend, saved sessions come
+   back as a restore error ("Couldn't restore your saved … sign-in from this
+   device."), signing in reports the storage failure, and nothing is written
+   anywhere else. A normal `flatpak run` afterwards recovers with the
+   credentials intact. On a host whose portal provides the Secret
+   implementation, libsecret uses the portal-backed file backend and this
+   launch behaves normally, which is the expected difference between the two
+   paths, not a failed test.
+
+Use one-shot `flatpak run` flags rather than `flatpak override`: overrides
+persist and then hide what the manifest actually grants.
 
 ## Regenerating the pinned sources
 
@@ -267,12 +418,11 @@ side's, so the two cannot drift into a silent fallback.
 
 Not in this manifest — each has its own issue:
 
-* **The remaining filesystem-permission audit** (#439) and **Secret Service**
-  (#441) — no `--filesystem=host|home` or
-  `--talk-name=org.freedesktop.secrets`. Jellyfin/Subsonic/Plex session restore
-  and secure-storage reads already degrade to "not signed in" without them
-  (`docs/linux-desktop.md` §"Secure storage"). Picking a music folder no longer
-  needs a filesystem grant at all — see [Local music folders](#local-music-folders).
+* **The remaining filesystem-permission audit** (#439): still no
+  `--filesystem=host|home`. Picking a music folder does not need a filesystem
+  grant at all (see [Local music folders](#local-music-folders)), and neither
+  does credential storage (see
+  [Secure credential storage](#secure-credential-storage)).
 * **Video codecs, hardware acceleration/hwaccel, subtitle-adjacent tuning
   beyond what libmpv/libass require to build** — Linthra is audio-only; the
   ffmpeg/mpv build stays scoped to the container/codec/protocol support

--- a/flatpak/flatpak-flutter.yml
+++ b/flatpak/flatpak-flutter.yml
@@ -57,27 +57,39 @@ finish-args:
   # host files or adding a D-Bus permission. Provider discovery remains out of
   # scope: direct configured endpoints need no discovery-specific grant.
   - --share=network
-  # Secure credential storage (#441). flutter_secure_storage's Linux
-  # implementation (flutter_secure_storage_linux 1.2.3) is a thin wrapper over
-  # libsecret: secret_password_storev_sync/lookupv_sync, no storage of its own
-  # and no file fallback. libsecret picks its backend at runtime
-  # (secret-backend.c, backend_get_impl_type):
-  #   * If /.flatpak-info exists *and* xdg-desktop-portal answers
-  #     org.freedesktop.portal.Secret version 1, it uses its own file backend:
-  #     an encrypted file under the app's data dir whose master key comes from
-  #     the portal. Every Flatpak may talk to the portal, so that path needs
-  #     nothing here (this is the usual GNOME case, where gnome-keyring
-  #     provides the portal implementation).
-  #   * Otherwise it falls back to the Secret Service backend and calls the
-  #     session-bus name org.freedesktop.secrets (SECRET_SERVICE_BUS_NAME).
-  #     The sandbox's D-Bus proxy hides that name unless it is granted, so
-  #     without this line every read and write fails on any host whose portal
-  #     has no Secret implementation, KDE/kwallet sessions among them.
-  # --talk-name is the narrowest grant that covers the second path: talk (not
-  # own) to exactly one well-known name. Not --socket=session-bus, not a
-  # wildcard, and no filesystem grant: the secret stays in the platform
-  # keyring either way, and Linthra never writes credentials to a file itself.
-  - --talk-name=org.freedesktop.secrets
+  #
+  # Secure credential storage (#441) needs nothing here either, for the same
+  # reason local music folders don't: the sandbox path is a portal.
+  # flutter_secure_storage's Linux implementation
+  # (flutter_secure_storage_linux 1.2.3) is a thin wrapper over libsecret,
+  # which chooses its own backend at runtime (secret-backend.c,
+  # backend_get_impl_type): when /.flatpak-info exists and xdg-desktop-portal
+  # answers org.freedesktop.portal.Secret v1, it uses its file backend, an
+  # encrypted store under the app's own data dir whose master secret is handed
+  # over by the portal (and held by the host's keyring). Every Flatpak may talk
+  # to the portal, so no finish-arg grants it.
+  #
+  # That portal is exported only when the desktop ships an
+  # org.freedesktop.impl.portal.Secret backend (xdg-desktop-portal
+  # desktop-portal/secret.c, init_secret: no impl configured means the
+  # interface is never exported). Both desktops this targets do:
+  #   * GNOME, via gnome-keyring (daemon/dbus/gkd-secret-portal.c).
+  #   * KDE Plasma 6, via KWallet's ksecretd
+  #     (src/runtime/ksecretd/kwalletportalsecrets.cpp, which installs
+  #     org.freedesktop.impl.portal.desktop.kwallet.service and
+  #     kwallet.portal). KF6 only; the KF5 kwalletd had no portal backend.
+  # org.gnome.Platform//50 carries libsecret 0.21.7 built with libgcrypt
+  # (freedesktop-sdk 25.08 elements/components/libsecret.bst), so that file
+  # backend is compiled in and the sandbox detection above is live.
+  #
+  # So --talk-name=org.freedesktop.secrets is deliberately NOT granted. On a
+  # host with no Secret portal backend (a KF5-era KDE, a bare WM running only
+  # a Secret Service daemon) libsecret falls back to the Secret Service bus
+  # name, the sandbox's D-Bus proxy hides it, and Linthra reports a
+  # recoverable storage error and stays signed out rather than falling back to
+  # any storage of its own. A user who wants that fallback can grant it
+  # themselves with `flatpak override --user`; it is not worth a permission on
+  # every install (docs/flatpak-development.md "Secure credential storage").
   #
   # Local music folders (#438) need nothing here on purpose. Linthra's Linux
   # runner opens GTK's GtkFileChooserNative, which GTK routes to the
@@ -94,13 +106,14 @@ finish-args:
   #   --filesystem=host/home     (broad filesystem access. Not needed for the
   #                                local library, per the portal note above;
   #                                the remaining permission audit is #439.)
-  #   --socket=session-bus       (the whole session bus. #441 needs one name.)
-  #   --talk-name=org.freedesktop.secrets.*  and any other wildcard: one exact
-  #                                name is what libsecret connects to.
-  # Their absence is safe: a Secret Service that is missing, locked or denied
+  #   --socket=session-bus, --talk-name=org.freedesktop.secrets, and every
+  #                                wildcard or --own-name form of it (#441
+  #                                is served by the Secret portal instead,
+  #                                per the note above).
+  # Their absence is safe: secure storage that is missing, locked or denied
   # surfaces as a recoverable sign-in/storage error and Jellyfin/Subsonic/Plex
-  # stay signed out, never a plaintext fallback (docs/linux-desktop.md
-  # "Secure storage").
+  # stay signed out. Linthra never writes a credential to storage of its own,
+  # in plaintext or otherwise (docs/linux-desktop.md "Secure storage").
 
 modules:
   # === Self-contained libmpv audio runtime, built from pinned upstream source

--- a/flatpak/flatpak-flutter.yml
+++ b/flatpak/flatpak-flutter.yml
@@ -57,6 +57,27 @@ finish-args:
   # host files or adding a D-Bus permission. Provider discovery remains out of
   # scope: direct configured endpoints need no discovery-specific grant.
   - --share=network
+  # Secure credential storage (#441). flutter_secure_storage's Linux
+  # implementation (flutter_secure_storage_linux 1.2.3) is a thin wrapper over
+  # libsecret: secret_password_storev_sync/lookupv_sync, no storage of its own
+  # and no file fallback. libsecret picks its backend at runtime
+  # (secret-backend.c, backend_get_impl_type):
+  #   * If /.flatpak-info exists *and* xdg-desktop-portal answers
+  #     org.freedesktop.portal.Secret version 1, it uses its own file backend:
+  #     an encrypted file under the app's data dir whose master key comes from
+  #     the portal. Every Flatpak may talk to the portal, so that path needs
+  #     nothing here (this is the usual GNOME case, where gnome-keyring
+  #     provides the portal implementation).
+  #   * Otherwise it falls back to the Secret Service backend and calls the
+  #     session-bus name org.freedesktop.secrets (SECRET_SERVICE_BUS_NAME).
+  #     The sandbox's D-Bus proxy hides that name unless it is granted, so
+  #     without this line every read and write fails on any host whose portal
+  #     has no Secret implementation, KDE/kwallet sessions among them.
+  # --talk-name is the narrowest grant that covers the second path: talk (not
+  # own) to exactly one well-known name. Not --socket=session-bus, not a
+  # wildcard, and no filesystem grant: the secret stays in the platform
+  # keyring either way, and Linthra never writes credentials to a file itself.
+  - --talk-name=org.freedesktop.secrets
   #
   # Local music folders (#438) need nothing here on purpose. Linthra's Linux
   # runner opens GTK's GtkFileChooserNative, which GTK routes to the
@@ -73,10 +94,13 @@ finish-args:
   #   --filesystem=host/home     (broad filesystem access. Not needed for the
   #                                local library, per the portal note above;
   #                                the remaining permission audit is #439.)
-  #   --talk-name=org.freedesktop.secrets  (Secret Service: #441)
-  # Their absence is safe: flutter_secure_storage/Jellyfin-Subsonic-Plex
-  # session restore on Linux treats every read/write failure as "not signed
-  # in" and keeps running (docs/linux-desktop.md "Secure storage").
+  #   --socket=session-bus       (the whole session bus. #441 needs one name.)
+  #   --talk-name=org.freedesktop.secrets.*  and any other wildcard: one exact
+  #                                name is what libsecret connects to.
+  # Their absence is safe: a Secret Service that is missing, locked or denied
+  # surfaces as a recoverable sign-in/storage error and Jellyfin/Subsonic/Plex
+  # stay signed out, never a plaintext fallback (docs/linux-desktop.md
+  # "Secure storage").
 
 modules:
   # === Self-contained libmpv audio runtime, built from pinned upstream source

--- a/flatpak/io.github.thezupzup.linthra.yml
+++ b/flatpak/io.github.thezupzup.linthra.yml
@@ -20,7 +20,6 @@ finish-args:
   - --device=dri
   - --socket=pulseaudio
   - --share=network
-  - --talk-name=org.freedesktop.secrets
 modules:
   - name: ffmpeg
     cleanup:

--- a/flatpak/io.github.thezupzup.linthra.yml
+++ b/flatpak/io.github.thezupzup.linthra.yml
@@ -20,6 +20,7 @@ finish-args:
   - --device=dri
   - --socket=pulseaudio
   - --share=network
+  - --talk-name=org.freedesktop.secrets
 modules:
   - name: ffmpeg
     cleanup:

--- a/lib/core/repositories/secure_storage_exception.dart
+++ b/lib/core/repositories/secure_storage_exception.dart
@@ -1,0 +1,69 @@
+/// Why a platform secure-storage (keyring) operation failed.
+///
+/// The Linux implementation of `flutter_secure_storage` is a thin libsecret
+/// wrapper, so on that platform these map onto the freedesktop Secret Service:
+/// no provider running, a locked keyring, or a sandbox that refuses the
+/// service. Android's Keystore fails far more rarely, but the same kinds
+/// describe it well enough for a message, and the app behaves identically on
+/// both: it stays signed out and says so.
+enum SecureStorageFailure {
+  /// No secure storage to talk to: no Secret Service on the session bus (bare
+  /// window manager, no keyring daemon), or a sandbox that hides the name.
+  unavailable,
+
+  /// Secure storage exists but is locked, or the unlock prompt was dismissed.
+  locked,
+
+  /// Secure storage answered and refused. Distinct from [unavailable]: the
+  /// service is there, the access is not granted.
+  denied,
+
+  /// Anything else the platform reported. Recoverable in the same way (retry,
+  /// or sign in again), just not attributable to a specific cause.
+  unknown,
+}
+
+/// Which operation failed, so a message can say whether a credential failed to
+/// be saved, read back, or removed.
+enum SecureStorageOperation { read, write, delete }
+
+/// A secure-storage failure, carrying only what is safe to show and log.
+///
+/// Deliberately narrow: it holds the [operation] and a [failure] kind and
+/// **nothing from the platform error**: not the message, not the details, not
+/// the key, and above all not the value that was being stored. Platform error
+/// text is classified into [SecureStorageFailure] at the boundary and then
+/// dropped, so no part of a token, password or session secret can reach a log,
+/// a diagnostics report, an exception message, or a crash report through this
+/// type.
+class SecureStorageException implements Exception {
+  const SecureStorageException({
+    required this.operation,
+    required this.failure,
+  });
+
+  final SecureStorageOperation operation;
+  final SecureStorageFailure failure;
+
+  /// A short, secret-free sentence telling the user what to do next.
+  ///
+  /// Callers prefix it with their own provider-specific lead ("Couldn't save
+  /// your Jellyfin session on this device."), so the phrasing here stays
+  /// generic and actionable.
+  String get remedy {
+    switch (failure) {
+      case SecureStorageFailure.unavailable:
+        return 'This device has no keyring available to store it securely.';
+      case SecureStorageFailure.locked:
+        return 'Unlock your keyring and try again.';
+      case SecureStorageFailure.denied:
+        return 'Your keyring refused access to Linthra.';
+      case SecureStorageFailure.unknown:
+        return 'Try again.';
+    }
+  }
+
+  @override
+  String toString() =>
+      'SecureStorageException(${operation.name}: ${failure.name})';
+}

--- a/lib/data/repositories/secure_jellyfin_session_store.dart
+++ b/lib/data/repositories/secure_jellyfin_session_store.dart
@@ -7,19 +7,19 @@ import 'secure_session_storage.dart';
 /// A [JellyfinSessionStore] backed by `flutter_secure_storage`.
 ///
 /// The session is serialized to JSON and written to platform secure storage
-/// under a single key: the Android Keystore-backed store on Android, and the
-/// freedesktop Secret Service (libsecret) on Linux, i.e. the desktop keyring
-/// the user's other apps already use. The access token is never at rest in
-/// plaintext (unlike `shared_preferences`) on either platform, and there is
-/// no file
-/// fallback when the platform store is unavailable. This is the production
-/// binding; it's intentionally never touched by tests, which use the in-memory
-/// store so they stay free of platform channels.
+/// under a single key, through [SecureSessionStorage]: the Android
+/// Keystore-backed store on Android, and libsecret on Linux (the freedesktop
+/// Secret Service natively; inside a Flatpak, libsecret's own portal-keyed
+/// encrypted store). The access token is never at rest in plaintext (unlike
+/// `shared_preferences`) on either platform, and Linthra writes no file of its
+/// own when the platform store is unavailable. This is the production binding;
+/// it's intentionally never touched by tests, which use the in-memory store so
+/// they stay free of platform channels.
 ///
 /// A malformed/partial record reads back as `null` (treated as "signed out")
 /// rather than throwing, so a storage glitch can't wedge the app at launch. A
-/// keyring that is missing, locked or denied is a different thing and is not
-/// flattened into "signed out": [SecureSessionStorage] surfaces it as a
+/// platform store that is missing, locked or denied is a different thing and is
+/// not flattened into "signed out": [SecureSessionStorage] surfaces it as a
 /// `SecureStorageException`, which the caller reports so the user can act on
 /// it (unlock the keyring, sign in again) instead of losing the credential
 /// silently.

--- a/lib/data/repositories/secure_jellyfin_session_store.dart
+++ b/lib/data/repositories/secure_jellyfin_session_store.dart
@@ -1,26 +1,34 @@
 import 'dart:convert';
 
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-
 import '../../core/models/jellyfin_session.dart';
 import '../../core/repositories/jellyfin_session_store.dart';
+import 'secure_session_storage.dart';
 
 /// A [JellyfinSessionStore] backed by `flutter_secure_storage`.
 ///
-/// The session is serialized to JSON and written to platform-encrypted storage
-/// (Android Keystore-backed) under a single key, so the access token is never
-/// at rest in plaintext (unlike `shared_preferences`). This is the production
+/// The session is serialized to JSON and written to platform secure storage
+/// under a single key: the Android Keystore-backed store on Android, and the
+/// freedesktop Secret Service (libsecret) on Linux, i.e. the desktop keyring
+/// the user's other apps already use. The access token is never at rest in
+/// plaintext (unlike `shared_preferences`) on either platform, and there is
+/// no file
+/// fallback when the platform store is unavailable. This is the production
 /// binding; it's intentionally never touched by tests, which use the in-memory
 /// store so they stay free of platform channels.
 ///
 /// A malformed/partial record reads back as `null` (treated as "signed out")
-/// rather than throwing, so a storage glitch can't wedge the app at launch.
+/// rather than throwing, so a storage glitch can't wedge the app at launch. A
+/// keyring that is missing, locked or denied is a different thing and is not
+/// flattened into "signed out": [SecureSessionStorage] surfaces it as a
+/// `SecureStorageException`, which the caller reports so the user can act on
+/// it (unlock the keyring, sign in again) instead of losing the credential
+/// silently.
 class SecureJellyfinSessionStore implements JellyfinSessionStore {
   const SecureJellyfinSessionStore({
-    FlutterSecureStorage storage = const FlutterSecureStorage(),
+    SecureSessionStorage storage = const SecureSessionStorage(),
   }) : _storage = storage;
 
-  final FlutterSecureStorage _storage;
+  final SecureSessionStorage _storage;
 
   static const String _key = 'jellyfin_session_v1';
 

--- a/lib/data/repositories/secure_plex_session_store.dart
+++ b/lib/data/repositories/secure_plex_session_store.dart
@@ -1,26 +1,34 @@
 import 'dart:convert';
 
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-
 import '../../core/models/plex_session.dart';
 import '../../core/repositories/plex_session_store.dart';
+import 'secure_session_storage.dart';
 
 /// A [PlexSessionStore] backed by `flutter_secure_storage`.
 ///
-/// The session is serialized to JSON and written to platform-encrypted storage
-/// (Android Keystore-backed) under a single key, so the server-scoped token is
-/// never at rest in plaintext (unlike `shared_preferences`). This is the
-/// production binding; it's intentionally never touched by tests, which use the
-/// in-memory store so they stay free of platform channels.
+/// The session is serialized to JSON and written to platform secure storage
+/// under a single key: the Android Keystore-backed store on Android, and the
+/// freedesktop Secret Service (libsecret) on Linux, i.e. the desktop keyring
+/// the user's other apps already use. The server-scoped token is never at
+/// rest in plaintext (unlike `shared_preferences`) on either platform, and
+/// there is no file
+/// fallback when the platform store is unavailable. This is the production
+/// binding; it's intentionally never touched by tests, which use the in-memory
+/// store so they stay free of platform channels.
 ///
 /// A malformed/partial record reads back as `null` (treated as "signed out")
-/// rather than throwing, so a storage glitch can't wedge the app at launch.
+/// rather than throwing, so a storage glitch can't wedge the app at launch. A
+/// keyring that is missing, locked or denied is a different thing and is not
+/// flattened into "signed out": [SecureSessionStorage] surfaces it as a
+/// `SecureStorageException`, which the caller reports so the user can act on
+/// it (unlock the keyring, sign in again) instead of losing the credential
+/// silently.
 class SecurePlexSessionStore implements PlexSessionStore {
   const SecurePlexSessionStore({
-    FlutterSecureStorage storage = const FlutterSecureStorage(),
+    SecureSessionStorage storage = const SecureSessionStorage(),
   }) : _storage = storage;
 
-  final FlutterSecureStorage _storage;
+  final SecureSessionStorage _storage;
 
   static const String _key = 'plex_session_v1';
 

--- a/lib/data/repositories/secure_plex_session_store.dart
+++ b/lib/data/repositories/secure_plex_session_store.dart
@@ -7,19 +7,20 @@ import 'secure_session_storage.dart';
 /// A [PlexSessionStore] backed by `flutter_secure_storage`.
 ///
 /// The session is serialized to JSON and written to platform secure storage
-/// under a single key: the Android Keystore-backed store on Android, and the
-/// freedesktop Secret Service (libsecret) on Linux, i.e. the desktop keyring
-/// the user's other apps already use. The server-scoped token is never at
-/// rest in plaintext (unlike `shared_preferences`) on either platform, and
-/// there is no file
-/// fallback when the platform store is unavailable. This is the production
-/// binding; it's intentionally never touched by tests, which use the in-memory
-/// store so they stay free of platform channels.
+/// under a single key, through [SecureSessionStorage]: the Android
+/// Keystore-backed store on Android, and libsecret on Linux (the freedesktop
+/// Secret Service natively; inside a Flatpak, libsecret's own portal-keyed
+/// encrypted store). The server-scoped token is never at rest in plaintext
+/// (unlike `shared_preferences`) on either platform, and Linthra writes no
+/// file of its
+/// own when the platform store is unavailable. This is the production binding;
+/// it's intentionally never touched by tests, which use the in-memory store so
+/// they stay free of platform channels.
 ///
 /// A malformed/partial record reads back as `null` (treated as "signed out")
 /// rather than throwing, so a storage glitch can't wedge the app at launch. A
-/// keyring that is missing, locked or denied is a different thing and is not
-/// flattened into "signed out": [SecureSessionStorage] surfaces it as a
+/// platform store that is missing, locked or denied is a different thing and is
+/// not flattened into "signed out": [SecureSessionStorage] surfaces it as a
 /// `SecureStorageException`, which the caller reports so the user can act on
 /// it (unlock the keyring, sign in again) instead of losing the credential
 /// silently.

--- a/lib/data/repositories/secure_session_storage.dart
+++ b/lib/data/repositories/secure_session_storage.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import '../../core/repositories/secure_storage_exception.dart';
+
+/// The single door between Linthra and the platform's secure storage.
+///
+/// Every provider credential store goes through this, so the rules that keep
+/// secrets out of everything except the platform keyring are stated once:
+///
+/// * There is no fallback. If the platform store can't take a value, the
+///   write fails: nothing is written to preferences, the database, a cache,
+///   or a file. A failed read is a failure, not an empty result.
+/// * A platform failure is translated into a [SecureStorageException] carrying
+///   only an operation and a cause. The platform's own error text is inspected
+///   to classify it and then dropped, so nothing derived from a stored value
+///   can travel further (see [SecureStorageException]).
+/// * Nothing here logs. Not the value, not the key, not the platform message.
+///
+/// On Linux this is `flutter_secure_storage_linux`, a thin wrapper over
+/// libsecret (the freedesktop Secret Service); on Android it is the
+/// Keystore-backed implementation. The failure kinds below are written for the
+/// Linux stack because that is where a keyring can realistically be missing or
+/// locked; the mapping is harmless on the others.
+class SecureSessionStorage {
+  const SecureSessionStorage({
+    FlutterSecureStorage storage = const FlutterSecureStorage(),
+  }) : _storage = storage;
+
+  final FlutterSecureStorage _storage;
+
+  /// The value stored under [key], or `null` when there is none.
+  ///
+  /// Throws [SecureStorageException] when the platform store could not be
+  /// read: a missing, locked or denied keyring is *not* reported as "no value",
+  /// because that would look exactly like a clean sign-out and would quietly
+  /// discard a credential that is still there.
+  Future<String?> read({required String key}) =>
+      _guard(SecureStorageOperation.read, () => _storage.read(key: key));
+
+  /// Stores [value] under [key], replacing any previous value.
+  Future<void> write({required String key, required String value}) => _guard(
+        SecureStorageOperation.write,
+        () => _storage.write(key: key, value: value),
+      );
+
+  /// Removes whatever is stored under [key]. Succeeds when there was nothing.
+  Future<void> delete({required String key}) =>
+      _guard(SecureStorageOperation.delete, () => _storage.delete(key: key));
+
+  Future<T> _guard<T>(
+    SecureStorageOperation operation,
+    Future<T> Function() call,
+  ) async {
+    try {
+      return await call();
+    } on PlatformException catch (error) {
+      throw SecureStorageException(
+        operation: operation,
+        failure: _classify(error.code, error.message),
+      );
+    } on MissingPluginException {
+      // No secure-storage implementation registered for this platform at all.
+      throw SecureStorageException(
+        operation: operation,
+        failure: SecureStorageFailure.unavailable,
+      );
+    }
+  }
+}
+
+/// Classify a platform error into a cause, from its code and message.
+///
+/// The strings matched here are the ones the Linux stack actually produces.
+/// `flutter_secure_storage_linux` catches libsecret's `GError` message (or its
+/// own "Failed to unlock the keyring" when the keyring warm-up store fails) and
+/// returns it as a `PlatformException` with the code "Libsecret error", so the
+/// distinctions a user can act on (no service, locked, refused) are only
+/// available in that text. It is read here and never kept.
+SecureStorageFailure _classify(String code, String? message) {
+  final String text = '$code ${message ?? ''}'.toLowerCase();
+
+  // The plugin's own keyring warm-up (a dummy store, done before every read)
+  // failing, and libsecret's dismissed-prompt path: the service is there, the
+  // secrets are not reachable until the user unlocks it.
+  if (text.contains('failed to unlock') ||
+      text.contains('locked') ||
+      text.contains('dismissed') ||
+      text.contains('cancelled') ||
+      text.contains('canceled')) {
+    return SecureStorageFailure.locked;
+  }
+
+  // Nothing owns org.freedesktop.secrets on the session bus (no keyring daemon
+  // running), or a sandbox's D-Bus filter is hiding the name from us.
+  if (text.contains('serviceunknown') ||
+      text.contains('namehasnoowner') ||
+      text.contains('was not provided by any .service files') ||
+      text.contains('no such name') ||
+      text.contains('not provided')) {
+    return SecureStorageFailure.unavailable;
+  }
+
+  // The service answered and said no, including the Flatpak D-Bus proxy
+  // rejecting a call to a name the manifest does not grant.
+  if (text.contains('accessdenied') ||
+      text.contains('access denied') ||
+      text.contains('permission denied') ||
+      text.contains('not allowed') ||
+      text.contains('rejected send message')) {
+    return SecureStorageFailure.denied;
+  }
+
+  return SecureStorageFailure.unknown;
+}

--- a/lib/data/repositories/secure_session_storage.dart
+++ b/lib/data/repositories/secure_session_storage.dart
@@ -3,25 +3,39 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import '../../core/repositories/secure_storage_exception.dart';
 
-/// The single door between Linthra and the platform's secure storage.
+/// The one door between Linthra's provider credentials and platform secure
+/// storage.
 ///
-/// Every provider credential store goes through this, so the rules that keep
-/// secrets out of everything except the platform keyring are stated once:
+/// Used by the Jellyfin, Navidrome/Subsonic and Plex session stores, which are
+/// the credential path this class exists to hold to one set of rules. (The
+/// GitHub Sponsors token store calls `flutter_secure_storage` directly and is
+/// separate work; it stores no provider credential.)
 ///
-/// * There is no fallback. If the platform store can't take a value, the
-///   write fails: nothing is written to preferences, the database, a cache,
-///   or a file. A failed read is a failure, not an empty result.
+/// The rules, stated once:
+///
+/// * Linthra has no fallback of its own. If the platform store can't take a
+///   value, the write fails: Linthra writes nothing to preferences, the
+///   database, a cache, a log, or any file of its own, in plaintext or
+///   otherwise. A failed read is a failure, not an empty result.
 /// * A platform failure is translated into a [SecureStorageException] carrying
 ///   only an operation and a cause. The platform's own error text is inspected
 ///   to classify it and then dropped, so nothing derived from a stored value
 ///   can travel further (see [SecureStorageException]).
 /// * Nothing here logs. Not the value, not the key, not the platform message.
 ///
-/// On Linux this is `flutter_secure_storage_linux`, a thin wrapper over
-/// libsecret (the freedesktop Secret Service); on Android it is the
-/// Keystore-backed implementation. The failure kinds below are written for the
-/// Linux stack because that is where a keyring can realistically be missing or
-/// locked; the mapping is harmless on the others.
+/// What the platform then does with the value is the platform's business, and
+/// differs by more than just OS. On Android it is the Keystore-backed store.
+/// On Linux it is `flutter_secure_storage_linux`, a thin wrapper over
+/// libsecret, which picks its own backend: a native build talks to the
+/// freedesktop Secret Service (the desktop keyring), while inside a Flatpak
+/// with the Secret portal available libsecret keeps its own encrypted file
+/// under the app's data directory, with the master secret handed over by the
+/// portal from the host keyring. Both are libsecret-managed and encrypted at
+/// rest; neither is something Linthra writes or can read around.
+///
+/// The failure kinds below are written for the Linux stack because that is
+/// where secure storage can realistically be missing or locked; the mapping is
+/// harmless on the others.
 class SecureSessionStorage {
   const SecureSessionStorage({
     FlutterSecureStorage storage = const FlutterSecureStorage(),
@@ -92,7 +106,9 @@ SecureStorageFailure _classify(String code, String? message) {
   }
 
   // Nothing owns org.freedesktop.secrets on the session bus (no keyring daemon
-  // running), or a sandbox's D-Bus filter is hiding the name from us.
+  // running), or a sandbox's D-Bus filter is hiding the name from us: what a
+  // Flatpak sees on a host that provides neither the Secret portal nor a
+  // reachable Secret Service.
   if (text.contains('serviceunknown') ||
       text.contains('namehasnoowner') ||
       text.contains('was not provided by any .service files') ||

--- a/lib/data/repositories/secure_subsonic_session_store.dart
+++ b/lib/data/repositories/secure_subsonic_session_store.dart
@@ -1,26 +1,34 @@
 import 'dart:convert';
 
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-
 import '../../core/models/subsonic_session.dart';
 import '../../core/repositories/subsonic_session_store.dart';
+import 'secure_session_storage.dart';
 
 /// A [SubsonicSessionStore] backed by `flutter_secure_storage`.
 ///
-/// The session is serialized to JSON and written to platform-encrypted storage
-/// (Android Keystore-backed) under a single key, so the credential (salt +
-/// token) is never at rest in plaintext (unlike `shared_preferences`). This is
-/// the production binding; it's intentionally never touched by tests, which use
-/// the in-memory store so they stay free of platform channels.
+/// The session is serialized to JSON and written to platform secure storage
+/// under a single key: the Android Keystore-backed store on Android, and the
+/// freedesktop Secret Service (libsecret) on Linux, i.e. the desktop keyring
+/// the user's other apps already use. The credential (salt + token) is never
+/// at rest in plaintext (unlike `shared_preferences`) on either platform, and
+/// there is no file
+/// fallback when the platform store is unavailable. This is the production
+/// binding; it's intentionally never touched by tests, which use the in-memory
+/// store so they stay free of platform channels.
 ///
 /// A malformed/partial record reads back as `null` (treated as "signed out")
-/// rather than throwing, so a storage glitch can't wedge the app at launch.
+/// rather than throwing, so a storage glitch can't wedge the app at launch. A
+/// keyring that is missing, locked or denied is a different thing and is not
+/// flattened into "signed out": [SecureSessionStorage] surfaces it as a
+/// `SecureStorageException`, which the caller reports so the user can act on
+/// it (unlock the keyring, sign in again) instead of losing the credential
+/// silently.
 class SecureSubsonicSessionStore implements SubsonicSessionStore {
   const SecureSubsonicSessionStore({
-    FlutterSecureStorage storage = const FlutterSecureStorage(),
+    SecureSessionStorage storage = const SecureSessionStorage(),
   }) : _storage = storage;
 
-  final FlutterSecureStorage _storage;
+  final SecureSessionStorage _storage;
 
   static const String _key = 'subsonic_session_v1';
 

--- a/lib/data/repositories/secure_subsonic_session_store.dart
+++ b/lib/data/repositories/secure_subsonic_session_store.dart
@@ -7,19 +7,20 @@ import 'secure_session_storage.dart';
 /// A [SubsonicSessionStore] backed by `flutter_secure_storage`.
 ///
 /// The session is serialized to JSON and written to platform secure storage
-/// under a single key: the Android Keystore-backed store on Android, and the
-/// freedesktop Secret Service (libsecret) on Linux, i.e. the desktop keyring
-/// the user's other apps already use. The credential (salt + token) is never
-/// at rest in plaintext (unlike `shared_preferences`) on either platform, and
-/// there is no file
-/// fallback when the platform store is unavailable. This is the production
-/// binding; it's intentionally never touched by tests, which use the in-memory
-/// store so they stay free of platform channels.
+/// under a single key, through [SecureSessionStorage]: the Android
+/// Keystore-backed store on Android, and libsecret on Linux (the freedesktop
+/// Secret Service natively; inside a Flatpak, libsecret's own portal-keyed
+/// encrypted store). The credential (salt + token) is never at rest in
+/// plaintext (unlike `shared_preferences`) on either platform, and Linthra
+/// writes no file of its
+/// own when the platform store is unavailable. This is the production binding;
+/// it's intentionally never touched by tests, which use the in-memory store so
+/// they stay free of platform channels.
 ///
 /// A malformed/partial record reads back as `null` (treated as "signed out")
 /// rather than throwing, so a storage glitch can't wedge the app at launch. A
-/// keyring that is missing, locked or denied is a different thing and is not
-/// flattened into "signed out": [SecureSessionStorage] surfaces it as a
+/// platform store that is missing, locked or denied is a different thing and is
+/// not flattened into "signed out": [SecureSessionStorage] surfaces it as a
 /// `SecureStorageException`, which the caller reports so the user can act on
 /// it (unlock the keyring, sign in again) instead of losing the credential
 /// silently.

--- a/lib/features/settings/jellyfin/jellyfin_settings_controller.dart
+++ b/lib/features/settings/jellyfin/jellyfin_settings_controller.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/app_info.dart';
 import '../../../core/models/jellyfin_session.dart';
 import '../../../core/models/playlist.dart';
+import '../../../core/repositories/secure_storage_exception.dart';
 import '../../../core/services/remote_cache/remote_cache_key.dart';
 import '../../../core/sources/jellyfin/jellyfin_api.dart';
 import '../../../core/sources/jellyfin/jellyfin_diagnostics.dart';
@@ -64,9 +65,26 @@ class JellyfinSettingsController extends Notifier<JellyfinSettingsState> {
     final JellyfinSession? saved;
     try {
       saved = await ref.read(jellyfinSessionStoreProvider).read();
-    } catch (_) {
-      // A storage hiccup must not break startup or playback; stay disconnected
-      // and let the user reconnect in Settings. No secret is involved here.
+    } catch (error) {
+      // A keyring that is missing, locked or denied must not break startup or
+      // playback: stay disconnected, but say so (statically, token-free) so a
+      // user who *was* signed in isn't left wondering where their server went.
+      // A missing or corrupt record already reads back as null inside the
+      // store and stays silent. Nothing is retried and nothing is written
+      // anywhere else.
+      //
+      // Only when nothing has taken over the card in the meantime: a locked
+      // keyring can block this read behind an unlock prompt for as long as the
+      // user leaves it there, and a sign-in that already started (or finished)
+      // in that time owns the state now.
+      if (_session == null &&
+          state.phase == JellyfinConnectionPhase.disconnected &&
+          state.errorMessage == null) {
+        state = JellyfinSettingsState(
+          errorMessage: "Couldn't restore your saved Jellyfin sign-in from "
+              'this device. ${_storageRemedy(error)}',
+        );
+      }
       return;
     }
     if (saved == null) {
@@ -141,7 +159,21 @@ class JellyfinSettingsController extends Notifier<JellyfinSettingsState> {
                 password: password,
                 serverInfo: _knownServerInfo(),
               );
-      await ref.read(jellyfinSessionStoreProvider).write(newSession);
+      try {
+        await ref.read(jellyfinSessionStoreProvider).write(newSession);
+      } catch (error) {
+        // The new session couldn't reach the keyring. Adopting it anyway would
+        // look signed in until the next launch and then silently be gone, so
+        // don't: report it and let the user fix the keyring and retry. The
+        // token is dropped here rather than kept anywhere else.
+        _setFailure(
+          "Couldn't save your Jellyfin sign-in on this device. "
+          '${_storageRemedy(error)}',
+          url: url,
+          username: username,
+        );
+        return false;
+      }
       _session = newSession;
       // The just-signed-in server becomes the active/default provider for
       // picking among duplicate sources, so a song that also lives on another
@@ -185,7 +217,18 @@ class JellyfinSettingsController extends Notifier<JellyfinSettingsState> {
   /// favourites and local-only playlists are kept), and the now-stale
   /// "Synced N tracks" status is reset.
   Future<void> clear() async {
-    await ref.read(jellyfinSessionStoreProvider).clear();
+    try {
+      await ref.read(jellyfinSessionStoreProvider).clear();
+    } catch (error) {
+      // The token would stay in the keyring; report it rather than pretending
+      // the sign-out happened. Nothing else is torn down, so a retry after
+      // unlocking the keyring completes the same sign-out.
+      _setFailure(
+        "Couldn't remove your Jellyfin sign-in from this device. "
+        '${_storageRemedy(error)}',
+      );
+      return;
+    }
     _session = null;
     try {
       // Scope the drop to Jellyfin so a still-connected Subsonic/Navidrome
@@ -215,6 +258,12 @@ class JellyfinSettingsController extends Notifier<JellyfinSettingsState> {
         .read(remoteCacheIndexProvider)
         .removeSource(RemoteCacheKey.sourceIdJellyfin);
   }
+
+  /// The user-facing tail for a secure-storage failure: what went wrong with
+  /// the keyring and what to do about it. Never carries any part of the value
+  /// that was being read or written (see [SecureStorageException]).
+  String _storageRemedy(Object error) =>
+      error is SecureStorageException ? error.remedy : 'Try again.';
 
   /// Reports an error without dropping an existing connection: a failed test or
   /// re-auth keeps any session that's still valid, it just surfaces the message

--- a/lib/features/settings/plex/plex_settings_controller.dart
+++ b/lib/features/settings/plex/plex_settings_controller.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../app/external_link_launcher_provider.dart';
 import '../../../core/models/plex_session.dart';
+import '../../../core/repositories/secure_storage_exception.dart';
 import '../../../core/services/remote_cache/remote_cache_key.dart';
 import '../../../core/sources/music_provider.dart';
 import '../../../core/sources/plex/plex_api.dart';
@@ -120,18 +121,20 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
     final PlexSession? saved;
     try {
       saved = await ref.read(plexSessionStoreProvider).read();
-    } catch (_) {
-      // A storage hiccup must not break startup; stay disconnected but say
-      // so (statically, token-free), so a user who *was* connected isn't left
-      // wondering where their server went. (A missing/corrupt record already
-      // reads back as null inside the store and stays silent.) But if a
-      // "Connect with Plex" flow has since taken over the card, leave it
-      // alone — replacing it with a disconnected restore error would strip
-      // the user's Cancel/reopen controls while the poll keeps running.
+    } catch (error) {
+      // A keyring that is missing, locked or denied must not break startup;
+      // stay disconnected but say so (statically, token-free), so a user who
+      // *was* connected isn't left wondering where their server went. (A
+      // missing/corrupt record already reads back as null inside the store and
+      // stays silent.) But if a "Connect with Plex" flow has since taken over
+      // the card, leave it alone: replacing it with a disconnected restore
+      // error would strip the user's Cancel/reopen controls while the poll
+      // keeps running.
       if (!_restoreSuperseded && _session == null && !_linkFlowOwnsCard) {
-        state = const PlexSettingsState(
+        state = PlexSettingsState(
           errorMessage: "Couldn't restore your saved Plex connection from "
-              'this device. If you use Plex, connect again below.',
+              'this device. ${_storageRemedy(error)} If you use Plex, connect '
+              'again below.',
         );
       }
       return;
@@ -556,7 +559,7 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
     );
     try {
       await ref.read(plexSessionStoreProvider).write(stamped);
-    } catch (_) {
+    } catch (error) {
       // The new connection couldn't be persisted; without that it would
       // silently vanish on restart, so don't adopt it. The sign-in flow's
       // in-memory tokens are released here. A previous session, if any, is
@@ -566,8 +569,9 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
       // keeps serving it ([_setFailure] rebuilds from the live [_session], or
       // shows a plain signed-out error when there is none).
       _resetLinkFlow();
-      _setFailure(const PlexException(
-        "Couldn't save your Plex session on this device. Try again.",
+      _setFailure(PlexException(
+        "Couldn't save your Plex session on this device. "
+        '${_storageRemedy(error)}',
       ));
       return false;
     }
@@ -796,11 +800,12 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
     final PlexSession updated = current.copyWith(selectedSectionKeys: keys);
     try {
       await ref.read(plexSessionStoreProvider).write(updated);
-    } catch (_) {
+    } catch (error) {
       // Keep state and store consistent: don't apply a selection that won't
       // survive a restart.
       state = state.copyWith(
-        errorMessage: "Couldn't save your library selection. Try again.",
+        errorMessage:
+            "Couldn't save your library selection. ${_storageRemedy(error)}",
         errorKind: null,
       );
       return;
@@ -828,11 +833,11 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
     _resetLinkFlow();
     try {
       await ref.read(plexSessionStoreProvider).clear();
-    } catch (_) {
-      // The token would stay at rest; report it rather than pretending.
+    } catch (error) {
+      // The token would stay in the keyring; report it rather than pretending.
       state = state.copyWith(
-        errorMessage:
-            "Couldn't remove your Plex session from this device. Try again.",
+        errorMessage: "Couldn't remove your Plex session from this device. "
+            '${_storageRemedy(error)}',
         errorKind: null,
       );
       return;
@@ -890,6 +895,12 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
       // Best-effort: stale rows are replaced by the next successful sync.
     }
   }
+
+  /// The user-facing tail for a secure-storage failure: what went wrong with
+  /// the keyring and what to do about it. Never carries any part of the value
+  /// that was being read or written (see [SecureStorageException]).
+  String _storageRemedy(Object error) =>
+      error is SecureStorageException ? error.remedy : 'Try again.';
 
   /// Reports a failure without dropping an existing connection: a failed test
   /// or re-connect attempt keeps any session that's still valid — the

--- a/lib/features/settings/subsonic/subsonic_settings_controller.dart
+++ b/lib/features/settings/subsonic/subsonic_settings_controller.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/models/playlist.dart';
 import '../../../core/models/subsonic_session.dart';
+import '../../../core/repositories/secure_storage_exception.dart';
 import '../../../core/services/remote_cache/remote_cache_key.dart';
 import '../../../core/sources/music_provider.dart';
 import '../../../core/sources/subsonic/subsonic_api.dart';
@@ -54,8 +55,25 @@ class SubsonicSettingsController extends Notifier<SubsonicSettingsState> {
     final SubsonicSession? saved;
     try {
       saved = await ref.read(subsonicSessionStoreProvider).read();
-    } catch (_) {
-      // A storage hiccup must not break startup or playback; stay disconnected.
+    } catch (error) {
+      // A keyring that is missing, locked or denied must not break startup or
+      // playback: stay disconnected, but say so (statically, credential-free)
+      // so a user who *was* signed in isn't left wondering where their server
+      // went. A missing or corrupt record already reads back as null inside
+      // the store and stays silent.
+      //
+      // Only when nothing has taken over the card in the meantime: a locked
+      // keyring can block this read behind an unlock prompt for as long as the
+      // user leaves it there, and a sign-in that already started (or finished)
+      // in that time owns the state now.
+      if (_session == null &&
+          state.phase == SubsonicConnectionPhase.disconnected &&
+          state.errorMessage == null) {
+        state = SubsonicSettingsState(
+          errorMessage: "Couldn't restore your saved Navidrome/Subsonic "
+              'sign-in from this device. ${_storageRemedy(error)}',
+        );
+      }
       return;
     }
     if (saved == null) {
@@ -131,7 +149,21 @@ class SubsonicSettingsController extends Notifier<SubsonicSettingsState> {
                 username: username,
                 password: password,
               );
-      await ref.read(subsonicSessionStoreProvider).write(newSession);
+      try {
+        await ref.read(subsonicSessionStoreProvider).write(newSession);
+      } catch (error) {
+        // The new session couldn't reach the keyring. Adopting it anyway would
+        // look signed in until the next launch and then silently be gone, so
+        // don't: report it and let the user fix the keyring and retry. The
+        // derived salt+token is dropped here rather than kept anywhere else.
+        _setFailure(
+          "Couldn't save your Navidrome/Subsonic sign-in on this device. "
+          '${_storageRemedy(error)}',
+          url: url,
+          username: username,
+        );
+        return false;
+      }
       _session = newSession;
       // The just-signed-in server becomes the active/default provider for
       // picking among duplicate sources: a song that also lives on Jellyfin now
@@ -177,7 +209,18 @@ class SubsonicSettingsController extends Notifier<SubsonicSettingsState> {
   /// playlists (scoped to Subsonic, so a still-connected Jellyfin account keeps
   /// its own); on-device favourites and local-only playlists are kept.
   Future<void> clear() async {
-    await ref.read(subsonicSessionStoreProvider).clear();
+    try {
+      await ref.read(subsonicSessionStoreProvider).clear();
+    } catch (error) {
+      // The credential would stay in the keyring; report it rather than
+      // pretending the sign-out happened. Nothing else is torn down, so a
+      // retry after unlocking the keyring completes the same sign-out.
+      _setFailure(
+        "Couldn't remove your Navidrome/Subsonic sign-in from this device. "
+        '${_storageRemedy(error)}',
+      );
+      return;
+    }
     _session = null;
     try {
       await ref
@@ -205,6 +248,12 @@ class SubsonicSettingsController extends Notifier<SubsonicSettingsState> {
         .read(remoteCacheIndexProvider)
         .removeSource(RemoteCacheKey.sourceIdSubsonic);
   }
+
+  /// The user-facing tail for a secure-storage failure: what went wrong with
+  /// the keyring and what to do about it. Never carries any part of the value
+  /// that was being read or written (see [SecureStorageException]).
+  String _storageRemedy(Object error) =>
+      error is SecureStorageException ? error.remedy : 'Try again.';
 
   /// Reports an error without dropping an existing connection: a failed test or
   /// re-auth keeps any session that's still valid, it just surfaces the message.

--- a/scripts/check_linux_runner.py
+++ b/scripts/check_linux_runner.py
@@ -108,6 +108,13 @@ EXPECTED_FLATPAK_FINISH_ARGS = {
     "--device=dri",
     "--socket=pulseaudio",
     "--share=network",
+    # Secure credential storage (#441). flutter_secure_storage's Linux plugin
+    # is a libsecret wrapper, and libsecret's Secret Service backend talks to
+    # exactly this session-bus name. Being an exact string, every broader form
+    # a well-meaning change might reach for instead (--socket=session-bus, an
+    # org.freedesktop.* wildcard, --own-name, or the same name granted on the
+    # system bus) is rejected by this list rather than silently accepted.
+    "--talk-name=org.freedesktop.secrets",
 }
 
 # Where a Flatpak's desktop entry has to land: flatpak-builder exports what it

--- a/scripts/check_linux_runner.py
+++ b/scripts/check_linux_runner.py
@@ -101,6 +101,14 @@ FLATPAK_TEMPLATE = FLATPAK_DIR / "flatpak-flutter.yml"
 # exact allow-list (rather than checking only for --share=network) makes this a
 # regression guard against solving provider access with a filesystem or D-Bus
 # grant. Both the authoritative template and generated manifest are checked.
+#
+# There is deliberately no D-Bus entry at all. Secure credential storage (#441)
+# reaches the platform keyring through the xdg-desktop-portal Secret portal,
+# which every Flatpak may talk to without a finish-arg, so
+# --talk-name=org.freedesktop.secrets (and every broader form of it:
+# --socket=session-bus, an org.freedesktop.* wildcard, --own-name, the same
+# name on the system bus) is rejected by this list rather than quietly
+# accepted. See flatpak/flatpak-flutter.yml's finish-args comments.
 EXPECTED_FLATPAK_FINISH_ARGS = {
     "--socket=wayland",
     "--socket=fallback-x11",
@@ -108,13 +116,6 @@ EXPECTED_FLATPAK_FINISH_ARGS = {
     "--device=dri",
     "--socket=pulseaudio",
     "--share=network",
-    # Secure credential storage (#441). flutter_secure_storage's Linux plugin
-    # is a libsecret wrapper, and libsecret's Secret Service backend talks to
-    # exactly this session-bus name. Being an exact string, every broader form
-    # a well-meaning change might reach for instead (--socket=session-bus, an
-    # org.freedesktop.* wildcard, --own-name, or the same name granted on the
-    # system bus) is rejected by this list rather than silently accepted.
-    "--talk-name=org.freedesktop.secrets",
 }
 
 # Where a Flatpak's desktop entry has to land: flatpak-builder exports what it

--- a/test/data/repositories/secure_session_storage_test.dart
+++ b/test/data/repositories/secure_session_storage_test.dart
@@ -1,0 +1,433 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/jellyfin_session.dart';
+import 'package:linthra/core/models/plex_session.dart';
+import 'package:linthra/core/models/subsonic_session.dart';
+import 'package:linthra/core/repositories/secure_storage_exception.dart';
+import 'package:linthra/data/repositories/secure_jellyfin_session_store.dart';
+import 'package:linthra/data/repositories/secure_plex_session_store.dart';
+import 'package:linthra/data/repositories/secure_session_storage.dart';
+import 'package:linthra/data/repositories/secure_subsonic_session_store.dart';
+
+/// The real plugin channel. `flutter_secure_storage_linux` registers no Dart
+/// implementation of its own: on Linux the package talks to
+/// `MethodChannelFlutterSecureStorage`, which is this channel, and the C++
+/// plugin on the other side is a thin libsecret wrapper. Driving that channel
+/// is therefore the closest a host test can get to the real Secret Service
+/// path, and it keeps the failure semantics intact instead of stubbing out the
+/// store the app actually calls.
+const MethodChannel _channel =
+    MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+
+/// Channels a plaintext fallback would have to go through. Nothing in the
+/// credential path may touch them.
+const MethodChannel _sharedPreferences =
+    MethodChannel('plugins.flutter.io/shared_preferences');
+const MethodChannel _pathProvider =
+    MethodChannel('plugins.flutter.io/path_provider');
+
+const JellyfinSession _jellyfin = JellyfinSession(
+  baseUrl: 'https://jellyfin.example.com',
+  userId: 'user-1',
+  accessToken: 'jellyfin-token-do-not-leak',
+  deviceId: 'device-1',
+  userName: 'alice',
+  serverName: 'Home',
+);
+
+const SubsonicSession _subsonic = SubsonicSession(
+  baseUrl: 'https://navidrome.example.com',
+  username: 'alice',
+  salt: 'salt-do-not-leak',
+  token: 'subsonic-token-do-not-leak',
+  serverType: 'navidrome',
+);
+
+const PlexSession _plex = PlexSession(
+  baseUrl: 'https://plex.example.com:32400',
+  token: 'plex-token-do-not-leak',
+  machineIdentifier: 'machine-abc',
+  serverName: 'Living Room PMS',
+);
+
+/// The errors the Linux stack really produces, reproduced verbatim.
+///
+/// `flutter_secure_storage_linux` catches whatever libsecret threw and answers
+/// the channel with `fl_method_error_response_new("Libsecret error", <text>)`,
+/// so these are the exact `PlatformException`s Linthra sees when the Secret
+/// Service is missing, locked, or blocked by a sandbox.
+final PlatformException _noSecretService = PlatformException(
+  code: 'Libsecret error',
+  message: 'The name org.freedesktop.secrets was not provided by any '
+      '.service files (org.freedesktop.DBus.Error.ServiceUnknown)',
+);
+
+/// The plugin's own keyring warm-up failing: a locked keyring, or an unlock
+/// prompt the user dismissed.
+final PlatformException _lockedKeyring = PlatformException(
+  code: 'Libsecret error',
+  message: 'Failed to unlock the keyring',
+);
+
+/// What a Flatpak's D-Bus proxy answers for a name the manifest does not
+/// grant: the call is rejected rather than the service being absent.
+final PlatformException _sandboxDenied = PlatformException(
+  code: 'Libsecret error',
+  message: 'GDBus.Error:org.freedesktop.DBus.Error.AccessDenied: '
+      'Rejected send message',
+);
+
+/// A stand-in for the Secret Service behind the plugin channel.
+///
+/// It answers the same methods the C++ plugin does, with the same shapes: one
+/// keyring item per key, `read` of an absent key returns null, and any
+/// libsecret failure surfaces as a `PlatformException` from *every* method
+/// (including `delete`, which the plugin cannot complete without first reading
+/// the keyring back).
+class _FakeKeyring {
+  final Map<String, String> items = <String, String>{};
+  final List<String> methods = <String>[];
+
+  /// When set, every operation fails with it, the way libsecret fails when the
+  /// service is missing, locked, or refused.
+  PlatformException? failure;
+
+  Future<Object?> handle(MethodCall call) async {
+    methods.add(call.method);
+    final PlatformException? error = failure;
+    if (error != null) {
+      throw error;
+    }
+    final Map<Object?, Object?> arguments =
+        (call.arguments as Map<Object?, Object?>?) ?? <Object?, Object?>{};
+    final String? key = arguments['key'] as String?;
+    switch (call.method) {
+      case 'read':
+        return items[key];
+      case 'write':
+        items[key!] = arguments['value']! as String;
+        return null;
+      case 'delete':
+        items.remove(key);
+        return null;
+      case 'containsKey':
+        return items.containsKey(key);
+      default:
+        throw MissingPluginException('unexpected method ${call.method}');
+    }
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _FakeKeyring keyring;
+  late SecureSessionStorage storage;
+  late List<String> fallbackChannelCalls;
+
+  setUp(() {
+    keyring = _FakeKeyring();
+    storage = const SecureSessionStorage();
+    fallbackChannelCalls = <String>[];
+    final TestDefaultBinaryMessenger messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(_channel, keyring.handle);
+    for (final MethodChannel channel in <MethodChannel>[
+      _sharedPreferences,
+      _pathProvider,
+    ]) {
+      messenger.setMockMethodCallHandler(channel, (MethodCall call) async {
+        fallbackChannelCalls.add('${channel.name}#${call.method}');
+        return null;
+      });
+    }
+  });
+
+  tearDown(() {
+    final TestDefaultBinaryMessenger messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    for (final MethodChannel channel in <MethodChannel>[
+      _channel,
+      _sharedPreferences,
+      _pathProvider,
+    ]) {
+      messenger.setMockMethodCallHandler(channel, null);
+    }
+  });
+
+  group('SecureSessionStorage', () {
+    test('writes, reads back, and deletes through the platform store',
+        () async {
+      await storage.write(key: 'k', value: 'v');
+      expect(keyring.items['k'], 'v');
+
+      expect(await storage.read(key: 'k'), 'v');
+
+      await storage.delete(key: 'k');
+      expect(keyring.items, isEmpty);
+      expect(await storage.read(key: 'k'), isNull);
+    });
+
+    test('a missing Secret Service fails as unavailable on every operation',
+        () async {
+      keyring.failure = _noSecretService;
+
+      for (final Future<void> Function() operation in <Future<void> Function()>[
+        () => storage.read(key: 'k'),
+        () => storage.write(key: 'k', value: 'v'),
+        () => storage.delete(key: 'k'),
+      ]) {
+        await expectLater(
+          operation(),
+          throwsA(
+            isA<SecureStorageException>().having(
+              (SecureStorageException error) => error.failure,
+              'failure',
+              SecureStorageFailure.unavailable,
+            ),
+          ),
+        );
+      }
+    });
+
+    test('a locked keyring fails as locked, and says so', () async {
+      keyring.failure = _lockedKeyring;
+
+      await expectLater(
+        storage.read(key: 'k'),
+        throwsA(
+          isA<SecureStorageException>()
+              .having(
+                (SecureStorageException error) => error.failure,
+                'failure',
+                SecureStorageFailure.locked,
+              )
+              .having(
+                (SecureStorageException error) => error.operation,
+                'operation',
+                SecureStorageOperation.read,
+              )
+              .having(
+                (SecureStorageException error) => error.remedy,
+                'remedy',
+                contains('Unlock'),
+              ),
+        ),
+      );
+    });
+
+    test('a sandbox that denies the Secret Service name fails as denied',
+        () async {
+      keyring.failure = _sandboxDenied;
+
+      await expectLater(
+        storage.write(key: 'k', value: 'v'),
+        throwsA(
+          isA<SecureStorageException>().having(
+            (SecureStorageException error) => error.failure,
+            'failure',
+            SecureStorageFailure.denied,
+          ),
+        ),
+      );
+    });
+
+    test('an unrecognised platform error still fails safely, as unknown',
+        () async {
+      keyring.failure = PlatformException(
+        code: 'Libsecret error',
+        message: 'something libsecret has never said before',
+      );
+
+      await expectLater(
+        storage.read(key: 'k'),
+        throwsA(
+          isA<SecureStorageException>().having(
+            (SecureStorageException error) => error.failure,
+            'failure',
+            SecureStorageFailure.unknown,
+          ),
+        ),
+      );
+    });
+
+    test('no secure-storage implementation at all reads as unavailable',
+        () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(_channel, null);
+
+      await expectLater(
+        storage.read(key: 'k'),
+        throwsA(
+          isA<SecureStorageException>().having(
+            (SecureStorageException error) => error.failure,
+            'failure',
+            SecureStorageFailure.unavailable,
+          ),
+        ),
+      );
+    });
+
+    test('the failure carries nothing from the platform error', () async {
+      // A platform message that quotes back what was being stored is the
+      // nightmare case: the exception must not carry it onward into a log, a
+      // diagnostics report, or a crash reporter.
+      keyring.failure = PlatformException(
+        code: 'Libsecret error',
+        message: 'could not store value jellyfin-token-do-not-leak',
+        details: 'jellyfin-token-do-not-leak',
+      );
+
+      Object? thrown;
+      try {
+        await storage.write(key: 'k', value: 'jellyfin-token-do-not-leak');
+      } catch (error) {
+        thrown = error;
+      }
+
+      final SecureStorageException failure = thrown! as SecureStorageException;
+      expect(failure.toString(), isNot(contains('jellyfin-token-do-not-leak')));
+      expect(failure.remedy, isNot(contains('jellyfin-token-do-not-leak')));
+      expect(failure.toString(), 'SecureStorageException(write: unknown)');
+    });
+
+    test('a failed write leaves nothing behind, anywhere', () async {
+      keyring.failure = _noSecretService;
+
+      await expectLater(
+        storage.write(key: 'k', value: 'jellyfin-token-do-not-leak'),
+        throwsA(isA<SecureStorageException>()),
+      );
+
+      // Not in the keyring (the write failed), and not in the two stores a
+      // plaintext fallback would reach for instead.
+      expect(keyring.items, isEmpty);
+      expect(fallbackChannelCalls, isEmpty);
+    });
+  });
+
+  group('provider session stores', () {
+    test('Jellyfin: saves, restores after a restart, and signs out clean',
+        () async {
+      const SecureJellyfinSessionStore store = SecureJellyfinSessionStore();
+      await store.write(_jellyfin);
+
+      // The credential reached the platform store, and only it.
+      expect(keyring.items.keys, <String>['jellyfin_session_v1']);
+      expect(fallbackChannelCalls, isEmpty);
+
+      // A restart is a fresh store instance reading the same keyring.
+      const SecureJellyfinSessionStore afterRestart =
+          SecureJellyfinSessionStore();
+      expect(await afterRestart.read(), _jellyfin);
+      expect((await afterRestart.read())!.accessToken, _jellyfin.accessToken);
+
+      await afterRestart.clear();
+      expect(keyring.items, isEmpty);
+      expect(await afterRestart.read(), isNull);
+    });
+
+    test(
+        'Navidrome/Subsonic: saves, restores after a restart, and signs out '
+        'clean', () async {
+      const SecureSubsonicSessionStore store = SecureSubsonicSessionStore();
+      await store.write(_subsonic);
+      expect(keyring.items.keys, <String>['subsonic_session_v1']);
+
+      const SecureSubsonicSessionStore afterRestart =
+          SecureSubsonicSessionStore();
+      final SubsonicSession? restored = await afterRestart.read();
+      expect(restored, _subsonic);
+      expect(restored!.token, _subsonic.token);
+      expect(restored.salt, _subsonic.salt);
+
+      await afterRestart.clear();
+      expect(keyring.items, isEmpty);
+      expect(await afterRestart.read(), isNull);
+    });
+
+    test('Plex: saves, restores after a restart, and signs out clean',
+        () async {
+      const SecurePlexSessionStore store = SecurePlexSessionStore();
+      await store.write(_plex);
+      expect(keyring.items.keys, <String>['plex_session_v1']);
+
+      const SecurePlexSessionStore afterRestart = SecurePlexSessionStore();
+      final PlexSession? restored = await afterRestart.read();
+      expect(restored, _plex);
+      expect(restored!.token, _plex.token);
+
+      await afterRestart.clear();
+      expect(keyring.items, isEmpty);
+      expect(await afterRestart.read(), isNull);
+    });
+
+    test('a locked keyring is reported, not mistaken for a signed-out user',
+        () async {
+      // The important distinction: "there is no saved session" and "I could
+      // not read the saved session" must not look the same, or a locked
+      // keyring silently presents as a signed-out app and the next write
+      // overwrites a credential that was fine.
+      const SecureJellyfinSessionStore store = SecureJellyfinSessionStore();
+      await store.write(_jellyfin);
+      keyring.failure = _lockedKeyring;
+
+      await expectLater(
+        store.read(),
+        throwsA(
+          isA<SecureStorageException>().having(
+            (SecureStorageException error) => error.failure,
+            'failure',
+            SecureStorageFailure.locked,
+          ),
+        ),
+      );
+    });
+
+    test('an unavailable Secret Service fails every operation, storing nothing',
+        () async {
+      keyring.failure = _noSecretService;
+      const SecurePlexSessionStore store = SecurePlexSessionStore();
+
+      await expectLater(
+          store.write(_plex), throwsA(isA<SecureStorageException>()));
+      await expectLater(store.read(), throwsA(isA<SecureStorageException>()));
+      await expectLater(store.clear(), throwsA(isA<SecureStorageException>()));
+
+      expect(keyring.items, isEmpty);
+      expect(fallbackChannelCalls, isEmpty);
+    });
+
+    test('a corrupt record still reads as signed out', () async {
+      keyring.items['jellyfin_session_v1'] = 'not json';
+      const SecureJellyfinSessionStore store = SecureJellyfinSessionStore();
+
+      expect(await store.read(), isNull);
+    });
+
+    test('nothing but the provider key is read, written or deleted', () async {
+      const SecureJellyfinSessionStore store = SecureJellyfinSessionStore();
+      await store.write(_jellyfin);
+      await store.read();
+      await store.clear();
+
+      // No readAll/deleteAll: Linthra touches its own keys and leaves the rest
+      // of the user's keyring alone.
+      expect(keyring.methods, <String>['write', 'read', 'delete']);
+    });
+
+    test('what is stored is the session JSON and nothing more', () async {
+      const SecureJellyfinSessionStore store = SecureJellyfinSessionStore();
+      await store.write(_jellyfin);
+
+      final Object? stored = jsonDecode(keyring.items['jellyfin_session_v1']!);
+      expect(stored, isA<Map<String, dynamic>>());
+      expect(
+        (stored! as Map<String, dynamic>).keys,
+        containsAll(<String>['baseUrl', 'userId', 'accessToken']),
+      );
+    });
+  });
+}

--- a/test/features/settings/jellyfin/jellyfin_settings_controller_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_settings_controller_test.dart
@@ -1,11 +1,15 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/jellyfin_session.dart';
 import 'package:linthra/core/models/playlist.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/repositories/favorites_repository.dart';
+import 'package:linthra/core/repositories/jellyfin_session_store.dart';
 import 'package:linthra/core/repositories/playlist_repository.dart';
 import 'package:linthra/core/repositories/remote_sync_result.dart';
+import 'package:linthra/core/repositories/secure_storage_exception.dart';
 import 'package:linthra/core/services/remote_cache/remote_cache_index.dart';
 import 'package:linthra/core/services/remote_cache/remote_cache_record.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_api.dart';
@@ -130,9 +134,67 @@ class _SpyPlaylistRepository implements PlaylistRepository {
       throw UnimplementedError();
 }
 
+/// A session store standing in for a platform keyring that cannot be used:
+/// missing, locked, or refused by a sandbox. It fails exactly the way
+/// [SecureJellyfinSessionStore] does through [SecureSessionStorage] (a typed
+/// [SecureStorageException]), so these tests exercise the controller's real
+/// failure path rather than a generic thrown object.
+class _UnusableKeyringStore implements JellyfinSessionStore {
+  _UnusableKeyringStore({
+    JellyfinSession? initialSession,
+    this.readFailure,
+    this.writeFailure,
+    this.clearFailure,
+    this.readGate,
+  }) : _session = initialSession;
+
+  JellyfinSession? _session;
+  final SecureStorageException? readFailure;
+  final SecureStorageException? writeFailure;
+  final SecureStorageException? clearFailure;
+
+  /// Holds the restore read open, the way a keyring that is waiting on an
+  /// unlock prompt does.
+  final Completer<void>? readGate;
+
+  @override
+  Future<JellyfinSession?> read() async {
+    if (readGate != null) await readGate!.future;
+    if (readFailure != null) throw readFailure!;
+    return _session;
+  }
+
+  @override
+  Future<void> write(JellyfinSession session) async {
+    if (writeFailure != null) throw writeFailure!;
+    _session = session;
+  }
+
+  @override
+  Future<void> clear() async {
+    if (clearFailure != null) throw clearFailure!;
+    _session = null;
+  }
+}
+
+const SecureStorageException _lockedRead = SecureStorageException(
+  operation: SecureStorageOperation.read,
+  failure: SecureStorageFailure.locked,
+);
+
+const SecureStorageException _unavailableWrite = SecureStorageException(
+  operation: SecureStorageOperation.write,
+  failure: SecureStorageFailure.unavailable,
+);
+
+const SecureStorageException _lockedDelete = SecureStorageException(
+  operation: SecureStorageOperation.delete,
+  failure: SecureStorageFailure.locked,
+);
+
 ProviderContainer _container({
   FakeJellyfinAuthenticator? authenticator,
-  InMemoryJellyfinSessionStore? store,
+  JellyfinSessionStore? store,
 }) {
   final container = ProviderContainer(
     overrides: <Override>[
@@ -571,6 +633,140 @@ void main() {
       expect(source, isNotNull);
       expect(source!.session, _session);
       expect(source.id, 'jellyfin');
+    });
+  });
+
+  group('JellyfinSettingsController secure storage failures', () {
+    test(
+        'a keyring it cannot read reports a restore error, not a silent '
+        'sign-out', () async {
+      final container = _container(
+        store: _UnusableKeyringStore(
+          initialSession: _session,
+          readFailure: _lockedRead,
+        ),
+      );
+      container.read(jellyfinSettingsControllerProvider);
+      await _settle();
+
+      final state = container.read(jellyfinSettingsControllerProvider);
+      expect(state.phase, JellyfinConnectionPhase.disconnected);
+      expect(
+        state.errorMessage,
+        contains("Couldn't restore your saved Jellyfin sign-in"),
+      );
+      // The cause is actionable, not a shrug.
+      expect(state.errorMessage, contains('Unlock your keyring'));
+    });
+
+    test(
+        'a sign-in that cannot be saved fails with a storage error and keeps '
+        'no session', () async {
+      final store = _UnusableKeyringStore(writeFailure: _unavailableWrite);
+      final container = _container(
+        authenticator: FakeJellyfinAuthenticator(session: _session),
+        store: store,
+      );
+      final notifier =
+          container.read(jellyfinSettingsControllerProvider.notifier);
+      await _settle();
+
+      final ok = await notifier.signIn(
+        url: 'music.example.com',
+        username: 'alice',
+        password: 'hunter2',
+      );
+
+      expect(ok, isFalse);
+      final state = container.read(jellyfinSettingsControllerProvider);
+      expect(state.phase, JellyfinConnectionPhase.disconnected);
+      expect(
+        state.errorMessage,
+        contains("Couldn't save your Jellyfin sign-in on this device"),
+      );
+      expect(state.errorMessage, contains('no keyring available'));
+      // A session that could not be persisted is not adopted: it would look
+      // signed in now and be gone after a restart.
+      expect(notifier.session, isNull);
+      expect(container.read(jellyfinMusicSourceProvider), isNull);
+      expect(await store.read(), isNull);
+    });
+
+    test('the storage error carries no token and no password', () async {
+      final container = _container(
+        authenticator: FakeJellyfinAuthenticator(session: _session),
+        store: _UnusableKeyringStore(writeFailure: _unavailableWrite),
+      );
+      final notifier =
+          container.read(jellyfinSettingsControllerProvider.notifier);
+      await _settle();
+
+      await notifier.signIn(
+        url: 'music.example.com',
+        username: 'alice',
+        password: 'hunter2',
+      );
+
+      final state = container.read(jellyfinSettingsControllerProvider);
+      expect(state.errorMessage, isNot(contains('hunter2')));
+      expect(state.errorMessage, isNot(contains(_session.accessToken)));
+      expect(notifier.diagnosticsReport(), isNot(contains('hunter2')));
+      expect(
+        notifier.diagnosticsReport(),
+        isNot(contains(_session.accessToken)),
+      );
+    });
+
+    test('a restore failure never overwrites a sign-in that got there first',
+        () async {
+      // A locked keyring can hold the startup read open for as long as the
+      // unlock prompt sits there. If the user signs in meanwhile, the late
+      // failure must not replace their connected card with a restore error.
+      final gate = Completer<void>();
+      final container = _container(
+        authenticator: FakeJellyfinAuthenticator(session: _session),
+        store: _UnusableKeyringStore(readFailure: _lockedRead, readGate: gate),
+      );
+      final notifier =
+          container.read(jellyfinSettingsControllerProvider.notifier);
+
+      final ok = await notifier.signIn(
+        url: 'music.example.com',
+        username: 'alice',
+        password: 'hunter2',
+      );
+      expect(ok, isTrue);
+
+      gate.complete();
+      await _settle();
+
+      final state = container.read(jellyfinSettingsControllerProvider);
+      expect(state.phase, JellyfinConnectionPhase.connected);
+      expect(state.errorMessage, isNull);
+    });
+
+    test('a sign-out the keyring refuses says so instead of pretending',
+        () async {
+      final store = _UnusableKeyringStore(
+        initialSession: _session,
+        clearFailure: _lockedDelete,
+      );
+      final container = _container(store: store);
+      final notifier =
+          container.read(jellyfinSettingsControllerProvider.notifier);
+      await notifier.ensureLoaded();
+
+      await notifier.clear();
+
+      final state = container.read(jellyfinSettingsControllerProvider);
+      expect(
+        state.errorMessage,
+        contains("Couldn't remove your Jellyfin sign-in from this device"),
+      );
+      // Still signed in, because the credential really is still in the
+      // keyring. Retrying after unlocking completes the same sign-out.
+      expect(state.phase, JellyfinConnectionPhase.connected);
+      expect(await store.read(), _session);
     });
   });
 }

--- a/test/features/settings/plex/plex_settings_controller_test.dart
+++ b/test/features/settings/plex/plex_settings_controller_test.dart
@@ -9,6 +9,7 @@ import 'package:linthra/core/models/plex_session.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/repositories/music_library_repository.dart';
 import 'package:linthra/core/repositories/plex_session_store.dart';
+import 'package:linthra/core/repositories/secure_storage_exception.dart';
 import 'package:linthra/core/services/external_link_launcher.dart';
 import 'package:linthra/core/services/remote_cache/remote_cache_index.dart';
 import 'package:linthra/core/services/remote_cache/remote_cache_record.dart';
@@ -598,6 +599,31 @@ void main() {
       expect(state.phase, PlexConnectionPhase.disconnected);
       expect(state.errorMessage, contains("Couldn't save your Plex session"));
       expect(container.read(plexMusicSourceProvider), isNull);
+    });
+
+    test('a keyring failure is reported with what to do about it', () async {
+      // The Plex card already refuses to adopt a session it could not save;
+      // what a locked keyring adds is a cause the user can act on, taken from
+      // the typed failure SecureSessionStorage raises (and carrying nothing
+      // from the platform error, let alone the token).
+      final container = _container(
+        store: _FlakyPlexSessionStore(
+          writeError: const SecureStorageException(
+            operation: SecureStorageOperation.write,
+            failure: SecureStorageFailure.locked,
+          ),
+        ),
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+
+      final ok = await notifier.connect(url: 'plex.example.com', token: _token);
+
+      expect(ok, isFalse);
+      final state = container.read(plexSettingsControllerProvider);
+      expect(state.errorMessage, contains("Couldn't save your Plex session"));
+      expect(state.errorMessage, contains('Unlock your keyring'));
+      expect(state.errorMessage, isNot(contains(_token)));
     });
 
     test('a section-listing failure keeps the connection and is retryable',

--- a/test/features/settings/subsonic/subsonic_settings_controller_test.dart
+++ b/test/features/settings/subsonic/subsonic_settings_controller_test.dart
@@ -1,6 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/subsonic_session.dart';
+import 'package:linthra/core/repositories/secure_storage_exception.dart';
+import 'package:linthra/core/repositories/subsonic_session_store.dart';
 import 'package:linthra/core/services/remote_cache/remote_cache_index.dart';
 import 'package:linthra/core/services/remote_cache/remote_cache_record.dart';
 import 'package:linthra/core/sources/subsonic/subsonic_exception.dart';
@@ -25,9 +29,67 @@ const _session = SubsonicSession(
 
 Future<void> _settle() => Future<void>.delayed(Duration.zero);
 
+/// A session store standing in for a platform keyring that cannot be used:
+/// missing, locked, or refused by a sandbox. It fails exactly the way
+/// [SecureSubsonicSessionStore] does through [SecureSessionStorage] (a typed
+/// [SecureStorageException]), so these tests exercise the controller's real
+/// failure path rather than a generic thrown object.
+class _UnusableKeyringStore implements SubsonicSessionStore {
+  _UnusableKeyringStore({
+    SubsonicSession? initialSession,
+    this.readFailure,
+    this.writeFailure,
+    this.clearFailure,
+    this.readGate,
+  }) : _session = initialSession;
+
+  SubsonicSession? _session;
+  final SecureStorageException? readFailure;
+  final SecureStorageException? writeFailure;
+  final SecureStorageException? clearFailure;
+
+  /// Holds the restore read open, the way a keyring that is waiting on an
+  /// unlock prompt does.
+  final Completer<void>? readGate;
+
+  @override
+  Future<SubsonicSession?> read() async {
+    if (readGate != null) await readGate!.future;
+    if (readFailure != null) throw readFailure!;
+    return _session;
+  }
+
+  @override
+  Future<void> write(SubsonicSession session) async {
+    if (writeFailure != null) throw writeFailure!;
+    _session = session;
+  }
+
+  @override
+  Future<void> clear() async {
+    if (clearFailure != null) throw clearFailure!;
+    _session = null;
+  }
+}
+
+const SecureStorageException _lockedRead = SecureStorageException(
+  operation: SecureStorageOperation.read,
+  failure: SecureStorageFailure.locked,
+);
+
+const SecureStorageException _unavailableWrite = SecureStorageException(
+  operation: SecureStorageOperation.write,
+  failure: SecureStorageFailure.unavailable,
+);
+
+const SecureStorageException _lockedDelete = SecureStorageException(
+  operation: SecureStorageOperation.delete,
+  failure: SecureStorageFailure.locked,
+);
+
 ProviderContainer _container({
   FakeSubsonicClient? client,
-  InMemorySubsonicSessionStore? store,
+  SubsonicSessionStore? store,
 }) {
   final container = ProviderContainer(
     overrides: <Override>[
@@ -232,6 +294,113 @@ void main() {
       final source = container.read(subsonicMusicSourceProvider);
       expect(source, isNotNull);
       expect(source!.id, 'subsonic');
+    });
+  });
+
+  group('secure storage failures', () {
+    test(
+        'a keyring it cannot read reports a restore error, not a silent '
+        'sign-out', () async {
+      final container = _container(
+        store: _UnusableKeyringStore(
+          initialSession: _session,
+          readFailure: _lockedRead,
+        ),
+      );
+      container.read(subsonicSettingsControllerProvider);
+      await _settle();
+
+      final state = container.read(subsonicSettingsControllerProvider);
+      expect(state.phase, SubsonicConnectionPhase.disconnected);
+      expect(
+        state.errorMessage,
+        contains("Couldn't restore your saved Navidrome/Subsonic sign-in"),
+      );
+      expect(state.errorMessage, contains('Unlock your keyring'));
+    });
+
+    test(
+        'a sign-in that cannot be saved fails with a storage error and keeps '
+        'no session', () async {
+      final store = _UnusableKeyringStore(writeFailure: _unavailableWrite);
+      final container = _container(store: store);
+      final notifier =
+          container.read(subsonicSettingsControllerProvider.notifier);
+      await _settle();
+
+      final ok = await notifier.signIn(
+        url: 'music.example.com',
+        username: 'alice',
+        password: 'hunter2',
+      );
+
+      expect(ok, isFalse);
+      final state = container.read(subsonicSettingsControllerProvider);
+      expect(state.phase, SubsonicConnectionPhase.disconnected);
+      expect(
+        state.errorMessage,
+        contains("Couldn't save your Navidrome/Subsonic sign-in on this "
+            'device'),
+      );
+      expect(state.errorMessage, contains('no keyring available'));
+      // Not adopted: a session that could not be persisted would look signed
+      // in now and be gone after a restart.
+      expect(notifier.session, isNull);
+      expect(await store.read(), isNull);
+      // And the password that derived the credential never reaches the UI.
+      expect(state.errorMessage, isNot(contains('hunter2')));
+    });
+
+    test('a restore failure never overwrites a sign-in that got there first',
+        () async {
+      // A locked keyring can hold the startup read open for as long as the
+      // unlock prompt sits there. If the user signs in meanwhile, the late
+      // failure must not replace their connected card with a restore error.
+      final gate = Completer<void>();
+      final container = _container(
+        store: _UnusableKeyringStore(readFailure: _lockedRead, readGate: gate),
+      );
+      final notifier =
+          container.read(subsonicSettingsControllerProvider.notifier);
+
+      final ok = await notifier.signIn(
+        url: 'music.example.com',
+        username: 'alice',
+        password: 'hunter2',
+      );
+      expect(ok, isTrue);
+
+      gate.complete();
+      await _settle();
+
+      final state = container.read(subsonicSettingsControllerProvider);
+      expect(state.phase, SubsonicConnectionPhase.connected);
+      expect(state.errorMessage, isNull);
+    });
+
+    test('a sign-out the keyring refuses says so instead of pretending',
+        () async {
+      final store = _UnusableKeyringStore(
+        initialSession: _session,
+        clearFailure: _lockedDelete,
+      );
+      final container = _container(store: store);
+      final notifier =
+          container.read(subsonicSettingsControllerProvider.notifier);
+      await notifier.ensureLoaded();
+
+      await notifier.clear();
+
+      final state = container.read(subsonicSettingsControllerProvider);
+      expect(
+        state.errorMessage,
+        contains("Couldn't remove your Navidrome/Subsonic sign-in from this "
+            'device'),
+      );
+      // Still signed in, because the credential really is still in the
+      // keyring. Retrying after unlocking completes the same sign-out.
+      expect(state.phase, SubsonicConnectionPhase.connected);
+      expect(await store.read(), _session);
     });
   });
 }

--- a/test/tooling/check_linux_runner_test.py
+++ b/test/tooling/check_linux_runner_test.py
@@ -189,6 +189,7 @@ finish-args:
   - --device=dri
   - --socket=pulseaudio
   - --share=network
+  - --talk-name=org.freedesktop.secrets
 modules:
   - name: {binary}
     buildsystem: simple
@@ -565,6 +566,113 @@ class FlatpakPermissionTest(CheckoutCase):
         problems = checker.check(self.root)
         self.assertEqual(len(problems), 1)
         self.assertIn("--talk-name=org.example.Service", problems[0])
+
+    def test_generated_manifest_without_secret_service_is_caught(self) -> None:
+        # The permission #441 actually needs: libsecret's Secret Service
+        # backend talks to this one session-bus name, and without it every
+        # credential read and write fails inside the sandbox.
+        build_checkout(
+            self.root,
+            flatpak_manifest=FLATPAK_MANIFEST.format(
+                app_id=APP_ID, binary=BINARY
+            ).replace("  - --talk-name=org.freedesktop.secrets\n", ""),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn(f"flatpak/{APP_ID}.yml", problems[0])
+        self.assertIn("--talk-name=org.freedesktop.secrets", problems[0])
+
+    def test_secret_service_dropped_from_the_template_is_caught(self) -> None:
+        # The other half of the same drift: the template is the authoritative
+        # input, so losing the grant there is a real regression even while the
+        # generated manifest still carries it.
+        manifest = FLATPAK_MANIFEST.format(app_id=APP_ID, binary=BINARY)
+        build_checkout(self.root, flatpak_manifest=manifest)
+        (self.root / "flatpak" / "flatpak-flutter.yml").write_text(
+            manifest.replace("  - --talk-name=org.freedesktop.secrets\n", ""),
+            encoding="utf-8",
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("flatpak/flatpak-flutter.yml", problems[0])
+        self.assertIn("--talk-name=org.freedesktop.secrets", problems[0])
+
+    def test_broader_secret_service_permissions_are_caught(self) -> None:
+        # Every broader way to reach the same service. One exact well-known
+        # name on the session bus is what libsecret connects to; anything
+        # wider is a bigger sandbox for no benefit.
+        for permission in (
+            "--socket=session-bus",
+            "--talk-name=org.freedesktop.*",
+            "--talk-name=org.freedesktop.secrets.*",
+            "--own-name=org.freedesktop.secrets",
+            "--system-talk-name=org.freedesktop.secrets",
+            "--talk-name=org.freedesktop.impl.portal.Secret",
+        ):
+            with self.subTest(permission=permission):
+                root = self.root / permission.replace("/", "_").replace(
+                    "*", "star"
+                )
+                root.mkdir(parents=True, exist_ok=True)
+                build_checkout(
+                    root,
+                    flatpak_manifest=FLATPAK_MANIFEST.format(
+                        app_id=APP_ID, binary=BINARY
+                    ).replace(
+                        "  - --talk-name=org.freedesktop.secrets\n",
+                        "  - --talk-name=org.freedesktop.secrets\n"
+                        f"  - {permission}\n",
+                    ),
+                )
+                problems = checker.check(root)
+                self.assertEqual(len(problems), 1)
+                self.assertIn("unrelated permission", problems[0])
+                self.assertIn(permission, problems[0])
+
+    def test_filesystem_permissions_stay_rejected(self) -> None:
+        # A keyring grant must not become a reason to hand out host files:
+        # nothing in the credential path reads or writes a file.
+        for permission in (
+            "--filesystem=host",
+            "--filesystem=home",
+            "--filesystem=xdg-data/keyrings",
+            "--persist=.local/share/keyrings",
+        ):
+            with self.subTest(permission=permission):
+                root = self.root / permission.replace("/", "_").replace(
+                    "=", "_"
+                )
+                root.mkdir(parents=True, exist_ok=True)
+                build_checkout(
+                    root,
+                    flatpak_manifest=FLATPAK_MANIFEST.format(
+                        app_id=APP_ID, binary=BINARY
+                    ).replace(
+                        "  - --share=network\n",
+                        f"  - --share=network\n  - {permission}\n",
+                    ),
+                )
+                problems = checker.check(root)
+                self.assertEqual(len(problems), 1)
+                self.assertIn("unrelated permission", problems[0])
+                self.assertIn(permission, problems[0])
+
+    def test_network_permission_is_unchanged_by_the_keyring_grant(self) -> None:
+        # #543's grant and #441's are independent: the checker holds both, so
+        # neither can be traded for the other.
+        self.assertIn("--share=network", checker.EXPECTED_FLATPAK_FINISH_ARGS)
+        self.assertIn(
+            "--talk-name=org.freedesktop.secrets",
+            checker.EXPECTED_FLATPAK_FINISH_ARGS,
+        )
+        self.assertEqual(
+            {
+                permission
+                for permission in checker.EXPECTED_FLATPAK_FINISH_ARGS
+                if permission.startswith(("--talk-name", "--system-talk-name"))
+            },
+            {"--talk-name=org.freedesktop.secrets"},
+        )
 
     def test_allowed_permission_with_inline_comment_is_recognised(self) -> None:
         manifest = FLATPAK_MANIFEST.format(app_id=APP_ID, binary=BINARY).replace(

--- a/test/tooling/check_linux_runner_test.py
+++ b/test/tooling/check_linux_runner_test.py
@@ -189,7 +189,6 @@ finish-args:
   - --device=dri
   - --socket=pulseaudio
   - --share=network
-  - --talk-name=org.freedesktop.secrets
 modules:
   - name: {binary}
     buildsystem: simple
@@ -567,34 +566,26 @@ class FlatpakPermissionTest(CheckoutCase):
         self.assertEqual(len(problems), 1)
         self.assertIn("--talk-name=org.example.Service", problems[0])
 
-    def test_generated_manifest_without_secret_service_is_caught(self) -> None:
-        # The permission #441 actually needs: libsecret's Secret Service
-        # backend talks to this one session-bus name, and without it every
-        # credential read and write fails inside the sandbox.
+    def test_the_secret_service_permission_is_not_granted(self) -> None:
+        # #441 is served by the xdg-desktop-portal Secret portal, which needs
+        # no finish-arg, so the direct Secret Service name is not shipped. If
+        # someone adds it back, this list says so rather than absorbing it.
+        self.assertNotIn(
+            "--talk-name=org.freedesktop.secrets",
+            checker.EXPECTED_FLATPAK_FINISH_ARGS,
+        )
         build_checkout(
             self.root,
             flatpak_manifest=FLATPAK_MANIFEST.format(
                 app_id=APP_ID, binary=BINARY
-            ).replace("  - --talk-name=org.freedesktop.secrets\n", ""),
+            ).replace(
+                "  - --share=network\n",
+                "  - --share=network\n  - --talk-name=org.freedesktop.secrets\n",
+            ),
         )
         problems = checker.check(self.root)
         self.assertEqual(len(problems), 1)
-        self.assertIn(f"flatpak/{APP_ID}.yml", problems[0])
-        self.assertIn("--talk-name=org.freedesktop.secrets", problems[0])
-
-    def test_secret_service_dropped_from_the_template_is_caught(self) -> None:
-        # The other half of the same drift: the template is the authoritative
-        # input, so losing the grant there is a real regression even while the
-        # generated manifest still carries it.
-        manifest = FLATPAK_MANIFEST.format(app_id=APP_ID, binary=BINARY)
-        build_checkout(self.root, flatpak_manifest=manifest)
-        (self.root / "flatpak" / "flatpak-flutter.yml").write_text(
-            manifest.replace("  - --talk-name=org.freedesktop.secrets\n", ""),
-            encoding="utf-8",
-        )
-        problems = checker.check(self.root)
-        self.assertEqual(len(problems), 1)
-        self.assertIn("flatpak/flatpak-flutter.yml", problems[0])
+        self.assertIn("unrelated permission", problems[0])
         self.assertIn("--talk-name=org.freedesktop.secrets", problems[0])
 
     def test_broader_secret_service_permissions_are_caught(self) -> None:
@@ -619,9 +610,8 @@ class FlatpakPermissionTest(CheckoutCase):
                     flatpak_manifest=FLATPAK_MANIFEST.format(
                         app_id=APP_ID, binary=BINARY
                     ).replace(
-                        "  - --talk-name=org.freedesktop.secrets\n",
-                        "  - --talk-name=org.freedesktop.secrets\n"
-                        f"  - {permission}\n",
+                        "  - --share=network\n",
+                        f"  - --share=network\n  - {permission}\n",
                     ),
                 )
                 problems = checker.check(root)
@@ -657,21 +647,26 @@ class FlatpakPermissionTest(CheckoutCase):
                 self.assertIn("unrelated permission", problems[0])
                 self.assertIn(permission, problems[0])
 
-    def test_network_permission_is_unchanged_by_the_keyring_grant(self) -> None:
-        # #543's grant and #441's are independent: the checker holds both, so
-        # neither can be traded for the other.
+    def test_the_approved_surface_carries_no_dbus_grant(self) -> None:
+        # #543's network grant stands; #441 adds nothing beside it. The
+        # approved surface has no D-Bus entry of any shape.
         self.assertIn("--share=network", checker.EXPECTED_FLATPAK_FINISH_ARGS)
-        self.assertIn(
-            "--talk-name=org.freedesktop.secrets",
-            checker.EXPECTED_FLATPAK_FINISH_ARGS,
-        )
         self.assertEqual(
-            {
+            [
                 permission
-                for permission in checker.EXPECTED_FLATPAK_FINISH_ARGS
-                if permission.startswith(("--talk-name", "--system-talk-name"))
-            },
-            {"--talk-name=org.freedesktop.secrets"},
+                for permission in sorted(checker.EXPECTED_FLATPAK_FINISH_ARGS)
+                if permission.startswith(
+                    (
+                        "--talk-name",
+                        "--system-talk-name",
+                        "--own-name",
+                        "--system-own-name",
+                        "--socket=session-bus",
+                        "--socket=system-bus",
+                    )
+                )
+            ],
+            [],
         )
 
     def test_allowed_permission_with_inline_comment_is_recognised(self) -> None:


### PR DESCRIPTION
Closes #441.

Provider credentials work from inside the Flatpak sandbox, in platform secure storage, and the sandbox needs **no new permission at all**. #542's portal folder access and #543's `--share=network` are untouched.

The first revision of this PR shipped `--talk-name=org.freedesktop.secrets`. Review pushed back on that, correctly: it is gone.

## Why no permission

`flutter_secure_storage_linux` 1.2.3 has no store of its own; it calls libsecret's `secret_password_storev_sync` / `secret_password_lookupv_sync` and nothing else. libsecret chooses its backend at runtime (`secret-backend.c`, `backend_get_impl_type`): with `/.flatpak-info` present and `org.freedesktop.portal.Secret` answering, it uses its own gcrypt-encrypted file backend whose master secret comes from the portal (and from the host keyring behind it). Every Flatpak may talk to the portal, so nothing grants that.

That portal exists only when the desktop ships an `org.freedesktop.impl.portal.Secret` backend, and both targets do:

| Desktop | Secret portal backend | Source |
| --- | --- | --- |
| GNOME | gnome-keyring | `daemon/dbus/gkd-secret-portal.c` |
| KDE Plasma 6 | KWallet's `ksecretd` | `src/runtime/ksecretd/kwalletportalsecrets.cpp`, installing `org.freedesktop.impl.portal.desktop.kwallet.service` + `kwallet.portal` |

Supporting facts I checked rather than assumed:

* xdg-desktop-portal `desktop-portal/secret.c`, `init_secret()`: `if (impl_config == NULL) return ...` before exporting, so with no backend the interface is simply absent, and libsecret's portal probe fails into the Secret Service path.
* KDE's backend is KF6-only (the file is absent on the `kf5` branch), which is exactly where the older "Flatpak apps can't use KWallet" reports come from. My earlier claim that direct Secret Service access is "the normal KDE path" was wrong for current Plasma.
* `org.gnome.Platform//50` carries libsecret 0.21.7 built with libgcrypt (freedesktop-sdk 25.08 `elements/components/libsecret.bst`, no `-Dcrypto=disabled`), so the file backend is compiled in and the sandbox detection is live in the runtime we actually ship against.

So the manifest keeps **zero D-Bus permissions**, and `scripts/check_linux_runner.py` now rejects `--talk-name=org.freedesktop.secrets` along with `--socket=session-bus`, `org.freedesktop.*` and `…secrets.*` wildcards, `--own-name`, and the system-bus forms.

On a host with no Secret portal backend (KF5-era KDE, a bare WM with only a Secret Service daemon), libsecret falls back to the bus name, the proxy hides it, and Linthra reports a recoverable storage error and stays signed out. Never a fallback of its own. A user who wants that path can take it for their own install with `flatpak override --user --talk-name=org.freedesktop.secrets`, which the docs describe and the package does not ship.

## What is stored, and the precise guarantee

One entry per provider (`jellyfin_session_v1`, `subsonic_session_v1`, `plex_session_v1`), each the JSON of a session object. No passwords: Jellyfin exchanges one for a token, Subsonic derives salt+token and discards it, Plex is token-based.

The guarantee, stated exactly (the earlier "nothing in the credential path opens a file" was wrong and is gone):

* **Linthra** has no plaintext or custom file fallback, and writes credentials only through `SecureSessionStorage`.
* Secrets never reach `shared_preferences`, SQLite, the app cache, logs, diagnostics, exceptions, or any file Linthra writes.
* **libsecret** may legitimately use its own encrypted, portal-keyed file backend at `~/.var/app/io.github.thezupzup.linthra/data/keyrings/default.keyring`. That is platform storage and ciphertext, not a Linthra fallback.
* The master secret comes through the Secret portal from the host keyring.
* When no libsecret backend can store the value, the write fails and nothing is written anywhere.

Docs no longer say credentials sit directly "in the desktop keyring" where the portal file path is in use; that phrasing is now scoped to the Secret Service backend, which is what native (non-Flatpak) Linthra uses.

## App side

`SecureSessionStorage` is the single wrapper used by the Jellyfin, Navidrome/Subsonic and Plex session stores. (`SecureGitHubSponsorTokenStore` still calls `flutter_secure_storage` directly; it holds no provider credential and is deliberately out of scope here. The earlier "app's only caller" claim was inaccurate and is corrected.)

* A failed read is an error, not a silent "no session" that would look like a clean sign-out and let the next write overwrite a credential that was fine.
* Failures become a typed `SecureStorageException` (unavailable, locked, denied, unknown) carrying no platform error text, no key, and no value.
* Jellyfin and Navidrome/Subsonic now handle storage failures the way Plex already did: a sign-in that cannot be saved is reported and not adopted, a sign-out the keyring refuses says so instead of pretending, and a restore failure does not clobber a sign-in that got there first. Plex's messages gained the same actionable cause.

Native Linux and Android are unchanged apart from better error reporting: same stores, same keys, same on-disk shape.

## Packaging

`flatpak/flatpak-flutter.yml` is the authoritative edit; `flatpak/io.github.thezupzup.linthra.yml` was regenerated with `./scripts/regenerate_flatpak_sources.sh`. Net effect on both committed manifests versus `main`: **no change** (the generated file and `generated/` are byte-identical to `main`), which is the point, the sandbox surface is the same six finish-args it was.

## Tests

* `test/data/repositories/secure_session_storage_test.dart` drives the real plugin channel with the exact `PlatformException`s the Linux plugin raises: save, read after restart, delete, missing service, locked keyring, sandbox denial, missing implementation, no fallback write, and an exception that carries nothing from a platform message that quoted the value back.
* Controller tests for all three providers: restore error, sign-in that cannot be saved, sign-out the keyring refuses, restore race, no token or password in any surfaced message.
* Checker tests, now inverted: the Secret Service name is **rejected** if reintroduced, broader D-Bus forms are rejected, filesystem and `--persist` grants stay rejected, the approved surface is asserted to contain no D-Bus entry of any shape, and both manifests must agree.

## Checks run

`dart format --set-exit-if-changed .`, `flutter analyze` (clean), `flutter test` (3925 passing), `check_linux_runner.py`, `check_linux_runner_test.py` (61), `check_linux_runner_quoted_permissions_test.py`, `ruff check` + `ruff format --check`, `check_vendored_packages.sh`, `check_secrets.sh`, `git diff --check`, and a clean re-run of the Flatpak regeneration for parity.

**Still not validated by me: no Flatpak build and no keyring smoke test.** This environment has no `flatpak`/`flatpak-builder` and no GTK/libsecret/libmpv, so the sandbox was never built or launched and neither GNOME nor KDE was exercised at runtime. The backend-selection reasoning above comes from reading xdg-desktop-portal, libsecret, gnome-keyring, kwallet and freedesktop-sdk sources. CI's "Build Linux desktop" job does compile the native Linux target with real libsecret, which covers the build but not sandbox behaviour. The manual pass (save, read after restart, delete, locked keyring, portal-less host, and how to inspect installed permissions) is written up in `flatpak/README.md` and `docs/flatpak-development.md` and still needs someone on a real desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYZU29fjjWgZC9erjy8EJU