### PR TITLE
ci(android): publish signed releases to Google Play testing

### DIFF
--- a/.github/workflows/google-play-closed-testing.yml
+++ b/.github/workflows/google-play-closed-testing.yml
@@ -1,0 +1,149 @@
+name: Google Play Closed Testing
+
+# Publishes the release-signed AAB produced by Android Release Build to a
+# non-production Google Play testing track. The workflow is intentionally
+# separate from the build workflow: the AAB is built once, then reused here.
+#
+# Before Google Play is configured, this workflow exits successfully with a
+# notice. See docs/google-play-publishing.md for the one-time setup.
+#
+# Safety rules:
+#   * only successful tag-triggered Android Release Build runs are considered;
+#   * only the release-signed AAB artifact is accepted;
+#   * manual release builds are never auto-published;
+#   * the production track is explicitly rejected.
+
+on:
+  workflow_run:
+    workflows:
+      - Android Release Build
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+
+env:
+  GOOGLE_PLAY_PACKAGE_NAME: io.github.thezupzup.linthra
+  GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+  GOOGLE_PLAY_TRACK: ${{ vars.GOOGLE_PLAY_TRACK }}
+
+jobs:
+  publish-closed-test:
+    name: Publish signed AAB to Google Play testing
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check Google Play configuration
+        id: config
+        shell: bash
+        run: |
+          enabled=true
+
+          if [ -z "$GOOGLE_PLAY_SERVICE_ACCOUNT_JSON" ]; then
+            echo "::notice::Google Play publishing is not connected yet: GOOGLE_PLAY_SERVICE_ACCOUNT_JSON is missing."
+            enabled=false
+          fi
+
+          if [ -z "$GOOGLE_PLAY_TRACK" ]; then
+            echo "::notice::Google Play publishing is not connected yet: GOOGLE_PLAY_TRACK is missing."
+            enabled=false
+          elif [ "$GOOGLE_PLAY_TRACK" = "production" ]; then
+            echo "::error::Automatic production publishing is intentionally disabled. Set GOOGLE_PLAY_TRACK to a testing track."
+            exit 1
+          fi
+
+          echo "enabled=$enabled" >> "$GITHUB_OUTPUT"
+
+          if [ "$enabled" != "true" ]; then
+            echo "Google Play upload skipped. Complete docs/google-play-publishing.md to enable it." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Find release-signed AAB artifact
+        id: artifact
+        if: steps.config.outputs.enabled == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+        shell: bash
+        run: |
+          count="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}/artifacts" \
+              --jq '[.artifacts[] | select(.name == "linthra-release-signed-aab" and .expired == false)] | length'
+          )"
+
+          if [ "$count" = "0" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::The source release did not produce a release-signed AAB. Google Play upload skipped."
+            echo "Google Play upload skipped because the source build was not release-signed." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if [ "$count" != "1" ]; then
+            echo "::error::Expected exactly one linthra-release-signed-aab artifact, found $count."
+            exit 1
+          fi
+
+          echo "available=true" >> "$GITHUB_OUTPUT"
+
+      - name: Download release-signed AAB
+        if: >-
+          steps.config.outputs.enabled == 'true' &&
+          steps.artifact.outputs.available == 'true'
+        uses: actions/download-artifact@v7
+        with:
+          name: linthra-release-signed-aab
+          path: play-upload
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Verify downloaded bundle
+        id: bundle
+        if: >-
+          steps.config.outputs.enabled == 'true' &&
+          steps.artifact.outputs.available == 'true'
+        shell: bash
+        run: |
+          mapfile -t bundles < <(find play-upload -type f -name '*.aab' -print)
+
+          if [ "${#bundles[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one downloaded AAB, found ${#bundles[@]}."
+            exit 1
+          fi
+
+          echo "path=${bundles[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to Google Play testing
+        if: >-
+          steps.config.outputs.enabled == 'true' &&
+          steps.artifact.outputs.available == 'true'
+        # v1.1.5 — pinned so a third-party action update cannot silently change
+        # the release pipeline. Update the SHA deliberately with its guardrail test.
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5
+        with:
+          serviceAccountJsonPlainText: ${{ env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: ${{ env.GOOGLE_PLAY_PACKAGE_NAME }}
+          releaseFiles: ${{ steps.bundle.outputs.path }}
+          tracks: ${{ env.GOOGLE_PLAY_TRACK }}
+          status: completed
+
+      - name: Record publication summary
+        if: >-
+          steps.config.outputs.enabled == 'true' &&
+          steps.artifact.outputs.available == 'true'
+        shell: bash
+        run: |
+          {
+            echo "### Google Play testing upload"
+            echo ""
+            echo "- Package: \`$GOOGLE_PLAY_PACKAGE_NAME\`"
+            echo "- Track: \`$GOOGLE_PLAY_TRACK\`"
+            echo "- Source run: \`${{ github.event.workflow_run.id }}\`"
+            echo "- Source commit: \`${{ github.event.workflow_run.head_sha }}\`"
+            echo "- Bundle: \`${{ steps.bundle.outputs.path }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/google-play-closed-testing.yml
+++ b/.github/workflows/google-play-closed-testing.yml
@@ -95,7 +95,7 @@ jobs:
         if: >-
           steps.config.outputs.enabled == 'true' &&
           steps.artifact.outputs.available == 'true'
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: linthra-release-signed-aab
           path: play-upload

--- a/docs/google-play-publishing.md
+++ b/docs/google-play-publishing.md
@@ -1,0 +1,156 @@
+# Google Play publishing
+
+Linthra's GitHub release pipeline builds the Android release artifacts once in
+`.github/workflows/android-release-build.yml`. The separate
+`.github/workflows/google-play-closed-testing.yml` workflow reuses the
+**release-signed AAB** from a successful tag build and uploads it to a Google
+Play testing track.
+
+The publisher never rebuilds the application and never publishes to production.
+If Google Play is not configured yet, the workflow exits successfully with a
+notice instead of breaking normal GitHub releases.
+
+## What is already automated
+
+For a tag-triggered `Android Release Build` that completes successfully:
+
+1. GitHub checks whether Google Play publishing is configured.
+2. It looks for the `linthra-release-signed-aab` artifact from that exact run.
+3. Debug-signed prereleases are skipped automatically.
+4. The signed AAB is downloaded without rebuilding Linthra.
+5. The bundle is uploaded to the configured Google Play testing track with
+   status `completed`.
+
+Manual `workflow_dispatch` release builds are never auto-published.
+
+The workflow explicitly rejects `production` as a track. Promotion to
+production stays a manual maintainer decision in Play Console.
+
+## One-time Google Play setup
+
+### 1. Create Linthra in Play Console
+
+Create the app in Google Play Console with the existing permanent Android
+package name:
+
+```text
+io.github.thezupzup.linthra
+```
+
+Do not create a second package name for Google Play. Android application IDs are
+part of the update identity and must remain stable.
+
+### 2. Upload the first AAB manually
+
+The publishing action requires the package to already exist in the Play Console
+account. Create the first testing release manually and upload a release-signed
+Linthra AAB once through Play Console.
+
+After that initial Play Console upload, later tagged releases can be delivered
+by GitHub Actions.
+
+### 3. Create the closed testing track and testers
+
+In Play Console, create or select the closed testing track that Linthra will use.
+Configure its tester list or Google Group and copy the track identifier used by
+the Google Play Developer API.
+
+The track title/identifier is what must be stored in the GitHub repository
+variable described below.
+
+### 4. Enable the Google Play Android Developer API
+
+In a Google Cloud project, enable the **Google Play Android Developer API** and
+create a service account dedicated to Linthra's GitHub release automation.
+
+Use a narrow service-account identity rather than a personal Google credential.
+
+### 5. Grant the service account Play Console access
+
+In Play Console **Users and permissions**, invite the service account email and
+grant access to Linthra only.
+
+The required Play permission is:
+
+- **Release apps to testing tracks**
+
+Do not grant production-release permission to this automation account. The
+workflow itself also rejects the `production` track as a second safety layer.
+
+### 6. Add the GitHub secret
+
+Create this repository Actions secret:
+
+```text
+GOOGLE_PLAY_SERVICE_ACCOUNT_JSON
+```
+
+Its value is the complete JSON service-account key.
+
+Never commit the JSON key, a copied private key, or a generated credentials file
+to the repository.
+
+A future migration to Google Workload Identity Federation can remove the
+long-lived JSON key without changing Linthra's release model.
+
+### 7. Add the GitHub track variable
+
+Create this repository Actions variable:
+
+```text
+GOOGLE_PLAY_TRACK
+```
+
+Set it to the closed testing track identifier from Play Console.
+
+Do **not** set it to `production`; the workflow fails deliberately if production
+is configured.
+
+## Result
+
+Once the secret and track variable are present, the normal Linthra release flow
+becomes:
+
+```text
+version/tag
+    ↓
+Android Release Build
+    ↓
+release-signed AAB artifact
+    ↓
+Google Play Closed Testing
+    ↓
+testers receive the new Play Store build
+```
+
+There is no second Flutter build and no separate version source. The AAB sent to
+Google Play is the same release artifact produced by the tagged GitHub build.
+
+## Failure and skip behavior
+
+The publisher is intentionally conservative:
+
+- missing service-account secret → skip with a notice;
+- missing track variable → skip with a notice;
+- `production` track → fail;
+- upstream Android release failed → publisher does not run;
+- manual Android release build → publisher does not run;
+- no release-signed AAB (for example, a debug-signed prerelease) → skip with a
+  notice;
+- multiple matching signed AAB artifacts → fail;
+- downloaded artifact does not contain exactly one `.aab` → fail.
+
+These checks keep an incomplete Google setup from breaking normal releases while
+preventing an ambiguous or debug-signed artifact from reaching Google Play.
+
+## Updating the upload action
+
+The Google Play publisher pins `r0adkll/upload-google-play` to an exact commit
+rather than a floating tag. When updating it:
+
+1. review the upstream release notes;
+2. replace the pinned SHA in
+   `.github/workflows/google-play-closed-testing.yml`;
+3. update the corresponding expected SHA in
+   `test/tooling/google_play_publishing_guardrails_test.dart`;
+4. run the tooling test and the normal Linthra CI suite.

--- a/test/tooling/google_play_publishing_guardrails_test.dart
+++ b/test/tooling/google_play_publishing_guardrails_test.dart
@@ -66,7 +66,7 @@ void main() {
 
   group('Google Play publisher safety', () {
     test('never accepts production as an automatic target', () {
-      expect(workflow, contains('[ "$GOOGLE_PLAY_TRACK" = "production" ]'));
+      expect(workflow, contains(r'[ "$GOOGLE_PLAY_TRACK" = "production" ]'));
       expect(
         workflow,
         contains('Automatic production publishing is intentionally disabled.'),

--- a/test/tooling/google_play_publishing_guardrails_test.dart
+++ b/test/tooling/google_play_publishing_guardrails_test.dart
@@ -1,0 +1,143 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  final String root = _repoRoot();
+  late String workflow;
+  late String documentation;
+
+  setUpAll(() {
+    workflow = _read(
+      p.join(root, '.github', 'workflows', 'google-play-closed-testing.yml'),
+    );
+    documentation = _read(p.join(root, 'docs', 'google-play-publishing.md'));
+  });
+
+  group('Google Play publisher trigger', () {
+    test('reuses the Android release build instead of rebuilding Linthra', () {
+      expect(workflow, contains('workflow_run:'));
+      expect(workflow, contains('Android Release Build'));
+      expect(workflow, isNot(contains('flutter build')));
+      expect(workflow, contains('linthra-release-signed-aab'));
+    });
+
+    test('only considers successful tag-triggered upstream runs', () {
+      expect(
+        workflow,
+        contains("github.event.workflow_run.conclusion == 'success'"),
+      );
+      expect(workflow, contains("github.event.workflow_run.event == 'push'"));
+    });
+
+    test('keeps repository permissions read-only', () {
+      expect(workflow, contains('actions: read'));
+      expect(workflow, contains('contents: read'));
+      expect(workflow, isNot(contains('contents: write')));
+      expect(workflow, isNot(contains('actions: write')));
+    });
+  });
+
+  group('Google Play publisher identity and credentials', () {
+    test('pins the permanent Linthra Android package name', () {
+      expect(
+        workflow,
+        contains('GOOGLE_PLAY_PACKAGE_NAME: io.github.thezupzup.linthra'),
+      );
+    });
+
+    test('reads credentials only from the expected Actions secret', () {
+      expect(
+        workflow,
+        contains(r'secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON'),
+      );
+      expect(
+        documentation,
+        contains('GOOGLE_PLAY_SERVICE_ACCOUNT_JSON'),
+      );
+    });
+
+    test('takes the testing track from a repository variable', () {
+      expect(workflow, contains(r'vars.GOOGLE_PLAY_TRACK'));
+      expect(documentation, contains('GOOGLE_PLAY_TRACK'));
+    });
+  });
+
+  group('Google Play publisher safety', () {
+    test('never accepts production as an automatic target', () {
+      expect(workflow, contains('[ "$GOOGLE_PLAY_TRACK" = "production" ]'));
+      expect(
+        workflow,
+        contains('Automatic production publishing is intentionally disabled.'),
+      );
+      expect(documentation, contains('Do **not** set it to `production`'));
+    });
+
+    test('requires the release-signed AAB artifact', () {
+      expect(
+        workflow,
+        contains('select(.name == "linthra-release-signed-aab"'),
+      );
+      expect(
+        workflow,
+        contains('Expected exactly one linthra-release-signed-aab artifact'),
+      );
+      expect(workflow, isNot(contains('linthra-debug-signed-aab')));
+    });
+
+    test('skips cleanly until Google Play is connected', () {
+      expect(
+        workflow,
+        contains('Google Play publishing is not connected yet'),
+      );
+      expect(
+        documentation,
+        contains('missing service-account secret → skip with a notice'),
+      );
+    });
+  });
+
+  group('Google Play upload action contract', () {
+    const String pinnedUploadAction =
+        'r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5';
+
+    test('pins the reviewed upload action commit', () {
+      expect(workflow, contains(pinnedUploadAction));
+      expect(workflow, isNot(contains('r0adkll/upload-google-play@v1')));
+    });
+
+    test('uses the current plural release and track inputs', () {
+      expect(workflow, contains('releaseFiles:'));
+      expect(workflow, contains('tracks:'));
+      expect(workflow, isNot(contains('\n          releaseFile:')));
+      expect(workflow, isNot(contains('\n          track:')));
+    });
+
+    test('publishes testing releases as completed', () {
+      expect(workflow, contains('status: completed'));
+    });
+  });
+}
+
+String _read(String path) {
+  final File file = File(path);
+  expect(file.existsSync(), isTrue, reason: 'Expected file is missing: $path');
+  return file.readAsStringSync();
+}
+
+String _repoRoot() {
+  Directory directory = Directory.current;
+  while (true) {
+    if (File(p.join(directory.path, 'pubspec.yaml')).existsSync() &&
+        Directory(p.join(directory.path, 'metadata')).existsSync()) {
+      return directory.path;
+    }
+
+    final Directory parent = directory.parent;
+    if (parent.path == directory.path) {
+      fail('Could not find repo root from ${Directory.current.path}');
+    }
+    directory = parent;
+  }
+}


### PR DESCRIPTION
## Goal

Prepare Linthra's GitHub release pipeline for Google Play closed testing without changing the existing Android build workflow.

## What this adds

- a dedicated `Google Play Closed Testing` workflow triggered after a successful tag-based `Android Release Build`;
- reuse of the exact `linthra-release-signed-aab` artifact instead of rebuilding Linthra;
- automatic skip behavior until Google Play credentials and a testing track are configured;
- explicit rejection of the `production` track;
- no auto-publish for manual release builds or debug-signed prereleases;
- exact-SHA pinning for `r0adkll/upload-google-play` v1.1.5;
- documentation for the one-time Google Play/service-account setup;
- tooling guardrail tests covering trigger, package identity, permissions, signed-artifact selection, production blocking, and upload-action inputs.

## One-time setup after merge

Google Play still needs to be connected manually:

1. Create/confirm Linthra in Play Console as `io.github.thezupzup.linthra`.
2. Upload the first release-signed AAB manually once so the package exists for the Publishing API.
3. Create/select the closed testing track and tester group.
4. Enable the Google Play Android Developer API and create a dedicated service account.
5. Grant that account **Release apps to testing tracks** for Linthra only.
6. Add repository secret `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`.
7. Add repository variable `GOOGLE_PLAY_TRACK` with the closed-test track identifier.

Until steps 6–7 are complete, the new workflow only reports a notice and does not break GitHub releases.

Production promotion intentionally remains manual.

## Files

- `.github/workflows/google-play-closed-testing.yml`
- `docs/google-play-publishing.md`
- `test/tooling/google_play_publishing_guardrails_test.dart`

Do not merge until CI/review are green.