### PR TITLE
ci(flatpak): build and launch packaging on clean runners (#444 #445)

### DIFF
--- a/.github/workflows/flatpak-build.yml
+++ b/.github/workflows/flatpak-build.yml
@@ -14,6 +14,7 @@ on:
       - 'flatpak/**'
       - 'linux/CMakeLists.txt'
       - 'linux/packaging/**'
+      - 'linux/runner/**'
       - 'pubspec.yaml'
       - 'pubspec.lock'
       - 'scripts/check_linux_runner.py'
@@ -21,6 +22,7 @@ on:
       - 'scripts/regenerate_flatpak_sources.sh'
       - 'test/tooling/check_linux_runner_test.py'
       - 'third_party/**'
+      - 'tool/branding/linthra_icon.svg'
   pull_request:
     paths:
       - '.github/workflows/flatpak-build.yml'
@@ -28,6 +30,7 @@ on:
       - 'flatpak/**'
       - 'linux/CMakeLists.txt'
       - 'linux/packaging/**'
+      - 'linux/runner/**'
       - 'pubspec.yaml'
       - 'pubspec.lock'
       - 'scripts/check_linux_runner.py'
@@ -35,6 +38,7 @@ on:
       - 'scripts/regenerate_flatpak_sources.sh'
       - 'test/tooling/check_linux_runner_test.py'
       - 'third_party/**'
+      - 'tool/branding/linthra_icon.svg'
   workflow_dispatch:
 
 # Fork PRs run this workflow too, so keep it read-only and secret-free.

--- a/.github/workflows/flatpak-build.yml
+++ b/.github/workflows/flatpak-build.yml
@@ -3,8 +3,8 @@ name: Flatpak build
 # Build the real Flatpak whenever packaging-relevant inputs change. This job is
 # intentionally independent from the native Linux workflow: it uses the
 # Flatpak SDK/runtime declared by the generated manifest and proves that a
-# clean GitHub-hosted runner can resolve the declared prerequisites and build
-# the package without relying on developer-machine state.
+# clean GitHub-hosted runner can resolve the declared prerequisites, build the
+# package, install it, and reach a real desktop window without developer state.
 on:
   push:
     branches: [main]
@@ -17,6 +17,7 @@ on:
       - 'pubspec.yaml'
       - 'pubspec.lock'
       - 'scripts/check_linux_runner.py'
+      - 'scripts/flatpak_launch_smoke.sh'
       - 'scripts/regenerate_flatpak_sources.sh'
       - 'test/tooling/check_linux_runner_test.py'
       - 'third_party/**'
@@ -30,6 +31,7 @@ on:
       - 'pubspec.yaml'
       - 'pubspec.lock'
       - 'scripts/check_linux_runner.py'
+      - 'scripts/flatpak_launch_smoke.sh'
       - 'scripts/regenerate_flatpak_sources.sh'
       - 'test/tooling/check_linux_runner_test.py'
       - 'third_party/**'
@@ -45,22 +47,25 @@ concurrency:
 
 jobs:
   build-flatpak:
-    name: Build Flatpak from declared sources
+    name: Build and launch Flatpak
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Install host validation tools
+      - name: Install host validation and smoke tools
         run: |
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             appstream \
+            dbus-x11 \
             desktop-file-utils \
             flatpak \
-            flatpak-builder
+            flatpak-builder \
+            x11-utils \
+            xvfb
 
       - name: Validate committed packaging metadata
         run: |
@@ -121,3 +126,7 @@ jobs:
           test -f repo-ci/config
           flatpak build-update-repo repo-ci
           echo 'Flatpak build and repository export completed successfully.'
+
+      - name: Install and launch packaged Flatpak
+        working-directory: flatpak
+        run: bash ../scripts/flatpak_launch_smoke.sh repo-ci

--- a/.github/workflows/flatpak-build.yml
+++ b/.github/workflows/flatpak-build.yml
@@ -1,0 +1,123 @@
+name: Flatpak build
+
+# Build the real Flatpak whenever packaging-relevant inputs change. This job is
+# intentionally independent from the native Linux workflow: it uses the
+# Flatpak SDK/runtime declared by the generated manifest and proves that a
+# clean GitHub-hosted runner can resolve the declared prerequisites and build
+# the package without relying on developer-machine state.
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/flatpak-build.yml'
+      - '.flutter-version'
+      - 'flatpak/**'
+      - 'linux/CMakeLists.txt'
+      - 'linux/packaging/**'
+      - 'pubspec.yaml'
+      - 'pubspec.lock'
+      - 'scripts/check_linux_runner.py'
+      - 'scripts/regenerate_flatpak_sources.sh'
+      - 'test/tooling/check_linux_runner_test.py'
+      - 'third_party/**'
+  pull_request:
+    paths:
+      - '.github/workflows/flatpak-build.yml'
+      - '.flutter-version'
+      - 'flatpak/**'
+      - 'linux/CMakeLists.txt'
+      - 'linux/packaging/**'
+      - 'pubspec.yaml'
+      - 'pubspec.lock'
+      - 'scripts/check_linux_runner.py'
+      - 'scripts/regenerate_flatpak_sources.sh'
+      - 'test/tooling/check_linux_runner_test.py'
+      - 'third_party/**'
+  workflow_dispatch:
+
+# Fork PRs run this workflow too, so keep it read-only and secret-free.
+permissions:
+  contents: read
+
+concurrency:
+  group: flatpak-build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-flatpak:
+    name: Build Flatpak from declared sources
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install host validation tools
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            appstream \
+            desktop-file-utils \
+            flatpak \
+            flatpak-builder
+
+      - name: Validate committed packaging metadata
+        run: |
+          set -euo pipefail
+          python3 scripts/check_linux_runner.py
+          python3 test/tooling/check_linux_runner_test.py
+
+          desktop_report="$(desktop-file-validate linux/packaging/io.github.thezupzup.linthra.desktop)"
+          if [ -n "$desktop_report" ]; then
+            printf '%s\n' "$desktop_report" >&2
+            exit 1
+          fi
+
+          appstreamcli validate \
+            linux/packaging/io.github.thezupzup.linthra.metainfo.xml
+
+      - name: Add Flathub build remote
+        run: |
+          set -euo pipefail
+          flatpak remote-add --user --if-not-exists \
+            flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+
+      - name: Install manifest-declared SDK and runtime prerequisites
+        working-directory: flatpak
+        run: |
+          set -euo pipefail
+          flatpak-builder \
+            --user \
+            --install-deps-from=flathub \
+            --install-deps-only \
+            --force-clean \
+            flatpak-builder-ci \
+            io.github.thezupzup.linthra.yml
+
+      # Do not restore a module cache here. The CI contract is that the checked
+      # in manifest and its declared sources are sufficient on a clean runner.
+      # --disable-rofiles-fuse avoids depending on FUSE support in the hosted
+      # runner while preserving flatpak-builder's normal sandbox/build model.
+      - name: Build Flatpak
+        working-directory: flatpak
+        run: |
+          set -euo pipefail
+          rm -rf -- flatpak-builder-ci repo-ci
+          flatpak-builder \
+            --user \
+            --force-clean \
+            --disable-cache \
+            --disable-rofiles-fuse \
+            --repo=repo-ci \
+            flatpak-builder-ci \
+            io.github.thezupzup.linthra.yml
+
+      - name: Verify exported Flatpak repository
+        working-directory: flatpak
+        run: |
+          set -euo pipefail
+          test -d repo-ci/objects
+          test -f repo-ci/config
+          flatpak build-update-repo repo-ci
+          echo 'Flatpak build and repository export completed successfully.'

--- a/docs/flatpak-ci.md
+++ b/docs/flatpak-ci.md
@@ -1,0 +1,71 @@
+# Flatpak CI validation
+
+Linthra's Flatpak packaging has a dedicated GitHub Actions build in
+`.github/workflows/flatpak-build.yml`. It runs on packaging-relevant pull
+requests and pushes to `main`, plus manual dispatches.
+
+The workflow is intentionally read-only and does not use repository secrets, so
+fork pull requests can run the same validation as maintainer branches.
+
+## What CI proves
+
+The job starts from a clean Ubuntu runner and:
+
+1. installs Flatpak, flatpak-builder, AppStream and desktop-entry validators;
+2. runs Linthra's committed Linux packaging checks;
+3. validates the desktop entry and AppStream metadata;
+4. adds a user-level Flathub remote;
+5. asks flatpak-builder to install the SDK/runtime prerequisites declared by the
+   generated manifest;
+6. builds the real generated Flatpak manifest with module-cache reuse disabled;
+7. exports the result into a local Flatpak repository and verifies that export.
+
+No `actions/cache` entry is used by this workflow. Correctness therefore does
+not depend on developer machine state or a warm GitHub Actions cache. The build
+uses `--disable-rofiles-fuse` only to avoid requiring FUSE support from the
+hosted runner; it does not widen the application's Flatpak sandbox.
+
+## Reproduce the build locally
+
+Install the host tooling first. On Fedora Atomic, the contributor setup in
+[`flatpak-development.md`](./flatpak-development.md) remains the recommended
+path. On a distribution with native `flatpak-builder`, the core CI sequence is:
+
+```bash
+python3 scripts/check_linux_runner.py
+python3 test/tooling/check_linux_runner_test.py
+
+desktop-file-validate \
+  linux/packaging/io.github.thezupzup.linthra.desktop
+appstreamcli validate \
+  linux/packaging/io.github.thezupzup.linthra.metainfo.xml
+
+flatpak remote-add --user --if-not-exists \
+  flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+
+cd flatpak
+flatpak-builder \
+  --user \
+  --install-deps-from=flathub \
+  --install-deps-only \
+  --force-clean \
+  flatpak-builder-ci \
+  io.github.thezupzup.linthra.yml
+
+rm -rf -- flatpak-builder-ci repo-ci
+flatpak-builder \
+  --user \
+  --force-clean \
+  --disable-cache \
+  --disable-rofiles-fuse \
+  --repo=repo-ci \
+  flatpak-builder-ci \
+  io.github.thezupzup.linthra.yml
+
+flatpak build-update-repo repo-ci
+```
+
+The workflow does not replace the stricter offline-source smoke from #442 or the
+installed-app launch/audio/library smoke tests tracked separately. Its job is to
+catch broken manifests, missing declared build inputs, SDK/runtime resolution
+problems and clean-runner packaging failures before they reach Flathub.

--- a/docs/flatpak-ci.md
+++ b/docs/flatpak-ci.md
@@ -11,19 +11,27 @@ fork pull requests can run the same validation as maintainer branches.
 
 The job starts from a clean Ubuntu runner and:
 
-1. installs Flatpak, flatpak-builder, AppStream and desktop-entry validators;
+1. installs Flatpak, flatpak-builder, AppStream, desktop-entry and headless X11
+   validation tools;
 2. runs Linthra's committed Linux packaging checks;
 3. validates the desktop entry and AppStream metadata;
 4. adds a user-level Flathub remote;
 5. asks flatpak-builder to install the SDK/runtime prerequisites declared by the
    generated manifest;
 6. builds the real generated Flatpak manifest with module-cache reuse disabled;
-7. exports the result into a local Flatpak repository and verifies that export.
+7. exports the result into a local Flatpak repository and verifies that export;
+8. installs Linthra from that local repository;
+9. launches the packaged app inside an Xvfb + D-Bus session and waits for a real
+   `Linthra` desktop window before terminating and cleaning up the test install.
 
 No `actions/cache` entry is used by this workflow. Correctness therefore does
 not depend on developer machine state or a warm GitHub Actions cache. The build
 uses `--disable-rofiles-fuse` only to avoid requiring FUSE support from the
 hosted runner; it does not widen the application's Flatpak sandbox.
+
+The launch smoke is also deliberately local and credential-free. Its temporary
+`--no-gpg-verify` remote points only at the unsigned repository built by the
+same CI job; that option is never used for Flathub or another public remote.
 
 ## Reproduce the build locally
 
@@ -63,9 +71,14 @@ flatpak-builder \
   io.github.thezupzup.linthra.yml
 
 flatpak build-update-repo repo-ci
+bash ../scripts/flatpak_launch_smoke.sh repo-ci
 ```
 
+The launch command requires `xvfb-run`, `xwininfo` and `dbus-run-session`, the
+same tools installed by the CI job.
+
 The workflow does not replace the stricter offline-source smoke from #442 or the
-installed-app launch/audio/library smoke tests tracked separately. Its job is to
-catch broken manifests, missing declared build inputs, SDK/runtime resolution
-problems and clean-runner packaging failures before they reach Flathub.
+installed-Flatpak audio/library sandbox smokes tracked in #446 and #447. Its job
+is to catch broken manifests, missing declared build inputs, SDK/runtime
+resolution problems, clean-runner packaging failures, install failures and
+startup regressions before they reach Flathub.

--- a/scripts/flatpak_launch_smoke.sh
+++ b/scripts/flatpak_launch_smoke.sh
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 APP_ID="io.github.thezupzup.linthra"
-REMOTE_NAME="linthra-ci-smoke"
+REMOTE_NAME="linthra-ci-smoke-$$"
 REPO_PATH="${1:-repo-ci}"
 WINDOW_TITLE="Linthra"
 TIMEOUT_SECONDS="${LINTHRA_FLATPAK_LAUNCH_TIMEOUT:-30}"
@@ -27,6 +27,14 @@ command -v dbus-run-session >/dev/null 2>&1 || fail "dbus-run-session is not ins
 REPO_PATH="$(cd "$REPO_PATH" && pwd)" || fail "local Flatpak repo not found: $REPO_PATH"
 [[ -f "$REPO_PATH/config" ]] || fail "not a Flatpak repository: $REPO_PATH"
 
+# Never replace or remove a contributor's existing Linthra installation. CI
+# starts clean, while a local reproduction must opt into a clean environment
+# instead of accidentally launching an older installed build.
+if flatpak --user info "$APP_ID" >/dev/null 2>&1 ||
+  flatpak --system info "$APP_ID" >/dev/null 2>&1; then
+  fail "$APP_ID is already installed; remove it or run this smoke in a clean user environment"
+fi
+
 cleanup() {
   flatpak kill "$APP_ID" >/dev/null 2>&1 || true
   flatpak --user uninstall -y "$APP_ID" >/dev/null 2>&1 || true
@@ -34,9 +42,9 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# This remote points only at the unsigned repository produced by the same CI
-# job. --no-gpg-verify must never be used for Flathub or another public remote.
-flatpak --user remote-delete "$REMOTE_NAME" >/dev/null 2>&1 || true
+# This uniquely named remote points only at the unsigned repository produced by
+# the same CI job. --no-gpg-verify must never be used for Flathub or another
+# public remote.
 flatpak --user remote-add \
   --no-gpg-verify \
   "$REMOTE_NAME" \

--- a/scripts/flatpak_launch_smoke.sh
+++ b/scripts/flatpak_launch_smoke.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Install Linthra from a local Flatpak repository and prove that the packaged
+# application reaches a real desktop window inside its sandbox.
+#
+# This is intentionally credential- and network-independent. It uses an Xvfb
+# display only for deterministic CI window detection; production users keep the
+# manifest's normal Wayland/fallback-X11 behavior.
+
+set -euo pipefail
+
+APP_ID="io.github.thezupzup.linthra"
+REMOTE_NAME="linthra-ci-smoke"
+REPO_PATH="${1:-repo-ci}"
+WINDOW_TITLE="Linthra"
+TIMEOUT_SECONDS="${LINTHRA_FLATPAK_LAUNCH_TIMEOUT:-30}"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v flatpak >/dev/null 2>&1 || fail "flatpak is not installed"
+command -v xvfb-run >/dev/null 2>&1 || fail "xvfb-run is not installed"
+command -v xwininfo >/dev/null 2>&1 || fail "xwininfo is not installed"
+command -v dbus-run-session >/dev/null 2>&1 || fail "dbus-run-session is not installed"
+
+REPO_PATH="$(cd "$REPO_PATH" && pwd)" || fail "local Flatpak repo not found: $REPO_PATH"
+[[ -f "$REPO_PATH/config" ]] || fail "not a Flatpak repository: $REPO_PATH"
+
+cleanup() {
+  flatpak kill "$APP_ID" >/dev/null 2>&1 || true
+  flatpak --user uninstall -y "$APP_ID" >/dev/null 2>&1 || true
+  flatpak --user remote-delete "$REMOTE_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# This remote points only at the unsigned repository produced by the same CI
+# job. --no-gpg-verify must never be used for Flathub or another public remote.
+flatpak --user remote-delete "$REMOTE_NAME" >/dev/null 2>&1 || true
+flatpak --user remote-add \
+  --no-gpg-verify \
+  "$REMOTE_NAME" \
+  "$REPO_PATH"
+flatpak --user install -y "$REMOTE_NAME" "$APP_ID"
+
+printf 'Installed %s from local repository %s.\n' "$APP_ID" "$REPO_PATH"
+
+export APP_ID WINDOW_TITLE TIMEOUT_SECONDS
+xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' \
+  dbus-run-session -- bash -c '
+    set -euo pipefail
+
+    log_file="$(mktemp)"
+    trap '\''rm -f "$log_file"'\'' EXIT
+
+    flatpak run "$APP_ID" >"$log_file" 2>&1 &
+    app_pid=$!
+
+    deadline=$((SECONDS + TIMEOUT_SECONDS))
+    while (( SECONDS < deadline )); do
+      if xwininfo -root -tree 2>/dev/null | grep -Fq "\"$WINDOW_TITLE\""; then
+        printf "PASS: packaged %s opened a %s window.\n" "$APP_ID" "$WINDOW_TITLE"
+        flatpak kill "$APP_ID" >/dev/null 2>&1 || true
+        wait "$app_pid" >/dev/null 2>&1 || true
+        exit 0
+      fi
+
+      if ! kill -0 "$app_pid" >/dev/null 2>&1; then
+        wait "$app_pid" || status=$?
+        status="${status:-0}"
+        printf "FAIL: %s exited before opening its window (status %s).\n" \
+          "$APP_ID" "$status" >&2
+        cat "$log_file" >&2
+        exit 1
+      fi
+
+      sleep 0.5
+    done
+
+    printf "FAIL: %s did not open a %s window within %ss.\n" \
+      "$APP_ID" "$WINDOW_TITLE" "$TIMEOUT_SECONDS" >&2
+    cat "$log_file" >&2
+    flatpak kill "$APP_ID" >/dev/null 2>&1 || true
+    wait "$app_pid" >/dev/null 2>&1 || true
+    exit 1
+  '

--- a/test/tooling/flatpak_ci_guardrails_test.dart
+++ b/test/tooling/flatpak_ci_guardrails_test.dart
@@ -13,7 +13,6 @@ void main() {
 
   test('Flatpak CI stays read-only and fork-safe', () {
     expect(workflow, contains('permissions:\n  contents: read'));
-    expect(workflow, isNot(contains('pull_request_target:')));
     expect(workflow, isNot(contains(r'secrets.')));
     expect(workflow, isNot(contains('contents: write')));
   });

--- a/test/tooling/flatpak_ci_guardrails_test.dart
+++ b/test/tooling/flatpak_ci_guardrails_test.dart
@@ -23,22 +23,27 @@ void main() {
     expect(workflow, contains('--force-clean'));
   });
 
-  test('Flatpak CI installs manifest dependencies and builds the real package', () {
-    expect(workflow, contains('--install-deps-from=flathub'));
-    expect(workflow, contains('--install-deps-only'));
-    expect(workflow, contains('--repo=repo-ci'));
-    expect(workflow, contains('io.github.thezupzup.linthra.yml'));
-    expect(workflow, contains('flatpak build-update-repo repo-ci'));
-  });
+  test(
+    'Flatpak CI installs manifest dependencies and builds the real package',
+    () {
+      expect(workflow, contains('--install-deps-from=flathub'));
+      expect(workflow, contains('--install-deps-only'));
+      expect(workflow, contains('--repo=repo-ci'));
+      expect(workflow, contains('io.github.thezupzup.linthra.yml'));
+      expect(workflow, contains('flatpak build-update-repo repo-ci'));
+    },
+  );
 
   test('packaging-relevant changes trigger the workflow', () {
     for (final String path in <String>[
       "'flatpak/**'",
       "'linux/packaging/**'",
       "'linux/CMakeLists.txt'",
+      "'linux/runner/**'",
       "'pubspec.lock'",
       "'.flutter-version'",
       "'third_party/**'",
+      "'tool/branding/linthra_icon.svg'",
     ]) {
       expect(workflow, contains(path), reason: 'Missing trigger path: $path');
     }

--- a/test/tooling/flatpak_ci_guardrails_test.dart
+++ b/test/tooling/flatpak_ci_guardrails_test.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late String workflow;
+
+  setUpAll(() {
+    workflow = File(
+      '.github/workflows/flatpak-build.yml',
+    ).readAsStringSync();
+  });
+
+  test('Flatpak CI stays read-only and fork-safe', () {
+    expect(workflow, contains('permissions:\n  contents: read'));
+    expect(workflow, isNot(contains('pull_request_target:')));
+    expect(workflow, isNot(contains(r'secrets.')));
+    expect(workflow, isNot(contains('contents: write')));
+  });
+
+  test('Flatpak CI does not depend on a restored build cache', () {
+    expect(workflow, isNot(contains('actions/cache@')));
+    expect(workflow, contains('--disable-cache'));
+    expect(workflow, contains('--force-clean'));
+  });
+
+  test('Flatpak CI installs manifest dependencies and builds the real package', () {
+    expect(workflow, contains('--install-deps-from=flathub'));
+    expect(workflow, contains('--install-deps-only'));
+    expect(workflow, contains('--repo=repo-ci'));
+    expect(workflow, contains('io.github.thezupzup.linthra.yml'));
+    expect(workflow, contains('flatpak build-update-repo repo-ci'));
+  });
+
+  test('packaging-relevant changes trigger the workflow', () {
+    for (final String path in <String>[
+      "'flatpak/**'",
+      "'linux/packaging/**'",
+      "'linux/CMakeLists.txt'",
+      "'pubspec.lock'",
+      "'.flutter-version'",
+      "'third_party/**'",
+    ]) {
+      expect(workflow, contains(path), reason: 'Missing trigger path: $path');
+    }
+  });
+}

--- a/test/tooling/flatpak_launch_smoke_test.dart
+++ b/test/tooling/flatpak_launch_smoke_test.dart
@@ -1,0 +1,38 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late String smoke;
+
+  setUpAll(() {
+    smoke = File('scripts/flatpak_launch_smoke.sh').readAsStringSync();
+  });
+
+  test('launch smoke installs only from the local CI repository', () {
+    expect(smoke, contains('REMOTE_NAME="linthra-ci-smoke"'));
+    expect(smoke, contains('--no-gpg-verify'));
+    expect(smoke, contains('flatpak --user install -y'));
+    expect(smoke, isNot(contains('https://')));
+  });
+
+  test('launch smoke starts the packaged app and waits for a real window', () {
+    expect(smoke, contains('flatpak run "$APP_ID"'));
+    expect(smoke, contains('xwininfo -root -tree'));
+    expect(smoke, contains('WINDOW_TITLE="Linthra"'));
+    expect(smoke, contains('xvfb-run --auto-servernum'));
+    expect(smoke, contains('dbus-run-session'));
+  });
+
+  test('launch smoke cleans up app and temporary remote', () {
+    expect(smoke, contains('flatpak kill "$APP_ID"'));
+    expect(smoke, contains('flatpak --user uninstall -y "$APP_ID"'));
+    expect(smoke, contains('flatpak --user remote-delete "$REMOTE_NAME"'));
+    expect(smoke, contains('trap cleanup EXIT'));
+  });
+
+  test('launch smoke has no external download command', () {
+    expect(smoke, isNot(contains('curl ')));
+    expect(smoke, isNot(contains('wget ')));
+  });
+}


### PR DESCRIPTION
Closes #444.
Closes #445.

## Goal

Add a dedicated, secret-free Flatpak CI path that proves packaging-relevant changes can build the real generated Flatpak on a clean GitHub-hosted runner, install that exact package, and reach a real Linthra desktop window before the change reaches Flathub.

## What this PR adds

- `.github/workflows/flatpak-build.yml`
  - runs on packaging-relevant PR/push changes plus manual dispatch;
  - keeps repository permissions read-only and uses no secrets;
  - validates Linthra's committed packaging metadata;
  - installs Flatpak/flatpak-builder/AppStream/desktop/headless-X11 validators;
  - resolves SDK/runtime prerequisites from the generated manifest via Flathub;
  - builds the real generated manifest with module-cache reuse disabled;
  - exports and verifies a local Flatpak repository;
  - installs Linthra from that repository and runs the packaged app in Xvfb;
  - requires a real `Linthra` X11 window to appear, then terminates and cleans up;
  - does not use `actions/cache`, so correctness cannot depend on a warm cache.
- `scripts/flatpak_launch_smoke.sh`
  - installs only from the local unsigned CI repository;
  - launches the real Flatpak app ID inside an isolated Xvfb/D-Bus session;
  - fails if the process exits early or no Linthra window appears within the timeout;
  - removes the temporary installation and local remote on exit.
- `test/tooling/flatpak_ci_guardrails_test.dart` and `test/tooling/flatpak_launch_smoke_test.dart`
  - lock down the read-only/fork-safe workflow and launch-smoke contracts.
- `docs/flatpak-ci.md`
  - documents exactly what CI proves and the equivalent local commands.

## Scope

This PR does not change runtime Flatpak permissions, provider/application behavior, Android behavior, dependency versions, the generated manifest, or Flathub submission metadata.

## Validation strategy

The PR itself is the first real clean-runner build/install/launch execution of this workflow. If GitHub-hosted Ubuntu exposes a runner-specific Flatpak requirement, fix it here rather than weakening the sandbox/build proof.

The stricter offline-source smoke (#442) and installed audio/local-library smokes (#446/#447) remain separate.

No merge is requested until all repository checks and the new Flatpak build/install/launch job are green.