### PR TITLE
feat(android): make local music access visible and explicit (#548)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,17 +45,7 @@ jobs:
         run: flutter pub get --enforce-lockfile
 
       - name: Verify formatting
-        run: |
-          set +e
-          dart format --set-exit-if-changed .
-          status=$?
-          if [ "$status" -ne 0 ]; then
-            git diff -- lib/core/sources/local/local_music_source.dart \
-              lib/features/settings/source/provider_summary_cards.dart \
-              test/core/sources/local/android_media_library_test.dart \
-              test/tooling/android_media_store_contract_test.dart
-            exit "$status"
-          fi
+        run: dart format --set-exit-if-changed .
 
       - name: Analyze
         run: flutter analyze

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,17 @@ jobs:
         run: flutter pub get --enforce-lockfile
 
       - name: Verify formatting
-        run: dart format --set-exit-if-changed .
+        run: |
+          set +e
+          dart format --set-exit-if-changed .
+          status=$?
+          if [ "$status" -ne 0 ]; then
+            git diff -- lib/core/sources/local/local_music_source.dart \
+              lib/features/settings/source/provider_summary_cards.dart \
+              test/core/sources/local/android_media_library_test.dart \
+              test/tooling/android_media_store_contract_test.dart
+            exit "$status"
+          fi
 
       - name: Analyze
         run: flutter analyze

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,12 +29,22 @@
          silently suppressed on modern devices. -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <!-- Optional device-wide local music mode (#548). Android 13+ exposes this
+         as the normal visible/revocable "Music and audio" permission. Older
+         Android releases use READ_EXTERNAL_STORAGE for the equivalent shared
+         audio-library access, capped at API 32 so it cannot turn into broader
+         storage access on modern devices. Neither permission is requested on
+         launch: Linthra asks only when the user explicitly chooses "All music
+         on this device". The existing SAF folder mode needs neither permission. -->
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+
     <!-- INTERNET: needed to reach a self-hosted Jellyfin server (connection
          test, sign-in, library sync, and streaming). Declared here so a
          release build can stream too; the debug/profile manifests also add it
-         for Flutter's tooling, and the manifest merger de-duplicates. No
-         storage permission is declared — folder access uses the Storage Access
-         Framework grant the user picks. -->
+         for Flutter's tooling, and the manifest merger de-duplicates. -->
     <uses-permission android:name="android.permission.INTERNET" />
 
     <!-- ACCESS_NETWORK_STATE: reads only the active connection's Android
@@ -66,6 +76,7 @@
         android:label="Linthra"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
+        android:appCategory="audio"
         android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".MainActivity"
@@ -204,10 +215,8 @@
              explicit per-URI read grants apply. It serves ONLY the private cover
              cache (res/xml/media_artwork_paths.xml), whose filenames are SHA-256
              hashes of a credential-free reference — never a username, token,
-             salt, server URL, or auth query. No storage permission is added. The
-             authority is fixed (matches kMediaArtworkAuthority in
-             lib/core/services/media_artwork_content_uri.dart) so it is identical
-             in debug and release. -->
+             salt, server URL, or auth query. The authority is fixed (matches
+             kMediaArtworkAuthority in media_artwork_content_uri.dart). -->
         <provider
             android:name=".MediaArtworkFileProvider"
             android:authorities="io.github.thezupzup.linthra.mediaartwork"

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/AndroidMediaLibraryChannel.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/AndroidMediaLibraryChannel.kt
@@ -157,13 +157,14 @@ class AndroidMediaLibraryChannel(private val activity: Activity) {
             MediaStore.Audio.Media.DURATION,
         )
         val documents = ArrayList<Map<String, Any?>>()
-        context.contentResolver.query(
+        val cursor = context.contentResolver.query(
             MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
             projection,
             "${MediaStore.Audio.Media.IS_MUSIC} != 0",
             null,
             "${MediaStore.Audio.Media.TITLE} COLLATE NOCASE ASC",
-        )?.use { cursor ->
+        ) ?: throw IllegalStateException("MediaStore query returned no cursor")
+        cursor.use {
             val idIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media._ID)
             val nameIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DISPLAY_NAME)
             val mimeIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.MIME_TYPE)

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/AndroidMediaLibraryChannel.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/AndroidMediaLibraryChannel.kt
@@ -147,21 +147,31 @@ class AndroidMediaLibraryChannel(private val activity: Activity) {
     }
 
     private fun queryDeviceAudio(): List<Map<String, Any?>> {
-        val projection = arrayOf(
-            MediaStore.Audio.Media._ID,
-            MediaStore.Audio.Media.DISPLAY_NAME,
-            MediaStore.Audio.Media.MIME_TYPE,
-            MediaStore.Audio.Media.TITLE,
-            MediaStore.Audio.Media.ARTIST,
-            MediaStore.Audio.Media.ALBUM,
-            MediaStore.Audio.Media.ALBUM_ID,
-            MediaStore.Audio.Media.TRACK,
-            MediaStore.Audio.Media.DURATION,
+        val projection = ArrayList(
+            listOf(
+                MediaStore.Audio.Media._ID,
+                MediaStore.Audio.Media.DISPLAY_NAME,
+                MediaStore.Audio.Media.MIME_TYPE,
+                MediaStore.Audio.Media.TITLE,
+                MediaStore.Audio.Media.ARTIST,
+                MediaStore.Audio.Media.ALBUM,
+                MediaStore.Audio.Media.ALBUM_ID,
+                MediaStore.Audio.Media.TRACK,
+                MediaStore.Audio.Media.DURATION,
+            ),
         )
+        // Android 10 is where EXTERNAL_CONTENT_URI became an aggregate over
+        // every external volume, and where VOLUME_NAME appeared to tell them
+        // apart. ALBUM_ID is only unique inside one volume's database, so on
+        // those releases the volume has to be part of the album key. Below 10
+        // there is a single external volume and no such column.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            projection.add(MediaStore.Audio.Media.VOLUME_NAME)
+        }
         val documents = ArrayList<Map<String, Any?>>()
         val cursor = context.contentResolver.query(
             MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
-            projection,
+            projection.toTypedArray(),
             "${MediaStore.Audio.Media.IS_MUSIC} != 0",
             null,
             "${MediaStore.Audio.Media.TITLE} COLLATE NOCASE ASC",
@@ -176,6 +186,11 @@ class AndroidMediaLibraryChannel(private val activity: Activity) {
             val albumIdIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM_ID)
             val trackIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.TRACK)
             val durationIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DURATION)
+            val volumeIndex = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                cursor.getColumnIndex(MediaStore.Audio.Media.VOLUME_NAME)
+            } else {
+                -1
+            }
 
             while (cursor.moveToNext()) {
                 val id = cursor.getLong(idIndex)
@@ -185,9 +200,14 @@ class AndroidMediaLibraryChannel(private val activity: Activity) {
                     ?: "Audio $id"
                 val rawTrack = cursor.getInt(trackIndex)
                 val track = (rawTrack % 1000).takeIf { it > 0 }
+                val volume = if (volumeIndex >= 0) {
+                    cleanMediaValue(cursor.getString(volumeIndex))
+                } else {
+                    null
+                }
                 val rawAlbumId = cursor.getLong(albumIdIndex)
                 val albumId = rawAlbumId.takeIf { it > 0L }
-                    ?.let { "android-mediastore:$it" }
+                    ?.let { albumKey(volume, it) }
                 val durationMs = cursor.getLong(durationIndex).takeIf { it > 0L }
                 val uri = ContentUris.withAppendedId(
                     MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
@@ -211,6 +231,21 @@ class AndroidMediaLibraryChannel(private val activity: Activity) {
             }
         }
         return documents
+    }
+
+    /**
+     * A stable, source-namespaced album key.
+     *
+     * The volume is part of the key wherever Android exposes it, because two
+     * external volumes (internal shared storage and an SD card, say) keep
+     * separate MediaStore databases and can hand out the same numeric ALBUM_ID
+     * for unrelated albums. Without it the catalog would merge them into one.
+     */
+    private fun albumKey(volume: String?, albumId: Long): String {
+        if (volume.isNullOrEmpty()) {
+            return "android-mediastore:$albumId"
+        }
+        return "android-mediastore:$volume:$albumId"
     }
 
     private fun cleanMediaValue(value: String?): String? {

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/AndroidMediaLibraryChannel.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/AndroidMediaLibraryChannel.kt
@@ -17,9 +17,10 @@ import io.flutter.plugin.common.MethodChannel
 /**
  * Android's device-wide local-music integration.
  *
- * This is intentionally separate from SAF folder access. The user opts into the
- * normal Android "Music and audio" permission for a MediaStore-wide scan, or can
- * keep using the existing folder picker for a targeted persisted grant. This
+ * This is intentionally separate from SAF folder access. Android 13+ exposes
+ * the normal "Music and audio" permission for MediaStore; older supported
+ * releases use the legacy shared-storage read permission for this device-wide
+ * mode. The existing folder picker remains the narrower targeted option. This
  * class never requests MANAGE_EXTERNAL_STORAGE, photo, or video access.
  */
 class AndroidMediaLibraryChannel(private val activity: Activity) {
@@ -106,7 +107,7 @@ class AndroidMediaLibraryChannel(private val activity: Activity) {
         if (permissionStatus() != STATUS_ALLOWED) {
             result.error(
                 "permission_denied",
-                "Music and audio permission is not granted.",
+                "Device music access is not granted.",
                 null,
             )
             return
@@ -129,7 +130,7 @@ class AndroidMediaLibraryChannel(private val activity: Activity) {
                 activity.runOnUiThread {
                     result.error(
                         "permission_denied",
-                        "Music and audio permission is not granted.",
+                        "Device music access is not granted.",
                         null,
                     )
                 }
@@ -153,6 +154,7 @@ class AndroidMediaLibraryChannel(private val activity: Activity) {
             MediaStore.Audio.Media.TITLE,
             MediaStore.Audio.Media.ARTIST,
             MediaStore.Audio.Media.ALBUM,
+            MediaStore.Audio.Media.ALBUM_ID,
             MediaStore.Audio.Media.TRACK,
             MediaStore.Audio.Media.DURATION,
         )
@@ -171,6 +173,7 @@ class AndroidMediaLibraryChannel(private val activity: Activity) {
             val titleIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.TITLE)
             val artistIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ARTIST)
             val albumIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM)
+            val albumIdIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM_ID)
             val trackIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.TRACK)
             val durationIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DURATION)
 
@@ -180,7 +183,11 @@ class AndroidMediaLibraryChannel(private val activity: Activity) {
                 val name = cleanMediaValue(cursor.getString(nameIndex))
                     ?: title
                     ?: "Audio $id"
-                val track = cursor.getInt(trackIndex).takeIf { it > 0 }
+                val rawTrack = cursor.getInt(trackIndex)
+                val track = (rawTrack % 1000).takeIf { it > 0 }
+                val rawAlbumId = cursor.getLong(albumIdIndex)
+                val albumId = rawAlbumId.takeIf { it > 0L }
+                    ?.let { "android-mediastore:$it" }
                 val durationMs = cursor.getLong(durationIndex).takeIf { it > 0L }
                 val uri = ContentUris.withAppendedId(
                     MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
@@ -195,6 +202,7 @@ class AndroidMediaLibraryChannel(private val activity: Activity) {
                         "artist" to cleanMediaValue(cursor.getString(artistIndex)),
                         "albumArtist" to null,
                         "album" to cleanMediaValue(cursor.getString(albumIndex)),
+                        "albumId" to albumId,
                         "track" to track,
                         "durationMs" to durationMs,
                         "artworkUri" to null,

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/AndroidMediaLibraryChannel.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/AndroidMediaLibraryChannel.kt
@@ -1,0 +1,235 @@
+package io.github.thezupzup.linthra
+
+import android.Manifest
+import android.app.Activity
+import android.content.ContentUris
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import android.provider.Settings
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Android's device-wide local-music integration.
+ *
+ * This is intentionally separate from SAF folder access. The user opts into the
+ * normal Android "Music and audio" permission for a MediaStore-wide scan, or can
+ * keep using the existing folder picker for a targeted persisted grant. This
+ * class never requests MANAGE_EXTERNAL_STORAGE, photo, or video access.
+ */
+class AndroidMediaLibraryChannel(private val activity: Activity) {
+    private val context: Context = activity.applicationContext
+
+    fun configure(messenger: BinaryMessenger) {
+        MethodChannel(messenger, CHANNEL).setMethodCallHandler { call, result ->
+            handle(call, result)
+        }
+    }
+
+    private fun handle(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "permissionStatus" -> result.success(permissionStatus())
+            "requestPermission" -> requestPermission(result)
+            "openAppSettings" -> openAppSettings(result)
+            "listDeviceAudio" -> listDeviceAudio(result)
+            else -> result.notImplemented()
+        }
+    }
+
+    private fun permissionStatus(): String {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return STATUS_ALLOWED
+        if (activity.checkSelfPermission(readPermission()) == PackageManager.PERMISSION_GRANTED) {
+            return STATUS_ALLOWED
+        }
+        val requested = context
+            .getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .getBoolean(KEY_REQUESTED, false)
+        return if (requested) STATUS_DENIED else STATUS_NOT_REQUESTED
+    }
+
+    private fun requestPermission(result: MethodChannel.Result) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M ||
+            permissionStatus() == STATUS_ALLOWED
+        ) {
+            result.success(STATUS_ALLOWED)
+            return
+        }
+        if (pendingPermissionResult != null) {
+            result.error(
+                "permission_in_progress",
+                "A music permission request is already in progress.",
+                null,
+            )
+            return
+        }
+
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(KEY_REQUESTED, true)
+            .apply()
+        pendingPermissionResult = result
+        activity.requestPermissions(arrayOf(readPermission()), REQUEST_CODE_PERMISSION)
+    }
+
+    fun onRequestPermissionsResult(
+        requestCode: Int,
+        grantResults: IntArray,
+    ): Boolean {
+        if (requestCode != REQUEST_CODE_PERMISSION) return false
+        val result = pendingPermissionResult
+        pendingPermissionResult = null
+        val granted = grantResults.isNotEmpty() &&
+            grantResults[0] == PackageManager.PERMISSION_GRANTED
+        result?.success(if (granted) STATUS_ALLOWED else STATUS_DENIED)
+        return true
+    }
+
+    private fun openAppSettings(result: MethodChannel.Result) {
+        try {
+            val intent = Intent(
+                Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                Uri.fromParts("package", context.packageName, null),
+            ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(intent)
+            result.success(null)
+        } catch (e: Exception) {
+            result.error("settings_unavailable", "Android app settings are unavailable.", null)
+        }
+    }
+
+    private fun listDeviceAudio(result: MethodChannel.Result) {
+        if (permissionStatus() != STATUS_ALLOWED) {
+            result.error(
+                "permission_denied",
+                "Music and audio permission is not granted.",
+                null,
+            )
+            return
+        }
+
+        Thread({
+            try {
+                val documents = queryDeviceAudio()
+                activity.runOnUiThread {
+                    result.success(
+                        mapOf(
+                            "documents" to documents,
+                            "filesVisited" to documents.size,
+                            "foldersVisited" to 0,
+                            "readFailures" to 0,
+                        ),
+                    )
+                }
+            } catch (e: SecurityException) {
+                activity.runOnUiThread {
+                    result.error(
+                        "permission_denied",
+                        "Music and audio permission is not granted.",
+                        null,
+                    )
+                }
+            } catch (e: Exception) {
+                activity.runOnUiThread {
+                    result.error(
+                        "media_store_failed",
+                        "Android MediaStore could not be read.",
+                        null,
+                    )
+                }
+            }
+        }, "linthra-media-store-scan").start()
+    }
+
+    private fun queryDeviceAudio(): List<Map<String, Any?>> {
+        val projection = arrayOf(
+            MediaStore.Audio.Media._ID,
+            MediaStore.Audio.Media.DISPLAY_NAME,
+            MediaStore.Audio.Media.MIME_TYPE,
+            MediaStore.Audio.Media.TITLE,
+            MediaStore.Audio.Media.ARTIST,
+            MediaStore.Audio.Media.ALBUM,
+            MediaStore.Audio.Media.TRACK,
+            MediaStore.Audio.Media.DURATION,
+        )
+        val documents = ArrayList<Map<String, Any?>>()
+        context.contentResolver.query(
+            MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+            projection,
+            "${MediaStore.Audio.Media.IS_MUSIC} != 0",
+            null,
+            "${MediaStore.Audio.Media.TITLE} COLLATE NOCASE ASC",
+        )?.use { cursor ->
+            val idIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media._ID)
+            val nameIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DISPLAY_NAME)
+            val mimeIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.MIME_TYPE)
+            val titleIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.TITLE)
+            val artistIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ARTIST)
+            val albumIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM)
+            val trackIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.TRACK)
+            val durationIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DURATION)
+
+            while (cursor.moveToNext()) {
+                val id = cursor.getLong(idIndex)
+                val title = cleanMediaValue(cursor.getString(titleIndex))
+                val name = cleanMediaValue(cursor.getString(nameIndex))
+                    ?: title
+                    ?: "Audio $id"
+                val track = cursor.getInt(trackIndex).takeIf { it > 0 }
+                val durationMs = cursor.getLong(durationIndex).takeIf { it > 0L }
+                val uri = ContentUris.withAppendedId(
+                    MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+                    id,
+                )
+                documents.add(
+                    mapOf(
+                        "uri" to uri.toString(),
+                        "name" to name,
+                        "mime" to cleanMediaValue(cursor.getString(mimeIndex)),
+                        "title" to title,
+                        "artist" to cleanMediaValue(cursor.getString(artistIndex)),
+                        "albumArtist" to null,
+                        "album" to cleanMediaValue(cursor.getString(albumIndex)),
+                        "track" to track,
+                        "durationMs" to durationMs,
+                        "artworkUri" to null,
+                    ),
+                )
+            }
+        }
+        return documents
+    }
+
+    private fun cleanMediaValue(value: String?): String? {
+        if (value == null) return null
+        val trimmed = value.trim()
+        if (trimmed.isEmpty() || trimmed == MediaStore.UNKNOWN_STRING) return null
+        return trimmed
+    }
+
+    private fun readPermission(): String =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            Manifest.permission.READ_MEDIA_AUDIO
+        } else {
+            Manifest.permission.READ_EXTERNAL_STORAGE
+        }
+
+    companion object {
+        const val CHANNEL = "io.github.thezupzup.linthra/media_library"
+
+        private const val PREFS = "linthra_media_permissions"
+        private const val KEY_REQUESTED = "music_audio_permission_requested"
+        private const val STATUS_ALLOWED = "allowed"
+        private const val STATUS_DENIED = "denied"
+        private const val STATUS_NOT_REQUESTED = "notRequested"
+        private const val REQUEST_CODE_PERMISSION = 0xA0D1
+
+        // Process-scoped for the same reason as MainActivity's SAF picker reply:
+        // a permission dialog may recreate the activity before the callback.
+        private var pendingPermissionResult: MethodChannel.Result? = null
+    }
+}

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
@@ -43,6 +43,14 @@ class MainActivity : AudioServiceActivity() {
         InstallHistoryChannel(applicationContext)
     }
 
+    // Optional device-wide local-library path. Unlike SAF, this uses Android's
+    // explicit Music and audio runtime permission and MediaStore. Kept on its
+    // own channel so broad-library access is auditable separately from targeted
+    // folder grants.
+    private val androidMediaLibraryChannel by lazy {
+        AndroidMediaLibraryChannel(this)
+    }
+
     override fun onResume() {
         super.onResume()
         displayRefreshRate.onResume()
@@ -110,6 +118,9 @@ class MainActivity : AudioServiceActivity() {
                 }
             }
 
+        // Android's explicit Music and audio permission + MediaStore library.
+        androidMediaLibraryChannel.configure(flutterEngine.dartExecutor.binaryMessenger)
+
         // Android metering-aware network state: one-shot current value plus a
         // change stream. Separate from SAF/share/icon channels so the data guard
         // stays small and auditable.
@@ -137,6 +148,17 @@ class MainActivity : AudioServiceActivity() {
         ).setMethodCallHandler { call, result ->
             shareChannel.handle(call, result)
         }
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray,
+    ) {
+        if (androidMediaLibraryChannel.onRequestPermissionsResult(requestCode, grantResults)) {
+            return
+        }
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
     }
 
     private fun startFolderPick(result: MethodChannel.Result) {

--- a/docs/flatpak-ci.md
+++ b/docs/flatpak-ci.md
@@ -75,7 +75,10 @@ bash ../scripts/flatpak_launch_smoke.sh repo-ci
 ```
 
 The launch command requires `xvfb-run`, `xwininfo` and `dbus-run-session`, the
-same tools installed by the CI job.
+same tools installed by the CI job. It intentionally refuses to run if Linthra
+is already installed for the current user or system-wide, so a local smoke can
+never launch or remove a contributor's existing installation. Use a clean test
+user/environment for this final step when Linthra is already installed.
 
 The workflow does not replace the stricter offline-source smoke from #442 or the
 installed-Flatpak audio/library sandbox smokes tracked in #446 and #447. Its job

--- a/lib/core/sources/local/android_media_library.dart
+++ b/lib/core/sources/local/android_media_library.dart
@@ -1,0 +1,61 @@
+import 'saf_document_lister.dart';
+
+/// Android's system-level permission state for reading the shared audio library.
+enum AndroidMusicPermissionStatus {
+  /// The user has not been prompted by Linthra yet.
+  notRequested,
+
+  /// The permission is currently denied or was revoked.
+  denied,
+
+  /// Android currently grants Linthra access to the shared audio library.
+  allowed,
+
+  /// This platform/build does not expose Android's media-library permission.
+  unavailable,
+}
+
+/// Android-specific seam for the device-wide MediaStore music library.
+///
+/// This is deliberately separate from SAF folder access. A user can either
+/// grant the normal Android "Music and audio" permission and scan the shared
+/// MediaStore library, or keep using the existing targeted folder picker with a
+/// persisted SAF grant. Neither path requires MANAGE_EXTERNAL_STORAGE.
+abstract interface class AndroidMediaLibrary {
+  /// Current Android permission state, without prompting.
+  Future<AndroidMusicPermissionStatus> permissionStatus();
+
+  /// Requests the narrow audio/media permission when required by this Android
+  /// version and returns the resulting state.
+  Future<AndroidMusicPermissionStatus> requestPermission();
+
+  /// Opens Linthra's Android app-details/settings screen when supported.
+  Future<void> openAppSettings();
+
+  /// Lists audio rows exposed by Android MediaStore.
+  ///
+  /// The returned document DTO is shared with the SAF scanner because both
+  /// paths ultimately produce content:// URIs plus the same optional metadata.
+  Future<SafScanResult> listDeviceAudio();
+}
+
+/// Safe non-Android/default binding.
+class UnsupportedAndroidMediaLibrary implements AndroidMediaLibrary {
+  const UnsupportedAndroidMediaLibrary();
+
+  @override
+  Future<AndroidMusicPermissionStatus> permissionStatus() async =>
+      AndroidMusicPermissionStatus.unavailable;
+
+  @override
+  Future<AndroidMusicPermissionStatus> requestPermission() async =>
+      AndroidMusicPermissionStatus.unavailable;
+
+  @override
+  Future<void> openAppSettings() async {}
+
+  @override
+  Future<SafScanResult> listDeviceAudio() async {
+    throw const SafUnsupportedException();
+  }
+}

--- a/lib/core/sources/local/audio_file_scanner.dart
+++ b/lib/core/sources/local/audio_file_scanner.dart
@@ -160,7 +160,9 @@ class ContentUriAudioFileScanner implements AudioFileScanner {
 /// Desktop/Linux selections are filesystem paths and go straight to
 /// [IoAudioFileScanner], preserving existing behavior exactly. Android SAF
 /// selections are `content://` URIs and go to [ContentUriAudioFileScanner].
-/// This is the only place that knows about the platform split.
+/// MediaStore is handled before this scanner by [LocalMusicSource]; seeing that
+/// sentinel here is a programming error and fails closed rather than treating it
+/// as a filesystem path.
 class PlatformAudioFileScanner implements AudioFileScanner {
   const PlatformAudioFileScanner({
     AudioFileScanner filesystemScanner = const IoAudioFileScanner(),
@@ -179,6 +181,12 @@ class PlatformAudioFileScanner implements AudioFileScanner {
         return _filesystemScanner.listFiles(folder);
       case FolderLocationKind.contentUri:
         return _contentUriScanner.listFiles(folder);
+      case FolderLocationKind.androidMediaStore:
+        throw FolderScanException(
+          'Android MediaStore must be scanned through the media library bridge.',
+          folder: folder,
+          code: 'media_store_wrong_scanner',
+        );
     }
   }
 }

--- a/lib/core/sources/local/folder_location.dart
+++ b/lib/core/sources/local/folder_location.dart
@@ -1,27 +1,39 @@
-/// How a selected music folder is addressed on the current platform.
+/// How a selected local-music location is addressed on the current platform.
 ///
-/// The folder picker hands back a single opaque string (see
+/// The folder picker normally hands back a single opaque string (see
 /// [FolderPickerService]). On desktop that is a real filesystem path; on
 /// Android the Storage Access Framework returns a `content://…/tree/…` URI.
-/// Scanning has to treat those two cases differently, so this classifies a raw
-/// selection without anyone downstream having to re-parse the string.
+/// Android can also use [androidMediaStoreAudio], a Linthra-owned sentinel for
+/// the explicit device-wide "Music and audio" / MediaStore mode.
 enum FolderLocationKind {
   /// A real filesystem path the `dart:io` scanner can walk directly.
   filesystemPath,
 
   /// An Android SAF `content://` tree/document URI.
   contentUri,
+
+  /// Android's shared audio library, read through MediaStore after the user
+  /// explicitly grants the normal Music and audio runtime permission.
+  androidMediaStore,
 }
 
-/// A parsed view of a selected folder string and how to reach it.
+/// A parsed view of a selected local-music location and how to reach it.
 class FolderLocation {
   const FolderLocation({required this.kind, required this.raw});
 
-  /// Classifies [raw]. Anything using the `content` URI scheme is treated as a
-  /// SAF selection; everything else is treated as a filesystem path. The check
-  /// is scheme-based and case-insensitive, so `CONTENT://…` is still a content
-  /// URI while `/home/me/Music` and `C:\Music` are paths.
+  /// Persisted sentinel for the optional device-wide Android music library.
+  /// It is not a filesystem path and never leaves Linthra as an external URI.
+  static const String androidMediaStoreAudio = 'mediastore://audio';
+
+  /// Classifies [raw]. The Linthra MediaStore sentinel wins first, then any
+  /// `content` URI is a SAF selection; everything else is a filesystem path.
   factory FolderLocation.parse(String raw) {
+    if (raw == androidMediaStoreAudio) {
+      return const FolderLocation(
+        kind: FolderLocationKind.androidMediaStore,
+        raw: androidMediaStoreAudio,
+      );
+    }
     final Uri? uri = Uri.tryParse(raw);
     final bool isContent = uri != null && uri.scheme.toLowerCase() == 'content';
     return FolderLocation(
@@ -37,13 +49,13 @@ class FolderLocation {
 
   bool get isContentUri => kind == FolderLocationKind.contentUri;
   bool get isFilesystemPath => kind == FolderLocationKind.filesystemPath;
+  bool get isAndroidMediaStore => kind == FolderLocationKind.androidMediaStore;
 
-  /// A human-readable label for showing the user *their own* chosen folder in
-  /// the app (never a public bug report). A SAF `content://` tree URI is reduced
-  /// to its document id — e.g. `content://…/tree/primary%3AMusic%2Fmusi5`
-  /// becomes `primary:Music/musi5` — so the user sees a recognizable folder
-  /// instead of an opaque URI. A filesystem path is returned unchanged.
+  /// A human-readable label for showing the user their own selection in-app.
   String get displayLabel {
+    if (isAndroidMediaStore) {
+      return 'All music on this device';
+    }
     if (!isContentUri) {
       return raw;
     }

--- a/lib/core/sources/local/folder_scan_exception.dart
+++ b/lib/core/sources/local/folder_scan_exception.dart
@@ -6,13 +6,19 @@
 /// `content://` tree URI that cannot be reached as a filesystem path on this
 /// device (see [SafTreeUriResolver]).
 class FolderScanException implements Exception {
-  const FolderScanException(this.message, {this.folder});
+  const FolderScanException(this.message, {this.folder, this.code});
 
   /// A user-facing explanation of why the scan could not run.
   final String message;
 
   /// The folder path or URI that could not be scanned, when known.
   final String? folder;
+
+  /// Optional machine-readable failure kind from the platform/scanner layer.
+  ///
+  /// Controllers can use this to distinguish a revoked permission from a
+  /// transient provider failure without parsing the user-facing [message].
+  final String? code;
 
   @override
   String toString() => message;

--- a/lib/core/sources/local/local_audio_metadata.dart
+++ b/lib/core/sources/local/local_audio_metadata.dart
@@ -13,6 +13,7 @@ class LocalAudioMetadata {
     this.artist,
     this.albumArtist,
     this.album,
+    this.albumId,
     this.trackNumber,
     this.duration,
     this.artworkUri,
@@ -32,6 +33,11 @@ class LocalAudioMetadata {
 
   /// The album title (e.g. ID3 `TALB`).
   final String? album;
+
+  /// A stable, already source-namespaced album identifier when the native
+  /// source exposes one. Android MediaStore provides this even when individual
+  /// tracks in a compilation have different artist values.
+  final String? albumId;
 
   /// The 1-based track number within its album, when known.
   final int? trackNumber;
@@ -57,6 +63,7 @@ class LocalAudioMetadata {
       artist == null &&
       albumArtist == null &&
       album == null &&
+      albumId == null &&
       trackNumber == null &&
       duration == null &&
       artworkUri == null;

--- a/lib/core/sources/local/local_music_source.dart
+++ b/lib/core/sources/local/local_music_source.dart
@@ -41,10 +41,10 @@ class LocalMusicSource implements MusicSource {
     AndroidMediaLibrary androidMediaLibrary =
         const UnsupportedAndroidMediaLibrary(),
     LocalMetadataReader metadataReader = const UnsupportedLocalMetadataReader(),
-  }) : _scanner = scanner,
-       _safDocumentLister = safDocumentLister,
-       _androidMediaLibrary = androidMediaLibrary,
-       _metadataReader = metadataReader;
+  })  : _scanner = scanner,
+        _safDocumentLister = safDocumentLister,
+        _androidMediaLibrary = androidMediaLibrary,
+        _metadataReader = metadataReader;
 
   /// Filesystem path, SAF tree URI, [FolderLocation.androidMediaStoreAudio], or
   /// null when the user has not configured local music.
@@ -153,13 +153,11 @@ class LocalMusicSource implements MusicSource {
       if (AudioFileTypes.isSupported(path)) {
         final LocalAudioMetadata? metadata =
             await _metadataReader.readFromPath(path);
-        tracks.add(
-          LocalTrackMapper.fromPath(
-            path,
-            metadata: metadata,
-            scanRoot: folder,
-          ),
-        );
+        tracks.add(LocalTrackMapper.fromPath(
+          path,
+          metadata: metadata,
+          scanRoot: folder,
+        ));
       }
     }
     final int visited = files.length;

--- a/lib/core/sources/local/local_music_source.dart
+++ b/lib/core/sources/local/local_music_source.dart
@@ -41,10 +41,10 @@ class LocalMusicSource implements MusicSource {
     AndroidMediaLibrary androidMediaLibrary =
         const UnsupportedAndroidMediaLibrary(),
     LocalMetadataReader metadataReader = const UnsupportedLocalMetadataReader(),
-  })  : _scanner = scanner,
-        _safDocumentLister = safDocumentLister,
-        _androidMediaLibrary = androidMediaLibrary,
-        _metadataReader = metadataReader;
+  }) : _scanner = scanner,
+       _safDocumentLister = safDocumentLister,
+       _androidMediaLibrary = androidMediaLibrary,
+       _metadataReader = metadataReader;
 
   /// Filesystem path, SAF tree URI, [FolderLocation.androidMediaStoreAudio], or
   /// null when the user has not configured local music.
@@ -153,11 +153,13 @@ class LocalMusicSource implements MusicSource {
       if (AudioFileTypes.isSupported(path)) {
         final LocalAudioMetadata? metadata =
             await _metadataReader.readFromPath(path);
-        tracks.add(LocalTrackMapper.fromPath(
-          path,
-          metadata: metadata,
-          scanRoot: folder,
-        ));
+        tracks.add(
+          LocalTrackMapper.fromPath(
+            path,
+            metadata: metadata,
+            scanRoot: folder,
+          ),
+        );
       }
     }
     final int visited = files.length;

--- a/lib/core/sources/local/local_music_source.dart
+++ b/lib/core/sources/local/local_music_source.dart
@@ -92,7 +92,7 @@ class LocalMusicSource implements MusicSource {
 
   Future<LocalScan> _scanAndroidMediaStore() async {
     final SafScanResult result = await _androidMediaLibrary.listDeviceAudio();
-    return _scanDocuments(result, isContentUri: false);
+    return _scanDocuments(result, isContentUri: false, isDeviceLibrary: true);
   }
 
   /// Walks an Android SAF tree through the content resolver. Falls back to the
@@ -113,6 +113,7 @@ class LocalMusicSource implements MusicSource {
   LocalScan _scanDocuments(
     SafScanResult result, {
     required bool isContentUri,
+    bool isDeviceLibrary = false,
   }) {
     final List<Track> tracks = <Track>[];
     for (final SafAudioDocument document in result.documents) {
@@ -132,6 +133,7 @@ class LocalMusicSource implements MusicSource {
       report: LocalScanReport(
         folderSelected: true,
         isContentUri: isContentUri,
+        isDeviceLibrary: isDeviceLibrary,
         filesVisited: result.filesVisited,
         foldersVisited: result.foldersVisited,
         audioCandidates: candidates,

--- a/lib/core/sources/local/local_music_source.dart
+++ b/lib/core/sources/local/local_music_source.dart
@@ -4,6 +4,7 @@ import '../../models/artist.dart';
 import '../../models/track.dart';
 import '../../services/local_playable_uri_resolver.dart';
 import '../../services/music_source.dart';
+import 'android_media_library.dart';
 import 'audio_file_scanner.dart';
 import 'audio_file_types.dart';
 import 'folder_location.dart';
@@ -14,9 +15,7 @@ import 'local_track_mapper.dart';
 import 'saf_document_lister.dart';
 
 /// The tracks a local scan discovered, paired with a secret-free
-/// [LocalScanReport] describing what the scan saw (visited/candidates/skipped/
-/// read-failure counts). The controller persists the [tracks] and records the
-/// [report] for diagnostics.
+/// [LocalScanReport] describing what the scan saw.
 class LocalScan {
   const LocalScan({required this.tracks, required this.report});
 
@@ -26,42 +25,34 @@ class LocalScan {
 
 /// A [MusicSource] that scans audio files already present on the device.
 ///
-/// This is the first concrete source and the reference implementation of the
-/// contract. A scan keeps only recognized audio files (see [AudioFileTypes]) and
-/// maps each one to a [Track] via [LocalTrackMapper], which reads the file's
-/// audio tags (title/artist/album/duration/track number) when they are available
-/// and falls back to a clean filename/folder derivation otherwise — so a local
-/// library indexes and groups like a real source rather than a flat file list.
+/// Three storage strategies sit behind it:
+///  - filesystem paths on desktop/Linux;
+///  - Android SAF `content://` trees for a targeted folder grant;
+///  - Android MediaStore when the user explicitly selects "All music on this
+///    device" and grants the normal Music and audio runtime permission.
 ///
-/// Two storage strategies sit behind it, chosen by what the picker returned:
-///  - a filesystem path (desktop/Linux, and any path Android hands back) is
-///    walked by an [AudioFileScanner]; per-file tags come from the injected
-///    [LocalMetadataReader] (none by default — see [UnsupportedLocalMetadataReader]
-///    — so filesystem scans currently rely on filename/folder metadata);
-///  - an Android SAF `content://` tree URI is traversed through the content
-///    resolver by a [SafDocumentLister], the scoped-storage-friendly path, which
-///    also reads each document's tags natively. When that traversal isn't
-///    available on the build, it falls back to the filesystem scanner so
-///    behaviour never regresses.
-///
-/// Every seam is injectable so scanning and tag reading stay testable without a
-/// real disk, device, or platform channel.
+/// Every seam is injectable so scanning stays testable without a real disk,
+/// device, permission dialog, or platform channel.
 class LocalMusicSource implements MusicSource {
   const LocalMusicSource({
     required this.folderPath,
     AudioFileScanner scanner = const IoAudioFileScanner(),
     SafDocumentLister safDocumentLister = const UnsupportedSafDocumentLister(),
+    AndroidMediaLibrary androidMediaLibrary =
+        const UnsupportedAndroidMediaLibrary(),
     LocalMetadataReader metadataReader = const UnsupportedLocalMetadataReader(),
   })  : _scanner = scanner,
         _safDocumentLister = safDocumentLister,
+        _androidMediaLibrary = androidMediaLibrary,
         _metadataReader = metadataReader;
 
-  /// Absolute path or SAF tree URI of the folder to scan, or `null` when the
-  /// user has not chosen one yet — in which case scans simply return nothing.
+  /// Filesystem path, SAF tree URI, [FolderLocation.androidMediaStoreAudio], or
+  /// null when the user has not configured local music.
   final String? folderPath;
 
   final AudioFileScanner _scanner;
   final SafDocumentLister _safDocumentLister;
+  final AndroidMediaLibrary _androidMediaLibrary;
   final LocalMetadataReader _metadataReader;
 
   @override
@@ -73,15 +64,6 @@ class LocalMusicSource implements MusicSource {
   @override
   Future<List<Track>> fetchTracks() async => (await scanTracks()).tracks;
 
-  /// Scans the selected folder and returns the discovered [Track]s alongside a
-  /// secret-free [LocalScanReport]. This is the richer entry point the library
-  /// controller uses so it can both persist the tracks and record diagnostics;
-  /// [fetchTracks] is the thin [MusicSource] view over it.
-  ///
-  /// A genuine traversal failure still throws a `FolderScanException` (the
-  /// caller turns it into a clear message and an error report); an empty or
-  /// permission-blocked folder instead returns an empty result whose report
-  /// counts explain why.
   Future<LocalScan> scanTracks() async {
     final String? folder = folderPath;
     if (folder == null || folder.isEmpty) {
@@ -97,58 +79,68 @@ class LocalMusicSource implements MusicSource {
         ),
       );
     }
-    if (FolderLocation.parse(folder).isContentUri) {
+
+    final FolderLocation location = FolderLocation.parse(folder);
+    if (location.isAndroidMediaStore) {
+      return _scanAndroidMediaStore();
+    }
+    if (location.isContentUri) {
       return _scanSaf(folder);
     }
     return _scanFiles(folder, isContentUri: false);
   }
 
+  Future<LocalScan> _scanAndroidMediaStore() async {
+    final SafScanResult result = await _androidMediaLibrary.listDeviceAudio();
+    return _scanDocuments(result, isContentUri: false);
+  }
+
   /// Walks an Android SAF tree through the content resolver. Falls back to the
-  /// filesystem path scanner only when SAF traversal isn't available on this
-  /// build (e.g. desktop); a genuine traversal failure propagates as a
-  /// `FolderScanException`.
+  /// filesystem path scanner only when SAF traversal isn't available here.
   Future<LocalScan> _scanSaf(String folder) async {
     try {
       final SafScanResult result =
           await _safDocumentLister.listAudioDocuments(folder);
-      final List<Track> tracks = <Track>[];
-      for (final SafAudioDocument document in result.documents) {
-        // Accept either signal the provider offered — a known extension or an
-        // `audio/*` MIME — so an audio file the platform recognised by content
-        // type isn't dropped just because its name has no known extension.
-        if (AudioFileTypes.isSupportedDocument(
-          document.name,
-          document.mimeType,
-        )) {
-          tracks.add(LocalTrackMapper.fromSafDocument(document));
-        }
-      }
-      // `candidates` is what the provider's audio filter (extension OR audio/*
-      // MIME) returned; `imported` is what the catalog's own filter kept. The
-      // two predicates match today, so these are normally equal — reported
-      // separately so a future divergence (a stricter catalog filter) is visible
-      // in diagnostics rather than silent.
-      final int candidates = result.documents.length;
-      final int imported = tracks.length;
-      final int skipped = result.filesVisited > candidates
-          ? result.filesVisited - candidates
-          : 0;
-      return LocalScan(
-        tracks: tracks,
-        report: LocalScanReport(
-          folderSelected: true,
-          isContentUri: true,
-          filesVisited: result.filesVisited,
-          foldersVisited: result.foldersVisited,
-          audioCandidates: candidates,
-          importedTracks: imported,
-          skippedUnsupported: skipped,
-          readFailures: result.readFailures,
-        ),
-      );
+      return _scanDocuments(result, isContentUri: true);
     } on SafUnsupportedException {
       return _scanFiles(folder, isContentUri: true);
     }
+  }
+
+  /// Turns content-resolver rows (SAF or MediaStore) into local tracks using the
+  /// same mapper, so title/artist/album/duration/track-number behavior stays
+  /// identical across Android's two local-library modes.
+  LocalScan _scanDocuments(
+    SafScanResult result, {
+    required bool isContentUri,
+  }) {
+    final List<Track> tracks = <Track>[];
+    for (final SafAudioDocument document in result.documents) {
+      if (AudioFileTypes.isSupportedDocument(
+        document.name,
+        document.mimeType,
+      )) {
+        tracks.add(LocalTrackMapper.fromSafDocument(document));
+      }
+    }
+    final int candidates = result.documents.length;
+    final int imported = tracks.length;
+    final int skipped = result.filesVisited > candidates
+        ? result.filesVisited - candidates
+        : 0;
+    return LocalScan(
+      tracks: tracks,
+      report: LocalScanReport(
+        folderSelected: true,
+        isContentUri: isContentUri,
+        filesVisited: result.filesVisited,
+        foldersVisited: result.foldersVisited,
+        audioCandidates: candidates,
+        importedTracks: imported,
+        skippedUnsupported: skipped,
+        readFailures: result.readFailures,
+      ),
+    );
   }
 
   Future<LocalScan> _scanFiles(
@@ -159,8 +151,6 @@ class LocalMusicSource implements MusicSource {
     final List<Track> tracks = <Track>[];
     for (final String path in files) {
       if (AudioFileTypes.isSupported(path)) {
-        // A reader that can't read this file (or this build) returns null, so
-        // the mapper falls back to the filename/folder metadata.
         final LocalAudioMetadata? metadata =
             await _metadataReader.readFromPath(path);
         tracks.add(LocalTrackMapper.fromPath(
@@ -178,7 +168,6 @@ class LocalMusicSource implements MusicSource {
         folderSelected: true,
         isContentUri: isContentUri,
         filesVisited: visited,
-        // The filesystem walk reports files, not a directory count.
         foldersVisited: 0,
         audioCandidates: candidates,
         importedTracks: candidates,
@@ -188,14 +177,9 @@ class LocalMusicSource implements MusicSource {
     );
   }
 
-  /// The albums present in the scanned folder, grouped from the tracks' tags the
-  /// same way the unified library groups every source. Empty when nothing was
-  /// scanned. (The library catalog derives its own groupings from the stored
-  /// tracks; this keeps the source contract honest for any direct consumer.)
   @override
   Future<List<Album>> fetchAlbums() async => groupAlbums(await fetchTracks());
 
-  /// The artists present in the scanned folder — see [fetchAlbums].
   @override
   Future<List<Artist>> fetchArtists() async =>
       groupArtists(await fetchTracks());

--- a/lib/core/sources/local/local_music_source.dart
+++ b/lib/core/sources/local/local_music_source.dart
@@ -125,9 +125,8 @@ class LocalMusicSource implements MusicSource {
     }
     final int candidates = result.documents.length;
     final int imported = tracks.length;
-    final int skipped = result.filesVisited > candidates
-        ? result.filesVisited - candidates
-        : 0;
+    final int skipped =
+        result.filesVisited > candidates ? result.filesVisited - candidates : 0;
     return LocalScan(
       tracks: tracks,
       report: LocalScanReport(

--- a/lib/core/sources/local/local_scan_diagnostics.dart
+++ b/lib/core/sources/local/local_scan_diagnostics.dart
@@ -44,7 +44,7 @@ abstract final class LocalScanDiagnostics {
   static String describe(LocalScanReport report) {
     return <String>[
       'folder=${report.folderSelected ? 'selected' : 'none'}',
-      if (report.folderSelected) 'kind=${report.isContentUri ? 'saf' : 'path'}',
+      if (report.folderSelected) 'kind=${_kind(report)}',
       'visited=${report.filesVisited}',
       'folders=${report.foldersVisited}',
       'audio=${report.audioCandidates}',
@@ -54,5 +54,11 @@ abstract final class LocalScanDiagnostics {
       'recursive=${report.recursive ? 'yes' : 'no'}',
       if (report.error != null) 'error=${report.error!.name}',
     ].join(' ');
+  }
+
+  /// Which backend the scan actually read. A structural label, not a path.
+  static String _kind(LocalScanReport report) {
+    if (report.isDeviceLibrary) return 'mediastore';
+    return report.isContentUri ? 'saf' : 'path';
   }
 }

--- a/lib/core/sources/local/local_scan_report.dart
+++ b/lib/core/sources/local/local_scan_report.dart
@@ -6,11 +6,14 @@ enum LocalScanError {
   /// Access Framework (revoked grant, unresolvable provider, unreadable path).
   safTraversal,
 
+  /// Android's device-wide Music and audio / MediaStore access is unavailable
+  /// or revoked. This is distinct from SAF because the recovery action is the
+  /// normal Android app-permission screen, not re-picking a folder.
+  mediaPermission,
+
   /// The selected folder itself could not be opened on a filesystem scan: it
   /// is missing, unreadable, or (in the Flatpak) the portal document that
-  /// exposed it was revoked. Recoverable by reselecting the folder, and
-  /// deliberately distinct from [safTraversal] so a desktop report does not
-  /// read as an Android permission problem.
+  /// exposed it was revoked. Recoverable by reselecting the folder.
   folderUnavailable,
 
   /// Any other unexpected scan failure (a `dart:io` fault, a plugin error).
@@ -19,12 +22,6 @@ enum LocalScanError {
 
 /// A secret-free snapshot of the last local-folder scan, so a bug report can
 /// show *why* a scan turned up empty without revealing anything private.
-///
-/// Security: by construction this holds only booleans, counts, and a fixed
-/// [LocalScanError] enum name. There is deliberately **no** field for the folder
-/// path/URI, a file name, or a raw error message — the things that could leak a
-/// user's library layout. This mirrors the "diagnostic, never secret" rule the
-/// rest of the diagnostics utilities follow.
 class LocalScanReport {
   const LocalScanReport({
     required this.folderSelected,
@@ -53,45 +50,15 @@ class LocalScanReport {
         readFailures = 0,
         recursive = true;
 
-  /// Whether a music folder was selected at all when the scan ran.
   final bool folderSelected;
-
-  /// Whether the selection was an Android SAF `content://` tree URI (vs a plain
-  /// filesystem path). Tells a "no music found" report apart by storage kind.
   final bool isContentUri;
-
-  /// How many non-directory entries the scan walked (audio and non-audio).
   final int filesVisited;
-
-  /// How many directories the scan successfully listed — the selected root plus
-  /// any readable subfolders. Surfaced on the SAF path (the Android case);
-  /// filesystem-path scans report 0 here.
   final int foldersVisited;
-
-  /// How many of those entries looked like audio (a recognized extension or an
-  /// `audio/*` content type) — the candidates before the catalog's own filter.
   final int audioCandidates;
-
-  /// How many candidates actually became tracks in the catalog. Normally equal
-  /// to [audioCandidates] — the catalog's supported-types filter mirrors the
-  /// provider's — but kept distinct so a future divergence stays visible.
   final int importedTracks;
-
-  /// How many entries were skipped because they were not a recognized audio
-  /// file (the usual `cover.jpg`/`notes.txt` case).
   final int skippedUnsupported;
-
-  /// How many entries or subfolders could not be read and were skipped — the
-  /// scoped-storage / removable-SD-card signal. A non-zero value with zero
-  /// candidates points at a permission problem rather than an empty folder.
   final int readFailures;
-
-  /// Whether the scan descended into subfolders (it always does; surfaced so a
-  /// report can confirm nested artist/album folders were searched).
   final bool recursive;
-
-  /// The failure kind when the scan threw, or null when it completed (even if it
-  /// completed with zero candidates).
   final LocalScanError? error;
 
   bool get hadError => error != null;

--- a/lib/core/sources/local/local_scan_report.dart
+++ b/lib/core/sources/local/local_scan_report.dart
@@ -33,8 +33,12 @@ class LocalScanReport {
     this.foldersVisited = 0,
     this.importedTracks = 0,
     this.recursive = true,
+    this.isDeviceLibrary = false,
     this.error,
-  });
+  }) : assert(
+          !(isContentUri && isDeviceLibrary),
+          'a scan reads either a SAF tree or the device library, never both',
+        );
 
   /// Builds a failure report (all counts zero) from what the caller knows about
   /// the selection — used when the scan threw before producing any counts.
@@ -42,16 +46,29 @@ class LocalScanReport {
     required this.folderSelected,
     required this.isContentUri,
     required LocalScanError this.error,
+    this.isDeviceLibrary = false,
   })  : filesVisited = 0,
         foldersVisited = 0,
         audioCandidates = 0,
         importedTracks = 0,
         skippedUnsupported = 0,
         readFailures = 0,
-        recursive = true;
+        recursive = true,
+        assert(
+          !(isContentUri && isDeviceLibrary),
+          'a scan reads either a SAF tree or the device library, never both',
+        );
 
   final bool folderSelected;
   final bool isContentUri;
+
+  /// Whether this scan read Android's device-wide MediaStore library rather
+  /// than a folder. MediaStore reads no content-URI *tree* and walks no
+  /// directories, so without this flag its reports are indistinguishable from a
+  /// plain filesystem scan: the diagnostics line would call it `kind=path`, and
+  /// recovery text would send the user to a folder chooser for a source that is
+  /// not a folder.
+  final bool isDeviceLibrary;
   final int filesVisited;
   final int foldersVisited;
   final int audioCandidates;

--- a/lib/core/sources/local/local_track_mapper.dart
+++ b/lib/core/sources/local/local_track_mapper.dart
@@ -7,37 +7,7 @@ import 'saf_document_lister.dart';
 /// Builds a [Track] from an on-device source — a local file path or an Android
 /// SAF document — merging any audio tags the source read over a clean
 /// filename/folder fallback.
-///
-/// This is intentionally the *only* place that turns an on-device item into a
-/// [Track], so the metadata story lives in one tested spot.
-///
-/// ## Tags first, then a clean fallback
-///
-/// When [LocalAudioMetadata] is present (the native SAF walk read tags, or a
-/// future desktop reader did), its fields win — so a tagged file indexes with a
-/// proper title, artist, album, duration, and track number, exactly like a
-/// Jellyfin/Subsonic track. Each field falls back **independently** when its tag
-/// is missing or blank, so a half-tagged file still gets the best of both. The
-/// file's embedded cover art, when the source extracted one, rides through as
-/// [Track.artworkUri]; a file with none keeps a null artwork (the placeholder).
-///
-/// The fallback never shows an ugly path. From the file's own name it derives a
-/// leading track number and a clean title (`01 - Holocene` → #1, "Holocene");
-/// from a filesystem layout it reads the conventional `…/Artist/Album/Track`
-/// folders for the artist and album. (A SAF content URI exposes no folder path,
-/// so SAF album/artist come only from tags — usually present on Android.)
-///
-/// The path / content URI is always both the stable [Track.id] and the
-/// [Track.uri], independent of the (mutable) tags, so a re-scan after an edit
-/// keeps the same identity.
 abstract final class LocalTrackMapper {
-  /// Maps [path] to a [Track].
-  ///
-  /// [metadata] are the file's tags when a reader provided them; [scanRoot] is
-  /// the scanned folder, used to read the `Artist/Album` folders *relative to
-  /// it* (so the scan root itself is never mistaken for an album). Both are
-  /// optional: with neither, the title and any leading track number still come
-  /// from the file name.
   static Track fromPath(
     String path, {
     LocalAudioMetadata? metadata,
@@ -55,9 +25,6 @@ abstract final class LocalTrackMapper {
     );
   }
 
-  /// Maps a SAF [document] to a [Track]. The `content://` URI is both the stable
-  /// id and the playable uri; tags come from [SafAudioDocument.metadata] and the
-  /// title/track-number fallback from the display name.
   static Track fromSafDocument(SafAudioDocument document) {
     return _build(
       id: document.uri,
@@ -67,8 +34,6 @@ abstract final class LocalTrackMapper {
     );
   }
 
-  /// Merges [metadata] over the name/folder fallback into a [Track]. Every field
-  /// falls back independently, and a blank tag value is treated as absent.
   static Track _build({
     required String id,
     required String uri,
@@ -89,31 +54,14 @@ abstract final class LocalTrackMapper {
         folderArtist,
       ]),
       albumName: _firstNonBlank(<String?>[metadata?.album, folderAlbum]),
-      // No stable local album id exists (there is no server to mint one), so
-      // [Track.albumId] stays null — grouping falls to the name-based tiers.
-      // [Track.albumArtistName], though, comes straight from the file's own
-      // embedded album-artist tag when present: it is already a trustworthy,
-      // stable local value (used above for [artistName] too), so a tagged
-      // "various artists" / collaboration album groups correctly even for
-      // local files, the same as a server that reports a distinct album
-      // artist.
+      albumId: _blankToNull(metadata?.albumId),
       albumArtistName: _blankToNull(metadata?.albumArtist),
       trackNumber: metadata?.trackNumber ?? parts.trackNumber,
       duration: metadata?.duration ?? Duration.zero,
-      // Embedded cover art has no filename fallback — it is present only when the
-      // source actually extracted one — so it passes straight through, leaving
-      // [Track.artworkUri] null (the calm placeholder) when there is none.
       artworkUri: metadata?.artworkUri,
     );
   }
 
-  /// A leading track number (`01 - `, `01.`, `01 `, …) and the remaining title,
-  /// parsed from a file/display name without its extension.
-  ///
-  /// A number is only taken when a separator follows it and a non-empty title
-  /// remains, so a name that *is* a number ("1984") or has no separator keeps
-  /// its whole self as the title and reports no track number. A real tag title,
-  /// when present, is used verbatim instead — this only shapes the fallback.
   static _NameParts _parseName(String nameWithoutExtension) {
     final String trimmed = nameWithoutExtension.trim();
     final RegExpMatch? match = _leadingTrackNumber.firstMatch(trimmed);
@@ -123,28 +71,18 @@ abstract final class LocalTrackMapper {
         return _NameParts(int.tryParse(match.group(1)!), rest);
       }
     }
-    // No usable leading number: the whole (trimmed) name is the title. Guard the
-    // pathological empty name so a track is never titled "".
     return _NameParts(null, trimmed.isEmpty ? nameWithoutExtension : trimmed);
   }
 
-  /// `1`–`3` leading digits, then at least one separator, then a non-empty rest.
-  /// The separators cover the common `01 - `, `01.`, `01_`, `01)` and bare-space
-  /// conventions without stripping a number that is part of the title.
   static final RegExp _leadingTrackNumber =
       RegExp(r'^(\d{1,3})[\s._\-)\]]+(.+)$');
 
-  /// The conventional `Artist/Album` folder names for [path], read *relative to*
-  /// [scanRoot] so the scanned root is never treated as an album/artist. Returns
-  /// empty names when there is no folder context (no root, or the file is not
-  /// under it — e.g. a content-URI scan resolved to a path elsewhere).
   static _FolderNames _folderNamesFor(String path, String? scanRoot) {
     if (scanRoot == null || scanRoot.isEmpty) return const _FolderNames();
     final String root = p.normalize(scanRoot);
     final String full = p.normalize(path);
     if (!p.isWithin(root, full)) return const _FolderNames();
     final List<String> segments = p.split(p.relative(full, from: root));
-    // Drop the file name itself; what's left are the folders below the root.
     final List<String> folders = segments.sublist(0, segments.length - 1);
     final String? album =
         folders.isNotEmpty ? _blankToNull(folders.last) : null;
@@ -153,7 +91,6 @@ abstract final class LocalTrackMapper {
     return _FolderNames(artist: artist, album: album);
   }
 
-  /// The first non-null, non-blank (after trimming) value, or null when none.
   static String? _firstNonBlank(List<String?> values) {
     for (final String? value in values) {
       final String? cleaned = _blankToNull(value);
@@ -162,7 +99,6 @@ abstract final class LocalTrackMapper {
     return null;
   }
 
-  /// [value] trimmed, or null when it is null or blank.
   static String? _blankToNull(String? value) {
     if (value == null) return null;
     final String trimmed = value.trim();
@@ -170,7 +106,6 @@ abstract final class LocalTrackMapper {
   }
 }
 
-/// A leading track number and the remaining title parsed from a name.
 class _NameParts {
   const _NameParts(this.trackNumber, this.title);
 
@@ -178,7 +113,6 @@ class _NameParts {
   final String title;
 }
 
-/// The conventional `Artist/Album` folder names derived from a file's path.
 class _FolderNames {
   const _FolderNames({this.artist, this.album});
 

--- a/lib/core/sources/local/method_channel_android_media_library.dart
+++ b/lib/core/sources/local/method_channel_android_media_library.dart
@@ -25,7 +25,8 @@ class MethodChannelAndroidMediaLibrary implements AndroidMediaLibrary {
       return AndroidMusicPermissionStatus.unavailable;
     }
     try {
-      final String? raw = await _channel.invokeMethod<String>('permissionStatus');
+      final String? raw =
+          await _channel.invokeMethod<String>('permissionStatus');
       return parsePermissionStatus(raw);
     } on MissingPluginException {
       return AndroidMusicPermissionStatus.unavailable;
@@ -40,7 +41,8 @@ class MethodChannelAndroidMediaLibrary implements AndroidMediaLibrary {
       return AndroidMusicPermissionStatus.unavailable;
     }
     try {
-      final String? raw = await _channel.invokeMethod<String>('requestPermission');
+      final String? raw =
+          await _channel.invokeMethod<String>('requestPermission');
       return parsePermissionStatus(raw);
     } on MissingPluginException {
       return AndroidMusicPermissionStatus.unavailable;
@@ -78,11 +80,13 @@ class MethodChannelAndroidMediaLibrary implements AndroidMediaLibrary {
         throw const FolderScanException(
           'Music and audio access is turned off. Enable it in Android settings '
           'or choose a folder instead.',
+          code: 'permission_denied',
         );
       }
-      throw const FolderScanException(
+      throw FolderScanException(
         "Couldn't read Android's shared music library. Try again, or choose a "
         'folder instead.',
+        code: error.code,
       );
     }
     return MethodChannelSafDocumentLister.parseScanResult(result);

--- a/lib/core/sources/local/method_channel_android_media_library.dart
+++ b/lib/core/sources/local/method_channel_android_media_library.dart
@@ -1,0 +1,104 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+import 'android_media_library.dart';
+import 'folder_scan_exception.dart';
+import 'method_channel_saf_document_lister.dart';
+import 'saf_document_lister.dart';
+
+/// Native Android implementation of [AndroidMediaLibrary].
+///
+/// The platform side owns runtime-permission prompting and the MediaStore query;
+/// Dart receives only a small typed status plus the same secret-free document
+/// shape used by the SAF scanner.
+class MethodChannelAndroidMediaLibrary implements AndroidMediaLibrary {
+  const MethodChannelAndroidMediaLibrary();
+
+  static const String _channelName =
+      'io.github.thezupzup.linthra/media_library';
+  static const MethodChannel _channel = MethodChannel(_channelName);
+
+  @override
+  Future<AndroidMusicPermissionStatus> permissionStatus() async {
+    if (!Platform.isAndroid) {
+      return AndroidMusicPermissionStatus.unavailable;
+    }
+    try {
+      final String? raw = await _channel.invokeMethod<String>('permissionStatus');
+      return parsePermissionStatus(raw);
+    } on MissingPluginException {
+      return AndroidMusicPermissionStatus.unavailable;
+    } on PlatformException {
+      return AndroidMusicPermissionStatus.unavailable;
+    }
+  }
+
+  @override
+  Future<AndroidMusicPermissionStatus> requestPermission() async {
+    if (!Platform.isAndroid) {
+      return AndroidMusicPermissionStatus.unavailable;
+    }
+    try {
+      final String? raw = await _channel.invokeMethod<String>('requestPermission');
+      return parsePermissionStatus(raw);
+    } on MissingPluginException {
+      return AndroidMusicPermissionStatus.unavailable;
+    } on PlatformException {
+      return AndroidMusicPermissionStatus.denied;
+    }
+  }
+
+  @override
+  Future<void> openAppSettings() async {
+    if (!Platform.isAndroid) return;
+    try {
+      await _channel.invokeMethod<void>('openAppSettings');
+    } on MissingPluginException {
+      // Older builds simply omit the shortcut; no permission is broadened.
+    } on PlatformException {
+      // The settings shortcut is convenience only; failure is non-fatal.
+    }
+  }
+
+  @override
+  Future<SafScanResult> listDeviceAudio() async {
+    if (!Platform.isAndroid) {
+      throw const SafUnsupportedException();
+    }
+    final Map<Object?, Object?>? result;
+    try {
+      result = await _channel.invokeMapMethod<Object?, Object?>(
+        'listDeviceAudio',
+      );
+    } on MissingPluginException {
+      throw const SafUnsupportedException();
+    } on PlatformException catch (error) {
+      if (error.code == 'permission_denied') {
+        throw const FolderScanException(
+          'Music and audio access is turned off. Enable it in Android settings '
+          'or choose a folder instead.',
+        );
+      }
+      throw const FolderScanException(
+        "Couldn't read Android's shared music library. Try again, or choose a "
+        'folder instead.',
+      );
+    }
+    return MethodChannelSafDocumentLister.parseScanResult(result);
+  }
+
+  /// Pure parser so status handling is testable without a device/channel.
+  static AndroidMusicPermissionStatus parsePermissionStatus(String? raw) {
+    switch (raw) {
+      case 'allowed':
+        return AndroidMusicPermissionStatus.allowed;
+      case 'denied':
+        return AndroidMusicPermissionStatus.denied;
+      case 'notRequested':
+        return AndroidMusicPermissionStatus.notRequested;
+      default:
+        return AndroidMusicPermissionStatus.unavailable;
+    }
+  }
+}

--- a/lib/core/sources/local/method_channel_saf_document_lister.dart
+++ b/lib/core/sources/local/method_channel_saf_document_lister.dart
@@ -70,12 +70,14 @@ class MethodChannelSafDocumentLister implements SafDocumentLister {
           final Object? name = entry['name'];
           final Object? mime = entry['mime'];
           if (uri is String && uri.isNotEmpty && name is String) {
-            documents.add(SafAudioDocument(
-              uri: uri,
-              name: name,
-              mimeType: mime is String ? mime : null,
-              metadata: parseMetadata(entry),
-            ));
+            documents.add(
+              SafAudioDocument(
+                uri: uri,
+                name: name,
+                mimeType: mime is String ? mime : null,
+                metadata: parseMetadata(entry),
+              ),
+            );
           }
         }
       }
@@ -95,8 +97,9 @@ class MethodChannelSafDocumentLister implements SafDocumentLister {
 
   /// Builds the [LocalAudioMetadata] for one document [entry] from the optional
   /// tag fields the native walk attached (`title`, `artist`, `albumArtist`,
-  /// `album`, `track`, `durationMs`, `artworkUri`), or null when none are present
-  /// — an older native build, or a file the platform could not read tags from.
+  /// `album`, `albumId`, `track`, `durationMs`, `artworkUri`), or null when none
+  /// are present — an older native build, or a file the platform could not read
+  /// tags from.
   ///
   /// Pure and tolerant so it is unit-testable and never throws on a malformed or
   /// partial reply: a non-string text field, a `track` like `"3/12"`, a
@@ -109,6 +112,7 @@ class MethodChannelSafDocumentLister implements SafDocumentLister {
     final String? artist = _string(entry['artist']);
     final String? albumArtist = _string(entry['albumArtist']);
     final String? album = _string(entry['album']);
+    final String? albumId = _string(entry['albumId']);
     final int? trackNumber = _trackNumber(entry['track']);
     final Duration? duration = _durationMs(entry['durationMs']);
     final Uri? artworkUri = _artworkUri(entry['artworkUri']);
@@ -116,6 +120,7 @@ class MethodChannelSafDocumentLister implements SafDocumentLister {
         artist == null &&
         albumArtist == null &&
         album == null &&
+        albumId == null &&
         trackNumber == null &&
         duration == null &&
         artworkUri == null) {
@@ -126,6 +131,7 @@ class MethodChannelSafDocumentLister implements SafDocumentLister {
       artist: artist,
       albumArtist: albumArtist,
       album: album,
+      albumId: albumId,
       trackNumber: trackNumber,
       duration: duration,
       artworkUri: artworkUri,

--- a/lib/features/library/library_controller.dart
+++ b/lib/features/library/library_controller.dart
@@ -49,6 +49,7 @@ class LibraryController extends Notifier<LibraryState> {
             LocalScanReport.failure(
               folderSelected: folderPath.isNotEmpty,
               isContentUri: location.isContentUri,
+              isDeviceLibrary: location.isAndroidMediaStore,
               error: location.isAndroidMediaStore
                   ? error.code == 'permission_denied'
                       ? LocalScanError.mediaPermission
@@ -64,6 +65,7 @@ class LibraryController extends Notifier<LibraryState> {
             LocalScanReport.failure(
               folderSelected: folderPath.isNotEmpty,
               isContentUri: location.isContentUri,
+              isDeviceLibrary: location.isAndroidMediaStore,
               error: LocalScanError.unexpected,
             ),
           );

--- a/lib/features/library/library_controller.dart
+++ b/lib/features/library/library_controller.dart
@@ -45,22 +45,28 @@ class LibraryController extends Notifier<LibraryState> {
       ref.read(localScanReportProvider.notifier).record(scan.report);
       await _load();
     } on FolderScanException catch (error) {
-      ref.read(localScanReportProvider.notifier).record(LocalScanReport.failure(
-            folderSelected: folderPath.isNotEmpty,
-            isContentUri: location.isContentUri,
-            error: location.isAndroidMediaStore
-                ? LocalScanError.mediaPermission
-                : location.isContentUri
-                    ? LocalScanError.safTraversal
-                    : LocalScanError.folderUnavailable,
-          ));
+      ref.read(localScanReportProvider.notifier).record(
+            LocalScanReport.failure(
+              folderSelected: folderPath.isNotEmpty,
+              isContentUri: location.isContentUri,
+              error: location.isAndroidMediaStore
+                  ? error.code == 'permission_denied'
+                      ? LocalScanError.mediaPermission
+                      : LocalScanError.unexpected
+                  : location.isContentUri
+                      ? LocalScanError.safTraversal
+                      : LocalScanError.folderUnavailable,
+            ),
+          );
       state = LibraryState.error(error.message);
     } catch (_) {
-      ref.read(localScanReportProvider.notifier).record(LocalScanReport.failure(
-            folderSelected: folderPath.isNotEmpty,
-            isContentUri: location.isContentUri,
-            error: LocalScanError.unexpected,
-          ));
+      ref.read(localScanReportProvider.notifier).record(
+            LocalScanReport.failure(
+              folderSelected: folderPath.isNotEmpty,
+              isContentUri: location.isContentUri,
+              error: LocalScanError.unexpected,
+            ),
+          );
       state = const LibraryState.error(_scanFailedMessage);
     }
   }

--- a/lib/features/library/library_controller.dart
+++ b/lib/features/library/library_controller.dart
@@ -11,22 +11,18 @@ import 'library_state.dart';
 import 'local_scan_report_provider.dart';
 
 /// Drives the Library screen: loads tracks from the [MusicLibraryRepository]
-/// and exposes them as a [LibraryState]. Keeps the UI free of any direct
-/// knowledge of the repository or its backing store.
+/// and exposes them as a [LibraryState].
 class LibraryController extends Notifier<LibraryState> {
   @override
   LibraryState build() {
-    // Kick off the initial load; the screen shows a spinner until it lands.
     _load();
     return const LibraryState.loading();
   }
 
-  /// Re-reads the catalog. Safe to call again (e.g. after a scan).
   Future<void> refresh() => _load();
 
-  /// Scans [folderPath] with a [LocalMusicSource], persists the discovered
-  /// tracks through the [MusicLibraryRepository], then reloads so the screen
-  /// shows what was just stored. Any failure surfaces as an error state.
+  /// Scans a filesystem folder, SAF tree, or Android device-wide MediaStore
+  /// selection, persists the discovered tracks, then reloads the catalog.
   Future<void> scanFolder(String folderPath) async {
     state = const LibraryState.loading();
     final FolderLocation location = FolderLocation.parse(folderPath);
@@ -35,43 +31,31 @@ class LibraryController extends Notifier<LibraryState> {
         folderPath: folderPath,
         scanner: ref.read(audioFileScannerProvider),
         safDocumentLister: ref.read(safDocumentListerProvider),
+        androidMediaLibrary: ref.read(androidMediaLibraryProvider),
         metadataReader: ref.read(localMetadataReaderProvider),
       );
       final LocalScan scan = await source.scanTracks();
       final repository = ref.read(musicLibraryRepositoryProvider);
-      // Derive the album/artist groupings from the just-scanned tracks rather
-      // than re-scanning the folder (which would re-read every file's tags); the
-      // unified library derives its own groupings from the stored tracks the same
-      // way, so this only feeds repositories that persist them.
       await repository.upsertCatalog(
         sourceId: source.id,
         tracks: scan.tracks,
         albums: groupAlbums(scan.tracks),
         artists: groupArtists(scan.tracks),
       );
-      // Record the counts (visited / folders / audio / imported / skipped /
-      // read failures) so a "no music found" report can show what the scan
-      // actually saw — reactively (Settings ▸ Local music) and in diagnostics.
       ref.read(localScanReportProvider.notifier).record(scan.report);
       await _load();
     } on FolderScanException catch (error) {
-      // The scanning layer already phrased a clear, secret-free message
-      // (unreachable SAF tree, unreadable scoped-storage path, a folder that
-      // is gone, …); show it. The catalog is deliberately left untouched: a
-      // folder Linthra cannot reach right now is a recoverable source state,
-      // not a reason to drop the tracks the user already has indexed.
       ref.read(localScanReportProvider.notifier).record(LocalScanReport.failure(
             folderSelected: folderPath.isNotEmpty,
             isContentUri: location.isContentUri,
-            error: location.isContentUri
-                ? LocalScanError.safTraversal
-                : LocalScanError.folderUnavailable,
+            error: location.isAndroidMediaStore
+                ? LocalScanError.mediaPermission
+                : location.isContentUri
+                    ? LocalScanError.safTraversal
+                    : LocalScanError.folderUnavailable,
           ));
       state = LibraryState.error(error.message);
     } catch (_) {
-      // Anything else is an unexpected scan failure — a raw `dart:io`
-      // permission error or a plugin fault. Don't leak its text (errno codes,
-      // paths) to the user; show one friendly, actionable line instead.
       ref.read(localScanReportProvider.notifier).record(LocalScanReport.failure(
             folderSelected: folderPath.isNotEmpty,
             isContentUri: location.isContentUri,
@@ -96,8 +80,6 @@ class LibraryController extends Notifier<LibraryState> {
           await ref.read(musicLibraryRepositoryProvider).getAllTracks();
       state = LibraryState.loaded(tracks);
     } catch (_) {
-      // Don't leak raw store/exception text (file paths, SQL, errno) to the
-      // UI; show one friendly, actionable line instead.
       state = const LibraryState.error(_loadFailedMessage);
     }
   }

--- a/lib/features/library/library_providers.dart
+++ b/lib/features/library/library_providers.dart
@@ -2,9 +2,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/services/folder_picker_service.dart';
 import '../../core/services/platform_folder_picker_service.dart';
+import '../../core/sources/local/android_media_library.dart';
 import '../../core/sources/local/audio_file_scanner.dart';
 import '../../core/sources/local/directory_readability.dart';
 import '../../core/sources/local/local_metadata_reader.dart';
+import '../../core/sources/local/method_channel_android_media_library.dart';
 import '../../core/sources/local/method_channel_saf_document_lister.dart';
 import '../../core/sources/local/method_channel_saf_permission_probe.dart';
 import '../../core/sources/local/saf_document_lister.dart';
@@ -12,67 +14,58 @@ import '../../core/sources/local/saf_permission_probe.dart';
 import '../../data/repositories/host_platform_provider.dart';
 
 /// The storage seam the library scan uses to discover audio files.
-///
-/// Defaults to [PlatformAudioFileScanner], which routes a selected folder to
-/// the right backend: a `dart:io` walk for desktop/Linux filesystem paths, and
-/// the SAF-aware [ContentUriAudioFileScanner] for Android `content://` tree
-/// URIs. Tests override it with a fake so a scan can run end-to-end without
-/// touching a real disk. This is the only new provider the scan flow needs —
-/// the repository and library state already have their own providers
-/// (`musicLibraryRepositoryProvider`, `libraryControllerProvider`).
 final audioFileScannerProvider = Provider<AudioFileScanner>((ref) {
   return const PlatformAudioFileScanner();
 });
 
 /// The folder-chooser seam the Library uses to let the user pick a music
-/// folder. Defaults to [PlatformFolderPickerService], which on Android returns
-/// the picked `content://` tree URI (with a persisted read grant) and elsewhere
-/// falls back to the `file_picker` filesystem chooser. Tests override it with a
-/// fake so the pick-and-scan flow runs without a real OS dialog.
+/// folder. Android returns a persisted SAF tree URI; desktop uses its native
+/// chooser/portal.
 final folderPickerServiceProvider = Provider<FolderPickerService>((ref) {
   return const PlatformFolderPickerService();
 });
 
 /// The SAF traversal seam used to scan an Android `content://` folder through
-/// the content resolver. Native content-resolver traversal is Android-only, so
-/// elsewhere (desktop, tests) the unsupported binding makes a content-URI scan
-/// fall back to filesystem path resolution. Tests override it with a fake.
+/// the content resolver.
 final safDocumentListerProvider = Provider<SafDocumentLister>((ref) {
   return ref.watch(hostPlatformProvider).isAndroid
       ? const MethodChannelSafDocumentLister()
       : const UnsupportedSafDocumentLister();
 });
 
+/// Optional Android device-wide local library. This is intentionally distinct
+/// from SAF: it is backed by Android's visible/revocable Music and audio
+/// permission plus MediaStore, while the existing folder mode remains a narrow
+/// persisted grant with no broad storage permission.
+final androidMediaLibraryProvider = Provider<AndroidMediaLibrary>((ref) {
+  return ref.watch(hostPlatformProvider).isAndroid
+      ? const MethodChannelAndroidMediaLibrary()
+      : const UnsupportedAndroidMediaLibrary();
+});
+
+/// Reactive permission state shown in Settings ▸ Local music. Auto-dispose means
+/// leaving and reopening the screen asks Android again rather than keeping stale
+/// permission state forever; actions also invalidate it after a request.
+final androidMusicPermissionStatusProvider =
+    FutureProvider.autoDispose<AndroidMusicPermissionStatus>((ref) {
+  return ref.watch(androidMediaLibraryProvider).permissionStatus();
+});
+
 /// The seam diagnostics use to check whether a persisted SAF read grant is still
-/// held for the selected `content://` folder — the removable-SD-card signal that
-/// tells "no music found" apart from a lost folder permission. Android-only;
-/// elsewhere (desktop, tests) the unsupported binding reports `null` so the
-/// persisted-permission line is simply omitted. Tests override it with a fake.
+/// held for the selected `content://` folder.
 final safPermissionProbeProvider = Provider<SafPermissionProbe>((ref) {
   return ref.watch(hostPlatformProvider).isAndroid
       ? const MethodChannelSafPermissionProbe()
       : const UnsupportedSafPermissionProbe();
 });
 
-/// The seam that answers whether a *filesystem* music folder can still be
-/// listed right now — the desktop half of the "did we lose access?" signal the
-/// SAF probe above answers on Android.
-///
-/// It is what tells a Flatpak whose portal document was revoked (the exported
-/// path simply disappears) apart from a folder that is genuinely empty, and it
-/// is equally the answer for an unplugged drive or a folder the user deleted on
-/// a native Linux build. Tests override it with a fake so neither case needs a
-/// real disk.
+/// The seam that answers whether a filesystem music folder can still be listed.
 final directoryReadabilityProvider = Provider<DirectoryReadability>((ref) {
   return const IoDirectoryReadability();
 });
 
-/// The tag-reading seam used to enrich *filesystem* (desktop/Linux and
-/// resolved-path) tracks with their audio metadata. Android SAF documents read
-/// their tags natively during the content-resolver walk, so this only covers the
-/// filesystem path; until a real pure-Dart reader lands it is the unsupported
-/// binding, which reads nothing and leaves the mapper on filename/folder
-/// fallback. Tests override it with a fake to drive the tag-merge path.
+/// The tag-reading seam used to enrich filesystem (desktop/Linux and
+/// resolved-path) tracks with their audio metadata.
 final localMetadataReaderProvider = Provider<LocalMetadataReader>((ref) {
   return const UnsupportedLocalMetadataReader();
 });

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -510,11 +510,13 @@ class _LibrarySyncing extends StatelessWidget {
   }
 }
 
-/// The empty state, split by whether a folder has been selected yet so the
-/// user always sees the right next step:
-///  - no folder chosen → invite them to pick one;
-///  - folder chosen but nothing found → show the folder and offer a re-scan or
-///    a change of folder.
+/// The empty state, split by which local source is selected so the user always
+/// sees the right next step:
+///  - nothing chosen → invite them to pick a folder;
+///  - a folder chosen but nothing found → show the folder and offer a re-scan
+///    or a change of folder;
+///  - Android's device-wide MediaStore library chosen → there is no folder to
+///    reselect, so say the device reported no music and offer a rescan.
 class _LibraryEmpty extends StatelessWidget {
   const _LibraryEmpty({
     required this.selectedFolder,
@@ -530,12 +532,15 @@ class _LibraryEmpty extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final hasFolder = selectedFolder != null;
+    final FolderLocation? location =
+        hasFolder ? FolderLocation.parse(selectedFolder!) : null;
+    final bool isDeviceLibrary = location?.isAndroidMediaStore ?? false;
     // A folder selected as a plain filesystem path on Android is the legacy/
     // broken case: scoped storage won't let Linthra read it, so it turns up
     // empty. Nudge the user to pick it again, which now returns a SAF grant.
-    final bool needsRepick = hasFolder &&
-        Platform.isAndroid &&
-        !FolderLocation.parse(selectedFolder!).isContentUri;
+    // The MediaStore sentinel is not a path, so it must not land here.
+    final bool needsRepick =
+        hasFolder && Platform.isAndroid && location!.isFilesystemPath;
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(AppSpacing.xl),
@@ -557,10 +562,12 @@ class _LibraryEmpty extends StatelessWidget {
             ),
             const SizedBox(height: AppSpacing.sm),
             Text(
-              hasFolder
-                  ? 'Nothing playable turned up in:\n'
-                      '${FolderLocation.parse(selectedFolder!).displayLabel}'
-                  : 'Choose a folder on your device to scan for music.',
+              isDeviceLibrary
+                  ? "Android's music library reported no audio on this device."
+                  : hasFolder
+                      ? 'Nothing playable turned up in:\n'
+                          '${location!.displayLabel}'
+                      : 'Choose a folder on your device to scan for music.',
               style: theme.textTheme.bodyMedium?.copyWith(
                 color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
               ),
@@ -580,12 +587,16 @@ class _LibraryEmpty extends StatelessWidget {
             if (hasFolder) ...[
               FilledButton.tonal(
                 onPressed: onRescan,
-                child: const Text('Rescan folder'),
+                child: Text(
+                  isDeviceLibrary ? 'Rescan this device' : 'Rescan folder',
+                ),
               ),
               const SizedBox(height: AppSpacing.sm),
               TextButton(
                 onPressed: onPick,
-                child: const Text('Change folder'),
+                child: Text(
+                  isDeviceLibrary ? 'Use a folder instead' : 'Change folder',
+                ),
               ),
             ] else
               FilledButton(

--- a/lib/features/library/selected_folder_controller.dart
+++ b/lib/features/library/selected_folder_controller.dart
@@ -3,31 +3,32 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../data/repositories/selected_music_folder_repository_provider.dart';
 import 'library_providers.dart';
 
-/// Owns the user's chosen music folder: loads the persisted selection, lets the
-/// user pick a new one, and persists the result.
-///
-/// Deliberately separate from the library controller/scanning — this only
-/// answers "which folder did the user choose?". The screen combines it with the
-/// scan flow. State is the selected folder path/URI, or `null` when none is set.
+/// Owns the user's chosen local-music location: a folder path/SAF URI, or an
+/// app-defined source sentinel such as Android's device-wide MediaStore library.
 class SelectedFolderController extends AsyncNotifier<String?> {
   @override
   Future<String?> build() {
     return ref.read(selectedMusicFolderRepositoryProvider).getSelectedFolder();
   }
 
-  /// Opens the folder picker and, if the user chooses one, persists it and
-  /// updates state. Returns the chosen folder, or `null` when cancelled (state
-  /// is left unchanged in that case).
+  /// Opens the folder picker and, if the user chooses one, persists it.
   Future<String?> pickAndPersist() async {
     final picked = await ref.read(folderPickerServiceProvider).pickFolder();
     if (picked == null || picked.isEmpty) {
       return null;
     }
+    await setAndPersist(picked);
+    return picked;
+  }
+
+  /// Persists a known local-library location without opening the folder picker.
+  /// Used by Android's explicit device-wide MediaStore mode.
+  Future<void> setAndPersist(String location) async {
+    if (location.isEmpty) return;
     await ref
         .read(selectedMusicFolderRepositoryProvider)
-        .setSelectedFolder(picked);
-    state = AsyncData<String?>(picked);
-    return picked;
+        .setSelectedFolder(location);
+    state = AsyncData<String?>(location);
   }
 
   /// Forgets the current selection.

--- a/lib/features/settings/source/local_music_controller.dart
+++ b/lib/features/settings/source/local_music_controller.dart
@@ -28,7 +28,8 @@ class LocalMusicActionState {
 ///
 /// Android exposes two deliberate choices:
 ///  - a targeted SAF folder grant; or
-///  - the system-visible Music and audio permission for the device MediaStore.
+///  - device-wide MediaStore access, backed by READ_MEDIA_AUDIO on Android 13+
+///    and the legacy shared-storage read permission on older Android releases.
 /// The second path is only requested when the user explicitly chooses it.
 class LocalMusicController extends Notifier<LocalMusicActionState> {
   @override
@@ -48,8 +49,7 @@ class LocalMusicController extends Notifier<LocalMusicActionState> {
 
   /// Opts into Android's device-wide shared music library.
   ///
-  /// This requests only the narrow audio/media permission for the current
-  /// Android release. A denial leaves the existing folder/catalog untouched.
+  /// A denial leaves the existing folder/catalog untouched.
   Future<void> useAllDeviceMusic() async {
     if (!ref.read(hostPlatformProvider).isAndroid) return;
     state = const LocalMusicActionState(busy: true);
@@ -59,7 +59,7 @@ class LocalMusicController extends Notifier<LocalMusicActionState> {
     ref.invalidate(localFolderAccessProvider);
     if (status != AndroidMusicPermissionStatus.allowed) {
       state = const LocalMusicActionState(
-        message: 'Music and audio access was not granted. You can keep using a '
+        message: 'Device music access was not granted. You can keep using a '
             'selected folder instead.',
         isError: true,
       );
@@ -119,7 +119,7 @@ class LocalMusicController extends Notifier<LocalMusicActionState> {
       final String message;
       if (location.isAndroidMediaStore) {
         message = report.error == LocalScanError.mediaPermission
-            ? 'Could not scan the device music library. Check Music and audio '
+            ? 'Could not scan the device music library. Check device music '
                 'access in Android settings, or choose a folder instead.'
             : "Couldn't read Android's shared music library. Try again, or "
                 'choose a folder instead.';

--- a/lib/features/settings/source/local_music_controller.dart
+++ b/lib/features/settings/source/local_music_controller.dart
@@ -49,7 +49,12 @@ class LocalMusicController extends Notifier<LocalMusicActionState> {
 
   /// Opts into Android's device-wide shared music library.
   ///
-  /// A denial leaves the existing folder/catalog untouched.
+  /// The switch is transactional: the permission is requested, the first
+  /// MediaStore scan runs, and only a scan that actually succeeded persists the
+  /// MediaStore sentinel. A denial or a failed first scan therefore leaves an
+  /// existing folder selection *and* its indexed catalog exactly as they were,
+  /// rather than stranding the app in MediaStore mode while it still shows
+  /// tracks from a folder it can no longer name.
   Future<void> useAllDeviceMusic() async {
     if (!ref.read(hostPlatformProvider).isAndroid) return;
     state = const LocalMusicActionState(busy: true);
@@ -66,10 +71,19 @@ class LocalMusicController extends Notifier<LocalMusicActionState> {
       return;
     }
 
+    // Scan before persisting. `scanFolder` takes the location explicitly, so
+    // nothing has to be saved first, and a failure leaves the stored selection
+    // untouched: no restore step, and no window where a crash could strand a
+    // half-applied switch.
+    final LocalScanReport? report =
+        await _scan(FolderLocation.androidMediaStoreAudio);
+    if (report == null || report.hadError) {
+      return;
+    }
     await ref
         .read(selectedFolderControllerProvider.notifier)
         .setAndPersist(FolderLocation.androidMediaStoreAudio);
-    await _scan(FolderLocation.androidMediaStoreAudio);
+    ref.invalidate(localFolderAccessProvider);
   }
 
   Future<void> refreshAndroidPermissionStatus() async {
@@ -107,13 +121,15 @@ class LocalMusicController extends Notifier<LocalMusicActionState> {
     );
   }
 
-  Future<void> _scan(String folder) async {
+  /// Scans [folder], turns the resulting report into the card's status line,
+  /// and hands the report back so a caller can act on the outcome.
+  Future<LocalScanReport?> _scan(String folder) async {
     await ref.read(libraryControllerProvider.notifier).scanFolder(folder);
     final report = ref.read(localScanReportProvider);
     final FolderLocation location = FolderLocation.parse(folder);
     if (report == null) {
       state = const LocalMusicActionState();
-      return;
+      return null;
     }
     if (report.hadError) {
       final String message;
@@ -127,7 +143,7 @@ class LocalMusicController extends Notifier<LocalMusicActionState> {
         message = "Couldn't scan that folder. Try selecting it again.";
       }
       state = LocalMusicActionState(message: message, isError: true);
-      return;
+      return report;
     }
     if (report.importedTracks > 0) {
       state = LocalMusicActionState(
@@ -135,7 +151,7 @@ class LocalMusicController extends Notifier<LocalMusicActionState> {
             '${report.importedTracks == 1 ? 'track' : 'tracks'} from '
             '${location.isAndroidMediaStore ? 'this device' : 'this folder'}.',
       );
-      return;
+      return report;
     }
     final bool looksBlocked = report.readFailures > 0 ||
         (location.isContentUri && report.filesVisited == 0);
@@ -148,6 +164,7 @@ class LocalMusicController extends Notifier<LocalMusicActionState> {
               : 'No playable audio found in that folder.',
       isError: looksBlocked,
     );
+    return report;
   }
 }
 

--- a/lib/features/settings/source/local_music_controller.dart
+++ b/lib/features/settings/source/local_music_controller.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/sources/local/android_media_library.dart';
 import '../../../core/sources/local/folder_location.dart';
 import '../../../core/sources/local/local_music_source.dart';
+import '../../../core/sources/local/local_scan_report.dart';
 import '../../../data/repositories/host_platform_provider.dart';
 import '../../../data/repositories/music_library_repository_provider.dart';
 import '../../library/library_controller.dart';
@@ -55,6 +56,7 @@ class LocalMusicController extends Notifier<LocalMusicActionState> {
     final AndroidMusicPermissionStatus status =
         await ref.read(androidMediaLibraryProvider).requestPermission();
     ref.invalidate(androidMusicPermissionStatusProvider);
+    ref.invalidate(localFolderAccessProvider);
     if (status != AndroidMusicPermissionStatus.allowed) {
       state = const LocalMusicActionState(
         message: 'Music and audio access was not granted. You can keep using a '
@@ -72,6 +74,7 @@ class LocalMusicController extends Notifier<LocalMusicActionState> {
 
   Future<void> refreshAndroidPermissionStatus() async {
     ref.invalidate(androidMusicPermissionStatusProvider);
+    ref.invalidate(localFolderAccessProvider);
   }
 
   Future<void> openAndroidPermissions() async {
@@ -113,13 +116,17 @@ class LocalMusicController extends Notifier<LocalMusicActionState> {
       return;
     }
     if (report.hadError) {
-      state = LocalMusicActionState(
-        message: location.isAndroidMediaStore
+      final String message;
+      if (location.isAndroidMediaStore) {
+        message = report.error == LocalScanError.mediaPermission
             ? 'Could not scan the device music library. Check Music and audio '
                 'access in Android settings, or choose a folder instead.'
-            : "Couldn't scan that folder. Try selecting it again.",
-        isError: true,
-      );
+            : "Couldn't read Android's shared music library. Try again, or "
+                'choose a folder instead.';
+      } else {
+        message = "Couldn't scan that folder. Try selecting it again.";
+      }
+      state = LocalMusicActionState(message: message, isError: true);
       return;
     }
     if (report.importedTracks > 0) {

--- a/lib/features/settings/source/local_music_controller.dart
+++ b/lib/features/settings/source/local_music_controller.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/sources/local/android_media_library.dart';
 import '../../../core/sources/local/folder_location.dart';
 import '../../../core/sources/local/local_music_source.dart';
 import '../../../data/repositories/host_platform_provider.dart';
@@ -9,8 +10,7 @@ import '../../library/library_providers.dart';
 import '../../library/local_scan_report_provider.dart';
 import '../../library/selected_folder_controller.dart';
 
-/// Transient state for the Settings ▸ Local music card: whether an action is
-/// running and the last one-line outcome to surface.
+/// Transient state for the Settings ▸ Local music card.
 class LocalMusicActionState {
   const LocalMusicActionState({
     this.busy = false,
@@ -18,51 +18,66 @@ class LocalMusicActionState {
     this.isError = false,
   });
 
-  /// True while a pick/rescan/forget is in flight (drives the spinner).
   final bool busy;
-
-  /// A short, secret-free outcome line for the card, or null when there's
-  /// nothing to say. Never a path or file name.
   final String? message;
-
-  /// Whether [message] reports a failure (rendered in the error colour).
   final bool isError;
 }
 
-/// Drives the Settings ▸ Local music source card: choose a folder, rescan it,
-/// or forget it. It is the source-shaped peer of the Jellyfin/Subsonic settings
-/// controllers, and the configuration home the empty-state "Change folder"
-/// button mirrors.
+/// Drives the Settings ▸ Local music source card.
 ///
-/// It owns no scanning logic of its own — it reuses the same pick/scan path the
-/// Library screen uses ([SelectedFolderController] + [LibraryController]) so a
-/// folder configured here and one configured from the Library behave
-/// identically and both refresh the catalog. The selected folder and the last
-/// scan counts are read reactively from their own providers by the widget; this
-/// controller only carries the in-flight/outcome state and the actions.
+/// Android exposes two deliberate choices:
+///  - a targeted SAF folder grant; or
+///  - the system-visible Music and audio permission for the device MediaStore.
+/// The second path is only requested when the user explicitly chooses it.
 class LocalMusicController extends Notifier<LocalMusicActionState> {
   @override
   LocalMusicActionState build() => const LocalMusicActionState();
 
-  /// Opens the folder chooser, persists the choice, and scans it. On Android
-  /// this returns a `content://` tree URI with a persisted read grant — the
-  /// scoped-storage-correct selection. A cancelled pick leaves everything as it
-  /// was.
   Future<void> pickFolder() async {
     state = const LocalMusicActionState(busy: true);
     final String? picked = await ref
         .read(selectedFolderControllerProvider.notifier)
         .pickAndPersist();
     if (picked == null || picked.isEmpty) {
-      // Cancelled — say nothing, change nothing.
       state = const LocalMusicActionState();
       return;
     }
     await _scan(picked);
   }
 
-  /// Re-scans the folder already selected, without opening the chooser. No-op
-  /// when nothing is selected yet.
+  /// Opts into Android's device-wide shared music library.
+  ///
+  /// This requests only the narrow audio/media permission for the current
+  /// Android release. A denial leaves the existing folder/catalog untouched.
+  Future<void> useAllDeviceMusic() async {
+    if (!ref.read(hostPlatformProvider).isAndroid) return;
+    state = const LocalMusicActionState(busy: true);
+    final AndroidMusicPermissionStatus status =
+        await ref.read(androidMediaLibraryProvider).requestPermission();
+    ref.invalidate(androidMusicPermissionStatusProvider);
+    if (status != AndroidMusicPermissionStatus.allowed) {
+      state = const LocalMusicActionState(
+        message: 'Music and audio access was not granted. You can keep using a '
+            'selected folder instead.',
+        isError: true,
+      );
+      return;
+    }
+
+    await ref
+        .read(selectedFolderControllerProvider.notifier)
+        .setAndPersist(FolderLocation.androidMediaStoreAudio);
+    await _scan(FolderLocation.androidMediaStoreAudio);
+  }
+
+  Future<void> refreshAndroidPermissionStatus() async {
+    ref.invalidate(androidMusicPermissionStatusProvider);
+  }
+
+  Future<void> openAndroidPermissions() async {
+    await ref.read(androidMediaLibraryProvider).openAppSettings();
+  }
+
   Future<void> rescan() async {
     final String? folder =
         ref.read(selectedFolderControllerProvider).valueOrNull;
@@ -73,9 +88,6 @@ class LocalMusicController extends Notifier<LocalMusicActionState> {
     await _scan(folder);
   }
 
-  /// Forgets the selected folder and removes the local tracks from the catalog.
-  /// Deletes nothing on disk — it only clears Linthra's index for the `local`
-  /// source, so re-selecting the folder brings everything back.
   Future<void> forget() async {
     state = const LocalMusicActionState(busy: true);
     await ref.read(selectedFolderControllerProvider.notifier).clear();
@@ -88,23 +100,24 @@ class LocalMusicController extends Notifier<LocalMusicActionState> {
     ref.read(localScanReportProvider.notifier).clear();
     await ref.read(libraryControllerProvider.notifier).refresh();
     state = const LocalMusicActionState(
-      message: 'Local folder forgotten. Your files were not deleted.',
+      message: 'Local music forgotten. Your files were not deleted.',
     );
   }
 
-  /// Runs the shared scan-and-persist path, then summarizes the outcome from the
-  /// recorded scan report (counts only — never a path or file name).
   Future<void> _scan(String folder) async {
     await ref.read(libraryControllerProvider.notifier).scanFolder(folder);
     final report = ref.read(localScanReportProvider);
-    final bool isContentUri = FolderLocation.parse(folder).isContentUri;
+    final FolderLocation location = FolderLocation.parse(folder);
     if (report == null) {
       state = const LocalMusicActionState();
       return;
     }
     if (report.hadError) {
-      state = const LocalMusicActionState(
-        message: "Couldn't scan that folder. Try selecting it again.",
+      state = LocalMusicActionState(
+        message: location.isAndroidMediaStore
+            ? 'Could not scan the device music library. Check Music and audio '
+                'access in Android settings, or choose a folder instead.'
+            : "Couldn't scan that folder. Try selecting it again.",
         isError: true,
       );
       return;
@@ -112,20 +125,20 @@ class LocalMusicController extends Notifier<LocalMusicActionState> {
     if (report.importedTracks > 0) {
       state = LocalMusicActionState(
         message: 'Added ${report.importedTracks} '
-            '${report.importedTracks == 1 ? 'track' : 'tracks'} from this '
-            'folder.',
+            '${report.importedTracks == 1 ? 'track' : 'tracks'} from '
+            '${location.isAndroidMediaStore ? 'this device' : 'this folder'}.',
       );
       return;
     }
-    // Completed, but nothing playable. Distinguish a likely access problem from
-    // a genuinely empty folder so the message is actionable.
-    final bool looksBlocked =
-        report.readFailures > 0 || (isContentUri && report.filesVisited == 0);
+    final bool looksBlocked = report.readFailures > 0 ||
+        (location.isContentUri && report.filesVisited == 0);
     state = LocalMusicActionState(
-      message: looksBlocked
-          ? 'No music found. Linthra may not have access to that folder — try '
-              'selecting it again.'
-          : 'No playable audio found in that folder.',
+      message: location.isAndroidMediaStore
+          ? 'No music was found in Android MediaStore.'
+          : looksBlocked
+              ? 'No music found. Linthra may not have access to that folder — '
+                  'try selecting it again.'
+              : 'No playable audio found in that folder.',
       isError: looksBlocked,
     );
   }
@@ -136,42 +149,24 @@ final localMusicControllerProvider =
   LocalMusicController.new,
 );
 
-/// Whether Linthra can still reach the selected folder — the lost-access
-/// signal shown on the Local music card. Re-evaluated whenever the selection
-/// changes.
-///
-/// Two storage kinds, one question:
-///  - an Android `content://` tree: does the app still hold the persisted SAF
-///    read grant (the removable-SD-card / revoked-permission case)?
-///  - a desktop filesystem path: can the folder still be listed? On a Flatpak
-///    that is the portal document exported for the folder the user chose;
-///    revoking it (or unplugging the drive, or deleting the folder) makes the
-///    path stop resolving, which is the same recoverable "select it again"
-///    state rather than an empty library (#438).
-///
-/// Returns `null` when it doesn't apply (no folder) or can't be determined (a
-/// filesystem path on a platform without a desktop chooser), so the card simply
-/// omits the line.
+/// Whether Linthra can still reach the currently selected local-music source.
 final localFolderAccessProvider = FutureProvider<bool?>((ref) async {
   final String? folder =
       ref.watch(selectedFolderControllerProvider).valueOrNull;
-  // Re-probed on every recorded scan, not only when the *selection* changes.
-  // Access is lost while the app is running — a drive unplugged, a portal
-  // document revoked, a folder deleted — and the selection does not change when
-  // it happens, so a cached "yes" would outlive the truth and leave both cards
-  // showing a healthy folder right after a rescan failed on it. Every scan path
-  // (this card and the Library empty state) records through this provider, so
-  // watching it is what makes a rescan the natural way to re-check.
   ref.watch(localScanReportProvider);
   if (folder == null || folder.isEmpty) {
     return null;
   }
-  if (FolderLocation.parse(folder).isContentUri) {
+
+  final FolderLocation location = FolderLocation.parse(folder);
+  if (location.isAndroidMediaStore) {
+    final AndroidMusicPermissionStatus status =
+        await ref.read(androidMediaLibraryProvider).permissionStatus();
+    return status == AndroidMusicPermissionStatus.allowed;
+  }
+  if (location.isContentUri) {
     return ref.read(safPermissionProbeProvider).hasPersistedPermission(folder);
   }
-  // Desktop only: on Android a filesystem path is a legacy selection whose
-  // access story is scoped storage's, not this probe's, so it keeps reporting
-  // "can't tell" exactly as before.
   if (!ref.watch(hostPlatformProvider).isDesktop) {
     return null;
   }

--- a/lib/features/settings/source/local_music_settings_section.dart
+++ b/lib/features/settings/source/local_music_settings_section.dart
@@ -302,32 +302,27 @@ class _SelectedFolderView extends StatelessWidget {
         ],
         if (report != null) ...[
           const SizedBox(height: AppSpacing.sm),
-          _ScanSummary(
-            report: report!,
-            host: host,
-            isDeviceLibrary: isDeviceLibrary,
-          ),
+          _ScanSummary(report: report!, host: host),
         ],
       ],
     );
   }
 }
 
+/// The recap of the last scan.
+///
+/// It describes *the scan the report came from*, not whatever source happens to
+/// be selected right now: trying device-wide mode and failing leaves the old
+/// folder selected while the newest report is a MediaStore one, and telling
+/// that user to reselect a folder Linthra never scanned would be nonsense. So
+/// the source kind is read off the report itself.
 class _ScanSummary extends StatelessWidget {
-  const _ScanSummary({
-    required this.report,
-    required this.host,
-    required this.isDeviceLibrary,
-  });
+  const _ScanSummary({required this.report, required this.host});
 
   final LocalScanReport report;
   final HostPlatform host;
 
-  /// Whether the *currently selected* source is Android's device-wide
-  /// MediaStore library rather than a folder. The report alone cannot say so
-  /// (a MediaStore scan carries no content URI and no folder counts), and
-  /// without it an empty or failed device scan reads as an unreadable folder.
-  final bool isDeviceLibrary;
+  bool get isDeviceLibrary => report.isDeviceLibrary;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/settings/source/local_music_settings_section.dart
+++ b/lib/features/settings/source/local_music_settings_section.dart
@@ -14,9 +14,11 @@ import 'local_music_controller.dart';
 
 /// Settings home for music already stored on the device.
 ///
-/// Android deliberately exposes two privacy levels: the normal system-visible
-/// Music and audio permission for a device-wide MediaStore scan, or a targeted
-/// SAF folder grant. The UI names both so no local access is a "ghost" setting.
+/// Android deliberately exposes two privacy levels: device-wide MediaStore
+/// access, or a targeted SAF folder grant. Android 13+ names the device-wide
+/// runtime permission "Music and audio"; Android 12 and older use the legacy
+/// shared-storage read permission instead. The UI states that distinction so
+/// no local access is a "ghost" setting.
 class LocalMusicSettingsSection extends ConsumerWidget {
   const LocalMusicSettingsSection({super.key});
 
@@ -142,9 +144,11 @@ class LocalMusicSettingsSection extends ConsumerWidget {
 
 String _blurbFor(HostPlatform host) {
   if (host.isAndroid) {
-    return 'Choose all music on this device to use Android’s visible Music and '
-        'audio permission, or select one folder for narrower Android folder '
-        'access. Linthra never requests All files access.';
+    return 'Choose all music on this device for device-wide MediaStore access, '
+        'or select one folder for narrower Android folder access. Android 13+ '
+        'uses the Music and audio permission; Android 12 and older use the '
+        'legacy shared-storage read permission. Linthra never requests All '
+        'files access.';
   }
   return 'Play music from a folder on this computer or an external drive. '
       'Linthra reads only the folder you choose in the system file chooser — '
@@ -182,7 +186,7 @@ class _AndroidPrivacyStatus extends StatelessWidget {
             Text('Privacy & permissions', style: theme.textTheme.titleSmall),
             const SizedBox(height: AppSpacing.xs),
             Text(
-              'Music and audio: ${_permissionLabel(permission)}',
+              'Device music access: ${_permissionLabel(permission)}',
               style: theme.textTheme.bodyMedium,
             ),
             const SizedBox(height: AppSpacing.xs),
@@ -228,7 +232,9 @@ class _AndroidPrivacyStatus extends StatelessWidget {
   static String _accessExplanation(FolderLocation? location) {
     if (location?.isAndroidMediaStore ?? false) {
       return 'Local library mode: all device music through Android MediaStore. '
-          'Revoking Music and audio access stops this scan.';
+          'Android 13+ exposes Music and audio; older Android versions use the '
+          'legacy shared-storage read permission for this device-wide mode. '
+          'Revoking that access stops this scan.';
     }
     if (location?.isContentUri ?? false) {
       return 'Selected folder: targeted Storage Access Framework grant. This '
@@ -286,8 +292,8 @@ class _SelectedFolderView extends StatelessWidget {
           const SizedBox(height: AppSpacing.xs),
           Text(
             isDeviceLibrary
-                ? 'Music and audio access is currently off. Your indexed '
-                    'library stays in Linthra; re-enable access to rescan.'
+                ? 'Device music access is currently off. Your indexed library '
+                    'stays in Linthra; re-enable access to rescan.'
                 : 'Linthra can no longer reach this folder. Select it again to '
                     'restore access — your library stays as it is until you do.',
             style: theme.textTheme.bodySmall
@@ -363,8 +369,8 @@ class _ScanSummary extends StatelessWidget {
   static String? _hint(LocalScanReport report, HostPlatform host) {
     if (report.importedTracks > 0) return null;
     if (report.error == LocalScanError.mediaPermission) {
-      return 'Music and audio access is off. Re-enable it in Android settings '
-          'or select a folder instead.';
+      return 'Device music access is off. Re-enable it in Android settings or '
+          'select a folder instead.';
     }
     final bool blocked = report.hadError ||
         report.readFailures > 0 ||

--- a/lib/features/settings/source/local_music_settings_section.dart
+++ b/lib/features/settings/source/local_music_settings_section.dart
@@ -48,8 +48,10 @@ class LocalMusicSettingsSection extends ConsumerWidget {
           children: [
             Row(
               children: [
-                Icon(Icons.folder_special_outlined,
-                    color: theme.colorScheme.primary),
+                Icon(
+                  Icons.folder_special_outlined,
+                  color: theme.colorScheme.primary,
+                ),
                 const SizedBox(width: AppSpacing.sm),
                 Text('Local music', style: theme.textTheme.titleMedium),
               ],
@@ -98,6 +100,10 @@ class LocalMusicSettingsSection extends ConsumerWidget {
                 onRescan: controller.rescan,
                 onChange: controller.pickFolder,
                 onForget: controller.forget,
+                onUseAllDeviceMusic:
+                    host.isAndroid && !location!.isAndroidMediaStore
+                        ? controller.useAllDeviceMusic
+                        : null,
                 host: host,
               )
             else if (host.isAndroid)
@@ -315,7 +321,10 @@ class _ScanSummary extends StatelessWidget {
         Text(_headline(report), style: theme.textTheme.bodyMedium),
         if (counts != null) ...[
           const SizedBox(height: AppSpacing.xs),
-          Text(counts, style: theme.textTheme.bodySmall?.copyWith(color: muted)),
+          Text(
+            counts,
+            style: theme.textTheme.bodySmall?.copyWith(color: muted),
+          ),
         ],
         if (hint != null) ...[
           const SizedBox(height: AppSpacing.xs),
@@ -406,11 +415,13 @@ class _FolderActions extends StatelessWidget {
     required this.onChange,
     required this.onForget,
     required this.host,
+    this.onUseAllDeviceMusic,
   });
 
   final VoidCallback onRescan;
   final VoidCallback onChange;
   final VoidCallback onForget;
+  final VoidCallback? onUseAllDeviceMusic;
   final HostPlatform host;
 
   @override
@@ -418,6 +429,14 @@ class _FolderActions extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
+        if (onUseAllDeviceMusic != null) ...[
+          FilledButton.icon(
+            onPressed: onUseAllDeviceMusic,
+            icon: const Icon(Icons.library_music_outlined),
+            label: const Text('All music on this device'),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+        ],
         Row(
           children: [
             Expanded(

--- a/lib/features/settings/source/local_music_settings_section.dart
+++ b/lib/features/settings/source/local_music_settings_section.dart
@@ -3,28 +3,20 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../app/dimens.dart';
 import '../../../core/platform/host_platform.dart';
+import '../../../core/sources/local/android_media_library.dart';
 import '../../../core/sources/local/folder_location.dart';
 import '../../../core/sources/local/local_scan_report.dart';
 import '../../../data/repositories/host_platform_provider.dart';
+import '../../library/library_providers.dart';
 import '../../library/local_scan_report_provider.dart';
 import '../../library/selected_folder_controller.dart';
 import 'local_music_controller.dart';
 
-/// The "Local music" source card on the Settings screen, grouped with the other
-/// music sources (Jellyfin, Navidrome/Subsonic).
+/// Settings home for music already stored on the device.
 ///
-/// This is the primary place to configure on-device music: choose a folder on
-/// this phone or an SD card, rescan it, or forget it. It reuses the same pick +
-/// scan path as the Library empty-state "Change folder" button, so the two stay
-/// in sync. Everything it shows is read reactively from the selected-folder and
-/// last-scan providers; the card itself holds no scanning logic.
-///
-/// "Local music" is deliberately distinct from two neighbours users conflate,
-/// both of which live under Settings ▸ Storage & offline:
-///  - Offline downloads — copies Linthra makes for offline playback of a server
-///    track (the download action), and
-///  - Cache — Linthra-managed storage that speeds playback up.
-/// This card only points Linthra at music that already lives on the device.
+/// Android deliberately exposes two privacy levels: the normal system-visible
+/// Music and audio permission for a device-wide MediaStore scan, or a targeted
+/// SAF folder grant. The UI names both so no local access is a "ghost" setting.
 class LocalMusicSettingsSection extends ConsumerWidget {
   const LocalMusicSettingsSection({super.key});
 
@@ -32,7 +24,6 @@ class LocalMusicSettingsSection extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final ThemeData theme = Theme.of(context);
     final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
-
     final String? folder =
         ref.watch(selectedFolderControllerProvider).valueOrNull;
     final LocalScanReport? report = ref.watch(localScanReportProvider);
@@ -41,7 +32,11 @@ class LocalMusicSettingsSection extends ConsumerWidget {
     final bool? persisted = ref.watch(localFolderAccessProvider).valueOrNull;
     final bool hasFolder = folder != null && folder.isNotEmpty;
     final HostPlatform host = ref.watch(hostPlatformProvider);
-
+    final FolderLocation? location =
+        hasFolder ? FolderLocation.parse(folder) : null;
+    final AndroidMusicPermissionStatus? musicPermission = host.isAndroid
+        ? ref.watch(androidMusicPermissionStatusProvider).valueOrNull
+        : null;
     final LocalMusicController controller =
         ref.read(localMusicControllerProvider.notifier);
 
@@ -64,17 +59,27 @@ class LocalMusicSettingsSection extends ConsumerWidget {
               _blurbFor(host),
               style: theme.textTheme.bodySmall?.copyWith(color: muted),
             ),
+            if (host.isAndroid) ...[
+              const SizedBox(height: AppSpacing.md),
+              _AndroidPrivacyStatus(
+                permission: musicPermission,
+                location: location,
+                onOpenSettings: controller.openAndroidPermissions,
+                onRefresh: controller.refreshAndroidPermissionStatus,
+              ),
+            ],
             const SizedBox(height: AppSpacing.md),
             if (hasFolder)
               _SelectedFolderView(
-                folderLabel: FolderLocation.parse(folder).displayLabel,
+                folderLabel: location!.displayLabel,
                 persisted: persisted,
                 report: report,
                 host: host,
+                isDeviceLibrary: location.isAndroidMediaStore,
               )
             else
               Text(
-                'No folder selected yet.',
+                'No local music source selected yet.',
                 style: theme.textTheme.bodyMedium?.copyWith(color: muted),
               ),
             const SizedBox(height: AppSpacing.md),
@@ -93,6 +98,24 @@ class LocalMusicSettingsSection extends ConsumerWidget {
                 onRescan: controller.rescan,
                 onChange: controller.pickFolder,
                 onForget: controller.forget,
+                host: host,
+              )
+            else if (host.isAndroid)
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  FilledButton.icon(
+                    onPressed: controller.useAllDeviceMusic,
+                    icon: const Icon(Icons.library_music_outlined),
+                    label: const Text('All music on this device'),
+                  ),
+                  const SizedBox(height: AppSpacing.sm),
+                  OutlinedButton.icon(
+                    onPressed: controller.pickFolder,
+                    icon: const Icon(Icons.create_new_folder_outlined),
+                    label: const Text('Select a folder'),
+                  ),
+                ],
               )
             else
               FilledButton.icon(
@@ -111,16 +134,11 @@ class LocalMusicSettingsSection extends ConsumerWidget {
   }
 }
 
-/// How the folder gets read, in the user's terms. The two platforms grant
-/// access in genuinely different ways — Android's folder access (SAF) and the
-/// desktop chooser, which inside a Flatpak is the system's file portal — and
-/// both are worth stating, because in both cases the point is the same: only
-/// the folder the user picked, and no broad storage permission.
 String _blurbFor(HostPlatform host) {
   if (host.isAndroid) {
-    return 'Play music from a folder on this device or an SD card. Linthra '
-        "reads it through Android's folder access — it needs no broad storage "
-        'permission, and your files are never moved or copied.';
+    return 'Choose all music on this device to use Android’s visible Music and '
+        'audio permission, or select one folder for narrower Android folder '
+        'access. Linthra never requests All files access.';
   }
   return 'Play music from a folder on this computer or an external drive. '
       'Linthra reads only the folder you choose in the system file chooser — '
@@ -128,22 +146,107 @@ String _blurbFor(HostPlatform host) {
       'moved or copied.';
 }
 
-/// The selected-folder summary: which folder, whether access is still held, and
-/// what the last scan saw.
+class _AndroidPrivacyStatus extends StatelessWidget {
+  const _AndroidPrivacyStatus({
+    required this.permission,
+    required this.location,
+    required this.onOpenSettings,
+    required this.onRefresh,
+  });
+
+  final AndroidMusicPermissionStatus? permission;
+  final FolderLocation? location;
+  final VoidCallback onOpenSettings;
+  final VoidCallback onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        border: Border.all(color: theme.colorScheme.outlineVariant),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.sm),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Privacy & permissions', style: theme.textTheme.titleSmall),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              'Music and audio: ${_permissionLabel(permission)}',
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              _accessExplanation(location),
+              style: theme.textTheme.bodySmall?.copyWith(color: muted),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Wrap(
+              spacing: AppSpacing.sm,
+              children: [
+                TextButton(
+                  onPressed: onOpenSettings,
+                  child: const Text('Android settings'),
+                ),
+                TextButton(
+                  onPressed: onRefresh,
+                  child: const Text('Refresh status'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static String _permissionLabel(AndroidMusicPermissionStatus? status) {
+    switch (status) {
+      case AndroidMusicPermissionStatus.allowed:
+        return 'Allowed';
+      case AndroidMusicPermissionStatus.denied:
+        return 'Denied';
+      case AndroidMusicPermissionStatus.notRequested:
+        return 'Not requested';
+      case AndroidMusicPermissionStatus.unavailable:
+        return 'Unavailable';
+      case null:
+        return 'Checking…';
+    }
+  }
+
+  static String _accessExplanation(FolderLocation? location) {
+    if (location?.isAndroidMediaStore ?? false) {
+      return 'Local library mode: all device music through Android MediaStore. '
+          'Revoking Music and audio access stops this scan.';
+    }
+    if (location?.isContentUri ?? false) {
+      return 'Selected folder: targeted Storage Access Framework grant. This '
+          'folder grant may not appear as a normal Android runtime permission.';
+    }
+    return 'Device-wide access is requested only if you choose All music on '
+        'this device. Folder access stays targeted and separate.';
+  }
+}
+
 class _SelectedFolderView extends StatelessWidget {
   const _SelectedFolderView({
     required this.folderLabel,
     required this.persisted,
     required this.report,
     required this.host,
+    required this.isDeviceLibrary,
   });
 
   final String folderLabel;
   final bool? persisted;
   final LocalScanReport? report;
-
-  /// Which platform's folder chooser the recovery hint should name.
   final HostPlatform host;
+  final bool isDeviceLibrary;
 
   @override
   Widget build(BuildContext context) {
@@ -155,7 +258,13 @@ class _SelectedFolderView extends StatelessWidget {
         Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Icon(Icons.folder_outlined, size: 20, color: muted),
+            Icon(
+              isDeviceLibrary
+                  ? Icons.library_music_outlined
+                  : Icons.folder_outlined,
+              size: 20,
+              color: muted,
+            ),
             const SizedBox(width: AppSpacing.sm),
             Expanded(
               child: Text(
@@ -170,8 +279,11 @@ class _SelectedFolderView extends StatelessWidget {
         if (persisted == false) ...[
           const SizedBox(height: AppSpacing.xs),
           Text(
-            'Linthra can no longer reach this folder. Select it again to '
-            'restore access — your library stays as it is until you do.',
+            isDeviceLibrary
+                ? 'Music and audio access is currently off. Your indexed '
+                    'library stays in Linthra; re-enable access to rescan.'
+                : 'Linthra can no longer reach this folder. Select it again to '
+                    'restore access — your library stays as it is until you do.',
             style: theme.textTheme.bodySmall
                 ?.copyWith(color: theme.colorScheme.error),
           ),
@@ -185,40 +297,25 @@ class _SelectedFolderView extends StatelessWidget {
   }
 }
 
-/// A clear, secret-free recap of the last local scan, shown under the selected
-/// folder: a status headline, the safe counts the scan produced, and — when the
-/// scan turned up nothing playable — a calm, non-blaming hint on what to try.
-///
-/// Everything here derives from [LocalScanReport], which by construction holds
-/// only booleans and counts (never a path, file name, or raw error), so nothing
-/// private about the user's library can reach the card.
 class _ScanSummary extends StatelessWidget {
   const _ScanSummary({required this.report, required this.host});
 
   final LocalScanReport report;
-
-  /// The platform whose folder chooser the hint points the user back to.
   final HostPlatform host;
 
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
-    // A scan that threw produced no trustworthy counts, so the breakdown is
-    // dropped and only the status + hint are shown.
     final String? counts = report.hadError ? null : _counts(report);
     final String? hint = _hint(report, host);
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(_headline(report), style: theme.textTheme.bodyMedium),
         if (counts != null) ...[
           const SizedBox(height: AppSpacing.xs),
-          Text(
-            counts,
-            style: theme.textTheme.bodySmall?.copyWith(color: muted),
-          ),
+          Text(counts, style: theme.textTheme.bodySmall?.copyWith(color: muted)),
         ],
         if (hint != null) ...[
           const SizedBox(height: AppSpacing.xs),
@@ -228,13 +325,8 @@ class _ScanSummary extends StatelessWidget {
     );
   }
 
-  /// The headline: what the scan did, in the user's terms. Imported-count first
-  /// (the thing they care about), then the "nothing found" and "couldn't finish"
-  /// cases — never a path or file name.
   static String _headline(LocalScanReport report) {
-    if (report.hadError) {
-      return "Last scan couldn't finish";
-    }
+    if (report.hadError) return "Last scan couldn't finish";
     if (report.importedTracks > 0) {
       final String word = report.importedTracks == 1 ? 'track' : 'tracks';
       return 'Last scan: ${report.importedTracks} $word added';
@@ -242,9 +334,6 @@ class _ScanSummary extends StatelessWidget {
     return 'Last scan: no tracks found';
   }
 
-  /// The secret-free count breakdown — folders and files seen, how many looked
-  /// like audio, and how many were skipped or unreadable. Folders are omitted
-  /// when zero (a filesystem-path scan reports no folder count).
   static String _counts(LocalScanReport report) {
     final List<String> parts = <String>[
       if (report.foldersVisited > 0)
@@ -262,14 +351,11 @@ class _ScanSummary extends StatelessWidget {
     return parts.join(' · ');
   }
 
-  /// A calm, non-blaming next step when the scan imported nothing. Two shapes: a
-  /// likely access problem (the SD-card / lost-grant / unreachable-folder case)
-  /// versus a folder that simply held no recognized audio. Both point at
-  /// re-picking the folder in the chooser the user actually has; neither faults
-  /// the user.
   static String? _hint(LocalScanReport report, HostPlatform host) {
-    if (report.importedTracks > 0) {
-      return null;
+    if (report.importedTracks > 0) return null;
+    if (report.error == LocalScanError.mediaPermission) {
+      return 'Music and audio access is off. Re-enable it in Android settings '
+          'or select a folder instead.';
     }
     final bool blocked = report.hadError ||
         report.readFailures > 0 ||
@@ -285,21 +371,10 @@ class _ScanSummary extends StatelessWidget {
         'select the folder again with ${_chooserName(host)}.';
   }
 
-  /// What to call the chooser the user re-picks the folder in.
-  ///
-  /// Android's is the system folder chooser (SAF), and saying so is the
-  /// clearest phrasing there. On a desktop it is the system's own chooser —
-  /// inside the Flatpak, the xdg-desktop-portal one — so naming Android's would
-  /// send the user looking for something that is not on their machine. This
-  /// keys off the platform rather than the report's `isContentUri`, which is a
-  /// storage kind: a legacy filesystem selection on Android is still Android.
   static String _chooserName(HostPlatform host) =>
       host.isAndroid ? "Android's folder chooser" : 'the system folder chooser';
 }
 
-/// One line of calm guidance (info icon + muted text) shown when a scan needs a
-/// follow-up action. Kept visually lighter than [_StatusLine] so a longer hint
-/// reads as help, not an alarm.
 class _ScanHintLine extends StatelessWidget {
   const _ScanHintLine({required this.message});
 
@@ -325,17 +400,18 @@ class _ScanHintLine extends StatelessWidget {
   }
 }
 
-/// The Rescan / Change / Forget actions shown once a folder is selected.
 class _FolderActions extends StatelessWidget {
   const _FolderActions({
     required this.onRescan,
     required this.onChange,
     required this.onForget,
+    required this.host,
   });
 
   final VoidCallback onRescan;
   final VoidCallback onChange;
   final VoidCallback onForget;
+  final HostPlatform host;
 
   @override
   Widget build(BuildContext context) {
@@ -356,7 +432,7 @@ class _FolderActions extends StatelessWidget {
               child: OutlinedButton.icon(
                 onPressed: onChange,
                 icon: const Icon(Icons.folder_open_outlined),
-                label: const Text('Change'),
+                label: Text(host.isAndroid ? 'Use a folder' : 'Change'),
               ),
             ),
           ],
@@ -367,7 +443,7 @@ class _FolderActions extends StatelessWidget {
           child: TextButton.icon(
             onPressed: onForget,
             icon: const Icon(Icons.delete_outline, size: 18),
-            label: const Text('Forget folder'),
+            label: const Text('Forget local music'),
           ),
         ),
       ],
@@ -375,7 +451,6 @@ class _FolderActions extends StatelessWidget {
   }
 }
 
-/// A friendly one-line status or error message under the actions.
 class _StatusLine extends StatelessWidget {
   const _StatusLine({required this.message, required this.isError});
 

--- a/lib/features/settings/source/local_music_settings_section.dart
+++ b/lib/features/settings/source/local_music_settings_section.dart
@@ -302,7 +302,11 @@ class _SelectedFolderView extends StatelessWidget {
         ],
         if (report != null) ...[
           const SizedBox(height: AppSpacing.sm),
-          _ScanSummary(report: report!, host: host),
+          _ScanSummary(
+            report: report!,
+            host: host,
+            isDeviceLibrary: isDeviceLibrary,
+          ),
         ],
       ],
     );
@@ -310,21 +314,34 @@ class _SelectedFolderView extends StatelessWidget {
 }
 
 class _ScanSummary extends StatelessWidget {
-  const _ScanSummary({required this.report, required this.host});
+  const _ScanSummary({
+    required this.report,
+    required this.host,
+    required this.isDeviceLibrary,
+  });
 
   final LocalScanReport report;
   final HostPlatform host;
+
+  /// Whether the *currently selected* source is Android's device-wide
+  /// MediaStore library rather than a folder. The report alone cannot say so
+  /// (a MediaStore scan carries no content URI and no folder counts), and
+  /// without it an empty or failed device scan reads as an unreadable folder.
+  final bool isDeviceLibrary;
 
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
     final String? counts = report.hadError ? null : _counts(report);
-    final String? hint = _hint(report, host);
+    final String? hint = _hint(report, host, isDeviceLibrary);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(_headline(report), style: theme.textTheme.bodyMedium),
+        Text(
+          _headline(report, isDeviceLibrary),
+          style: theme.textTheme.bodyMedium,
+        ),
         if (counts != null) ...[
           const SizedBox(height: AppSpacing.xs),
           Text(
@@ -340,13 +357,15 @@ class _ScanSummary extends StatelessWidget {
     );
   }
 
-  static String _headline(LocalScanReport report) {
+  static String _headline(LocalScanReport report, bool isDeviceLibrary) {
     if (report.hadError) return "Last scan couldn't finish";
     if (report.importedTracks > 0) {
       final String word = report.importedTracks == 1 ? 'track' : 'tracks';
       return 'Last scan: ${report.importedTracks} $word added';
     }
-    return 'Last scan: no tracks found';
+    return isDeviceLibrary
+        ? 'Last scan: no music on this device'
+        : 'Last scan: no tracks found';
   }
 
   static String _counts(LocalScanReport report) {
@@ -366,11 +385,27 @@ class _ScanSummary extends StatelessWidget {
     return parts.join(' · ');
   }
 
-  static String? _hint(LocalScanReport report, HostPlatform host) {
+  static String? _hint(
+    LocalScanReport report,
+    HostPlatform host,
+    bool isDeviceLibrary,
+  ) {
     if (report.importedTracks > 0) return null;
+    // A revoked Music and audio permission is recovered in Android's app
+    // settings, whichever source is selected.
     if (report.error == LocalScanError.mediaPermission) {
       return 'Device music access is off. Re-enable it in Android settings or '
           'select a folder instead.';
+    }
+    // Device-wide mode has no folder to reselect: an empty or failed MediaStore
+    // scan must never point at the folder chooser.
+    if (isDeviceLibrary) {
+      if (report.hadError) {
+        return "Linthra couldn't read Android's shared music library. Try "
+            'scanning this device again. Your indexed music stays as it is.';
+      }
+      return "Android's music library reported no audio on this device. Music "
+          'added since the last scan shows up after another scan.';
     }
     final bool blocked = report.hadError ||
         report.readFailures > 0 ||

--- a/lib/features/settings/source/provider_summary_cards.dart
+++ b/lib/features/settings/source/provider_summary_cards.dart
@@ -606,9 +606,8 @@ class LocalMusicProviderCard extends ConsumerWidget {
               ? 'Device music selected'
               : 'Folder selected';
       tone = ProviderStatusTone.positive;
-      detail = isDeviceLibrary
-          ? 'All music on this device'
-          : location!.displayLabel;
+      detail =
+          isDeviceLibrary ? 'All music on this device' : location!.displayLabel;
     }
 
     return ProviderSummaryCard(

--- a/lib/features/settings/source/provider_summary_cards.dart
+++ b/lib/features/settings/source/provider_summary_cards.dart
@@ -571,6 +571,9 @@ class LocalMusicProviderCard extends ConsumerWidget {
         ref.watch(localMusicControllerProvider);
     final bool? persisted = ref.watch(localFolderAccessProvider).valueOrNull;
     final bool hasFolder = folder != null && folder.isNotEmpty;
+    final FolderLocation? location =
+        hasFolder ? FolderLocation.parse(folder) : null;
+    final bool isDeviceLibrary = location?.isAndroidMediaStore ?? false;
     final LocalMusicController controller =
         ref.read(localMusicControllerProvider.notifier);
 
@@ -587,20 +590,31 @@ class LocalMusicProviderCard extends ConsumerWidget {
       tone = ProviderStatusTone.neutral;
       detail = 'Pick a folder on this device to play your own music.';
     } else if (persisted == false) {
-      status = 'Folder access lost';
+      if (isDeviceLibrary) {
+        status = 'Device music access off';
+        detail = 'All music on this device';
+      } else {
+        status = 'Folder access lost';
+        detail = location!.displayLabel;
+      }
       tone = ProviderStatusTone.error;
-      detail = FolderLocation.parse(folder).displayLabel;
     } else {
       final int tracks = report?.importedTracks ?? 0;
       status = tracks > 0
           ? '$tracks ${tracks == 1 ? 'track' : 'tracks'}'
-          : 'Folder selected';
+          : isDeviceLibrary
+              ? 'Device music selected'
+              : 'Folder selected';
       tone = ProviderStatusTone.positive;
-      detail = FolderLocation.parse(folder).displayLabel;
+      detail = isDeviceLibrary
+          ? 'All music on this device'
+          : location!.displayLabel;
     }
 
     return ProviderSummaryCard(
-      icon: Icons.folder_special_outlined,
+      icon: isDeviceLibrary
+          ? Icons.library_music_outlined
+          : Icons.folder_special_outlined,
       title: 'Local music',
       statusLabel: status,
       statusTone: tone,

--- a/test/core/sources/local/android_media_library_test.dart
+++ b/test/core/sources/local/android_media_library_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/local/android_media_library.dart';
+import 'package:linthra/core/sources/local/folder_location.dart';
+import 'package:linthra/core/sources/local/local_audio_metadata.dart';
+import 'package:linthra/core/sources/local/local_music_source.dart';
+import 'package:linthra/core/sources/local/method_channel_android_media_library.dart';
+import 'package:linthra/core/sources/local/saf_document_lister.dart';
+
+class _FakeAndroidMediaLibrary implements AndroidMediaLibrary {
+  const _FakeAndroidMediaLibrary({required this.result});
+
+  final SafScanResult result;
+
+  @override
+  Future<SafScanResult> listDeviceAudio() async => result;
+
+  @override
+  Future<void> openAppSettings() async {}
+
+  @override
+  Future<AndroidMusicPermissionStatus> permissionStatus() async =>
+      AndroidMusicPermissionStatus.allowed;
+
+  @override
+  Future<AndroidMusicPermissionStatus> requestPermission() async =>
+      AndroidMusicPermissionStatus.allowed;
+}
+
+void main() {
+  group('Android device-wide local music', () {
+    test('MediaStore sentinel is not treated as a filesystem path', () {
+      final FolderLocation location =
+          FolderLocation.parse(FolderLocation.androidMediaStoreAudio);
+
+      expect(location.isAndroidMediaStore, isTrue);
+      expect(location.isFilesystemPath, isFalse);
+      expect(location.isContentUri, isFalse);
+      expect(location.displayLabel, 'All music on this device');
+    });
+
+    test('permission status wire values are conservative', () {
+      expect(
+        MethodChannelAndroidMediaLibrary.parsePermissionStatus('allowed'),
+        AndroidMusicPermissionStatus.allowed,
+      );
+      expect(
+        MethodChannelAndroidMediaLibrary.parsePermissionStatus('denied'),
+        AndroidMusicPermissionStatus.denied,
+      );
+      expect(
+        MethodChannelAndroidMediaLibrary.parsePermissionStatus('notRequested'),
+        AndroidMusicPermissionStatus.notRequested,
+      );
+      expect(
+        MethodChannelAndroidMediaLibrary.parsePermissionStatus('unexpected'),
+        AndroidMusicPermissionStatus.unavailable,
+      );
+    });
+
+    test('MediaStore rows use the existing local track mapper', () async {
+      final LocalMusicSource source = LocalMusicSource(
+        folderPath: FolderLocation.androidMediaStoreAudio,
+        androidMediaLibrary: _FakeAndroidMediaLibrary(
+          result: SafScanResult(
+            documents: <SafAudioDocument>[
+              SafAudioDocument(
+                uri: 'content://media/external/audio/media/42',
+                name: '03 - Fallback.mp3',
+                mimeType: 'audio/mpeg',
+                metadata: const LocalAudioMetadata(
+                  title: 'Tagged title',
+                  artist: 'Artist',
+                  album: 'Album',
+                  trackNumber: 3,
+                  duration: Duration(seconds: 123),
+                ),
+              ),
+            ],
+            filesVisited: 1,
+          ),
+        ),
+      );
+
+      final LocalScan scan = await source.scanTracks();
+
+      expect(scan.tracks, hasLength(1));
+      expect(scan.tracks.single.uri, 'content://media/external/audio/media/42');
+      expect(scan.tracks.single.title, 'Tagged title');
+      expect(scan.tracks.single.artistName, 'Artist');
+      expect(scan.tracks.single.albumName, 'Album');
+      expect(scan.tracks.single.trackNumber, 3);
+      expect(scan.tracks.single.duration, const Duration(seconds: 123));
+      expect(scan.report.importedTracks, 1);
+      expect(scan.report.isContentUri, isFalse);
+    });
+  });
+}

--- a/test/core/sources/local/android_media_library_test.dart
+++ b/test/core/sources/local/android_media_library_test.dart
@@ -59,7 +59,8 @@ void main() {
     });
 
     test('MediaStore parser preserves the source-namespaced album id', () {
-      final SafScanResult result = MethodChannelSafDocumentLister.parseScanResult(
+      final SafScanResult result =
+          MethodChannelSafDocumentLister.parseScanResult(
         <Object?, Object?>{
           'documents': <Object?>[
             <Object?, Object?>{

--- a/test/core/sources/local/android_media_library_test.dart
+++ b/test/core/sources/local/android_media_library_test.dart
@@ -116,6 +116,9 @@ void main() {
       expect(scan.tracks.single.duration, const Duration(seconds: 123));
       expect(scan.report.importedTracks, 1);
       expect(scan.report.isContentUri, isFalse);
+      // Not a SAF tree and not a filesystem path: the report has to say which
+      // backend it read, or diagnostics call a MediaStore scan `kind=path`.
+      expect(scan.report.isDeviceLibrary, isTrue);
     });
   });
 }

--- a/test/core/sources/local/android_media_library_test.dart
+++ b/test/core/sources/local/android_media_library_test.dart
@@ -4,6 +4,7 @@ import 'package:linthra/core/sources/local/folder_location.dart';
 import 'package:linthra/core/sources/local/local_audio_metadata.dart';
 import 'package:linthra/core/sources/local/local_music_source.dart';
 import 'package:linthra/core/sources/local/method_channel_android_media_library.dart';
+import 'package:linthra/core/sources/local/method_channel_saf_document_lister.dart';
 import 'package:linthra/core/sources/local/saf_document_lister.dart';
 
 class _FakeAndroidMediaLibrary implements AndroidMediaLibrary {
@@ -57,6 +58,26 @@ void main() {
       );
     });
 
+    test('MediaStore parser preserves the source-namespaced album id', () {
+      final SafScanResult result = MethodChannelSafDocumentLister.parseScanResult(
+        <Object?, Object?>{
+          'documents': <Object?>[
+            <Object?, Object?>{
+              'uri': 'content://media/external/audio/media/42',
+              'name': '03 - Song.mp3',
+              'mime': 'audio/mpeg',
+              'albumId': 'android-mediastore:7',
+              'track': 3,
+            },
+          ],
+          'filesVisited': 1,
+        },
+      );
+
+      expect(result.documents.single.metadata?.albumId, 'android-mediastore:7');
+      expect(result.documents.single.metadata?.trackNumber, 3);
+    });
+
     test('MediaStore rows use the existing local track mapper', () async {
       final LocalMusicSource source = LocalMusicSource(
         folderPath: FolderLocation.androidMediaStoreAudio,
@@ -71,6 +92,7 @@ void main() {
                   title: 'Tagged title',
                   artist: 'Artist',
                   album: 'Album',
+                  albumId: 'android-mediastore:7',
                   trackNumber: 3,
                   duration: Duration(seconds: 123),
                 ),
@@ -88,6 +110,7 @@ void main() {
       expect(scan.tracks.single.title, 'Tagged title');
       expect(scan.tracks.single.artistName, 'Artist');
       expect(scan.tracks.single.albumName, 'Album');
+      expect(scan.tracks.single.albumId, 'android-mediastore:7');
       expect(scan.tracks.single.trackNumber, 3);
       expect(scan.tracks.single.duration, const Duration(seconds: 123));
       expect(scan.report.importedTracks, 1);

--- a/test/core/sources/local/android_media_library_test.dart
+++ b/test/core/sources/local/android_media_library_test.dart
@@ -80,7 +80,7 @@ void main() {
     });
 
     test('MediaStore rows use the existing local track mapper', () async {
-      final LocalMusicSource source = LocalMusicSource(
+      const LocalMusicSource source = LocalMusicSource(
         folderPath: FolderLocation.androidMediaStoreAudio,
         androidMediaLibrary: _FakeAndroidMediaLibrary(
           result: SafScanResult(
@@ -89,7 +89,7 @@ void main() {
                 uri: 'content://media/external/audio/media/42',
                 name: '03 - Fallback.mp3',
                 mimeType: 'audio/mpeg',
-                metadata: const LocalAudioMetadata(
+                metadata: LocalAudioMetadata(
                   title: 'Tagged title',
                   artist: 'Artist',
                   album: 'Album',

--- a/test/core/sources/local/local_scan_diagnostics_test.dart
+++ b/test/core/sources/local/local_scan_diagnostics_test.dart
@@ -105,6 +105,44 @@ void main() {
       expect(summary, contains('error=unexpected'));
     });
 
+    test('a device-wide scan is labelled mediastore, not path', () {
+      // MediaStore reads no SAF tree and walks no directories, so without an
+      // explicit kind its reports look exactly like a filesystem scan and the
+      // bug report would name the wrong backend.
+      const report = LocalScanReport(
+        folderSelected: true,
+        isContentUri: false,
+        isDeviceLibrary: true,
+        filesVisited: 12,
+        audioCandidates: 12,
+        importedTracks: 12,
+        skippedUnsupported: 0,
+        readFailures: 0,
+      );
+
+      final summary = LocalScanDiagnostics.describe(report);
+
+      expect(summary, contains('kind=mediastore'));
+      expect(summary, isNot(contains('kind=path')));
+    });
+
+    test('an empty device-wide scan is still labelled mediastore', () {
+      const report = LocalScanReport(
+        folderSelected: true,
+        isContentUri: false,
+        isDeviceLibrary: true,
+        filesVisited: 0,
+        audioCandidates: 0,
+        skippedUnsupported: 0,
+        readFailures: 0,
+      );
+
+      expect(
+        LocalScanDiagnostics.describe(report),
+        contains('kind=mediastore'),
+      );
+    });
+
     test('a summary carries no path, URI, or file name', () {
       const report = LocalScanReport(
         folderSelected: true,

--- a/test/features/library/library_screen_test.dart
+++ b/test/features/library/library_screen_test.dart
@@ -2,8 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/sources/local/folder_location.dart';
 import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
+import 'package:linthra/data/repositories/in_memory_selected_music_folder_repository.dart';
 import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/data/repositories/selected_music_folder_repository_provider.dart';
 import 'package:linthra/features/library/library_providers.dart';
 import 'package:linthra/features/library/library_screen.dart';
 
@@ -140,6 +143,42 @@ void main() {
 
       expect(picker.pickCount, 1);
       expect(find.text('No music folder selected'), findsOneWidget);
+    });
+
+    testWidgets('an empty device-wide library never points at a folder', (
+      tester,
+    ) async {
+      // Android's MediaStore sentinel is not a filesystem path and not a folder
+      // the user can reselect (#550). An empty result there has to read as "the
+      // device reported no music", not as a folder that needs re-picking.
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            musicLibraryRepositoryProvider.overrideWithValue(
+              InMemoryMusicLibraryRepository(),
+            ),
+            selectedMusicFolderRepositoryProvider.overrideWithValue(
+              InMemorySelectedMusicFolderRepository(
+                initialFolder: FolderLocation.androidMediaStoreAudio,
+              ),
+            ),
+          ],
+          child: const MaterialApp(home: LibraryScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('reported no audio on this device'),
+        findsOneWidget,
+      );
+      expect(find.text('Rescan this device'), findsOneWidget);
+      expect(find.text('Use a folder instead'), findsOneWidget);
+      expect(find.text('Rescan folder'), findsNothing);
+      expect(find.text('Change folder'), findsNothing);
+      expect(find.text('Choose the folder again so Linthra can read it.'),
+          findsNothing);
+      expect(find.textContaining('mediastore://'), findsNothing);
     });
   });
 }

--- a/test/features/settings/source/local_music_controller_test.dart
+++ b/test/features/settings/source/local_music_controller_test.dart
@@ -1,11 +1,14 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/core/sources/local/android_media_library.dart';
 import 'package:linthra/core/sources/local/audio_file_scanner.dart';
 import 'package:linthra/core/sources/local/directory_readability.dart';
+import 'package:linthra/core/sources/local/folder_location.dart';
 import 'package:linthra/core/sources/local/folder_scan_exception.dart';
 import 'package:linthra/core/sources/local/local_scan_diagnostics.dart';
 import 'package:linthra/core/sources/local/local_scan_report.dart';
+import 'package:linthra/core/sources/local/saf_document_lister.dart';
 import 'package:linthra/data/repositories/host_platform_provider.dart';
 import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
 import 'package:linthra/data/repositories/in_memory_selected_music_folder_repository.dart';
@@ -37,6 +40,52 @@ class _MutableScanner implements AudioFileScanner {
   }
 }
 
+/// A scriptable stand-in for Android's MediaStore seam: the permission answer
+/// and the device-audio result (rows, or a thrown failure) are both set by the
+/// test, so a switch to device-wide mode can be walked without a device.
+class _FakeAndroidMediaLibrary implements AndroidMediaLibrary {
+  _FakeAndroidMediaLibrary({
+    this.status = AndroidMusicPermissionStatus.allowed,
+    this.documents = const <SafAudioDocument>[],
+    this.failure,
+  });
+
+  AndroidMusicPermissionStatus status;
+  List<SafAudioDocument> documents;
+  Object? failure;
+  int requestCount = 0;
+
+  @override
+  Future<AndroidMusicPermissionStatus> permissionStatus() async => status;
+
+  @override
+  Future<AndroidMusicPermissionStatus> requestPermission() async {
+    requestCount++;
+    return status;
+  }
+
+  @override
+  Future<void> openAppSettings() async {}
+
+  @override
+  Future<SafScanResult> listDeviceAudio() async {
+    final Object? error = failure;
+    if (error != null) {
+      throw error;
+    }
+    return SafScanResult(
+      documents: documents,
+      filesVisited: documents.length,
+    );
+  }
+}
+
+const SafAudioDocument _deviceSong = SafAudioDocument(
+  uri: 'content://media/external/audio/media/7',
+  name: 'Device song.mp3',
+  mimeType: 'audio/mpeg',
+);
+
 /// The desktop access probe, likewise flippable mid-test.
 class _MutableReadability implements DirectoryReadability {
   _MutableReadability(this.readable);
@@ -64,6 +113,12 @@ ProviderContainer _container({
   addTearDown(container.dispose);
   return container;
 }
+
+/// What is actually on disk (well, in the in-memory repository) rather than the
+/// controller's in-flight state — the distinction the transactional switch is
+/// about.
+Future<String?> folderRepoValue(ProviderContainer container) =>
+    container.read(selectedMusicFolderRepositoryProvider).getSelectedFolder();
 
 void main() {
   setUp(LocalScanDiagnostics.reset);
@@ -213,6 +268,181 @@ void main() {
       await container.read(localMusicControllerProvider.notifier).rescan();
 
       expect(container.read(localMusicControllerProvider).message, isNull);
+    });
+
+    // Switching an existing folder user to device-wide mode has to be all or
+    // nothing (#550): the catalog is deliberately preserved when a scan fails,
+    // so persisting the MediaStore sentinel before the first scan succeeded
+    // would leave the app configured for MediaStore while still showing the old
+    // folder's tracks — with the folder reference needed to rescan them gone.
+    group('switching to device-wide music', () {
+      ProviderContainer androidContainer({
+        required _FakeAndroidMediaLibrary media,
+        required InMemorySelectedMusicFolderRepository folderRepo,
+        required InMemoryMusicLibraryRepository libraryRepo,
+        FakeAudioFileScanner? scanner,
+      }) {
+        final container = ProviderContainer(
+          overrides: [
+            hostPlatformProvider.overrideWithValue(HostPlatform.android),
+            androidMediaLibraryProvider.overrideWithValue(media),
+            selectedMusicFolderRepositoryProvider.overrideWithValue(folderRepo),
+            musicLibraryRepositoryProvider.overrideWithValue(libraryRepo),
+            audioFileScannerProvider
+                .overrideWithValue(scanner ?? FakeAudioFileScanner()),
+            folderPickerServiceProvider
+                .overrideWithValue(FakeFolderPickerService()),
+          ],
+        );
+        addTearDown(container.dispose);
+        return container;
+      }
+
+      test('a successful first scan persists the MediaStore selection',
+          () async {
+        final libraryRepo = InMemoryMusicLibraryRepository();
+        final container = androidContainer(
+          media: _FakeAndroidMediaLibrary(
+            documents: const <SafAudioDocument>[_deviceSong],
+          ),
+          folderRepo:
+              InMemorySelectedMusicFolderRepository(initialFolder: '/music'),
+          libraryRepo: libraryRepo,
+        );
+        await container.read(selectedFolderControllerProvider.future);
+
+        await container
+            .read(localMusicControllerProvider.notifier)
+            .useAllDeviceMusic();
+
+        expect(
+          container.read(selectedFolderControllerProvider).valueOrNull,
+          FolderLocation.androidMediaStoreAudio,
+        );
+        expect(await folderRepoValue(container), 'mediastore://audio');
+        expect(await libraryRepo.getAllTracks(), hasLength(1));
+        expect(
+          container.read(localMusicControllerProvider).message,
+          contains('from this device'),
+        );
+      });
+
+      test('a failed first scan leaves the previous folder selected', () async {
+        final container = androidContainer(
+          media: _FakeAndroidMediaLibrary(
+            failure: const FolderScanException(
+              "Couldn't read Android's shared music library.",
+              code: 'media_store_failed',
+            ),
+          ),
+          folderRepo:
+              InMemorySelectedMusicFolderRepository(initialFolder: '/music'),
+          libraryRepo: InMemoryMusicLibraryRepository(),
+        );
+        await container.read(selectedFolderControllerProvider.future);
+
+        await container
+            .read(localMusicControllerProvider.notifier)
+            .useAllDeviceMusic();
+
+        expect(
+          container.read(selectedFolderControllerProvider).valueOrNull,
+          '/music',
+          reason: 'the folder must survive a failed switch',
+        );
+        expect(await folderRepoValue(container), '/music');
+        // A provider fault is not a permission problem, and says so.
+        expect(
+          container.read(localScanReportProvider)?.error,
+          LocalScanError.unexpected,
+        );
+        expect(container.read(localMusicControllerProvider).isError, isTrue);
+      });
+
+      test('a failed first scan preserves the already indexed catalog',
+          () async {
+        final libraryRepo = InMemoryMusicLibraryRepository();
+        final container = androidContainer(
+          media: _FakeAndroidMediaLibrary(
+            failure: const FolderScanException(
+              "Couldn't read Android's shared music library.",
+              code: 'media_store_failed',
+            ),
+          ),
+          folderRepo: InMemorySelectedMusicFolderRepository(),
+          libraryRepo: libraryRepo,
+          scanner: FakeAudioFileScanner(files: const <String>['/music/a.mp3']),
+        );
+        // Index a folder the normal way first, then attempt the switch.
+        await container
+            .read(selectedFolderControllerProvider.notifier)
+            .setAndPersist('/music');
+        await container.read(localMusicControllerProvider.notifier).rescan();
+        expect(await libraryRepo.getAllTracks(), hasLength(1));
+
+        await container
+            .read(localMusicControllerProvider.notifier)
+            .useAllDeviceMusic();
+
+        expect(
+          await libraryRepo.getAllTracks(),
+          hasLength(1),
+          reason: 'a failed switch must not touch the indexed music',
+        );
+        expect(
+          container.read(selectedFolderControllerProvider).valueOrNull,
+          '/music',
+        );
+      });
+
+      test('with no previous folder, a successful scan still selects it',
+          () async {
+        final container = androidContainer(
+          media: _FakeAndroidMediaLibrary(
+            documents: const <SafAudioDocument>[_deviceSong],
+          ),
+          folderRepo: InMemorySelectedMusicFolderRepository(),
+          libraryRepo: InMemoryMusicLibraryRepository(),
+        );
+        await container.read(selectedFolderControllerProvider.future);
+
+        await container
+            .read(localMusicControllerProvider.notifier)
+            .useAllDeviceMusic();
+
+        expect(
+          container.read(selectedFolderControllerProvider).valueOrNull,
+          FolderLocation.androidMediaStoreAudio,
+        );
+      });
+
+      test('a denied permission never changes the selected source', () async {
+        final media = _FakeAndroidMediaLibrary(
+          status: AndroidMusicPermissionStatus.denied,
+        );
+        final container = androidContainer(
+          media: media,
+          folderRepo:
+              InMemorySelectedMusicFolderRepository(initialFolder: '/music'),
+          libraryRepo: InMemoryMusicLibraryRepository(),
+        );
+        await container.read(selectedFolderControllerProvider.future);
+
+        await container
+            .read(localMusicControllerProvider.notifier)
+            .useAllDeviceMusic();
+
+        expect(media.requestCount, 1);
+        expect(
+          container.read(selectedFolderControllerProvider).valueOrNull,
+          '/music',
+        );
+        expect(await folderRepoValue(container), '/music');
+        expect(
+          container.read(localMusicControllerProvider).message,
+          contains('was not granted'),
+        );
+      });
     });
 
     test('forget clears the selection, the local catalog, and the report',

--- a/test/features/settings/source/local_music_settings_section_test.dart
+++ b/test/features/settings/source/local_music_settings_section_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/platform/host_platform.dart';
 import 'package:linthra/core/sources/local/directory_readability.dart';
+import 'package:linthra/core/sources/local/folder_location.dart';
 import 'package:linthra/core/sources/local/local_scan_diagnostics.dart';
 import 'package:linthra/core/sources/local/local_scan_report.dart';
 import 'package:linthra/data/repositories/host_platform_provider.dart';
@@ -25,6 +26,14 @@ class _FixedReadability implements DirectoryReadability {
 
 const String _safFolder =
     'content://com.android.externalstorage.documents/tree/primary%3AMusic';
+
+const String _deviceLibrary = FolderLocation.androidMediaStoreAudio;
+
+/// Every rendered string on the card, so a test can assert what the whole
+/// surface does — and does not — say.
+Iterable<String> _renderedText(WidgetTester tester) => tester
+    .widgetList<Text>(find.byType(Text))
+    .map((Text text) => text.data ?? '');
 
 Future<void> _pump(
   WidgetTester tester, {
@@ -50,7 +59,12 @@ Future<void> _pump(
           directoryReadabilityProvider.overrideWithValue(readability),
       ],
       child: const MaterialApp(
-        home: Scaffold(body: LocalMusicSettingsSection()),
+        // The card ships inside the scrollable provider sheet, so scroll here
+        // too: the Android variant is taller than the test surface once the
+        // privacy panel and a scan hint are on screen.
+        home: Scaffold(
+          body: SingleChildScrollView(child: LocalMusicSettingsSection()),
+        ),
       ),
     ),
   );
@@ -351,6 +365,113 @@ void main() {
         expect(value, isNot(contains('/storage/')));
         expect(value.toLowerCase(), isNot(contains('.mp3')));
       }
+    });
+
+    // The device-wide MediaStore mode has no folder behind it. Any outcome that
+    // falls back to folder wording sends the user to Android's folder chooser
+    // for a library that is not a folder — the two states below (nothing found,
+    // and a provider failure) are exactly where that used to happen.
+    testWidgets('device-wide mode with no music says so without folder wording',
+        (tester) async {
+      await _pump(
+        tester,
+        host: HostPlatform.android,
+        initialFolder: _deviceLibrary,
+        report: const LocalScanReport(
+          folderSelected: true,
+          isContentUri: false,
+          filesVisited: 0,
+          foldersVisited: 0,
+          audioCandidates: 0,
+          importedTracks: 0,
+          skippedUnsupported: 0,
+          readFailures: 0,
+        ),
+      );
+
+      expect(find.textContaining('no music on this device'), findsOneWidget);
+      expect(
+        find.textContaining('reported no audio on this device'),
+        findsOneWidget,
+      );
+      for (final String text in _renderedText(tester)) {
+        expect(text, isNot(contains('folder chooser')));
+        expect(text, isNot(contains('this folder')));
+        expect(text, isNot(contains('that folder')));
+      }
+    });
+
+    testWidgets('a MediaStore provider failure keeps device-library wording',
+        (tester) async {
+      // `media_store_failed` (a null cursor, a provider fault) is classified as
+      // `unexpected`, not `mediaPermission` — permission may well still be
+      // granted. It must not be described as an unreadable folder.
+      await _pump(
+        tester,
+        host: HostPlatform.android,
+        initialFolder: _deviceLibrary,
+        report: const LocalScanReport.failure(
+          folderSelected: true,
+          isContentUri: false,
+          error: LocalScanError.unexpected,
+        ),
+      );
+
+      expect(find.textContaining("couldn't finish"), findsOneWidget);
+      expect(
+        find.textContaining("couldn't read Android's shared music library"),
+        findsOneWidget,
+      );
+      for (final String text in _renderedText(tester)) {
+        expect(text, isNot(contains('folder chooser')));
+        expect(text, isNot(contains('Select it again')));
+      }
+    });
+
+    testWidgets('a revoked permission still routes to Android settings',
+        (tester) async {
+      // The one MediaStore failure that *is* about permission keeps the
+      // permission-specific recovery path.
+      await _pump(
+        tester,
+        host: HostPlatform.android,
+        initialFolder: _deviceLibrary,
+        report: const LocalScanReport.failure(
+          folderSelected: true,
+          isContentUri: false,
+          error: LocalScanError.mediaPermission,
+        ),
+      );
+
+      expect(
+        find.textContaining('Re-enable it in Android settings'),
+        findsOneWidget,
+      );
+      for (final String text in _renderedText(tester)) {
+        expect(text, isNot(contains('folder chooser')));
+      }
+    });
+
+    testWidgets('a SAF folder still gets folder-specific recovery text',
+        (tester) async {
+      // The folder half of the same branch: real folder sources keep pointing
+      // at the folder chooser.
+      await _pump(
+        tester,
+        host: HostPlatform.android,
+        initialFolder: _safFolder,
+        report: const LocalScanReport.failure(
+          folderSelected: true,
+          isContentUri: true,
+          error: LocalScanError.safTraversal,
+        ),
+      );
+
+      expect(find.textContaining("Android's folder chooser"), findsOneWidget);
+      expect(
+        find.textContaining("shared music library"),
+        findsNothing,
+      );
     });
   });
 }

--- a/test/features/settings/source/local_music_settings_section_test.dart
+++ b/test/features/settings/source/local_music_settings_section_test.dart
@@ -85,7 +85,7 @@ void main() {
       // Recoverable, not destructive: reselecting is the fix, and the actions
       // to do it are still on the card.
       expect(find.text('Change'), findsOneWidget);
-      expect(find.text('Forget folder'), findsOneWidget);
+      expect(find.text('Forget local music'), findsOneWidget);
     });
 
     testWidgets('on Linux, a reachable folder says nothing about access', (
@@ -126,11 +126,11 @@ void main() {
       await _pump(tester);
 
       expect(find.text('Local music'), findsOneWidget);
-      expect(find.text('No folder selected yet.'), findsOneWidget);
+      expect(find.text('No local music source selected yet.'), findsOneWidget);
       expect(find.text('Select a folder'), findsOneWidget);
       // No rescan/forget actions until a folder exists.
       expect(find.text('Rescan'), findsNothing);
-      expect(find.text('Forget folder'), findsNothing);
+      expect(find.text('Forget local music'), findsNothing);
     });
 
     testWidgets('with a SAF folder, shows a friendly label and the actions',
@@ -145,7 +145,7 @@ void main() {
       expect(find.text('primary:Music/musi5'), findsOneWidget);
       expect(find.text('Rescan'), findsOneWidget);
       expect(find.text('Change'), findsOneWidget);
-      expect(find.text('Forget folder'), findsOneWidget);
+      expect(find.text('Forget local music'), findsOneWidget);
     });
 
     testWidgets('after a successful scan, shows a clear summary with counts',
@@ -270,9 +270,11 @@ void main() {
       // Still a clear way back: reselect the folder in the chooser Linux has.
       expect(find.textContaining("couldn't read this folder"), findsOneWidget);
       expect(
-          find.textContaining('Select it again with the system folder '
-              'chooser'),
-          findsOneWidget);
+        find.textContaining(
+          'Select it again with the system folder chooser',
+        ),
+        findsOneWidget,
+      );
       expect(find.textContaining('restore access'), findsOneWidget);
       // The SD-card aside is an Android storage note; a desktop path is not it.
       expect(find.textContaining('SD cards'), findsNothing);

--- a/test/features/settings/source/local_music_settings_section_test.dart
+++ b/test/features/settings/source/local_music_settings_section_test.dart
@@ -380,6 +380,7 @@ void main() {
         report: const LocalScanReport(
           folderSelected: true,
           isContentUri: false,
+          isDeviceLibrary: true,
           filesVisited: 0,
           foldersVisited: 0,
           audioCandidates: 0,
@@ -413,6 +414,7 @@ void main() {
         report: const LocalScanReport.failure(
           folderSelected: true,
           isContentUri: false,
+          isDeviceLibrary: true,
           error: LocalScanError.unexpected,
         ),
       );
@@ -439,6 +441,7 @@ void main() {
         report: const LocalScanReport.failure(
           folderSelected: true,
           isContentUri: false,
+          isDeviceLibrary: true,
           error: LocalScanError.mediaPermission,
         ),
       );
@@ -472,6 +475,37 @@ void main() {
         find.textContaining("shared music library"),
         findsNothing,
       );
+    });
+
+    testWidgets('a failed trial of device mode is not blamed on the folder', (
+      tester,
+    ) async {
+      // The transactional switch keeps the folder selected when the first
+      // MediaStore scan fails, so the newest report describes a source that is
+      // not the selected one. The recap follows the report: the folder was
+      // never scanned, so telling the user to reselect it would be nonsense.
+      await _pump(
+        tester,
+        host: HostPlatform.android,
+        initialFolder: _safFolder,
+        report: const LocalScanReport.failure(
+          folderSelected: true,
+          isContentUri: false,
+          isDeviceLibrary: true,
+          error: LocalScanError.unexpected,
+        ),
+      );
+
+      // Still a folder user: the selection and its label are untouched.
+      expect(find.text('primary:Music'), findsOneWidget);
+      expect(
+        find.textContaining("couldn't read Android's shared music library"),
+        findsOneWidget,
+      );
+      for (final String text in _renderedText(tester)) {
+        expect(text, isNot(contains('folder chooser')));
+        expect(text, isNot(contains('Select it again')));
+      }
     });
   });
 }

--- a/test/features/settings/source/provider_summary_cards_test.dart
+++ b/test/features/settings/source/provider_summary_cards_test.dart
@@ -2,12 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/jellyfin_session.dart';
+import 'package:linthra/core/sources/local/android_media_library.dart';
+import 'package:linthra/core/sources/local/folder_location.dart';
 import 'package:linthra/core/sources/local/local_scan_diagnostics.dart';
 import 'package:linthra/core/sources/local/local_scan_report.dart';
+import 'package:linthra/core/sources/local/saf_document_lister.dart';
 import 'package:linthra/data/repositories/in_memory_jellyfin_session_store.dart';
 import 'package:linthra/data/repositories/in_memory_selected_music_folder_repository.dart';
 import 'package:linthra/data/repositories/jellyfin_session_store_provider.dart';
 import 'package:linthra/data/repositories/selected_music_folder_repository_provider.dart';
+import 'package:linthra/features/library/library_providers.dart';
 import 'package:linthra/features/settings/jellyfin/jellyfin_settings_providers.dart';
 import 'package:linthra/features/settings/source/provider_summary_cards.dart';
 
@@ -25,6 +29,24 @@ const JellyfinSession _session = JellyfinSession(
 
 const String _safFolder =
     'content://com.android.externalstorage.documents/tree/primary%3AMusic';
+
+class _FakeAndroidMediaLibrary implements AndroidMediaLibrary {
+  const _FakeAndroidMediaLibrary(this.status);
+
+  final AndroidMusicPermissionStatus status;
+
+  @override
+  Future<AndroidMusicPermissionStatus> permissionStatus() async => status;
+
+  @override
+  Future<AndroidMusicPermissionStatus> requestPermission() async => status;
+
+  @override
+  Future<void> openAppSettings() async {}
+
+  @override
+  Future<SafScanResult> listDeviceAudio() async => const SafScanResult();
+}
 
 Future<void> _pumpJellyfin(
   WidgetTester tester, {
@@ -54,6 +76,7 @@ Future<void> _pumpLocal(
   WidgetTester tester, {
   String? initialFolder,
   LocalScanReport? report,
+  AndroidMusicPermissionStatus? deviceMusicPermission,
 }) async {
   if (report != null) {
     LocalScanDiagnostics.record(report);
@@ -64,6 +87,10 @@ Future<void> _pumpLocal(
         selectedMusicFolderRepositoryProvider.overrideWithValue(
           InMemorySelectedMusicFolderRepository(initialFolder: initialFolder),
         ),
+        if (deviceMusicPermission != null)
+          androidMediaLibraryProvider.overrideWithValue(
+            _FakeAndroidMediaLibrary(deviceMusicPermission),
+          ),
       ],
       child: const MaterialApp(
         home: Scaffold(
@@ -145,6 +172,41 @@ void main() {
       expect(find.text('8 tracks'), findsOneWidget);
       expect(find.text('Rescan'), findsOneWidget);
       expect(find.text('Manage'), findsOneWidget);
+    });
+
+    testWidgets('MediaStore uses device-music wording when access is allowed',
+        (tester) async {
+      await _pumpLocal(
+        tester,
+        initialFolder: FolderLocation.androidMediaStoreAudio,
+        deviceMusicPermission: AndroidMusicPermissionStatus.allowed,
+        report: const LocalScanReport(
+          folderSelected: true,
+          isContentUri: false,
+          filesVisited: 0,
+          audioCandidates: 0,
+          importedTracks: 0,
+          skippedUnsupported: 0,
+          readFailures: 0,
+        ),
+      );
+
+      expect(find.text('Device music selected'), findsOneWidget);
+      expect(find.text('All music on this device'), findsOneWidget);
+      expect(find.text('Folder selected'), findsNothing);
+    });
+
+    testWidgets('MediaStore uses device-music wording when access is revoked',
+        (tester) async {
+      await _pumpLocal(
+        tester,
+        initialFolder: FolderLocation.androidMediaStoreAudio,
+        deviceMusicPermission: AndroidMusicPermissionStatus.denied,
+      );
+
+      expect(find.text('Device music access off'), findsOneWidget);
+      expect(find.text('All music on this device'), findsOneWidget);
+      expect(find.text('Folder access lost'), findsNothing);
     });
   });
 }

--- a/test/tooling/android_media_store_contract_test.dart
+++ b/test/tooling/android_media_store_contract_test.dart
@@ -15,7 +15,8 @@ void main() {
   test('MediaStore scan fails closed when no cursor is returned', () {
     expect(
       channel,
-      contains('?: throw IllegalStateException("MediaStore query returned no cursor")'),
+      contains(
+          '?: throw IllegalStateException("MediaStore query returned no cursor")'),
     );
   });
 

--- a/test/tooling/android_media_store_contract_test.dart
+++ b/test/tooling/android_media_store_contract_test.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late String channel;
+
+  setUpAll(() {
+    channel = File(
+      'android/app/src/main/kotlin/io/github/thezupzup/linthra/'
+      'AndroidMediaLibraryChannel.kt',
+    ).readAsStringSync();
+  });
+
+  test('MediaStore scan fails closed when no cursor is returned', () {
+    expect(
+      channel,
+      contains('?: throw IllegalStateException("MediaStore query returned no cursor")'),
+    );
+  });
+
+  test('MediaStore track numbers decode the disc-encoded thousands field', () {
+    expect(channel, contains('val rawTrack = cursor.getInt(trackIndex)'));
+    expect(channel, contains('(rawTrack % 1000).takeIf { it > 0 }'));
+  });
+
+  test('MediaStore rows carry a stable source-namespaced album id', () {
+    expect(channel, contains('MediaStore.Audio.Media.ALBUM_ID'));
+    expect(channel, contains(r'"android-mediastore:$it"'));
+    expect(channel, contains('"albumId" to albumId'));
+  });
+}

--- a/test/tooling/android_media_store_contract_test.dart
+++ b/test/tooling/android_media_store_contract_test.dart
@@ -27,7 +27,20 @@ void main() {
 
   test('MediaStore rows carry a stable source-namespaced album id', () {
     expect(channel, contains('MediaStore.Audio.Media.ALBUM_ID'));
-    expect(channel, contains(r'"android-mediastore:$it"'));
+    expect(channel, contains(r'"android-mediastore:$albumId"'));
     expect(channel, contains('"albumId" to albumId'));
+  });
+
+  test('album ids are namespaced by storage volume where Android exposes it',
+      () {
+    // EXTERNAL_CONTENT_URI aggregates every external volume from Android 10 on,
+    // and ALBUM_ID is only unique within one volume's database. Without the
+    // volume in the key, an album on an SD card can collide with an unrelated
+    // album on internal storage and the two get grouped as one.
+    expect(channel, contains('MediaStore.Audio.Media.VOLUME_NAME'));
+    expect(channel, contains(r'"android-mediastore:$volume:$albumId"'));
+    // Guarded, because VOLUME_NAME does not exist below Android 10 and asking
+    // for it there makes the whole query throw.
+    expect(channel, contains('Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q'));
   });
 }

--- a/test/tooling/android_music_permission_manifest_test.dart
+++ b/test/tooling/android_music_permission_manifest_test.dart
@@ -1,0 +1,27 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Android declares only the expected local-audio permissions', () {
+    final String manifest =
+        File('android/app/src/main/AndroidManifest.xml').readAsStringSync();
+
+    expect(
+      manifest,
+      contains('android.permission.READ_MEDIA_AUDIO'),
+    );
+    expect(
+      manifest,
+      contains('android.permission.READ_EXTERNAL_STORAGE'),
+    );
+    expect(
+      manifest,
+      contains('android:maxSdkVersion="32"'),
+    );
+    expect(
+      manifest,
+      contains('android:appCategory="audio"'),
+    );
+  });
+}

--- a/test/tooling/flatpak_launch_smoke_test.dart
+++ b/test/tooling/flatpak_launch_smoke_test.dart
@@ -10,10 +10,16 @@ void main() {
   });
 
   test('launch smoke installs only from the local CI repository', () {
-    expect(smoke, contains('REMOTE_NAME="linthra-ci-smoke"'));
+    expect(smoke, contains('REMOTE_NAME="linthra-ci-smoke-$$"'));
     expect(smoke, contains('--no-gpg-verify'));
     expect(smoke, contains('flatpak --user install -y'));
     expect(smoke, isNot(contains('https://')));
+  });
+
+  test('launch smoke preserves pre-existing Linthra installations', () {
+    expect(smoke, contains('flatpak --user info "$APP_ID"'));
+    expect(smoke, contains('flatpak --system info "$APP_ID"'));
+    expect(smoke, contains('$APP_ID is already installed'));
   });
 
   test('launch smoke starts the packaged app and waits for a real window', () {

--- a/test/tooling/flatpak_launch_smoke_test.dart
+++ b/test/tooling/flatpak_launch_smoke_test.dart
@@ -10,20 +10,20 @@ void main() {
   });
 
   test('launch smoke installs only from the local CI repository', () {
-    expect(smoke, contains('REMOTE_NAME="linthra-ci-smoke-$$"'));
+    expect(smoke, contains(r'REMOTE_NAME="linthra-ci-smoke-$$"'));
     expect(smoke, contains('--no-gpg-verify'));
     expect(smoke, contains('flatpak --user install -y'));
     expect(smoke, isNot(contains('https://')));
   });
 
   test('launch smoke preserves pre-existing Linthra installations', () {
-    expect(smoke, contains('flatpak --user info "$APP_ID"'));
-    expect(smoke, contains('flatpak --system info "$APP_ID"'));
-    expect(smoke, contains('$APP_ID is already installed'));
+    expect(smoke, contains(r'flatpak --user info "$APP_ID"'));
+    expect(smoke, contains(r'flatpak --system info "$APP_ID"'));
+    expect(smoke, contains(r'$APP_ID is already installed'));
   });
 
   test('launch smoke starts the packaged app and waits for a real window', () {
-    expect(smoke, contains('flatpak run "$APP_ID"'));
+    expect(smoke, contains(r'flatpak run "$APP_ID"'));
     expect(smoke, contains('xwininfo -root -tree'));
     expect(smoke, contains('WINDOW_TITLE="Linthra"'));
     expect(smoke, contains('xvfb-run --auto-servernum'));
@@ -31,9 +31,9 @@ void main() {
   });
 
   test('launch smoke cleans up app and temporary remote', () {
-    expect(smoke, contains('flatpak kill "$APP_ID"'));
-    expect(smoke, contains('flatpak --user uninstall -y "$APP_ID"'));
-    expect(smoke, contains('flatpak --user remote-delete "$REMOTE_NAME"'));
+    expect(smoke, contains(r'flatpak kill "$APP_ID"'));
+    expect(smoke, contains(r'flatpak --user uninstall -y "$APP_ID"'));
+    expect(smoke, contains(r'flatpak --user remote-delete "$REMOTE_NAME"'));
     expect(smoke, contains('trap cleanup EXIT'));
   });
 


### PR DESCRIPTION
Closes #548.

## Goal

Make Linthra's local-music access explicit at the Android system level instead of relying only on a SAF grant that is hard to see in the normal permission UI.

## What this PR adds

- declares `READ_MEDIA_AUDIO` on Android 13+ and legacy `READ_EXTERNAL_STORAGE` only through API 32;
- sets `android:appCategory="audio"`;
- never requests All files access, photo access, or video access;
- adds an explicit **All music on this device** mode backed by Android MediaStore;
- requests the music permission only after that explicit user action, never at first launch;
- preserves the existing **Select a folder** SAF path with its targeted persisted grant and no broad permission;
- persists device-wide mode through a Linthra-owned `mediastore://audio` sentinel rather than pretending it is a filesystem path;
- scans MediaStore off the Android UI thread and maps rows through the existing local-track mapper;
- adds a **Privacy & permissions** status in Settings ▸ Local music showing Music and audio as Allowed / Denied / Not requested, explaining SAF's targeted grant, and linking to Android app settings;
- permission revocation leaves the indexed catalog intact and becomes a recoverable scan state;
- adds focused tests for the sentinel/source mapping, permission-status parsing, and manifest declarations.

## Compatibility

- Android 13+: `READ_MEDIA_AUDIO`.
- Android 6–12: narrow legacy shared-audio read permission (`READ_EXTERNAL_STORAGE`, manifest-capped at API 32).
- Pre-runtime-permission Android: treated as allowed by the native bridge.
- Desktop/Linux behavior is unchanged.
- Existing SAF users keep their persisted folder selection and do not get a new permission prompt.

## Scope

No Flatpak files, workflows, provider/network code, dependency versions, F-Droid configuration, or playback/media-session declarations are changed.

Do not merge until Android/Flutter CI and review are green.