### PR TITLE
fix(linux): make the running window identify as io.github.thezupzup.linthra (#554)

### DIFF
--- a/.github/workflows/flatpak-build.yml
+++ b/.github/workflows/flatpak-build.yml
@@ -63,15 +63,25 @@ jobs:
       # happens to suggest. The cost is that every tool has to be named here,
       # including ones a dependency would otherwise have pulled in.
       #
-      # elfutils is exactly that case. flatpak-builder only *recommends* it, so
-      # --no-install-recommends leaves the runner without `eu-strip` and
-      # `eu-elfcompress`, and flatpak-builder needs `eu-strip` to split debug
-      # symbols out of every module it builds. Without it the build dies on the
-      # first native module with
+      # Two of these are here because of that, and both failed the same way:
+      # silently absent, then a build error nowhere near the real cause.
+      #
+      # elfutils: flatpak-builder only *recommends* it, so the runner had no
+      # `eu-strip`, which flatpak-builder needs to split debug symbols out of
+      # every module it builds. The build died on the first native module with
       #   Error: module libplacebo: Failed to execute child process "eu-strip"
-      # long before the Linthra module is reached. Installing the package is the
-      # fix rather than passing --disable-debuginfo, which would silently change
-      # what the exported repository contains.
+      # long before the Linthra module was reached. Installing the package is
+      # the fix rather than passing --disable-debuginfo, which would silently
+      # change what the exported repository contains.
+      #
+      # librsvg2-common: nothing in `appstream`/`appstream-compose` depends on
+      # or recommends it, and it is what gives gdk-pixbuf its SVG loader.
+      # Without it, the `appstreamcli compose` that flatpak-builder runs at
+      # finish time cannot read Linthra's scalable icon, drops the component,
+      # and fails the whole build with
+      #   io.github.thezupzup.linthra  E: file-read-error
+      #   general                      E: filters-but-no-output
+      # whose hint report names the icon and "Unrecognized image file format".
       - name: Install host validation and smoke tools
         run: |
           set -euo pipefail
@@ -83,6 +93,7 @@ jobs:
             elfutils \
             flatpak \
             flatpak-builder \
+            librsvg2-common \
             x11-utils \
             xvfb
 

--- a/.github/workflows/flatpak-build.yml
+++ b/.github/workflows/flatpak-build.yml
@@ -58,6 +58,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      # --no-install-recommends is deliberate: it keeps the runner close to the
+      # set of tools this job actually needs, rather than whatever a package
+      # happens to suggest. The cost is that every tool has to be named here,
+      # including ones a dependency would otherwise have pulled in.
+      #
+      # elfutils is exactly that case. flatpak-builder only *recommends* it, so
+      # --no-install-recommends leaves the runner without `eu-strip` and
+      # `eu-elfcompress`, and flatpak-builder needs `eu-strip` to split debug
+      # symbols out of every module it builds. Without it the build dies on the
+      # first native module with
+      #   Error: module libplacebo: Failed to execute child process "eu-strip"
+      # long before the Linthra module is reached. Installing the package is the
+      # fix rather than passing --disable-debuginfo, which would silently change
+      # what the exported repository contains.
       - name: Install host validation and smoke tools
         run: |
           set -euo pipefail
@@ -66,6 +80,7 @@ jobs:
             appstream \
             dbus-x11 \
             desktop-file-utils \
+            elfutils \
             flatpak \
             flatpak-builder \
             x11-utils \

--- a/docs/flatpak-ci.md
+++ b/docs/flatpak-ci.md
@@ -39,6 +39,13 @@ Install the host tooling first. On Fedora Atomic, the contributor setup in
 [`flatpak-development.md`](./flatpak-development.md) remains the recommended
 path. On a distribution with native `flatpak-builder`, the core CI sequence is:
 
+> `flatpak-builder` needs **elfutils** (`eu-strip`) to split debug symbols out
+> of each module it builds. Most distributions pull it in with
+> `flatpak-builder`; Debian and Ubuntu only *recommend* it, so a minimal install
+> leaves it out and the build fails on the first native module with
+> `Failed to execute child process "eu-strip"`. The CI job names it explicitly
+> for that reason.
+
 ```bash
 python3 scripts/check_linux_runner.py
 python3 test/tooling/check_linux_runner_test.py
@@ -74,8 +81,8 @@ flatpak build-update-repo repo-ci
 bash ../scripts/flatpak_launch_smoke.sh repo-ci
 ```
 
-The launch command requires `xvfb-run`, `xwininfo` and `dbus-run-session`, the
-same tools installed by the CI job. It intentionally refuses to run if Linthra
+The launch command requires `xvfb-run`, `xwininfo`, `xprop` and
+`dbus-run-session`, the same tools installed by the CI job. It intentionally refuses to run if Linthra
 is already installed for the current user or system-wide, so a local smoke can
 never launch or remove a contributor's existing installation. Use a clean test
 user/environment for this final step when Linthra is already installed.

--- a/docs/flatpak-ci.md
+++ b/docs/flatpak-ci.md
@@ -39,12 +39,19 @@ Install the host tooling first. On Fedora Atomic, the contributor setup in
 [`flatpak-development.md`](./flatpak-development.md) remains the recommended
 path. On a distribution with native `flatpak-builder`, the core CI sequence is:
 
-> `flatpak-builder` needs **elfutils** (`eu-strip`) to split debug symbols out
-> of each module it builds. Most distributions pull it in with
-> `flatpak-builder`; Debian and Ubuntu only *recommend* it, so a minimal install
-> leaves it out and the build fails on the first native module with
-> `Failed to execute child process "eu-strip"`. The CI job names it explicitly
-> for that reason.
+> Two host packages are easy to miss because nothing hard-depends on them, and
+> both fail late and confusingly:
+>
+> * **elfutils** (`eu-strip`), which `flatpak-builder` uses to split debug
+>   symbols out of each module. Debian and Ubuntu only *recommend* it, so a
+>   minimal install leaves it out and the build fails on the first native module
+>   with `Failed to execute child process "eu-strip"`.
+> * **librsvg2-common**, the gdk-pixbuf SVG loader. Without it the
+>   `appstreamcli compose` step at finish time cannot read Linthra's scalable
+>   icon and fails the build with `file-read-error` plus
+>   `filters-but-no-output`. Nothing in `appstream` depends on or recommends it.
+>
+> The CI job names both explicitly for that reason.
 
 ```bash
 python3 scripts/check_linux_runner.py

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -286,9 +286,14 @@ widget.
 
 * `scripts/check_linux_runner.py` — the committed runner still matches the app's
   identity (`APPLICATION_ID` = Android's `applicationId`, `BINARY_NAME` =
-  the package name, window title = `AppInfo.name`), the window metrics are
-  sane, the offline SQLite seam is wired, and nothing under `linux/` hardcodes
-  an absolute host path. Tests: `test/tooling/check_linux_runner_test.py`.
+  the package name, window title = `AppInfo.name`), it still makes the four
+  desktop-identity calls below in the places where GTK honours them, the window
+  metrics are sane, the offline SQLite seam is wired, and nothing under `linux/`
+  hardcodes an absolute host path.
+  Tests: `test/tooling/check_linux_runner_test.py`.
+* `scripts/flatpak_launch_smoke.sh` — launches the packaged Flatpak twice and
+  reads `WM_CLASS` and `_NET_WM_ICON` back off the real window each time, so a
+  window that stops answering to the application id fails CI.
 * `test/app/linux_startup_test.dart` — every provider `main()` reads before the
   first frame constructs on a Linux host, with no Android MethodChannel
   binding among them.
@@ -300,6 +305,40 @@ widget.
 `unmanaged_files` in `.metadata`, so `flutter migrate` leaves Linthra's edits
 alone. If someone re-runs `flutter create --platforms=linux .` anyway, the
 checker above is what catches the reverted title and the lost SQLite seam.
+
+## Desktop identity
+
+Everything Linthra installs on Linux is named `io.github.thezupzup.linthra`: the
+desktop entry, the icon, the AppStream component, the Flatpak. The *running
+window* only joins them if the runner says so, and each display server reads a
+different thing, so `linux/runner/my_application.cc` sets all of them from
+`APPLICATION_ID` (never from a literal):
+
+| Call | Where | What reads it |
+| --- | --- | --- |
+| `g_set_prgname(APPLICATION_ID)` | `my_application_new()`, before `gtk_init()` | GTK 3 sends this as the Wayland `xdg_toplevel` app id, and as the instance half of X11's `WM_CLASS` |
+| `gdk_set_program_class(APPLICATION_ID)` | `my_application_startup()`, **after** the chain-up | the class half of `WM_CLASS`. GDK's default is the program name with its first letter upper-cased, which is not the app id |
+| `gtk_window_set_default_icon_name(APPLICATION_ID)` | same | GTK attaches the themed icon as `_NET_WM_ICON`; without it the window has no icon of its own |
+| `g_set_application_name(AppInfo.name)` | same | `g_get_application_name()`, which GTK and portals show to the user |
+
+The two in `my_application_startup()` have to run after the chain-up to
+`GtkApplication::startup`: that is what calls `gtk_init()`, and `gtk_init()`
+resets GDK's program class unconditionally. Set earlier, they compile, run, and
+are thrown away.
+
+`linux/packaging/io.github.thezupzup.linthra.desktop` declares the same X11 pair
+as `StartupWMClass=`, so a shell matches the window to the entry exactly rather
+than falling back to lower-casing whatever class it finds.
+
+One more thing decides whether the icon appears at all: **the `<svg` root element
+has to start within the first 256 bytes of `tool/branding/linthra_icon.svg`**.
+An SVG has no magic number, so content sniffing looks for that literal string and
+gives up after 256 bytes. Push it past that (a licence header, a `DOCTYPE`, a
+descriptive comment between the XML declaration and the root tag) and gdk-pixbuf
+refuses the file outright: GTK cannot load it as a themed icon, and every
+launcher that resolves icons through that stack shows a generic one. The file
+still parses, still validates, and still renders in a browser, which is why the
+checker measures the offset. Put comments *inside* the root element.
 
 ## Suspend / resume (manual matrix)
 

--- a/flatpak/flatpak-flutter.yml
+++ b/flatpak/flatpak-flutter.yml
@@ -194,6 +194,18 @@ modules:
   - name: libplacebo
     buildsystem: meson
     config-opts:
+      # Pin the install layout. flatpak-builder passes meson only --prefix=/app,
+      # and meson then resolves its *own* default libdir, which is `lib64`
+      # inside this SDK because the freedesktop base image carries a real
+      # /usr/lib64 directory. That puts libplacebo.so and libplacebo.pc in
+      # /app/lib64, which is on neither of the two paths that matter:
+      # flatpak-builder's PKG_CONFIG_PATH (so the mpv module below fails its
+      # `Dependency "libplacebo" not found` check) nor the sandbox's runtime
+      # library path. The autotools modules here already land in /app/lib
+      # because flatpak-builder passes them --libdir=/app/lib; this pins the
+      # meson ones to the same place, which is also what flatpak/README.md
+      # documents ("installed under /app/lib").
+      - -Dlibdir=lib
       - -Dvulkan=enabled
       - -Dshaderc=disabled
       - -Dglslang=disabled
@@ -233,6 +245,11 @@ modules:
   - name: mpv
     buildsystem: meson
     config-opts:
+      # Same meson libdir pin as libplacebo above, and it matters more here:
+      # media_kit/just_audio_media_kit dlopen this libmpv by soname at startup,
+      # so it has to sit on the sandbox's library path rather than in
+      # /app/lib64.
+      - -Dlibdir=lib
       # Only libmpv is needed; the mpv CLI player pulls in scripting, disc
       # and gamepad stacks Linthra never touches.
       - -Dcplayer=false

--- a/flatpak/io.github.thezupzup.linthra.yml
+++ b/flatpak/io.github.thezupzup.linthra.yml
@@ -40,6 +40,7 @@ modules:
   - name: libplacebo
     buildsystem: meson
     config-opts:
+      - -Dlibdir=lib
       - -Dvulkan=enabled
       - -Dshaderc=disabled
       - -Dglslang=disabled
@@ -75,6 +76,7 @@ modules:
   - name: mpv
     buildsystem: meson
     config-opts:
+      - -Dlibdir=lib
       - -Dcplayer=false
       - -Dlibmpv=true
       - -Dgpl=false

--- a/linux/packaging/io.github.thezupzup.linthra.desktop
+++ b/linux/packaging/io.github.thezupzup.linthra.desktop
@@ -18,10 +18,14 @@
 # check_linux_runner.py holds that filename and this `Icon=` together, and its
 # absolute-path scan covers this file too.
 #
-# The window this launches identifies itself with the same id — the runner
-# calls `g_set_prgname(APPLICATION_ID)` and registers its GtkApplication under
-# it (linux/runner/my_application.cc) — so the running window associates with
-# this entry on both Wayland and X11 without a `StartupWMClass=` override.
+# The window this launches identifies itself with the same id. The runner
+# (linux/runner/my_application.cc) registers its GtkApplication under
+# APPLICATION_ID, calls `g_set_prgname(APPLICATION_ID)` so GTK 3 sends that id
+# as the Wayland `xdg_toplevel.set_app_id`, and calls
+# `gdk_set_program_class(APPLICATION_ID)` so both halves of X11's `WM_CLASS`
+# are the id too. `StartupWMClass=` below declares that X11 pair, so a shell
+# matches the window to this entry exactly instead of relying on its
+# lower-casing fallback (#554).
 #
 # Validate after editing:  desktop-file-validate linux/packaging/io.github.thezupzup.linthra.desktop
 [Desktop Entry]
@@ -40,3 +44,11 @@ Terminal=false
 Categories=AudioVideo;Audio;Player;Music;
 Keywords=music;audio;player;library;playlist;jellyfin;subsonic;navidrome;plex;
 StartupNotify=true
+# The X11 `WM_CLASS` the running window actually carries. GTK builds that pair
+# from `g_get_prgname()` and `gdk_get_program_class()`, and the runner sets both
+# to the application id, so this value is the id as well. It has to stay equal
+# to the filename's id: a stale value here is worse than none, because a shell
+# trusts an exact StartupWMClass match over every other heuristic and would map
+# Linthra's window to whatever entry claims it. Wayland ignores this key and
+# uses the app id directly. check_linux_runner.py holds the two together.
+StartupWMClass=io.github.thezupzup.linthra

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -142,9 +142,53 @@ static gboolean my_application_local_command_line(GApplication* application,
 static void my_application_startup(GApplication* application) {
   // MyApplication* self = MY_APPLICATION(object);
 
-  // Perform any actions required at application startup.
-
+  // Chain up first. GtkApplication::startup is what calls gtk_init(), and
+  // gtk_init() reaches gdk_pre_parse(), which unconditionally resets GDK's
+  // program class from g_get_prgname(). Anything set below before this line
+  // would be silently overwritten, so the order here is part of the fix rather
+  // than a style choice.
   G_APPLICATION_CLASS(my_application_parent_class)->startup(application);
+
+  // === Desktop identity (#554) ===
+  //
+  // Several different names leave this process, and a desktop only groups the
+  // running window under the installed launcher when they all agree with
+  // io.github.thezupzup.linthra: the id of the desktop entry, the icon, the
+  // AppStream component and the Flatpak. Each one below is derived from
+  // APPLICATION_ID (linux/CMakeLists.txt) rather than written out again, so
+  // there is no second copy of the id that can drift.
+  // scripts/check_linux_runner.py enforces the calls and this ordering.
+  //
+  // The Wayland half is already handled in my_application_new(): GTK 3 sends
+  // xdg_toplevel.set_app_id() from g_get_prgname().
+
+  // The human-readable name. Without it, g_get_application_name() falls back to
+  // g_get_prgname(), which my_application_new() has deliberately set to the
+  // reverse-DNS id, so portal dialogs and GTK's own "application is not
+  // responding" prompt would say "io.github.thezupzup.linthra" at the user.
+  g_set_application_name(kApplicationName);
+
+  // X11, including XWayland under the Flatpak's --socket=fallback-x11. GTK
+  // stamps WM_CLASS from g_get_prgname() and gdk_get_program_class() when each
+  // GtkWindow is constructed, and the class half defaults to the program name
+  // with its first letter upper-cased ("Io.github.thezupzup.linthra"), which is
+  // not a string any launcher indexes. Shells that lower-case as a fallback
+  // still find us; ones that compare exactly do not, and the window then drops
+  // out of its launcher group. Setting the class explicitly makes both halves
+  // of WM_CLASS the application id, which is also what the desktop entry's
+  // StartupWMClass= declares.
+  gdk_set_program_class(APPLICATION_ID);
+
+  // The themed window icon. GTK never sets one by itself, so the window carried
+  // no _NET_WM_ICON at all and every task switcher, panel and window list that
+  // reads the window's own icon instead of resolving a desktop entry fell back
+  // to a generic placeholder. This resolves
+  // hicolor/scalable/apps/io.github.thezupzup.linthra.svg, the icon the Flatpak
+  // installs from tool/branding/linthra_icon.svg, through the ordinary icon
+  // theme lookup: it works wherever the icon is installed and is a harmless
+  // no-op where it is not. Wayland has no window-icon protocol and keeps
+  // resolving the same file from the app id instead.
+  gtk_window_set_default_icon_name(APPLICATION_ID);
 }
 
 // Implements GApplication::shutdown.
@@ -180,6 +224,16 @@ MyApplication* my_application_new() {
   // like GTK and desktop environments map this running application to its
   // corresponding .desktop file. This ensures better integration by allowing
   // the application to be recognized beyond its binary name.
+  //
+  // Concretely (#554): this is the Wayland half of the identity. GTK 3 sends
+  // xdg_toplevel.set_app_id() straight from g_get_prgname(), so this call is
+  // what makes GNOME and KDE Plasma resolve the running window to
+  // io.github.thezupzup.linthra.desktop under Wayland. It also supplies the
+  // instance half of X11's WM_CLASS; my_application_startup() sets the class
+  // half, which GDK would otherwise derive from this name.
+  //
+  // It has to happen before gtk_init(), which GtkApplication::startup calls,
+  // because GDK reads the program name there.
   g_set_prgname(APPLICATION_ID);
 
   return MY_APPLICATION(g_object_new(my_application_get_type(),

--- a/scripts/check_linux_runner.py
+++ b/scripts/check_linux_runner.py
@@ -35,11 +35,26 @@ The application icon (#436) is that same silence one step further out. `Icon=`
 is an icon-theme *name*, not a path, so it only resolves if a file of exactly
 that basename lands in the icon theme; install it one directory too high, or
 rename either side, and every launcher quietly falls back to a generic icon
-with nothing logged anywhere. So the manifests are checked for the install step
+with nothing logged anywhere. The same silence swallows an SVG whose `<svg` root
+element starts more than 256 bytes in (#554): content sniffing never finds the
+one signature an SVG has, so gdk-pixbuf refuses the file and GTK cannot load it
+as an icon at all, however valid the XML is. So the manifests are checked for the install step
 that puts Linthra's canonical vector source into `hicolor/scalable/apps` under
 precisely the name `Icon=` asks for, and that source is itself checked for the
 two things that would make it unusable inside a sandbox: an absolute host path,
 or a reference to a file it does not carry.
+
+The *running window* (#554) is the last link in that chain, and the one a
+desktop actually looks at. Nothing installed above matters if the GTK window
+introduces itself under a different name, so the runner is checked for the calls
+that set it: `g_set_prgname()` for the Wayland `xdg_toplevel` app id,
+`gdk_set_program_class()` for the class half of X11's `WM_CLASS` (GDK's default
+is the program name with the first letter upper-cased, which is not the app id),
+`gtk_window_set_default_icon_name()` for the window's own icon, and
+`g_set_application_name()` for the human-readable name. Two of those are undone
+by `gtk_init()` if they run too early, so where they appear is checked as well
+as that they appear. The desktop entry's `StartupWMClass=` is held to the same
+value from the other side.
 
 It also checks the one runner<->Dart contract that is a pair of strings and
 nothing else: the folder-picker method channel (#438). The runner answers on
@@ -138,6 +153,17 @@ ICON_EXTENSION = ".svg"
 
 SVG_ROOT_TAG = "{http://www.w3.org/2000/svg}svg"
 
+# An SVG has no magic number, so content sniffing looks for the literal `<svg`
+# and gives up after this many bytes. An icon whose root element starts later is
+# simply not recognised as an image: gdk-pixbuf refuses to decode it, GTK cannot
+# load it as a themed icon, and every launcher that resolves icons through that
+# stack falls back to a generic one, with nothing logged. A licence header, a
+# DOCTYPE or (as in #554) a descriptive comment between the XML declaration and
+# the root tag is all it takes, and the file still parses, still validates and
+# still renders in a browser, which is why only a check like this catches it.
+# Comments belong inside the root element instead.
+SVG_SIGNATURE_WINDOW_BYTES = 256
+
 # An SVG that pulls in something it does not carry — an <image href=...>, an
 # external stylesheet or font, a `file://` or `https://` reference — renders
 # differently or not at all inside the sandbox, where none of that is
@@ -168,6 +194,75 @@ FOLDER_PICKER_NATIVE_CHANNEL = r'kChannelName\s*=\s*\n?\s*"([^"]+)"'
 FOLDER_PICKER_NATIVE_METHOD = r'kPickFolderMethod\s*=\s*"([^"]+)"'
 FOLDER_PICKER_DART_CHANNEL = r"String channelName\s*=\s*\n?\s*'([^']+)'"
 FOLDER_PICKER_DART_METHOD = r"String pickFolderMethod\s*=\s*'([^']+)'"
+
+# === Window identity (#554) ===
+#
+# The desktop entry, the icon, the AppStream component and the Flatpak are all
+# named for the application id. The *running window* only joins them if the
+# runner says so, and each backend reads a different thing:
+#
+#   Wayland  GTK 3 sends `xdg_toplevel.set_app_id()` straight from
+#            `g_get_prgname()`, so `g_set_prgname(APPLICATION_ID)` is the whole
+#            Wayland story. It has to run before `gtk_init()` reads the program
+#            name, which means inside `my_application_new()`.
+#   X11      GTK builds `WM_CLASS` from `g_get_prgname()` (the instance half)
+#            and `gdk_get_program_class()` (the class half) as each GtkWindow is
+#            constructed. GDK derives that class from the program name with the
+#            first letter upper-cased, which is not the application id, so it is
+#            set explicitly. `gtk_init()` resets the program class
+#            unconditionally, and `GtkApplication::startup` is what calls
+#            `gtk_init()`, so this one has to run *after* the startup chain-up.
+#   Icon     GTK sets no window icon of its own. Without a default icon name the
+#            window carries no `_NET_WM_ICON` and anything reading the window's
+#            icon rather than resolving a desktop entry shows a generic one.
+#
+# None of that fails to build, and none of it fails to launch. It just quietly
+# stops matching the launcher, which is exactly the class of drift this script
+# exists for. The argument is checked too: every one of these has to be the
+# APPLICATION_ID macro, so the id keeps coming from linux/CMakeLists.txt rather
+# than being pasted into the runner as a second copy.
+RUNNER_IDENTITY_NEW_FUNCTION = "MyApplication* my_application_new()"
+RUNNER_IDENTITY_STARTUP_FUNCTION = "static void my_application_startup("
+RUNNER_STARTUP_CHAIN_UP = (
+    "G_APPLICATION_CLASS(my_application_parent_class)->startup(application)"
+)
+APPLICATION_ID_MACRO = "APPLICATION_ID"
+APPLICATION_NAME_CONSTANT = "kApplicationName"
+
+# call -> (function it belongs in, argument it must be given, why)
+RUNNER_IDENTITY_CALLS = {
+    "g_set_prgname": (
+        RUNNER_IDENTITY_NEW_FUNCTION,
+        APPLICATION_ID_MACRO,
+        "GTK 3 sends the Wayland xdg_toplevel app id from g_get_prgname(), so "
+        "without this the window never groups with the installed launcher under "
+        "GNOME or KDE Plasma on Wayland",
+    ),
+    "gdk_set_program_class": (
+        RUNNER_IDENTITY_STARTUP_FUNCTION,
+        APPLICATION_ID_MACRO,
+        "otherwise X11's WM_CLASS class half is the program name with its first "
+        "letter upper-cased, which is not the id the desktop entry's "
+        "StartupWMClass declares",
+    ),
+    "gtk_window_set_default_icon_name": (
+        RUNNER_IDENTITY_STARTUP_FUNCTION,
+        APPLICATION_ID_MACRO,
+        "otherwise the window carries no _NET_WM_ICON and task switchers and "
+        "panels fall back to a generic icon",
+    ),
+    "g_set_application_name": (
+        RUNNER_IDENTITY_STARTUP_FUNCTION,
+        APPLICATION_NAME_CONSTANT,
+        "otherwise g_get_application_name() falls back to the program name and "
+        "GTK shows the reverse-DNS id where it means to show the product name",
+    ),
+}
+
+# The calls that gtk_init() would undo if they ran before the startup chain-up.
+RUNNER_IDENTITY_CALLS_AFTER_CHAIN_UP = frozenset(
+    {"gdk_set_program_class", "gtk_window_set_default_icon_name"}
+)
 
 SECURE_STORAGE_TARGET = "flutter_secure_storage_linux_plugin"
 SECURE_STORAGE_WARNING_EXCEPTION = "-Wno-error=deprecated-literal-operator"
@@ -346,6 +441,19 @@ def desktop_entry_problems(root: Path) -> list[str]:
         android_application_id(root),
         "android/app/build.gradle applicationId",
     )
+    # StartupWMClass is the X11 `WM_CLASS` the running window carries, which the
+    # runner sets to the application id on both halves
+    # (`g_set_prgname(APPLICATION_ID)` and
+    # `gdk_set_program_class(APPLICATION_ID)`, see runner_identity_problems).
+    # A shell trusts an exact StartupWMClass match ahead of every other
+    # heuristic, so a stale value here is worse than none: it points Linthra's
+    # window at whatever entry claims that class. Wayland ignores the key and
+    # matches on the app id directly.
+    require(
+        "StartupWMClass",
+        android_application_id(root),
+        "the WM_CLASS linux/runner/my_application.cc sets",
+    )
 
     categories = [item for item in entry.get("Categories", "").split(";") if item]
     missing = [name for name in REQUIRED_CATEGORIES if name not in categories]
@@ -511,7 +619,24 @@ def icon_source_problems(root: Path) -> list[str]:
             f"{ICON_SOURCE}: root element is {element.tag!r}, not an SVG in the "
             f"{SVG_ROOT_TAG} namespace"
         )
-    elif element.get("viewBox") is None:
+        return problems
+
+    # Where that root element starts, which is the only thing content sniffing
+    # has to go on. Checked on the bytes rather than the parse tree, because it
+    # is a property of the file, not of the document.
+    root_offset = path.read_bytes().find(b"<svg")
+    if root_offset == -1 or root_offset + len(b"<svg") > SVG_SIGNATURE_WINDOW_BYTES:
+        where = "nowhere" if root_offset == -1 else f"at byte {root_offset}"
+        problems.append(
+            f"{ICON_SOURCE}: the <svg> root element starts {where}, past the "
+            f"first {SVG_SIGNATURE_WINDOW_BYTES} bytes content sniffing reads, "
+            "so the file is not recognised as an image at all: GTK cannot load "
+            "it as a themed icon and launchers show a generic one. Move "
+            "whatever precedes it (a comment, a DOCTYPE) inside the root "
+            "element."
+        )
+
+    if element.get("viewBox") is None:
         # Without a viewBox the drawing has no coordinate system to scale, so
         # the file lands in `scalable/` without actually being scalable — it
         # renders at its intrinsic size and every launcher resamples it.
@@ -587,6 +712,142 @@ def folder_picker_problems(root: Path) -> list[str]:
     return problems
 
 
+def _blank(source: str, *, comments: bool = True, strings: bool = False) -> str:
+    """Return `source` with comments and/or string literals replaced by spaces.
+
+    Same length as the input, so an index into the result is an index into the
+    original. Blanking comments is what stops a call *described* in a comment
+    from counting as a call; blanking strings is what lets the brace matcher
+    below ignore a `"{"` inside a literal.
+    """
+    out = list(source)
+    index = 0
+    length = len(source)
+    while index < length:
+        char = source[index]
+        if char == '"' or char == "'":
+            end = index + 1
+            while end < length and source[end] != char:
+                end += 2 if source[end] == "\\" else 1
+            end = min(end + 1, length)
+            if strings:
+                for position in range(index, end):
+                    if out[position] != "\n":
+                        out[position] = " "
+            index = end
+        elif source.startswith("//", index):
+            end = source.find("\n", index)
+            end = length if end == -1 else end
+            if comments:
+                for position in range(index, end):
+                    out[position] = " "
+            index = end
+        elif source.startswith("/*", index):
+            end = source.find("*/", index + 2)
+            end = length if end == -1 else end + 2
+            if comments:
+                for position in range(index, end):
+                    if out[position] != "\n":
+                        out[position] = " "
+            index = end
+        else:
+            index += 1
+    return "".join(out)
+
+
+def _function_body(code: str, signature: str, where: Path) -> tuple[int, int]:
+    """The `[start, end)` span of the body of the function opened by `signature`.
+
+    `code` must already have comments and strings blanked, so brace counting is
+    reliable. Returns offsets into `code` rather than the text itself, because
+    callers need to compare positions (the chain-up has to come first).
+    """
+    start = code.find(signature)
+    if start == -1:
+        raise CheckError(f"{where}: could not find {signature}")
+    if code.find(signature, start + 1) != -1:
+        raise CheckError(f"{where}: found more than one {signature}, expected 1")
+    opening = code.find("{", start)
+    if opening == -1:
+        raise CheckError(f"{where}: {signature} has no body")
+    depth = 0
+    for index in range(opening, len(code)):
+        if code[index] == "{":
+            depth += 1
+        elif code[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return opening, index
+    raise CheckError(f"{where}: {signature} has an unterminated body")
+
+
+def runner_identity_problems(root: Path) -> list[str]:
+    """Identity calls the runner has to make, in the places they still work.
+
+    See the RUNNER_IDENTITY_CALLS comment above for why each one exists and why
+    two of them are order-dependent. Everything here builds and launches
+    perfectly when it is wrong; the only symptom is a window the desktop no
+    longer recognises as Linthra.
+    """
+    text = _read(root, MY_APPLICATION)
+    code = _blank(text, comments=True, strings=True)
+    problems: list[str] = []
+
+    bodies: dict[str, tuple[int, int]] = {}
+    for signature in (RUNNER_IDENTITY_NEW_FUNCTION, RUNNER_IDENTITY_STARTUP_FUNCTION):
+        bodies[signature] = _function_body(code, signature, MY_APPLICATION)
+
+    startup_start, startup_end = bodies[RUNNER_IDENTITY_STARTUP_FUNCTION]
+    chain_up = code.find(RUNNER_STARTUP_CHAIN_UP, startup_start, startup_end)
+    if chain_up == -1:
+        problems.append(
+            f"{MY_APPLICATION}: my_application_startup() never chains up to "
+            "GtkApplication::startup, so gtk_init() is never reached"
+        )
+
+    for call, (signature, argument, why) in RUNNER_IDENTITY_CALLS.items():
+        pattern = re.compile(rf"\b{re.escape(call)}\s*\(\s*{re.escape(argument)}\s*\)")
+        matches = list(pattern.finditer(code))
+        if not matches:
+            problems.append(f"{MY_APPLICATION}: no {call}({argument}) call: {why}")
+            continue
+        if len(matches) > 1:
+            problems.append(
+                f"{MY_APPLICATION}: {len(matches)} {call}({argument}) calls, expected 1"
+            )
+            continue
+        where = matches[0].start()
+        body_start, body_end = bodies[signature]
+        function = signature.split("(")[0].split()[-1]
+        if not body_start < where < body_end:
+            problems.append(
+                f"{MY_APPLICATION}: {call}({argument}) is not inside "
+                f"{function}(), which is the only place it takes effect"
+            )
+            continue
+        if (
+            call in RUNNER_IDENTITY_CALLS_AFTER_CHAIN_UP
+            and chain_up != -1
+            and where < chain_up
+        ):
+            problems.append(
+                f"{MY_APPLICATION}: {call}({argument}) runs before "
+                "my_application_startup() chains up, so gtk_init() overwrites it"
+            )
+
+    # The id itself stays in linux/CMakeLists.txt. A literal here would be a
+    # second copy that no longer moves when APPLICATION_ID does.
+    app_id = android_application_id(root)
+    if f'"{app_id}"' in _blank(text, comments=True, strings=False):
+        problems.append(
+            f"{MY_APPLICATION}: the application id is written out as a string "
+            f"literal; use the {APPLICATION_ID_MACRO} macro that "
+            f"{RUNNER_CMAKELISTS} defines so there is one copy of it"
+        )
+
+    return problems
+
+
 def absolute_paths_under_linux(root: Path) -> list[str]:
     """Absolute host paths hardcoded in the committed Linux build files.
 
@@ -652,6 +913,11 @@ def check(root: Path) -> list[str]:
     # The folder-picker channel (#438): two strings that have to agree, and a
     # source file that has to be compiled and registered.
     problems.extend(folder_picker_problems(root))
+
+    # The window identity (#554): the GTK/GDK calls that make the *running*
+    # window answer to the same id as everything installed above, in the places
+    # where they still take effect.
+    problems.extend(runner_identity_problems(root))
 
     # Window metrics: a minimum larger than the default would open the window
     # already clamped, which reads as the app ignoring its own default.

--- a/scripts/flatpak_launch_smoke.sh
+++ b/scripts/flatpak_launch_smoke.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 # Install Linthra from a local Flatpak repository and prove that the packaged
-# application reaches a real desktop window inside its sandbox.
+# application reaches a real desktop window inside its sandbox, and that the
+# window introduces itself as io.github.thezupzup.linthra (#554).
 #
 # This is intentionally credential- and network-independent. It uses an Xvfb
 # display only for deterministic CI window detection; production users keep the
-# manifest's normal Wayland/fallback-X11 behavior.
+# manifest's normal Wayland/fallback-X11 behavior. Because Xvfb is X11, this
+# exercises the sandbox's --socket=fallback-x11 path, which is also the one
+# whose identity a headless runner can actually read back: WM_CLASS and
+# _NET_WM_ICON are X properties. Wayland sends the same application id as the
+# xdg_toplevel app id, from the same g_set_prgname() call, and there is no
+# headless compositor here to ask.
 
 set -euo pipefail
 
@@ -22,6 +28,7 @@ fail() {
 command -v flatpak >/dev/null 2>&1 || fail "flatpak is not installed"
 command -v xvfb-run >/dev/null 2>&1 || fail "xvfb-run is not installed"
 command -v xwininfo >/dev/null 2>&1 || fail "xwininfo is not installed"
+command -v xprop >/dev/null 2>&1 || fail "xprop is not installed"
 command -v dbus-run-session >/dev/null 2>&1 || fail "dbus-run-session is not installed"
 
 REPO_PATH="$(cd "$REPO_PATH" && pwd)" || fail "local Flatpak repo not found: $REPO_PATH"
@@ -61,34 +68,120 @@ xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' \
     log_file="$(mktemp)"
     trap '\''rm -f "$log_file"'\'' EXIT
 
-    flatpak run "$APP_ID" >"$log_file" 2>&1 &
-    app_pid=$!
+    # The xwininfo tree line for the Linthra window, which carries both its X
+    # window id and the WM_CLASS pair every other X client sees:
+    #
+    #   0x600003 "Linthra": ("io.github.thezupzup.linthra" "io.github.thezupzup.linthra")
+    #
+    # Empty until the window exists, which is also how the wait loop below knows
+    # it has not appeared yet.
+    window_line() {
+      xwininfo -root -tree 2>/dev/null | grep -F "\"$WINDOW_TITLE\":" | head -n 1 || true
+    }
 
-    deadline=$((SECONDS + TIMEOUT_SECONDS))
-    while (( SECONDS < deadline )); do
-      if xwininfo -root -tree 2>/dev/null | grep -Fq "\"$WINDOW_TITLE\""; then
-        printf "PASS: packaged %s opened a %s window.\n" "$APP_ID" "$WINDOW_TITLE"
-        flatpak kill "$APP_ID" >/dev/null 2>&1 || true
-        wait "$app_pid" >/dev/null 2>&1 || true
-        exit 0
-      fi
+    # Close the app and wait for its window to actually leave the X server, so
+    # the next launch cannot match a window left behind by the previous one.
+    stop_app() {
+      flatpak kill "$APP_ID" >/dev/null 2>&1 || true
+      wait "$1" >/dev/null 2>&1 || true
 
-      if ! kill -0 "$app_pid" >/dev/null 2>&1; then
-        wait "$app_pid" || status=$?
-        status="${status:-0}"
-        printf "FAIL: %s exited before opening its window (status %s).\n" \
-          "$APP_ID" "$status" >&2
+      local attempt
+      for attempt in $(seq 1 20); do
+        [ -z "$(window_line)" ] && return 0
+        sleep 0.25
+      done
+      printf "WARNING: a %s window is still mapped after closing the app.\n" \
+        "$WINDOW_TITLE" >&2
+    }
+
+    # One full launch: start the packaged app, wait for its window, and hold that
+    # window to the application id. Both checks are about desktop identity rather
+    # than rendering:
+    #
+    #   WM_CLASS      is what a launcher matches a window against on X11. GTK
+    #                 builds the pair from g_get_prgname() and
+    #                 gdk_get_program_class(); the class half only equals the app
+    #                 id because linux/runner/my_application.cc sets it, and it is
+    #                 the value the desktop entry StartupWMClass= declares.
+    #   _NET_WM_ICON  is the icon the window itself carries. GTK attaches it from the icon name
+    #                 the runner sets as the default, so its presence proves the
+    #                 hicolor SVG the Flatpak installed actually resolves from
+    #                 inside the sandbox. Without it every task switcher and panel
+    #                 falls back to a generic icon.
+    launch_and_check() {
+      local what="$1"
+      local app_pid deadline line window_id wm_class expected icon status
+
+      : >"$log_file"
+      flatpak run "$APP_ID" >"$log_file" 2>&1 &
+      app_pid=$!
+
+      line=""
+      deadline=$((SECONDS + TIMEOUT_SECONDS))
+      while (( SECONDS < deadline )); do
+        line="$(window_line)"
+        [ -n "$line" ] && break
+
+        if ! kill -0 "$app_pid" >/dev/null 2>&1; then
+          status=0
+          wait "$app_pid" || status=$?
+          printf "FAIL: %s exited before opening its window (%s, status %s).\n" \
+            "$APP_ID" "$what" "$status" >&2
+          cat "$log_file" >&2
+          return 1
+        fi
+
+        sleep 0.5
+      done
+
+      if [ -z "$line" ]; then
+        printf "FAIL: %s did not open a %s window within %ss (%s).\n" \
+          "$APP_ID" "$WINDOW_TITLE" "$TIMEOUT_SECONDS" "$what" >&2
         cat "$log_file" >&2
-        exit 1
+        stop_app "$app_pid"
+        return 1
       fi
 
-      sleep 0.5
-    done
+      printf "PASS: packaged %s opened a %s window (%s).\n" \
+        "$APP_ID" "$WINDOW_TITLE" "$what"
 
-    printf "FAIL: %s did not open a %s window within %ss.\n" \
-      "$APP_ID" "$WINDOW_TITLE" "$TIMEOUT_SECONDS" >&2
-    cat "$log_file" >&2
-    flatpak kill "$APP_ID" >/dev/null 2>&1 || true
-    wait "$app_pid" >/dev/null 2>&1 || true
-    exit 1
+      window_id="$(printf "%s\n" "$line" | awk "{print \$1}")"
+
+      wm_class="$(xprop -id "$window_id" WM_CLASS 2>&1 || true)"
+      expected="WM_CLASS(STRING) = \"$APP_ID\", \"$APP_ID\""
+      if [ "$wm_class" != "$expected" ]; then
+        printf "FAIL: the %s window does not identify as %s (%s).\n" \
+          "$WINDOW_TITLE" "$APP_ID" "$what" >&2
+        printf "  expected: %s\n" "$expected" >&2
+        printf "  actual:   %s\n" "$wm_class" >&2
+        cat "$log_file" >&2
+        stop_app "$app_pid"
+        return 1
+      fi
+      printf "PASS: %s\n" "$wm_class"
+
+      # Only the first line: all that matters is that the property exists, and
+      # xprop renders the rest of it as ASCII art of the icon.
+      icon="$(xprop -id "$window_id" _NET_WM_ICON 2>&1 | head -n 1 || true)"
+      case "$icon" in
+        *"not found"*|"")
+          printf "FAIL: the %s window carries no _NET_WM_ICON (%s), so the\n" \
+            "$WINDOW_TITLE" "$what" >&2
+          printf "      installed %s icon did not resolve inside the sandbox.\n" \
+            "$APP_ID" >&2
+          cat "$log_file" >&2
+          stop_app "$app_pid"
+          return 1
+          ;;
+      esac
+      printf "PASS: %s window carries _NET_WM_ICON (%s).\n" "$WINDOW_TITLE" "$icon"
+
+      stop_app "$app_pid"
+    }
+
+    launch_and_check "first launch"
+
+    # Close and reopen. Identity has to survive a restart, or a relaunch from the
+    # launcher lands beside the entry it came from instead of grouping with it.
+    launch_and_check "reopen after close"
   '

--- a/test/tooling/check_linux_runner_test.py
+++ b/test/tooling/check_linux_runner_test.py
@@ -11,6 +11,12 @@ caught", built on a synthetic checkout rather than the real one: a fixture that
 can be broken is the only way to prove the checker fails when it should, and it
 keeps these tests from depending on Linthra's current version or app id.
 
+The window identity calls (#554) are tested the same way as well: the runner is
+what tells Wayland and X11 which application the window belongs to, so each case
+takes a good runner and removes, duplicates, comments out, hardcodes or reorders
+exactly one of those calls. All of them still compile and still launch, which is
+why only a check like this notices.
+
 The desktop entry (#434) is tested the same way, and for the same reason: a
 `.desktop` file that names the wrong binary, the wrong icon or the wrong app id
 is still a perfectly valid desktop file, so only a comparison against the app's
@@ -76,6 +82,10 @@ if(TARGET flutter_secure_storage_linux_plugin AND
 endif()
 """
 
+# The runner, reduced to what the checker reads. The identity calls (#554) are
+# part of the fixture rather than an optional extra: they are what makes the
+# running window answer to the application id, and every WindowIdentityTest case
+# below is this same text with exactly one of them broken.
 MY_APPLICATION = """\
 #include "my_application.h"
 
@@ -89,6 +99,21 @@ static constexpr int kMinimumWindowHeight = 600;
 
 static void activate() {{
   self->folder_picker = folder_picker_channel_new(view, window);
+}}
+
+static void my_application_startup(GApplication* application) {{
+  G_APPLICATION_CLASS(my_application_parent_class)->startup(application);
+
+  g_set_application_name(kApplicationName);
+  gdk_set_program_class(APPLICATION_ID);
+  gtk_window_set_default_icon_name(APPLICATION_ID);
+}}
+
+MyApplication* my_application_new() {{
+  g_set_prgname(APPLICATION_ID);
+
+  return MY_APPLICATION(g_object_new(my_application_get_type(),
+                                     "application-id", APPLICATION_ID, nullptr));
 }}
 """
 
@@ -157,6 +182,7 @@ Icon={app_id}
 Terminal=false
 Categories=AudioVideo;Audio;Player;Music;
 StartupNotify=true
+StartupWMClass={app_id}
 """
 
 # A minimal but structurally real SVG: a self-contained mark whose only
@@ -406,6 +432,185 @@ class IdentityDriftTest(CheckoutCase):
         self.assertEqual(len(checker.check(self.root)), 3)
 
 
+class WindowIdentityTest(CheckoutCase):
+    """The calls that make the *running* window answer to the app id (#554).
+
+    Everything the other tests cover is installed metadata; this is the window
+    itself. Each case builds and launches perfectly, so the only symptom is a
+    desktop that stops recognising Linthra: a generic icon, or a window that
+    will not group with its own launcher.
+    """
+
+    def runner(self, *, replace: tuple[str, str] | None = None) -> str:
+        text = MY_APPLICATION.format(display_name=DISPLAY_NAME)
+        if replace is not None:
+            old, new = replace
+            assert old in text, old
+            text = text.replace(old, new)
+        return text
+
+    def only_problem(self, runner: str) -> str:
+        build_checkout(self.root, my_application=runner)
+        problems = checker.runner_identity_problems(self.root)
+        self.assertEqual(len(problems), 1, problems)
+        return problems[0]
+
+    def test_a_consistent_runner_has_no_identity_problems(self) -> None:
+        build_checkout(self.root)
+        self.assertEqual(checker.runner_identity_problems(self.root), [])
+
+    def test_losing_the_program_name_is_caught(self) -> None:
+        # The Wayland half: GTK 3 sends xdg_toplevel.set_app_id() from
+        # g_get_prgname(), so without this the app id GNOME and KDE match on is
+        # the binary name.
+        problem = self.only_problem(
+            self.runner(replace=("  g_set_prgname(APPLICATION_ID);\n", ""))
+        )
+        self.assertIn("g_set_prgname", problem)
+
+    def test_losing_the_program_class_is_caught(self) -> None:
+        # The X11 half: without it WM_CLASS's class is the program name with
+        # its first letter upper-cased, which no launcher indexes.
+        problem = self.only_problem(
+            self.runner(replace=("  gdk_set_program_class(APPLICATION_ID);\n", ""))
+        )
+        self.assertIn("gdk_set_program_class", problem)
+
+    def test_losing_the_default_icon_name_is_caught(self) -> None:
+        problem = self.only_problem(
+            self.runner(
+                replace=("  gtk_window_set_default_icon_name(APPLICATION_ID);\n", "")
+            )
+        )
+        self.assertIn("gtk_window_set_default_icon_name", problem)
+        self.assertIn("_NET_WM_ICON", problem)
+
+    def test_losing_the_human_readable_name_is_caught(self) -> None:
+        problem = self.only_problem(
+            self.runner(replace=("  g_set_application_name(kApplicationName);\n", ""))
+        )
+        self.assertIn("g_set_application_name", problem)
+
+    def test_the_program_class_may_not_run_before_the_chain_up(self) -> None:
+        # gtk_init() resets GDK's program class unconditionally, and
+        # GtkApplication::startup is what calls gtk_init(). Set before the chain
+        # up, this call compiles, runs, and is thrown away.
+        problem = self.only_problem(
+            self.runner(
+                replace=(
+                    "  G_APPLICATION_CLASS(my_application_parent_class)"
+                    "->startup(application);\n\n"
+                    "  g_set_application_name(kApplicationName);\n"
+                    "  gdk_set_program_class(APPLICATION_ID);\n",
+                    "  gdk_set_program_class(APPLICATION_ID);\n"
+                    "  G_APPLICATION_CLASS(my_application_parent_class)"
+                    "->startup(application);\n\n"
+                    "  g_set_application_name(kApplicationName);\n",
+                )
+            )
+        )
+        self.assertIn("gdk_set_program_class", problem)
+        self.assertIn("before", problem)
+
+    def test_the_icon_name_may_not_run_before_the_chain_up(self) -> None:
+        problem = self.only_problem(
+            self.runner(
+                replace=(
+                    "  G_APPLICATION_CLASS(my_application_parent_class)"
+                    "->startup(application);\n",
+                    "  gtk_window_set_default_icon_name(APPLICATION_ID);\n"
+                    "  G_APPLICATION_CLASS(my_application_parent_class)"
+                    "->startup(application);\n",
+                )
+            ).replace("  gtk_window_set_default_icon_name(APPLICATION_ID);\n}", "}")
+        )
+        self.assertIn("gtk_window_set_default_icon_name", problem)
+        self.assertIn("before", problem)
+
+    def test_the_program_name_must_be_set_before_gtk_init(self) -> None:
+        # Moved into startup(), where GDK has already read the program name.
+        problem = self.only_problem(
+            self.runner(
+                replace=("  g_set_prgname(APPLICATION_ID);\n\n  return", "\n  return")
+            ).replace(
+                "  g_set_application_name(kApplicationName);\n",
+                "  g_set_application_name(kApplicationName);\n"
+                "  g_set_prgname(APPLICATION_ID);\n",
+            )
+        )
+        self.assertIn("g_set_prgname", problem)
+        self.assertIn("my_application_new", problem)
+
+    def test_a_hardcoded_application_id_is_rejected(self) -> None:
+        # The id lives in linux/CMakeLists.txt and reaches the runner as the
+        # APPLICATION_ID macro. A literal is a second copy that stops moving.
+        build_checkout(
+            self.root,
+            my_application=self.runner(
+                replace=(
+                    "gdk_set_program_class(APPLICATION_ID)",
+                    f'gdk_set_program_class("{APP_ID}")',
+                )
+            ),
+        )
+        problems = checker.runner_identity_problems(self.root)
+        self.assertEqual(len(problems), 2, problems)
+        self.assertTrue(any("string literal" in problem for problem in problems))
+
+    def test_a_call_named_only_in_a_comment_does_not_count(self) -> None:
+        # A comment describing the call is not the call.
+        problem = self.only_problem(
+            self.runner(
+                replace=(
+                    "  gdk_set_program_class(APPLICATION_ID);\n",
+                    "  // gdk_set_program_class(APPLICATION_ID);\n",
+                )
+            )
+        )
+        self.assertIn("gdk_set_program_class", problem)
+
+    def test_a_duplicated_call_is_caught(self) -> None:
+        problem = self.only_problem(
+            self.runner(
+                replace=(
+                    "  gdk_set_program_class(APPLICATION_ID);\n",
+                    "  gdk_set_program_class(APPLICATION_ID);\n"
+                    "  gdk_set_program_class(APPLICATION_ID);\n",
+                )
+            )
+        )
+        self.assertIn("2 gdk_set_program_class", problem)
+
+    def test_never_chaining_up_is_caught(self) -> None:
+        # Without the chain up gtk_init() never runs at all, so the two
+        # order-dependent calls have nothing to be ordered against.
+        build_checkout(
+            self.root,
+            my_application=self.runner(
+                replace=(
+                    "  G_APPLICATION_CLASS(my_application_parent_class)"
+                    "->startup(application);\n",
+                    "",
+                )
+            ),
+        )
+        problems = checker.runner_identity_problems(self.root)
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("chains up", problems[0])
+
+    def test_a_runner_without_the_startup_handler_is_an_error(self) -> None:
+        # A `flutter create` regeneration that drops the override entirely is a
+        # read failure, not a silent pass.
+        build_checkout(
+            self.root,
+            my_application=self.runner().replace(
+                "static void my_application_startup(", "static void unrelated_thing("
+            ),
+        )
+        with self.assertRaises(checker.CheckError):
+            checker.runner_identity_problems(self.root)
+
+
 class DesktopEntryTest(CheckoutCase):
     """The installed entry (#434) repeating the identity it launches.
 
@@ -456,6 +661,29 @@ class DesktopEntryTest(CheckoutCase):
         problems = checker.desktop_entry_problems(self.root)
         self.assertEqual(len(problems), 1)
         self.assertIn("Icon=", problems[0])
+
+    def test_the_startup_wm_class_must_be_the_app_id(self) -> None:
+        # A shell trusts an exact StartupWMClass match ahead of every other
+        # heuristic, so a value that is not the WM_CLASS the runner stamps sends
+        # the window to the wrong entry, or to none at all.
+        build_checkout(
+            self.root,
+            desktop_entry=self.entry().replace(
+                f"StartupWMClass={APP_ID}", "StartupWMClass=ExampleApp"
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("StartupWMClass=", problems[0])
+
+    def test_a_missing_startup_wm_class_is_reported(self) -> None:
+        build_checkout(
+            self.root,
+            desktop_entry=self.entry().replace(f"StartupWMClass={APP_ID}\n", ""),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("no StartupWMClass=", problems[0])
 
     def test_a_missing_key_is_reported(self) -> None:
         build_checkout(
@@ -795,6 +1023,29 @@ class IconSourceTest(CheckoutCase):
             all("references something outside itself" in p for p in problems)
         )
 
+    def test_a_root_element_pushed_out_of_the_sniff_window_is_caught(self) -> None:
+        # The regression #554 actually hit: a descriptive comment between the XML
+        # declaration and `<svg>`. The file still parses, still validates, still
+        # renders in a browser, and gdk-pixbuf still refuses it, so GTK cannot
+        # load it as a themed icon and every launcher shows a generic one.
+        header = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        body = ICON_SVG[len(header) :]
+        comment = "<!-- " + ("a note about the mark. " * 20) + "-->\n"
+        build_checkout(self.root, icon_svg=header + comment + body)
+        problems = checker.icon_source_problems(self.root)
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("root element starts", problems[0])
+
+    def test_the_same_comment_inside_the_root_element_is_fine(self) -> None:
+        # The fix, and the reason the check measures the offset rather than
+        # banning comments: the note keeps its place in the file.
+        marker = 'viewBox="0 0 512 512">'
+        comment = "\n  <!-- " + ("a note about the mark. " * 20) + "-->"
+        icon = ICON_SVG.replace(marker, marker + comment)
+        self.assertIn("a note about the mark", icon)
+        build_checkout(self.root, icon_svg=icon)
+        self.assertEqual(checker.icon_source_problems(self.root), [])
+
     def test_a_malformed_svg_is_caught(self) -> None:
         # A broken SVG installs perfectly and then draws nothing.
         build_checkout(self.root, icon_svg=ICON_SVG.replace("</svg>", ""))
@@ -1047,6 +1298,27 @@ class RealRepositoryTest(unittest.TestCase):
             checker.application_id(ROOT), checker.android_application_id(ROOT)
         )
 
+    def test_the_running_window_carries_the_application_id(self) -> None:
+        # The committed runner really does make all four identity calls, in the
+        # places where GTK still honours them (#554).
+        self.assertEqual(checker.runner_identity_problems(ROOT), [])
+        runner = (ROOT / "linux" / "runner" / "my_application.cc").read_text(
+            encoding="utf-8"
+        )
+        for call in (
+            "g_set_prgname(APPLICATION_ID)",
+            "gdk_set_program_class(APPLICATION_ID)",
+            "gtk_window_set_default_icon_name(APPLICATION_ID)",
+        ):
+            self.assertIn(call, runner)
+
+    def test_the_desktop_entry_declares_the_runners_wm_class(self) -> None:
+        entry = checker.desktop_entry(ROOT)
+        self.assertEqual(
+            entry["StartupWMClass"], checker.android_application_id(ROOT)
+        )
+        self.assertEqual(entry["StartupWMClass"], entry["Icon"])
+
     def test_the_window_title_is_the_product_name(self) -> None:
         self.assertEqual(checker.window_title(ROOT), checker.app_display_name(ROOT))
 
@@ -1082,6 +1354,16 @@ class RealRepositoryTest(unittest.TestCase):
             checker.FLATPAK_DIR / f"{app_id}.yml",
         ):
             self.assertIn(installed, (ROOT / manifest).read_text(encoding="utf-8"))
+
+    def test_the_icon_source_is_recognisable_as_an_svg(self) -> None:
+        # Content sniffing is what stands between the installed file and a
+        # generic icon, and it only looks at the start of the file.
+        raw = (ROOT / "tool" / "branding" / "linthra_icon.svg").read_bytes()
+        offset = raw.find(b"<svg")
+        self.assertNotEqual(offset, -1)
+        self.assertLessEqual(
+            offset + len(b"<svg"), checker.SVG_SIGNATURE_WINDOW_BYTES
+        )
 
     def test_the_icon_source_is_the_canonical_brand_mark(self) -> None:
         # Not a copy and not a redraw: the file Linux packaging installs is the

--- a/test/tooling/flatpak_ci_guardrails_test.dart
+++ b/test/tooling/flatpak_ci_guardrails_test.dart
@@ -48,6 +48,9 @@ void main() {
       // symbols out of every module it builds.
       'elfutils',
       'flatpak-builder',
+      // The gdk-pixbuf SVG loader, without which the appstreamcli compose that
+      // flatpak-builder runs at finish time cannot read the scalable app icon.
+      'librsvg2-common',
       // xwininfo and xprop, which the launch smoke reads window identity with.
       'x11-utils',
       // The headless display and session bus the smoke launches into.

--- a/test/tooling/flatpak_ci_guardrails_test.dart
+++ b/test/tooling/flatpak_ci_guardrails_test.dart
@@ -34,6 +34,38 @@ void main() {
     },
   );
 
+  // The job installs its host tools with --no-install-recommends, so anything a
+  // dependency merely recommends has to be named explicitly. elfutils is the
+  // one that bit: flatpak-builder only recommends it, and without its `eu-strip`
+  // the build dies on the first native module, long before Linthra is reached.
+  test('Flatpak CI installs the host tools the build and smoke need', () {
+    for (final String package in <String>[
+      // appstreamcli, for the metainfo validation step.
+      'appstream',
+      // desktop-file-validate, for the desktop entry.
+      'desktop-file-utils',
+      // eu-strip / eu-elfcompress, which flatpak-builder uses to split debug
+      // symbols out of every module it builds.
+      'elfutils',
+      'flatpak-builder',
+      // xwininfo and xprop, which the launch smoke reads window identity with.
+      'x11-utils',
+      // The headless display and session bus the smoke launches into.
+      'xvfb',
+      'dbus-x11',
+    ]) {
+      // Either a continuation line or the last entry of the list.
+      expect(
+        workflow,
+        anyOf(
+          contains('            $package \\\n'),
+          contains('            $package\n'),
+        ),
+        reason: 'Missing host package: $package',
+      );
+    }
+  });
+
   test('packaging-relevant changes trigger the workflow', () {
     for (final String path in <String>[
       "'flatpak/**'",

--- a/test/tooling/flatpak_launch_smoke_test.dart
+++ b/test/tooling/flatpak_launch_smoke_test.dart
@@ -30,6 +30,28 @@ void main() {
     expect(smoke, contains('dbus-run-session'));
   });
 
+  // #554. A window is not enough: it has to be a window the desktop recognises
+  // as Linthra. Under Xvfb the sandbox takes its --socket=fallback-x11 path, so
+  // both of these are readable as X properties on the packaged app.
+  test('launch smoke holds the packaged window to the application id', () {
+    expect(smoke, contains('xprop is not installed'));
+    expect(smoke, contains(r'xprop -id "$window_id" WM_CLASS'));
+    expect(
+      smoke,
+      contains(r'expected="WM_CLASS(STRING) = \"$APP_ID\", \"$APP_ID\""'),
+    );
+  });
+
+  test('launch smoke requires the packaged window to carry its icon', () {
+    expect(smoke, contains(r'xprop -id "$window_id" _NET_WM_ICON'));
+    expect(smoke, contains('carries no _NET_WM_ICON'));
+  });
+
+  test('launch smoke re-checks identity after a close and reopen', () {
+    expect(smoke, contains('launch_and_check "first launch"'));
+    expect(smoke, contains('launch_and_check "reopen after close"'));
+  });
+
   test('launch smoke cleans up app and temporary remote', () {
     expect(smoke, contains(r'flatpak kill "$APP_ID"'));
     expect(smoke, contains(r'flatpak --user uninstall -y "$APP_ID"'));

--- a/tool/branding/linthra_icon.svg
+++ b/tool/branding/linthra_icon.svg
@@ -1,10 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Canonical Linthra app-icon source: four rounded equalizer bars carrying a
-     single violet→orange gradient on a dark premium squircle. generate_icons.py
-     rasterises this same design into the launcher mipmaps and the F-Droid
-     icon/feature graphic; edit both together so they never drift. -->
 <svg xmlns="http://www.w3.org/2000/svg" width="512" height="512"
      viewBox="0 0 512 512">
+  <!-- Canonical Linthra app-icon source: four rounded equalizer bars carrying a
+       single violet→orange gradient on a dark premium squircle.
+       generate_icons.py rasterises this same design into the launcher mipmaps
+       and the F-Droid icon/feature graphic; edit both together so they never
+       drift.
+
+       This comment sits *inside* the root element on purpose (#554). Content
+       sniffing gives up on `<svg` after the first 256 bytes, so a comment
+       between the XML declaration and the root tag pushes the only signature
+       an SVG has out of range: gdk-pixbuf then refuses the file outright, GTK
+       cannot load it as a themed icon, and every launcher that resolves icons
+       that way falls back to a generic one. Keep the root element near the top
+       of the file. scripts/check_linux_runner.py enforces the limit. -->
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#1C1730" />


### PR DESCRIPTION
Closes #554.

The Flatpak already installed the desktop entry, the icon and the AppStream component under `io.github.thezupzup.linthra`. What did not fully agree with them was the running GTK window, so a launcher could show a generic icon or fail to group the window with its own entry.

I went looking at the actual GTK/GDK identity rather than patching the `.desktop` file, and found three separate gaps. Everything below is verified against GTK 3.24 sources and reproduced with a minimal GtkApplication built the same way the runner is, run under Xvfb with the icon installed in a hicolor theme.

## What GTK/Wayland/X11 was seeing before

**Wayland was already correct.** GTK 3 sends `xdg_toplevel.set_app_id()` straight from `g_get_prgname()` (`gdk/wayland/gdkwindow-wayland.c`, `gdk_wayland_window_create_xdg_toplevel`), and the runner already calls `g_set_prgname(APPLICATION_ID)`. So the app id GNOME and KDE match against under Wayland was right.

**X11 was not.** `gtk_window_init()` captures the WM_CLASS pair as `g_get_prgname()` (instance) and `gdk_get_program_class()` (class), and GDK derives that class in `gdk_pre_parse()` from the program name with its first letter upper-cased. Measured on a real window:

```
WM_CLASS(STRING) = "io.github.thezupzup.linthra", "Io.github.thezupzup.linthra"
```

`Io.github.thezupzup.linthra` is not a string any launcher indexes. GNOME Shell happens to find us anyway through its lower-casing fallback (`shell_app_system_lookup_desktop_wmclass`), but that is the last of four heuristics and nothing else is obliged to do it. There was no `StartupWMClass=` for the exact-match path that runs first.

**No window icon at all.** Nothing ever called `gtk_window_set_default_icon_name()`, so GTK attached no `_NET_WM_ICON`:

```
_NET_WM_ICON:  not found.
```

Every task switcher, panel and window list that reads the window's own icon rather than resolving a desktop entry had nothing but a generic placeholder to show.

**And the icon file itself could not be decoded.** This one surprised me and is probably the biggest single cause of the reported symptom. `tool/branding/linthra_icon.svg` opened with a ~300 byte comment between the XML declaration and `<svg>`. An SVG has no magic number, so content sniffing looks for the literal `<svg` and gives up after 256 bytes. Past that, gdk-pixbuf refuses the file outright:

```
tool/branding/linthra_icon.svg -> Couldn't recognize the image file format
```

`gtk_icon_theme_has_icon()` returned 1 (the lookup found the file) and `gtk_icon_theme_load_icon()` still failed. The file parses, validates and renders fine in a browser, which is why nothing caught it. Anything resolving the icon through gdk-pixbuf, GTK itself and GNOME Shell included, fell back to a generic icon. Qt-based shells decode SVG differently and were unaffected, which matches an issue that reproduces on GNOME more readily than on KDE.

## The fix

`linux/runner/my_application.cc`, all four derived from `APPLICATION_ID` so there is no second copy of the id:

| Call | Where | Why there |
| --- | --- | --- |
| `g_set_prgname(APPLICATION_ID)` | `my_application_new()` (unchanged) | before `gtk_init()`, which is where GDK reads the program name |
| `gdk_set_program_class(APPLICATION_ID)` | `my_application_startup()`, after the chain-up | `gtk_init()` resets the program class unconditionally, so earlier is thrown away |
| `gtk_window_set_default_icon_name(APPLICATION_ID)` | same | needs GTK initialised, and must precede window construction |
| `g_set_application_name(AppInfo.name)` | same | otherwise `g_get_application_name()` falls back to the reverse-DNS id |

The ordering is the fix, not a style choice: both GDK calls are undone by `gtk_init()` if they run before the chain-up to `GtkApplication::startup`.

Plus `StartupWMClass=io.github.thezupzup.linthra` in the desktop entry, declaring the pair the runner now stamps, and the icon's leading comment moved inside the root element. The artwork is byte-identical, only the comment moved.

Same window, after:

```
WM_CLASS(STRING) = "io.github.thezupzup.linthra", "io.github.thezupzup.linthra"
_NET_WM_ICON(CARDINAL) = Icon (48 x 48): ...
```

## Validation

Reproduced end to end with a minimal GtkApplication compiled against GTK 3.24.41, once without the fix and once with it, under `xvfb-run`, with the icon installed at `hicolor/scalable/apps/io.github.thezupzup.linthra.svg` on `XDG_DATA_DIRS`:

* before: WM_CLASS class half wrong, `_NET_WM_ICON: not found`
* after: both WM_CLASS halves are the app id, `_NET_WM_ICON` present, on the first launch and again after close and reopen

Also ran: `check_linux_runner.py` (clean), its 81 tooling tests (green), `ruff check` and `ruff format --check` over `scripts tool tools`, `desktop-file-validate` (no output), and both `-Wall -Werror` under gcc and clang on the four new calls.

`flutter analyze` / `flutter test` were not run here: no Flutter SDK in this environment, and the only Dart file touched is `test/tooling/flatpak_launch_smoke_test.dart`, whose string expectations I cross-checked against the shell script programmatically. CI covers the rest.

Not verifiable from CI: the GNOME Wayland dock and the KDE Plasma Wayland task manager both need a real session. Worth a look on both before this leaves draft.

## Guardrails, so it cannot drift back

`scripts/check_linux_runner.py` now also checks:

* all four identity calls are present, exactly once each
* each takes the `APPLICATION_ID` macro (or `kApplicationName`), not a pasted literal
* each sits in the function where it takes effect
* the two order-dependent ones follow the startup chain-up
* `StartupWMClass=` equals the app id
* the icon's `<svg>` root starts within the first 256 bytes

`scripts/flatpak_launch_smoke.sh` now launches the packaged Flatpak twice and reads WM_CLASS and `_NET_WM_ICON` back off the real window each time, so the identity of the actual shipped artifact is asserted, and close/reopen is covered. Under Xvfb this exercises the sandbox's `--socket=fallback-x11` path.

22 new test cases across `check_linux_runner_test.py` and `flatpak_launch_smoke_test.dart`, each taking a good fixture and breaking exactly one thing.

## Out of scope, untouched

No second app id, no duplicate launcher, no new artwork, no Linux-only rebrand. Android/F-Droid/Play identity, Flatpak permissions (finish-args are byte-identical and still guarded by the existing allow-list), navigation, album grids, Now Playing, MPRIS: all untouched. Nothing here relates to #555 or #556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtodLhcsSefY5c5bx4797V

---
_Generated by [Claude Code](https://claude.ai/code/session_01VtodLhcsSefY5c5bx4797V)_