### PR TITLE
test(flatpak): lock down filesystem sandbox access (#439)

### DIFF
--- a/docs/flatpak-filesystem-audit.md
+++ b/docs/flatpak-filesystem-audit.md
@@ -101,8 +101,9 @@ The smoke test does four things without modifying persistent Flatpak overrides:
 
 1. inspects the **installed** package and fails if it exposes a filesystem or
    persist permission;
-2. refuses to run if a local user override grants extra filesystem access,
-   because that would make the result meaningless;
+2. refuses to run if **any global or app-specific override, in either user or
+   system scope**, grants filesystem/persist access, because an effective
+   override would make the package-level result meaningless;
 3. creates a temporary sentinel in the real host home and proves a shell inside
    Linthra's sandbox cannot see or read it;
 4. proves the sandbox's own XDG data/cache directories remain writable, which
@@ -139,16 +140,20 @@ These commands are useful before a release or Flathub submission:
 
 ```bash
 flatpak info --show-permissions io.github.thezupzup.linthra
+flatpak override --user --show
 flatpak override --user --show io.github.thezupzup.linthra
+flatpak override --system --show
+flatpak override --system --show io.github.thezupzup.linthra
 ```
 
-Expected package result:
+Expected package/test result:
 
 - `shared=network;ipc;`
 - Wayland/fallback-X11, DRI and PulseAudio sockets/devices as documented by the
   manifest
-- **no `filesystems=` entry**
-- no filesystem-related persistent override for the validation run
+- **no `filesystems=` entry** in package metadata
+- no filesystem/persist grant in any global/app-specific user/system override
+  used for the validation run
 
 The filesystem audit should be repeated after any future change to Flatpak
 finish-args, local folder selection, cache/offline storage, or downloads.

--- a/docs/flatpak-filesystem-audit.md
+++ b/docs/flatpak-filesystem-audit.md
@@ -1,0 +1,154 @@
+# Flatpak filesystem sandbox audit
+
+Issue: #439  
+Parent: #376
+
+This document records the filesystem surface Linthra's Flatpak is allowed to
+use, why each path is reachable, and how to prove that unrelated host files
+remain outside the sandbox.
+
+## Result
+
+The shipped Flatpak needs **no `--filesystem=` finish argument and no
+`--persist=` grant**.
+
+The authoritative manifest (`flatpak/flatpak-flutter.yml`) and the generated
+manifest (`flatpak/io.github.thezupzup.linthra.yml`) intentionally contain none.
+`scripts/check_linux_runner.py` already compares both manifests against an exact
+finish-args allow-list, so adding `--filesystem=host`, `--filesystem=home`, an
+XDG filesystem grant, `--persist`, or any other new finish arg fails the Linux
+runner check until it is explicitly reviewed.
+
+The approved sandbox surface remains:
+
+```text
+--socket=wayland
+--socket=fallback-x11
+--share=ipc
+--device=dri
+--socket=pulseaudio
+--share=network
+```
+
+None of those grants host filesystem access.
+
+## Why local music still works
+
+The Linux runner uses `GtkFileChooserNative`. Inside Flatpak, GTK routes that
+chooser through `xdg-desktop-portal`.
+
+When the user chooses a music directory, the document portal exposes only that
+selection to the application. Linthra stores and reuses the portal-visible path;
+it does not need `--filesystem=home` or `--filesystem=host` to scan it.
+
+This is a user-mediated grant: choosing `/home/alice/Music` does not make
+`/home/alice/Documents`, `/etc`, another mounted disk, or the rest of `$HOME`
+readable to Linthra.
+
+If the portal grant later disappears, the local-source availability path added
+with #438 reports the folder as unavailable instead of treating an unreadable
+folder as an empty library and deleting unrelated catalog state.
+
+## App-owned data and cache
+
+Flatpak gives every application private writable XDG locations under
+`~/.var/app/<app-id>/`. Linthra uses platform/XDG APIs for app-owned state, so
+these paths need no host-filesystem permission.
+
+| Data | Linthra code | API | Flatpak behavior |
+| --- | --- | --- | --- |
+| SQLite catalog (`linthra.sqlite`) | `lib/data/database/linthra_database.dart` | `getApplicationDocumentsDirectory()` | resolves inside the app's private sandbox data tree |
+| Remote provider cache (`remote_cache/`) | `lib/data/repositories/file_remote_cache_store.dart` | `getApplicationSupportDirectory()` | private app support directory |
+| Artwork cache (`artwork_cache/`) | `lib/core/services/artwork_disk_cache.dart` | `getApplicationSupportDirectory()` | private app support directory |
+| Offline audio (`offline_audio/`) | `lib/data/repositories/file_system_offline_file_store.dart` | `getApplicationSupportDirectory()` | private app support directory |
+| Provider credentials | `SecureSessionStorage` / libsecret | Secret portal | encrypted platform storage; no filesystem finish arg |
+| Preferences | Flutter plugin/XDG | application-scoped platform path | private app configuration/data |
+
+The application never needs to write its database, artwork cache, remote cache,
+offline audio, or credentials into a user's arbitrary host directory.
+
+A user uninstall with `--delete-data` may remove the app-owned tree, which is
+expected. It must never remove the user's portal-selected music folder itself.
+
+## Deliberately forbidden workarounds
+
+Do not solve a filesystem problem by adding any of these to the manifest:
+
+```text
+--filesystem=host
+--filesystem=home
+--filesystem=host-os
+--filesystem=host-etc
+--filesystem=xdg-download
+--filesystem=xdg-music
+--filesystem=/some/absolute/path
+--persist=...
+```
+
+If a feature needs a user-selected host file or directory, prefer the relevant
+portal. If a future feature genuinely cannot use a portal, it needs a separate
+issue and security review instead of silently widening #439's policy.
+
+## Clean sandbox smoke test
+
+After building and installing the Flatpak, run:
+
+```bash
+bash scripts/flatpak_filesystem_smoke.sh
+```
+
+The smoke test does four things without modifying persistent Flatpak overrides:
+
+1. inspects the **installed** package and fails if it exposes a filesystem or
+   persist permission;
+2. refuses to run if a local user override grants extra filesystem access,
+   because that would make the result meaningless;
+3. creates a temporary sentinel in the real host home and proves a shell inside
+   Linthra's sandbox cannot see or read it;
+4. proves the sandbox's own XDG data/cache directories remain writable, which
+   is what Linthra's database/cache/offline stores rely on.
+
+The script removes its host and sandbox probes before exiting.
+
+### User-selected library check
+
+The host-isolation smoke cannot manufacture a real FileChooser portal grant,
+because that grant is intentionally created only by the user's chooser action.
+Complete the audit with this manual pass using the installed Flatpak:
+
+1. Create a small test directory outside `~/.var/app/`, containing one supported
+   audio file. Also create a neighbouring file **outside** that directory.
+2. Launch `flatpak run io.github.thezupzup.linthra`.
+3. In Local music, choose only the test music directory through Linthra's
+   system folder chooser.
+4. Scan it. The selected track must appear and be playable.
+5. Quit and relaunch. The selected library must remain usable while the portal
+   grant persists.
+6. Run `bash scripts/flatpak_filesystem_smoke.sh` again. The unrelated host
+   sentinel must still be invisible.
+7. Revoke/remove the selected directory's portal access or make the directory
+   unavailable, then rescan. Linthra must surface the recoverable unavailable
+   source state from #438 rather than wiping unrelated tracks.
+
+Do not use `flatpak override --filesystem=...` during this test. An override
+would test the override, not the package Linthra intends to ship.
+
+## Inspecting the final package manually
+
+These commands are useful before a release or Flathub submission:
+
+```bash
+flatpak info --show-permissions io.github.thezupzup.linthra
+flatpak override --user --show io.github.thezupzup.linthra
+```
+
+Expected package result:
+
+- `shared=network;ipc;`
+- Wayland/fallback-X11, DRI and PulseAudio sockets/devices as documented by the
+  manifest
+- **no `filesystems=` entry**
+- no filesystem-related persistent override for the validation run
+
+The filesystem audit should be repeated after any future change to Flatpak
+finish-args, local folder selection, cache/offline storage, or downloads.

--- a/scripts/flatpak_filesystem_smoke.sh
+++ b/scripts/flatpak_filesystem_smoke.sh
@@ -24,7 +24,15 @@ check_override_scope() {
   local label="$1"
   shift
   local overrides
-  overrides="$(flatpak override "$@" --show 2>/dev/null || true)"
+
+  # This audit is only meaningful if every effective override scope can be
+  # inspected. Fail closed on an unreadable/broken user or system override
+  # instead of treating a failed query as an empty, therefore clean, scope.
+  if ! overrides="$(flatpak override "$@" --show 2>&1)"; then
+    printf '%s\n' "$overrides" >&2
+    fail "could not inspect $label; refusing to assume the scope is clean"
+  fi
+
   if grep -Eq '^[[:space:]]*(filesystems|persistent)=' <<<"$overrides"; then
     printf '%s\n' "$overrides" >&2
     fail "$label contains a filesystem/persist override; remove it before testing"
@@ -53,6 +61,7 @@ fi
 # system overrides. Reject filesystem/persist entries in every scope. Otherwise
 # a globally granted xdg-music/home path could make a clean package look safely
 # sandboxed while this smoke was actually exercising the local override.
+# A query failure is also fatal: an unreadable/broken scope is unknown, not clean.
 check_override_scope "global user override" --user
 check_override_scope "app-specific user override" --user "$APP_ID"
 check_override_scope "global system override" --system

--- a/scripts/flatpak_filesystem_smoke.sh
+++ b/scripts/flatpak_filesystem_smoke.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Verify Linthra's installed Flatpak keeps host files outside the sandbox while
+# retaining writable application-scoped XDG storage. This is a host-side smoke
+# for issue #439; run it after installing the Flatpak.
+
+set -euo pipefail
+
+APP_ID="io.github.thezupzup.linthra"
+HOST_PROBE_DIR=""
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+cleanup() {
+  if [[ -n "$HOST_PROBE_DIR" && -d "$HOST_PROBE_DIR" ]]; then
+    rm -rf -- "$HOST_PROBE_DIR"
+  fi
+}
+trap cleanup EXIT
+
+command -v flatpak >/dev/null 2>&1 || fail "flatpak is not installed"
+flatpak info "$APP_ID" >/dev/null 2>&1 ||
+  fail "$APP_ID is not installed; build/install the Flatpak first"
+
+permissions="$(flatpak info --show-permissions "$APP_ID")"
+
+# Flatpak metadata renders filesystem grants as filesystems= and persist grants
+# as persistent=. Either one would invalidate #439's no-host-filesystem policy.
+if grep -Eq '^[[:space:]]*filesystems=' <<<"$permissions"; then
+  printf '%s\n' "$permissions" >&2
+  fail "the installed package declares a filesystem permission"
+fi
+if grep -Eq '^[[:space:]]*persistent=' <<<"$permissions"; then
+  printf '%s\n' "$permissions" >&2
+  fail "the installed package declares a persist permission"
+fi
+
+# A persistent user override can make a correctly packaged Flatpak appear to
+# pass a feature test with broader access than users actually receive. Refuse
+# that setup instead of producing a misleading result.
+overrides="$(flatpak override --user --show "$APP_ID" 2>/dev/null || true)"
+if grep -Eq '^[[:space:]]*(filesystems|persistent)=' <<<"$overrides"; then
+  printf '%s\n' "$overrides" >&2
+  fail "a user filesystem/persist override is active; remove it before testing"
+fi
+
+case "$HOME" in
+  "$HOME/.var/app/$APP_ID"|"$HOME/.var/app/$APP_ID/"*)
+    fail "host HOME unexpectedly points inside the Flatpak app-data tree"
+    ;;
+esac
+
+HOST_PROBE_DIR="$(mktemp -d "$HOME/.linthra-flatpak-fs-smoke.XXXXXX")"
+HOST_SENTINEL="$HOST_PROBE_DIR/host-only-sentinel"
+printf 'linthra-flatpak-host-only\n' > "$HOST_SENTINEL"
+chmod 600 "$HOST_SENTINEL"
+
+# Pass the absolute host path as data only. With no --filesystem grant the
+# sandbox must not be able to stat/read it. Then prove the private XDG data and
+# cache locations are writable: Linthra's SQLite catalog, artwork/remote cache,
+# and offline-audio stores use path_provider locations mapped into this private
+# app tree by Flatpak.
+if ! flatpak run --command=sh "$APP_ID" -c '
+  set -eu
+  host_sentinel="$1"
+
+  if [ -e "$host_sentinel" ] || [ -r "$host_sentinel" ]; then
+    printf "host sentinel unexpectedly visible: %s\n" "$host_sentinel" >&2
+    exit 42
+  fi
+
+  : "${XDG_DATA_HOME:?XDG_DATA_HOME is not set inside the sandbox}"
+  : "${XDG_CACHE_HOME:?XDG_CACHE_HOME is not set inside the sandbox}"
+  mkdir -p "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
+
+  data_probe="$XDG_DATA_HOME/.linthra-fs-smoke-$$"
+  cache_probe="$XDG_CACHE_HOME/.linthra-fs-smoke-$$"
+  trap '\''rm -f -- "$data_probe" "$cache_probe"'\'' EXIT
+
+  printf data > "$data_probe"
+  printf cache > "$cache_probe"
+  test -r "$data_probe"
+  test -r "$cache_probe"
+' sh "$HOST_SENTINEL"; then
+  fail "sandbox isolation/app-data write smoke failed"
+fi
+
+printf 'PASS: %s declares no filesystem/persist grant.\n' "$APP_ID"
+printf 'PASS: unrelated host file was invisible inside the sandbox.\n'
+printf 'PASS: sandbox-local XDG data and cache locations are writable.\n'
+printf 'Manual portal-selected library validation: docs/flatpak-filesystem-audit.md\n'

--- a/scripts/flatpak_filesystem_smoke.sh
+++ b/scripts/flatpak_filesystem_smoke.sh
@@ -20,6 +20,17 @@ cleanup() {
 }
 trap cleanup EXIT
 
+check_override_scope() {
+  local label="$1"
+  shift
+  local overrides
+  overrides="$(flatpak override "$@" --show 2>/dev/null || true)"
+  if grep -Eq '^[[:space:]]*(filesystems|persistent)=' <<<"$overrides"; then
+    printf '%s\n' "$overrides" >&2
+    fail "$label contains a filesystem/persist override; remove it before testing"
+  fi
+}
+
 command -v flatpak >/dev/null 2>&1 || fail "flatpak is not installed"
 flatpak info "$APP_ID" >/dev/null 2>&1 ||
   fail "$APP_ID is not installed; build/install the Flatpak first"
@@ -37,14 +48,15 @@ if grep -Eq '^[[:space:]]*persistent=' <<<"$permissions"; then
   fail "the installed package declares a persist permission"
 fi
 
-# A persistent user override can make a correctly packaged Flatpak appear to
-# pass a feature test with broader access than users actually receive. Refuse
-# that setup instead of producing a misleading result.
-overrides="$(flatpak override --user --show "$APP_ID" 2>/dev/null || true)"
-if grep -Eq '^[[:space:]]*(filesystems|persistent)=' <<<"$overrides"; then
-  printf '%s\n' "$overrides" >&2
-  fail "a user filesystem/persist override is active; remove it before testing"
-fi
+# Effective permissions can be widened outside the package metadata at four
+# levels: global user, app-specific user, global system, and app-specific
+# system overrides. Reject filesystem/persist entries in every scope. Otherwise
+# a globally granted xdg-music/home path could make a clean package look safely
+# sandboxed while this smoke was actually exercising the local override.
+check_override_scope "global user override" --user
+check_override_scope "app-specific user override" --user "$APP_ID"
+check_override_scope "global system override" --system
+check_override_scope "app-specific system override" --system "$APP_ID"
 
 case "$HOME" in
   "$HOME/.var/app/$APP_ID"|"$HOME/.var/app/$APP_ID/"*)
@@ -88,6 +100,7 @@ if ! flatpak run --command=sh "$APP_ID" -c '
 fi
 
 printf 'PASS: %s declares no filesystem/persist grant.\n' "$APP_ID"
+printf 'PASS: global/app user and system overrides add no filesystem/persist grant.\n'
 printf 'PASS: unrelated host file was invisible inside the sandbox.\n'
 printf 'PASS: sandbox-local XDG data and cache locations are writable.\n'
 printf 'Manual portal-selected library validation: docs/flatpak-filesystem-audit.md\n'


### PR DESCRIPTION
Closes #439.

## What this does

This is the final filesystem-permission audit for the current Flatpak.

The important result is that **Linthra does not need any `--filesystem=` or `--persist=` finish argument at all**. The current six approved finish args stay unchanged; local music remains user-mediated through the FileChooser/document portal from #438, while app-owned data stays in Flatpak's private XDG tree.

### Audit

Adds `docs/flatpak-filesystem-audit.md` with an explicit inventory of every filesystem-backed feature:

- SQLite catalog -> `getApplicationDocumentsDirectory()`
- remote provider cache -> `getApplicationSupportDirectory()`
- artwork cache -> `getApplicationSupportDirectory()`
- offline audio -> `getApplicationSupportDirectory()`
- provider credentials -> Secret portal/libsecret from #441/#544
- local music -> user-selected document-portal grant from #438

It also records the deliberately forbidden workarounds (`--filesystem=host`, `home`, XDG grants, absolute paths, `--persist`, etc.) and explains why none is needed.

The existing `scripts/check_linux_runner.py` exact finish-args allow-list already rejects any new filesystem/persist finish arg, so this PR deliberately does **not** widen or churn the manifests.

### Real installed-sandbox smoke

Adds `scripts/flatpak_filesystem_smoke.sh`.

Run it after installing a Flatpak build:

```bash
bash scripts/flatpak_filesystem_smoke.sh
```

It:

1. inspects `flatpak info --show-permissions` and fails on filesystem/persist grants;
2. refuses a test polluted by persistent user filesystem overrides;
3. creates a random sentinel in the real host `$HOME` and proves the Linthra sandbox cannot see/read it;
4. proves the sandbox-local XDG data/cache locations are still writable for the catalog/cache/offline stores;
5. cleans up all probes.

The audit doc also contains the manual portal-selected-library pass: select only a test music folder, scan/play/restart, confirm unrelated host data remains invisible, and verify revoked access is recoverable through #438 instead of wiping unrelated catalog state.

## Security properties preserved

- no `--filesystem=host`
- no `--filesystem=home`
- no XDG filesystem shortcut grant
- no `--persist`
- no D-Bus permission added
- #542 portal folder behavior unchanged
- #543 network behavior unchanged
- #544 secure-storage behavior unchanged
- no Android behavior change

## Validation

- compared the branch directly against main: only the audit document and smoke script are added
- `bash -n` passes for the new smoke script
- current main's exact Flatpak finish-args checker already rejects unrelated filesystem grants

**Not run here:** the installed-Flatpak smoke itself. This execution environment has no Flatpak installation/runtime, so the real sandbox pass still needs to be run on a Linux desktop with the locally installed Linthra Flatpak before merge.
