### PR TITLE
fix(ci): publish stable releases and reject production in track lists

### DIFF
--- a/.github/workflows/google-play-closed-testing.yml
+++ b/.github/workflows/google-play-closed-testing.yml
@@ -177,12 +177,28 @@ jobs:
           tag="${name#linthra-}"
           tag="${tag%-release-signed.aab}"
 
-          # Resolve the tag to its commit. This fails outright when the tag does
-          # not exist, and the Commits API dereferences annotated tags, which is
-          # what the stable release workflow creates.
-          if ! tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${tag}" --jq .sha 2>/dev/null)" || [ -z "$tag_sha" ]; then
+          # Look the name up as a tag ref specifically. The Commits API would
+          # also accept a branch or a raw SHA, so a branch named like a version
+          # would satisfy it with no such tag anywhere in the repository.
+          tag_ref="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" --jq '.object.type + " " + .object.sha' 2>/dev/null)" || tag_ref=""
+
+          if [ -z "$tag_ref" ]; then
             echo "::error::Bundle claims tag '${tag}', but no such tag exists in this repository. Refusing to publish an untagged build."
             exit 1
+          fi
+
+          tag_object_type="${tag_ref%% *}"
+          tag_sha="${tag_ref##* }"
+
+          # The stable release workflow creates an annotated tag, whose ref
+          # points at a tag object rather than at the commit. Dereference one
+          # more hop so the comparison below is commit against commit.
+          if [ "$tag_object_type" = "tag" ]; then
+            tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${tag_sha}" --jq .object.sha 2>/dev/null)" || tag_sha=""
+            if [ -z "$tag_sha" ]; then
+              echo "::error::Could not resolve annotated tag '${tag}' to a commit."
+              exit 1
+            fi
           fi
 
           # Existing is not the same as matching. Android Release Build checks

--- a/.github/workflows/google-play-closed-testing.yml
+++ b/.github/workflows/google-play-closed-testing.yml
@@ -13,7 +13,8 @@ name: Google Play Closed Testing
 #     workflow dispatched the build for it;
 #   * only the release-signed AAB artifact is accepted;
 #   * ad-hoc manual builds are never auto-published;
-#   * the release tag named by the bundle must actually exist;
+#   * the release tag named by the bundle must exist AND point at the commit
+#     the build actually ran on;
 #   * the production track is explicitly rejected, including as one entry of
 #     a multi-track value, whatever whitespace the value carries.
 
@@ -132,6 +133,7 @@ jobs:
           steps.artifact.outputs.available == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
         shell: bash
         run: |
           mapfile -t bundles < <(find play-upload -type f -name '*.aab' -print)
@@ -175,8 +177,22 @@ jobs:
           tag="${name#linthra-}"
           tag="${tag%-release-signed.aab}"
 
-          if ! gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" >/dev/null 2>&1; then
+          # Resolve the tag to its commit. This fails outright when the tag does
+          # not exist, and the Commits API dereferences annotated tags, which is
+          # what the stable release workflow creates.
+          if ! tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${tag}" --jq .sha 2>/dev/null)" || [ -z "$tag_sha" ]; then
             echo "::error::Bundle claims tag '${tag}', but no such tag exists in this repository. Refusing to publish an untagged build."
+            exit 1
+          fi
+
+          # Existing is not the same as matching. Android Release Build checks
+          # out its dispatch ref, never the tag, and uses `release_tag` only for
+          # validation and naming. A build dispatched while the branch carried
+          # commits past the tag therefore produces a tag-named bundle whose
+          # code the tag does not name. Publish only when the run really did
+          # build the tagged commit.
+          if [ "$tag_sha" != "$SOURCE_SHA" ]; then
+            echo "::error::Bundle claims tag '${tag}' (${tag_sha}), but the build ran on ${SOURCE_SHA}. Refusing to publish code the tag does not name."
             exit 1
           fi
 

--- a/.github/workflows/google-play-closed-testing.yml
+++ b/.github/workflows/google-play-closed-testing.yml
@@ -8,10 +8,13 @@ name: Google Play Closed Testing
 # notice. See docs/google-play-publishing.md for the one-time setup.
 #
 # Safety rules:
-#   * only successful tag-triggered Android Release Build runs are considered;
+#   * only successful Android Release Build runs for a tagged release are
+#     considered, whether the tag was pushed directly or the stable-release
+#     workflow dispatched the build for it;
 #   * only the release-signed AAB artifact is accepted;
-#   * manual release builds are never auto-published;
-#   * the production track is explicitly rejected.
+#   * ad-hoc manual builds are never auto-published;
+#   * the production track is explicitly rejected, including as one entry of
+#     a multi-track value.
 
 on:
   workflow_run:
@@ -34,7 +37,8 @@ jobs:
     name: Publish signed AAB to Google Play testing
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push'
+      (github.event.workflow_run.event == 'push' ||
+      github.event.workflow_run.event == 'workflow_dispatch')
     runs-on: ubuntu-latest
 
     steps:
@@ -52,9 +56,18 @@ jobs:
           if [ -z "$GOOGLE_PLAY_TRACK" ]; then
             echo "::notice::Google Play publishing is not connected yet: GOOGLE_PLAY_TRACK is missing."
             enabled=false
-          elif [ "$GOOGLE_PLAY_TRACK" = "production" ]; then
-            echo "::error::Automatic production publishing is intentionally disabled. Set GOOGLE_PLAY_TRACK to a testing track."
-            exit 1
+          else
+            # The upload action's `tracks` input is plural: a comma-separated
+            # list. Reject production as any entry, not just as the whole
+            # value, so "internal,production" cannot slip past the check.
+            IFS=',' read -ra requested_tracks <<< "$GOOGLE_PLAY_TRACK"
+            for requested in "${requested_tracks[@]}"; do
+              requested="$(printf '%s' "$requested" | tr -d '[:space:]')"
+              if [ "$requested" = "production" ]; then
+                echo "::error::Automatic production publishing is intentionally disabled. Set GOOGLE_PLAY_TRACK to a testing track."
+                exit 1
+              fi
+            done
           fi
 
           echo "enabled=$enabled" >> "$GITHUB_OUTPUT"
@@ -116,12 +129,36 @@ jobs:
             exit 1
           fi
 
-          echo "path=${bundles[0]}" >> "$GITHUB_OUTPUT"
+          bundle="${bundles[0]}"
+          name="$(basename "$bundle")"
+
+          # Android Release Build names a tag build's asset
+          # `linthra-<tag>-release-signed.aab`, and an ad-hoc manual build's
+          # `linthra-release-signed.aab`. Both arrive here as the same artifact
+          # name, so the file name is what tells a real release apart from a
+          # maintainer's one-off signed build. Publishing only the tag form
+          # covers both release paths (a pushed `v*` tag, and the stable
+          # release workflow dispatching this build with `release_tag`) while
+          # still never auto-publishing a manual build.
+          case "$name" in
+            linthra-v*-release-signed.aab)
+              ;;
+            *)
+              echo "publish=false" >> "$GITHUB_OUTPUT"
+              echo "::notice::'$name' is an ad-hoc manual build, not a tagged release. Google Play upload skipped."
+              echo "Google Play upload skipped because the source build was not a tagged release." >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+              ;;
+          esac
+
+          echo "publish=true" >> "$GITHUB_OUTPUT"
+          echo "path=$bundle" >> "$GITHUB_OUTPUT"
 
       - name: Upload to Google Play testing
         if: >-
           steps.config.outputs.enabled == 'true' &&
-          steps.artifact.outputs.available == 'true'
+          steps.artifact.outputs.available == 'true' &&
+          steps.bundle.outputs.publish == 'true'
         # v1.1.5 — pinned so a third-party action update cannot silently change
         # the release pipeline. Update the SHA deliberately with its guardrail test.
         uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5
@@ -135,7 +172,8 @@ jobs:
       - name: Record publication summary
         if: >-
           steps.config.outputs.enabled == 'true' &&
-          steps.artifact.outputs.available == 'true'
+          steps.artifact.outputs.available == 'true' &&
+          steps.bundle.outputs.publish == 'true'
         shell: bash
         run: |
           {

--- a/.github/workflows/google-play-closed-testing.yml
+++ b/.github/workflows/google-play-closed-testing.yml
@@ -13,8 +13,9 @@ name: Google Play Closed Testing
 #     workflow dispatched the build for it;
 #   * only the release-signed AAB artifact is accepted;
 #   * ad-hoc manual builds are never auto-published;
+#   * the release tag named by the bundle must actually exist;
 #   * the production track is explicitly rejected, including as one entry of
-#     a multi-track value.
+#     a multi-track value, whatever whitespace the value carries.
 
 on:
   workflow_run:
@@ -53,16 +54,24 @@ jobs:
             enabled=false
           fi
 
-          if [ -z "$GOOGLE_PLAY_TRACK" ]; then
+          # Strip every whitespace character from the whole value before
+          # looking at it. `read` stops at the first newline, so validating the
+          # raw variable would only ever see line one: a value like
+          # "internal,<newline>production" would pass the check below and still
+          # reach the upload action with production in it. Normalizing first
+          # also means the value shipped to the action is exactly the value
+          # that was validated.
+          tracks="$(printf '%s' "$GOOGLE_PLAY_TRACK" | tr -d '[:space:]')"
+
+          if [ -z "$tracks" ]; then
             echo "::notice::Google Play publishing is not connected yet: GOOGLE_PLAY_TRACK is missing."
             enabled=false
           else
             # The upload action's `tracks` input is plural: a comma-separated
             # list. Reject production as any entry, not just as the whole
             # value, so "internal,production" cannot slip past the check.
-            IFS=',' read -ra requested_tracks <<< "$GOOGLE_PLAY_TRACK"
+            IFS=',' read -ra requested_tracks <<< "$tracks"
             for requested in "${requested_tracks[@]}"; do
-              requested="$(printf '%s' "$requested" | tr -d '[:space:]')"
               if [ "$requested" = "production" ]; then
                 echo "::error::Automatic production publishing is intentionally disabled. Set GOOGLE_PLAY_TRACK to a testing track."
                 exit 1
@@ -71,6 +80,7 @@ jobs:
           fi
 
           echo "enabled=$enabled" >> "$GITHUB_OUTPUT"
+          echo "tracks=$tracks" >> "$GITHUB_OUTPUT"
 
           if [ "$enabled" != "true" ]; then
             echo "Google Play upload skipped. Complete docs/google-play-publishing.md to enable it." >> "$GITHUB_STEP_SUMMARY"
@@ -120,6 +130,8 @@ jobs:
         if: >-
           steps.config.outputs.enabled == 'true' &&
           steps.artifact.outputs.available == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
           mapfile -t bundles < <(find play-upload -type f -name '*.aab' -print)
@@ -151,6 +163,23 @@ jobs:
               ;;
           esac
 
+          # The file name only records what the upstream build was TOLD to
+          # target. A manual dispatch can pass a `release_tag` that matches
+          # pubspec.yaml but was never actually tagged: the upstream preflight
+          # still passes and its attach job treats the missing Release as a
+          # no-op success, so a run like that would reach here with a
+          # tag-shaped name. Confirm the tag really exists before anything
+          # reaches Play. The stable release workflow pushes the tag and
+          # creates the Release before dispatching the build, so a genuine
+          # release always passes this.
+          tag="${name#linthra-}"
+          tag="${tag%-release-signed.aab}"
+
+          if ! gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" >/dev/null 2>&1; then
+            echo "::error::Bundle claims tag '${tag}', but no such tag exists in this repository. Refusing to publish an untagged build."
+            exit 1
+          fi
+
           echo "publish=true" >> "$GITHUB_OUTPUT"
           echo "path=$bundle" >> "$GITHUB_OUTPUT"
 
@@ -166,7 +195,7 @@ jobs:
           serviceAccountJsonPlainText: ${{ env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: ${{ env.GOOGLE_PLAY_PACKAGE_NAME }}
           releaseFiles: ${{ steps.bundle.outputs.path }}
-          tracks: ${{ env.GOOGLE_PLAY_TRACK }}
+          tracks: ${{ steps.config.outputs.tracks }}
           status: completed
 
       - name: Record publication summary
@@ -174,13 +203,15 @@ jobs:
           steps.config.outputs.enabled == 'true' &&
           steps.artifact.outputs.available == 'true' &&
           steps.bundle.outputs.publish == 'true'
+        env:
+          PUBLISHED_TRACKS: ${{ steps.config.outputs.tracks }}
         shell: bash
         run: |
           {
             echo "### Google Play testing upload"
             echo ""
             echo "- Package: \`$GOOGLE_PLAY_PACKAGE_NAME\`"
-            echo "- Track: \`$GOOGLE_PLAY_TRACK\`"
+            echo "- Track: \`$PUBLISHED_TRACKS\`"
             echo "- Source run: \`${{ github.event.workflow_run.id }}\`"
             echo "- Source commit: \`${{ github.event.workflow_run.head_sha }}\`"
             echo "- Bundle: \`${{ steps.bundle.outputs.path }}\`"

--- a/docs/google-play-publishing.md
+++ b/docs/google-play-publishing.md
@@ -19,7 +19,8 @@ For an `Android Release Build` that completes successfully for a release tag:
 3. Debug-signed prereleases are skipped automatically.
 4. The signed AAB is downloaded without rebuilding Linthra.
 5. The bundle name is checked to confirm the build really was for a tag.
-6. The bundle is uploaded to the configured Google Play testing track with
+6. The tag named by that bundle is confirmed to exist in the repository.
+7. The bundle is uploaded to the configured Google Play testing track with
    status `completed`.
 
 Both release paths are covered: a directly pushed `v*` tag, and
@@ -30,10 +31,18 @@ the bundle name the build produces: a tag build writes
 `linthra-<tag>-release-signed.aab`, while a manual build writes
 `linthra-release-signed.aab`.
 
+The bundle name records only what the build was told to target, so it is not
+proof on its own: a manual dispatch can pass a `release_tag` that matches
+`pubspec.yaml` but was never tagged. The tag is confirmed through the API
+before anything is uploaded. `/publish-stable` pushes the tag and creates the
+Release before dispatching the build, so a genuine release always passes.
+
 The workflow explicitly rejects `production` as a track, including as one entry
 of a multi-track value such as `internal,production`, since the upload action
-accepts a comma-separated list. Promotion to production stays a manual
-maintainer decision in Play Console.
+accepts a comma-separated list. All whitespace is stripped from the value
+before it is split, so a newline cannot hide an entry from the check, and the
+upload action is given that same normalized value rather than the raw variable.
+Promotion to production stays a manual maintainer decision in Play Console.
 
 ## One-time Google Play setup
 
@@ -142,6 +151,7 @@ The publisher is intentionally conservative:
 - missing service-account secret → skip with a notice;
 - missing track variable → skip with a notice;
 - `production` track, alone or inside a multi-track value → fail;
+- bundle names a tag that does not exist → fail;
 - upstream Android release failed → publisher does not run;
 - ad-hoc manual Android release build (no release tag) → skip with a notice;
 - no release-signed AAB (for example, a debug-signed prerelease) → skip with a

--- a/docs/google-play-publishing.md
+++ b/docs/google-play-publishing.md
@@ -12,19 +12,28 @@ notice instead of breaking normal GitHub releases.
 
 ## What is already automated
 
-For a tag-triggered `Android Release Build` that completes successfully:
+For an `Android Release Build` that completes successfully for a release tag:
 
 1. GitHub checks whether Google Play publishing is configured.
 2. It looks for the `linthra-release-signed-aab` artifact from that exact run.
 3. Debug-signed prereleases are skipped automatically.
 4. The signed AAB is downloaded without rebuilding Linthra.
-5. The bundle is uploaded to the configured Google Play testing track with
+5. The bundle name is checked to confirm the build really was for a tag.
+6. The bundle is uploaded to the configured Google Play testing track with
    status `completed`.
 
-Manual `workflow_dispatch` release builds are never auto-published.
+Both release paths are covered: a directly pushed `v*` tag, and
+`/publish-stable`, which dispatches `Android Release Build` with a
+`release_tag` rather than pushing the tag itself. Ad-hoc manual
+`workflow_dispatch` builds are never auto-published. The two are told apart by
+the bundle name the build produces: a tag build writes
+`linthra-<tag>-release-signed.aab`, while a manual build writes
+`linthra-release-signed.aab`.
 
-The workflow explicitly rejects `production` as a track. Promotion to
-production stays a manual maintainer decision in Play Console.
+The workflow explicitly rejects `production` as a track, including as one entry
+of a multi-track value such as `internal,production`, since the upload action
+accepts a comma-separated list. Promotion to production stays a manual
+maintainer decision in Play Console.
 
 ## One-time Google Play setup
 
@@ -104,7 +113,7 @@ GOOGLE_PLAY_TRACK
 Set it to the closed testing track identifier from Play Console.
 
 Do **not** set it to `production`; the workflow fails deliberately if production
-is configured.
+is configured, including when it appears as one entry of a comma-separated list.
 
 ## Result
 
@@ -132,9 +141,9 @@ The publisher is intentionally conservative:
 
 - missing service-account secret → skip with a notice;
 - missing track variable → skip with a notice;
-- `production` track → fail;
+- `production` track, alone or inside a multi-track value → fail;
 - upstream Android release failed → publisher does not run;
-- manual Android release build → publisher does not run;
+- ad-hoc manual Android release build (no release tag) → skip with a notice;
 - no release-signed AAB (for example, a debug-signed prerelease) → skip with a
   notice;
 - multiple matching signed AAB artifacts → fail;

--- a/docs/google-play-publishing.md
+++ b/docs/google-play-publishing.md
@@ -37,8 +37,10 @@ proof on its own: a manual dispatch can pass a `release_tag` that matches
 `pubspec.yaml` but was never tagged. `Android Release Build` also checks out
 its dispatch ref rather than the tag, so a build started while the branch had
 moved past the tag would carry code the tag does not name. Before uploading,
-the tag is resolved through the API and must point at the commit the build
-actually ran on. Both a missing tag and a mismatched commit fail the run.
+the name is looked up as a tag ref specifically (`git/ref/tags/...`, not a
+generic ref that a branch of the same name would also satisfy), annotated tags
+are dereferenced to their commit, and that commit must equal the one the build
+actually ran on. A missing tag and a mismatched commit fail separately.
 
 If a stable release trips the commit check, the artifact genuinely is not the
 tagged code: re-run the build against the tagged commit rather than relaxing

--- a/docs/google-play-publishing.md
+++ b/docs/google-play-publishing.md
@@ -19,7 +19,8 @@ For an `Android Release Build` that completes successfully for a release tag:
 3. Debug-signed prereleases are skipped automatically.
 4. The signed AAB is downloaded without rebuilding Linthra.
 5. The bundle name is checked to confirm the build really was for a tag.
-6. The tag named by that bundle is confirmed to exist in the repository.
+6. The tag named by that bundle is resolved, and must point at the very
+   commit the build ran on.
 7. The bundle is uploaded to the configured Google Play testing track with
    status `completed`.
 
@@ -33,9 +34,15 @@ the bundle name the build produces: a tag build writes
 
 The bundle name records only what the build was told to target, so it is not
 proof on its own: a manual dispatch can pass a `release_tag` that matches
-`pubspec.yaml` but was never tagged. The tag is confirmed through the API
-before anything is uploaded. `/publish-stable` pushes the tag and creates the
-Release before dispatching the build, so a genuine release always passes.
+`pubspec.yaml` but was never tagged. `Android Release Build` also checks out
+its dispatch ref rather than the tag, so a build started while the branch had
+moved past the tag would carry code the tag does not name. Before uploading,
+the tag is resolved through the API and must point at the commit the build
+actually ran on. Both a missing tag and a mismatched commit fail the run.
+
+If a stable release trips the commit check, the artifact genuinely is not the
+tagged code: re-run the build against the tagged commit rather than relaxing
+the check.
 
 The workflow explicitly rejects `production` as a track, including as one entry
 of a multi-track value such as `internal,production`, since the upload action
@@ -152,6 +159,7 @@ The publisher is intentionally conservative:
 - missing track variable → skip with a notice;
 - `production` track, alone or inside a multi-track value → fail;
 - bundle names a tag that does not exist → fail;
+- tag does not point at the commit the build ran on → fail;
 - upstream Android release failed → publisher does not run;
 - ad-hoc manual Android release build (no release tag) → skip with a notice;
 - no release-signed AAB (for example, a debug-signed prerelease) → skip with a

--- a/test/tooling/google_play_publishing_guardrails_test.dart
+++ b/test/tooling/google_play_publishing_guardrails_test.dart
@@ -23,12 +23,32 @@ void main() {
       expect(workflow, contains('linthra-release-signed-aab'));
     });
 
-    test('only considers successful tag-triggered upstream runs', () {
+    test('only considers successful upstream runs', () {
       expect(
         workflow,
         contains("github.event.workflow_run.conclusion == 'success'"),
       );
+    });
+
+    // The stable-release workflow starts the signed Android build with
+    // `gh workflow run`, so its upstream run reports `workflow_dispatch`.
+    // Accepting only `push` would skip every stable release.
+    test('accepts both pushed tags and dispatched release builds', () {
       expect(workflow, contains("github.event.workflow_run.event == 'push'"));
+      expect(
+        workflow,
+        contains("github.event.workflow_run.event == 'workflow_dispatch'"),
+      );
+    });
+
+    test('auto-publishes tagged releases only, never ad-hoc manual builds', () {
+      expect(workflow, contains('linthra-v*-release-signed.aab)'));
+      expect(workflow, contains('publish=false'));
+      expect(workflow, contains('publish=true'));
+      expect(
+        workflow,
+        contains("steps.bundle.outputs.publish == 'true'"),
+      );
     });
 
     test('keeps repository permissions read-only', () {
@@ -66,12 +86,26 @@ void main() {
 
   group('Google Play publisher safety', () {
     test('never accepts production as an automatic target', () {
-      expect(workflow, contains(r'[ "$GOOGLE_PLAY_TRACK" = "production" ]'));
+      expect(workflow, contains(r'[ "$requested" = "production" ]'));
       expect(
         workflow,
         contains('Automatic production publishing is intentionally disabled.'),
       );
       expect(documentation, contains('Do **not** set it to `production`'));
+    });
+
+    // The pinned action's `tracks` input is plural, so a value like
+    // "internal,production" must not slip past an exact-string comparison.
+    test('rejects production inside a multi-track value', () {
+      expect(workflow, contains("IFS=',' read -ra requested_tracks"));
+      expect(
+        workflow,
+        contains(r'for requested in "${requested_tracks[@]}"'),
+      );
+      expect(
+        workflow,
+        isNot(contains(r'[ "$GOOGLE_PLAY_TRACK" = "production" ]')),
+      );
     });
 
     test('requires the release-signed AAB artifact', () {

--- a/test/tooling/google_play_publishing_guardrails_test.dart
+++ b/test/tooling/google_play_publishing_guardrails_test.dart
@@ -55,9 +55,27 @@ void main() {
     // was never actually tagged, which still produces a tag-shaped bundle
     // name. The name alone is therefore not proof that a release exists.
     test('confirms the tag named by the bundle actually exists', () {
+      // A tag ref specifically: the Commits API would also accept a branch
+      // named like a version, which would prove nothing about a tag.
       expect(
-          workflow, contains(r'gh api "repos/${GITHUB_REPOSITORY}/commits/'));
+        workflow,
+        contains(r'gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/'),
+      );
+      expect(
+        workflow,
+        isNot(contains(r'gh api "repos/${GITHUB_REPOSITORY}/commits/')),
+      );
       expect(workflow, contains('Refusing to publish an untagged build.'));
+    });
+
+    // The stable release workflow creates an annotated tag, whose ref points
+    // at a tag object rather than the commit it names.
+    test('dereferences annotated tags before comparing commits', () {
+      expect(workflow, contains(r'[ "$tag_object_type" = "tag" ]'));
+      expect(
+        workflow,
+        contains(r'gh api "repos/${GITHUB_REPOSITORY}/git/tags/'),
+      );
     });
 
     // Android Release Build checks out its dispatch ref, never the tag, so a

--- a/test/tooling/google_play_publishing_guardrails_test.dart
+++ b/test/tooling/google_play_publishing_guardrails_test.dart
@@ -51,6 +51,14 @@ void main() {
       );
     });
 
+    // A manual dispatch can pass a `release_tag` that matches pubspec.yaml but
+    // was never actually tagged, which still produces a tag-shaped bundle
+    // name. The name alone is therefore not proof that a release exists.
+    test('confirms the tag named by the bundle actually exists', () {
+      expect(workflow, contains('git/ref/tags/'));
+      expect(workflow, contains('Refusing to publish an untagged build.'));
+    });
+
     test('keeps repository permissions read-only', () {
       expect(workflow, contains('actions: read'));
       expect(workflow, contains('contents: read'));
@@ -105,6 +113,19 @@ void main() {
       expect(
         workflow,
         isNot(contains(r'[ "$GOOGLE_PLAY_TRACK" = "production" ]')),
+      );
+    });
+
+    // `read` stops at the first newline, so a value carrying one could hide an
+    // entry behind it. The whole value is stripped of whitespace before being
+    // split, and the upload action receives that same normalized value.
+    test('strips whitespace before splitting, and ships what it checked', () {
+      expect(workflow, contains("tr -d '[:space:]'"));
+      expect(workflow, contains(r'<<< "$tracks"'));
+      expect(workflow, contains(r'tracks: ${{ steps.config.outputs.tracks }}'));
+      expect(
+        workflow,
+        isNot(contains(r'tracks: ${{ env.GOOGLE_PLAY_TRACK }}')),
       );
     });
 

--- a/test/tooling/google_play_publishing_guardrails_test.dart
+++ b/test/tooling/google_play_publishing_guardrails_test.dart
@@ -55,8 +55,23 @@ void main() {
     // was never actually tagged, which still produces a tag-shaped bundle
     // name. The name alone is therefore not proof that a release exists.
     test('confirms the tag named by the bundle actually exists', () {
-      expect(workflow, contains('git/ref/tags/'));
+      expect(
+          workflow, contains(r'gh api "repos/${GITHUB_REPOSITORY}/commits/'));
       expect(workflow, contains('Refusing to publish an untagged build.'));
+    });
+
+    // Android Release Build checks out its dispatch ref, never the tag, so a
+    // build dispatched while the branch carried commits past the tag makes a
+    // tag-named bundle whose code the tag does not name. Existing is not
+    // enough; the tag has to point at the commit the build ran on.
+    test('binds the bundle to the commit the tag names', () {
+      expect(workflow,
+          contains(r'SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}'));
+      expect(workflow, contains(r'[ "$tag_sha" != "$SOURCE_SHA" ]'));
+      expect(
+        workflow,
+        contains('Refusing to publish code the tag does not name.'),
+      );
     });
 
     test('keeps repository permissions read-only', () {


### PR DESCRIPTION
Follow-up to #552. Two P1 findings were fixed and answered on that PR, but the merge landed on the earlier head so they never reached `main`. This carries them over and closes three further findings that came out of review here.

## Stable releases would never have published

The job only admitted `workflow_run.event == 'push'`. The official stable path (`/publish-stable`) starts the signed Android build with `gh workflow run` (`publish-stable-release.yml:140`), so its upstream run reports `workflow_dispatch`. Every stable release would have been skipped and its AAB would never have reached Play.

Admitting `workflow_dispatch` on its own would let ad-hoc manual signed builds auto-publish, which the workflow explicitly promises not to do. So the gate moved off the event and onto the bundle name: `Determine build mode` writes `linthra-<tag>-release-signed.aab` when a tag drives the build and `linthra-release-signed.aab` otherwise. Both upload under the same artifact name, so the file name is what distinguishes them. Only the tag form publishes; a manual build skips with a notice rather than failing.

## The bundle name alone is not proof of a release

The name records only what the build was *told* to target. Three ways that diverges from reality, all now checked:

- a dispatch can pass a `release_tag` that matches `pubspec.yaml` but was never tagged. The preflight passes and the attach job no-ops on the missing Release, producing a tag-shaped name for a tag that does not exist.
- `Android Release Build` checks out its dispatch ref, never the tag. The stable path tags the merged release commit but dispatches with `--ref main`, so anything landing on main in between would be built and published under the tag's name.
- a lookup that accepts any ref proves nothing about a tag: a branch named like a version would satisfy it.

So the name is looked up as a tag ref specifically (`git/ref/tags/<tag>`, the exact-match singular endpoint). Annotated tags, which is what `/publish-stable` creates, resolve to a tag object, so those get one more hop through `git/tags/<sha>` to reach the commit. That commit must equal the one the run actually built. Missing tag and mismatched commit fail separately so the log says which. If a stable release ever trips the commit check the artifact genuinely is not the tagged code, and the fix is to rebuild against the tagged commit rather than relax the check.

## production could slip past the track guard

Two separate holes:

- the check compared the whole variable, so `internal,production` passed while the pinned action's plural `tracks` input would still have shipped to production.
- `read` stops at the first newline, so a value like `internal,<newline>production` was checked as a single entry and production was never seen at all.

All whitespace is now stripped from the value before it is split, and the action receives that same normalized value rather than the raw variable, so what ships is exactly what was validated. A whitespace-only value reads as missing instead of as an empty track. The publication summary takes the track through an env var rather than splicing the expression into the shell.

## Verification

Ran against the pinned SDK (Flutter 3.44.7, same as CI). Both changed shell blocks were also extracted and exercised directly against a stubbed API:

- tracks rejected: `production`, `internal,production`, `internal, production`, `internal,<newline>production`, and the same with padding
- tracks accepted: `alpha,beta`, `productionish` (no false positive), `  internal  ` normalizing to `internal`
- bundles published: annotated tag at its own commit, lightweight tag at its own commit
- bundles rejected: right tag built on a different SHA (mismatch), a branch named `v1.2.3` with no such tag (untagged), a name resolving to nothing (untagged), zero or multiple `.aab` files
- bundles skipped: `linthra-release-signed.aab`, before either tag check runs

`dart format --set-exit-if-changed` clean, `flutter analyze` clean, `flutter test` 3983 passing. Guardrail tests (12 to 19) and `docs/google-play-publishing.md` updated so the stated safety rules match the actual behavior.

Google Play is still not connected, so the workflow keeps reporting a notice and does nothing until the secret and track variable exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012i7YNZDagrag7q5Ef9NsRY