### PR TITLE
Polish adaptive Linux layouts for a native music-player feel

### DIFF
--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -282,6 +282,50 @@ The seams that branch on it:
 Adding a platform-specific behaviour means adding a row here, not a check in a
 widget.
 
+## How the desktop layout adapts
+
+Presentation is the one thing that does *not* branch on `HostPlatform`. Layout
+adapts on the **width a widget is actually given**, so the same window is laid
+out the same way wherever it runs, and a Linux window narrowed to 600 px gets
+the phone layout rather than a cramped desktop one.
+
+`lib/shared/layout/adaptive_layout.dart` holds the whole vocabulary:
+
+| Piece | What it does |
+| --- | --- |
+| `WindowSizeClass` | `compact` (< 600), `medium` (< 1000), `expanded` (< 1600), `large` — Material's window size classes, with the phone thresholds left where Android already behaves |
+| `windowSizeClassFor(width)` | the pure breakpoint function, so the thresholds are unit-testable |
+| `AdaptiveLayoutBuilder` | resolves the class from the widget's own `BoxConstraints` — inside the desktop shell a screen is narrower than the window by the navigation rail, and a pane is narrower still |
+| `AdaptiveContentWidth` | caps and centres a single column (`maxContentWidth`, or `maxFormWidth` for settings), a no-op below the cap |
+
+What it buys, per surface:
+
+* **Album grid** — cards stay between 200 and 260 logical px and the grid adds
+  columns instead of inflating covers: 5 across at 1280, 7 at 1920, 10 at 2560,
+  where before every desktop width got the same six mobile-sized cards.
+* **Artists** — the same rows flow into 2–5 columns rather than one row per
+  monitor width.
+* **Songs, playlists, downloads, settings** — one column, capped and centred,
+  so a title and its trailing action never end up a screen apart.
+* **Album and artist detail** — at `expanded` and up, a persistent left pane
+  (cover/portrait, counts, Play and Shuffle) beside the scrolling track list.
+  Selection mode falls back to the single column.
+* **Now Playing** — at `expanded` and up, the cover sits beside the metadata
+  and transport, and lyrics open *next to* the cover instead of replacing it.
+  Same `_showLyrics` state and same playback state as the stacked layout.
+
+Both breakpoints in the app agree by construction: the shell swaps its bottom
+bar for the navigation rail at 900 px of window, and a feature screen inside it
+only reaches `expanded` once the space left over is 1000 px wide.
+
+Tests: `test/shared/layout/adaptive_layout_test.dart`,
+`test/features/library/album_grid_test.dart`,
+`test/features/library/artist_grid_test.dart`,
+`test/features/library/detail_desktop_layout_test.dart`,
+`test/features/player/player_desktop_layout_test.dart` — each covers the phone
+width alongside 1280, 1920, 2560 and ultrawide, so a change that only looks
+right on one monitor fails.
+
 ## Guardrails
 
 * `scripts/check_linux_runner.py` — the committed runner still matches the app's

--- a/lib/features/downloads/downloads_screen.dart
+++ b/lib/features/downloads/downloads_screen.dart
@@ -9,6 +9,7 @@ import '../../core/repositories/download_repository.dart';
 import '../../core/repositories/download_store.dart';
 import '../../core/services/offline_cache_manager.dart';
 import '../../data/repositories/download_repository_provider.dart';
+import '../../shared/layout/adaptive_layout.dart';
 import '../../shared/widgets/empty_state.dart';
 import '../player/now_playing.dart';
 import '../player/widgets/track_artwork.dart';
@@ -28,13 +29,17 @@ class DownloadsScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       appBar: AppBar(title: const Text('Downloads')),
-      body: const Column(
-        children: [
-          _CacheUsageHeader(),
-          MobileDataDownloadsTile(),
-          Divider(height: 1),
-          Expanded(child: _DownloadsBody()),
-        ],
+      // One download per row: capped and centred on a wide window rather than
+      // stretched edge to edge.
+      body: const AdaptiveContentWidth(
+        child: Column(
+          children: [
+            _CacheUsageHeader(),
+            MobileDataDownloadsTile(),
+            Divider(height: 1),
+            Expanded(child: _DownloadsBody()),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/library/album_detail_screen.dart
+++ b/lib/features/library/album_detail_screen.dart
@@ -7,6 +7,7 @@ import '../../app/routes.dart';
 import '../../core/catalog/library_grouping.dart';
 import '../../core/models/album.dart';
 import '../../core/models/track.dart';
+import '../../shared/layout/adaptive_layout.dart';
 import '../../shared/widgets/empty_state.dart';
 import '../player/player_providers.dart';
 import '../player/widgets/album_artwork.dart';
@@ -34,6 +35,11 @@ class AlbumDetailScreen extends ConsumerStatefulWidget {
   @override
   ConsumerState<AlbumDetailScreen> createState() => _AlbumDetailScreenState();
 }
+
+/// Width of the album pane in the desktop two-pane layout: enough for a
+/// comfortable cover and both transport buttons, narrow enough to leave the
+/// track list the majority of the window.
+const double _detailPaneWidth = 320;
 
 class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
   final Set<String> _selectedUris = <String>{};
@@ -78,6 +84,9 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
       );
     }
 
+    // Bound after the null check so the layout closures below see a non-null
+    // album; a promoted local can't be captured by one.
+    final Album resolved = album;
     final List<Track> selected = <Track>[
       for (final Track track in tracks)
         if (_selectedUris.contains(track.uri)) track,
@@ -100,33 +109,24 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
                 ),
               ],
             ),
-      body: CustomScrollView(
-        slivers: <Widget>[
-          if (!_selecting)
-            SliverToBoxAdapter(
-              child: _AlbumHeader(
-                album: album,
-                trackCount: tracks.length,
-                onPlay: () => _play(context, tracks),
-                onShuffle: () => _shuffle(context, tracks),
-              ),
-            ),
-          SliverList.builder(
-            itemCount: tracks.length,
-            itemBuilder: (context, index) {
-              final Track track = tracks[index];
-              return TrackTile(
-                tracks: tracks,
-                index: index,
-                selectable: true,
-                selectionActive: _selecting,
-                selected: _selectedUris.contains(track.uri),
-                onSelectStart: () => _enterSelection(track),
-                onSelectToggle: () => _toggle(track),
-              );
-            },
-          ),
-        ],
+      body: AdaptiveLayoutBuilder(
+        builder: (
+          BuildContext context,
+          BoxConstraints constraints,
+          WindowSizeClass sizeClass,
+        ) {
+          // One album is exactly the shape a desktop window has room for: the
+          // cover and its actions stay put in a side pane while the track list
+          // scrolls beside them, instead of the cover scrolling away off the
+          // top of a very tall list. Selection mode drops back to the single
+          // column, where the whole width is the list being selected in.
+          if (!_selecting && sizeClass.isAtLeast(WindowSizeClass.expanded)) {
+            return _twoPaneBody(resolved, tracks);
+          }
+          return AdaptiveContentWidth(
+            child: _singleColumnBody(resolved, tracks),
+          );
+        },
       ),
     );
 
@@ -137,6 +137,80 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
         if (!didPop) _exitSelection();
       },
       child: scaffold,
+    );
+  }
+
+  /// Phones, and any window too narrow for a second pane: the header scrolls
+  /// with the tracks, exactly as it always has.
+  Widget _singleColumnBody(Album album, List<Track> tracks) {
+    return CustomScrollView(
+      slivers: <Widget>[
+        if (!_selecting)
+          SliverToBoxAdapter(
+            child: _AlbumHeader(
+              album: album,
+              trackCount: tracks.length,
+              onPlay: () => _play(context, tracks),
+              onShuffle: () => _shuffle(context, tracks),
+            ),
+          ),
+        SliverList.builder(
+          itemCount: tracks.length,
+          itemBuilder: (BuildContext context, int index) =>
+              _trackTile(tracks, index),
+        ),
+      ],
+    );
+  }
+
+  /// Desktop-width composition: a persistent album pane beside the scrolling
+  /// track list. Both read the same `tracks` list and the same selection set,
+  /// so nothing here duplicates state — it is the single-column body, laid out.
+  Widget _twoPaneBody(Album album, List<Track> tracks) {
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: maxPaneLayoutWidth),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            SizedBox(
+              width: _detailPaneWidth,
+              child: SingleChildScrollView(
+                child: _AlbumHeader(
+                  album: album,
+                  trackCount: tracks.length,
+                  stacked: true,
+                  onPlay: () => _play(context, tracks),
+                  onShuffle: () => _shuffle(context, tracks),
+                ),
+              ),
+            ),
+            const VerticalDivider(width: 1),
+            Expanded(
+              child: ListView.builder(
+                key: const Key('album_detail_tracks'),
+                padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+                itemCount: tracks.length,
+                itemBuilder: (BuildContext context, int index) =>
+                    _trackTile(tracks, index),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _trackTile(List<Track> tracks, int index) {
+    final Track track = tracks[index];
+    return TrackTile(
+      tracks: tracks,
+      index: index,
+      selectable: true,
+      selectionActive: _selecting,
+      selected: _selectedUris.contains(track.uri),
+      onSelectStart: () => _enterSelection(track),
+      onSelectToggle: () => _toggle(track),
     );
   }
 
@@ -203,6 +277,7 @@ class _AlbumHeader extends StatelessWidget {
     required this.trackCount,
     required this.onPlay,
     required this.onShuffle,
+    this.stacked = false,
   });
 
   final Album album;
@@ -210,60 +285,38 @@ class _AlbumHeader extends StatelessWidget {
   final VoidCallback onPlay;
   final VoidCallback onShuffle;
 
+  /// Cover above the text rather than beside it. Used by the desktop pane,
+  /// which is tall and narrow — the reverse of the phone header's proportions
+  /// — so the cover gets the pane's full width instead of a 120 px thumbnail.
+  final bool stacked;
+
   @override
   Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-    final Color onSurface = theme.colorScheme.onSurface;
     final String count = trackCount == 1 ? '1 song' : '$trackCount songs';
     return Padding(
       padding: const EdgeInsets.all(AppSpacing.md),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              SizedBox.square(
-                dimension: 120,
-                child: AlbumArtwork(artworkUri: album.artworkUri),
-              ),
-              const SizedBox(width: AppSpacing.md),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    Text(
-                      album.title,
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                      style: theme.textTheme.titleLarge?.copyWith(
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                    if (album.artistName != null &&
-                        album.artistName!.isNotEmpty) ...<Widget>[
-                      const SizedBox(height: AppSpacing.xs),
-                      Text(
-                        album.artistName!,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.bodyLarge?.copyWith(
-                          color: onSurface.withValues(alpha: 0.7),
-                        ),
-                      ),
-                    ],
-                    const SizedBox(height: AppSpacing.xs),
-                    Text(
-                      count,
-                      style: theme.textTheme.bodyMedium?.copyWith(
-                        color: onSurface.withValues(alpha: 0.6),
-                      ),
-                    ),
-                  ],
+          if (stacked) ...<Widget>[
+            AspectRatio(
+              aspectRatio: 1,
+              child: AlbumArtwork(artworkUri: album.artworkUri),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            _AlbumTitleBlock(album: album, count: count),
+          ] else
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                SizedBox.square(
+                  dimension: 120,
+                  child: AlbumArtwork(artworkUri: album.artworkUri),
                 ),
-              ),
-            ],
-          ),
+                const SizedBox(width: AppSpacing.md),
+                Expanded(child: _AlbumTitleBlock(album: album, count: count)),
+              ],
+            ),
           const SizedBox(height: AppSpacing.md),
           Row(
             children: <Widget>[
@@ -286,6 +339,53 @@ class _AlbumHeader extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+/// Title, artist and song count. Identical in both header layouts, so the only
+/// thing [_AlbumHeader.stacked] changes is where the cover sits.
+class _AlbumTitleBlock extends StatelessWidget {
+  const _AlbumTitleBlock({required this.album, required this.count});
+
+  final Album album;
+  final String count;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color onSurface = theme.colorScheme.onSurface;
+    final String? artist = album.artistName;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          album.title,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        if (artist != null && artist.isNotEmpty) ...<Widget>[
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            artist,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: onSurface.withValues(alpha: 0.7),
+            ),
+          ),
+        ],
+        const SizedBox(height: AppSpacing.xs),
+        Text(
+          count,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: onSurface.withValues(alpha: 0.6),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/library/artist_detail_screen.dart
+++ b/lib/features/library/artist_detail_screen.dart
@@ -8,6 +8,7 @@ import '../../core/catalog/library_grouping.dart';
 import '../../core/models/album.dart';
 import '../../core/models/artist.dart';
 import '../../core/models/track.dart';
+import '../../shared/layout/adaptive_layout.dart';
 import '../../shared/widgets/artwork_image.dart';
 import '../../shared/widgets/empty_state.dart';
 import '../player/player_providers.dart';
@@ -36,6 +37,10 @@ class ArtistDetailScreen extends ConsumerStatefulWidget {
   @override
   ConsumerState<ArtistDetailScreen> createState() => _ArtistDetailScreenState();
 }
+
+/// Width of the artist pane in the desktop two-pane layout. Matches the album
+/// screen's pane, so moving between the two doesn't shift the list.
+const double _detailPaneWidth = 320;
 
 class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
   final Set<String> _selectedUris = <String>{};
@@ -77,6 +82,9 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
       );
     }
 
+    // Bound after the null check: the layout closures below can't capture a
+    // promoted local.
+    final Artist resolved = artist;
     final List<Album> albums = albumsForArtist(songs, widget.artistId);
     final List<Track> selected = <Track>[
       for (final Track track in tracks)
@@ -100,49 +108,46 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
                 ),
               ],
             ),
-      body: CustomScrollView(
-        slivers: <Widget>[
-          if (!_selecting) ...<Widget>[
-            SliverToBoxAdapter(
-              child: _ArtistHeader(
-                artist: artist,
-                albumCount: albums.length,
-                trackCount: tracks.length,
-                onPlay: () => _play(context, tracks),
-                onShuffle: () => _shuffle(context, tracks),
+      body: AdaptiveLayoutBuilder(
+        builder: (
+          BuildContext context,
+          BoxConstraints constraints,
+          WindowSizeClass sizeClass,
+        ) {
+          // Wide enough for two panes: the artist stays visible in a side pane
+          // while their albums and songs scroll beside it. Selection mode uses
+          // the single column, where the width belongs to the list.
+          if (!_selecting && sizeClass.isAtLeast(WindowSizeClass.expanded)) {
+            return Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: maxPaneLayoutWidth),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    SizedBox(
+                      width: _detailPaneWidth,
+                      child: SingleChildScrollView(
+                        child: _ArtistHeader(
+                          artist: resolved,
+                          albumCount: albums.length,
+                          trackCount: tracks.length,
+                          stacked: true,
+                          onPlay: () => _play(context, tracks),
+                          onShuffle: () => _shuffle(context, tracks),
+                        ),
+                      ),
+                    ),
+                    const VerticalDivider(width: 1),
+                    Expanded(child: _catalogList(albums, tracks)),
+                  ],
+                ),
               ),
-            ),
-            if (albums.length > 1) ...<Widget>[
-              const SliverToBoxAdapter(child: _SectionHeader(label: 'Albums')),
-              SliverList.builder(
-                itemCount: albums.length,
-                itemBuilder: (context, index) {
-                  final Album album = albums[index];
-                  return AlbumTile(
-                    album: album,
-                    onTap: () => _openAlbum(context, album.id),
-                  );
-                },
-              ),
-            ],
-            const SliverToBoxAdapter(child: _SectionHeader(label: 'Songs')),
-          ],
-          SliverList.builder(
-            itemCount: tracks.length,
-            itemBuilder: (context, index) {
-              final Track track = tracks[index];
-              return TrackTile(
-                tracks: tracks,
-                index: index,
-                selectable: true,
-                selectionActive: _selecting,
-                selected: _selectedUris.contains(track.uri),
-                onSelectStart: () => _enterSelection(track),
-                onSelectToggle: () => _toggle(track),
-              );
-            },
-          ),
-        ],
+            );
+          }
+          return AdaptiveContentWidth(
+            child: _singleColumnBody(resolved, albums, tracks),
+          );
+        },
       ),
     );
 
@@ -154,6 +159,74 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
       },
       child: scaffold,
     );
+  }
+
+  /// Phones and narrow windows: header, albums and songs in one column.
+  Widget _singleColumnBody(
+    Artist artist,
+    List<Album> albums,
+    List<Track> tracks,
+  ) {
+    return CustomScrollView(
+      slivers: <Widget>[
+        if (!_selecting)
+          SliverToBoxAdapter(
+            child: _ArtistHeader(
+              artist: artist,
+              albumCount: albums.length,
+              trackCount: tracks.length,
+              onPlay: () => _play(context, tracks),
+              onShuffle: () => _shuffle(context, tracks),
+            ),
+          ),
+        ..._catalogSlivers(albums, tracks),
+      ],
+    );
+  }
+
+  /// The albums + songs half of the screen, without the header: what the
+  /// desktop layout puts beside the artist pane.
+  Widget _catalogList(List<Album> albums, List<Track> tracks) {
+    return CustomScrollView(
+      key: const Key('artist_detail_catalog'),
+      slivers: _catalogSlivers(albums, tracks),
+    );
+  }
+
+  List<Widget> _catalogSlivers(List<Album> albums, List<Track> tracks) {
+    return <Widget>[
+      if (!_selecting) ...<Widget>[
+        if (albums.length > 1) ...<Widget>[
+          const SliverToBoxAdapter(child: _SectionHeader(label: 'Albums')),
+          SliverList.builder(
+            itemCount: albums.length,
+            itemBuilder: (BuildContext context, int index) {
+              final Album album = albums[index];
+              return AlbumTile(
+                album: album,
+                onTap: () => _openAlbum(context, album.id),
+              );
+            },
+          ),
+        ],
+        const SliverToBoxAdapter(child: _SectionHeader(label: 'Songs')),
+      ],
+      SliverList.builder(
+        itemCount: tracks.length,
+        itemBuilder: (BuildContext context, int index) {
+          final Track track = tracks[index];
+          return TrackTile(
+            tracks: tracks,
+            index: index,
+            selectable: true,
+            selectionActive: _selecting,
+            selected: _selectedUris.contains(track.uri),
+            onSelectStart: () => _enterSelection(track),
+            onSelectToggle: () => _toggle(track),
+          );
+        },
+      ),
+    ];
   }
 
   PreferredSizeWidget _selectionAppBar(List<Track> selected) {
@@ -224,6 +297,7 @@ class _ArtistHeader extends StatelessWidget {
     required this.trackCount,
     required this.onPlay,
     required this.onShuffle,
+    this.stacked = false,
   });
 
   final Artist artist;
@@ -232,10 +306,16 @@ class _ArtistHeader extends StatelessWidget {
   final VoidCallback onPlay;
   final VoidCallback onShuffle;
 
+  /// Portrait above the name rather than beside it, for the tall, narrow
+  /// desktop pane.
+  final bool stacked;
+
+  /// A bigger portrait for the desktop pane, where it has the pane's width to
+  /// itself rather than sharing a row with the name.
+  static const double _stackedPortraitRadius = 72;
+
   @override
   Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-    final Color onSurface = theme.colorScheme.onSurface;
     final String songs = trackCount == 1 ? '1 song' : '$trackCount songs';
     final String summary = albumCount > 0
         ? '${albumCount == 1 ? '1 album' : '$albumCount albums'} • $songs'
@@ -245,47 +325,27 @@ class _ArtistHeader extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
-          Row(
-            children: <Widget>[
-              CircleAvatar(
-                radius: 36,
-                backgroundColor: theme.colorScheme.surfaceContainerHighest,
-                backgroundImage: artist.artworkUri == null
-                    ? null
-                    : artworkImageProvider(artist.artworkUri!),
-                child: artist.artworkUri == null
-                    ? Icon(
-                        Icons.person,
-                        size: 36,
-                        color: onSurface.withValues(alpha: 0.35),
-                      )
-                    : null,
-              ),
-              const SizedBox(width: AppSpacing.md),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    Text(
-                      artist.name,
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                      style: theme.textTheme.titleLarge?.copyWith(
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                    const SizedBox(height: AppSpacing.xs),
-                    Text(
-                      summary,
-                      style: theme.textTheme.bodyMedium?.copyWith(
-                        color: onSurface.withValues(alpha: 0.6),
-                      ),
-                    ),
-                  ],
+          if (stacked) ...<Widget>[
+            _ArtistPortrait(artist: artist, radius: _stackedPortraitRadius),
+            const SizedBox(height: AppSpacing.md),
+            _ArtistTitleBlock(
+              name: artist.name,
+              summary: summary,
+              center: true,
+            ),
+          ] else
+            Row(
+              children: <Widget>[
+                _ArtistPortrait(artist: artist, radius: 36),
+                const SizedBox(width: AppSpacing.md),
+                Expanded(
+                  child: _ArtistTitleBlock(
+                    name: artist.name,
+                    summary: summary,
+                  ),
                 ),
-              ),
-            ],
-          ),
+              ],
+            ),
           const SizedBox(height: AppSpacing.md),
           Row(
             children: <Widget>[
@@ -308,6 +368,79 @@ class _ArtistHeader extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+/// The artist's circular portrait, or a tinted glyph when there is no artwork.
+class _ArtistPortrait extends StatelessWidget {
+  const _ArtistPortrait({required this.artist, required this.radius});
+
+  final Artist artist;
+  final double radius;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Uri? uri = artist.artworkUri;
+    // Centred rather than left-aligned: in the stacked pane the column
+    // stretches its children, and a stretched avatar is not a circle.
+    return Center(
+      child: CircleAvatar(
+        radius: radius,
+        backgroundColor: theme.colorScheme.surfaceContainerHighest,
+        backgroundImage: uri == null ? null : artworkImageProvider(uri),
+        child: uri == null
+            ? Icon(
+                Icons.person,
+                size: radius,
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.35),
+              )
+            : null,
+      ),
+    );
+  }
+}
+
+/// Name and the "3 albums • 41 songs" summary, shared by both header layouts.
+class _ArtistTitleBlock extends StatelessWidget {
+  const _ArtistTitleBlock({
+    required this.name,
+    required this.summary,
+    this.center = false,
+  });
+
+  final String name;
+  final String summary;
+  final bool center;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color onSurface = theme.colorScheme.onSurface;
+    final TextAlign align = center ? TextAlign.center : TextAlign.start;
+    return Column(
+      crossAxisAlignment:
+          center ? CrossAxisAlignment.center : CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          name,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+          textAlign: align,
+          style: theme.textTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        Text(
+          summary,
+          textAlign: align,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: onSurface.withValues(alpha: 0.6),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -12,6 +12,7 @@ import '../../core/models/artist.dart';
 import '../../core/models/track.dart';
 import '../../core/services/bulk_track_actions.dart';
 import '../../core/sources/local/folder_location.dart';
+import '../../shared/layout/adaptive_layout.dart';
 import '../../shared/widgets/empty_state.dart';
 import '../playlists/widgets/add_to_playlist_sheet.dart';
 import 'folder_browser_providers.dart';
@@ -25,7 +26,7 @@ import 'song_actions.dart';
 import 'unified_library_providers.dart';
 import 'widgets/album_grid.dart';
 import 'widgets/alphabet_track_list.dart';
-import 'widgets/artist_tile.dart';
+import 'widgets/artist_grid.dart';
 import 'widgets/folder_browser_tab.dart';
 import 'widgets/library_search_field.dart';
 
@@ -49,6 +50,9 @@ class LibraryScreen extends ConsumerStatefulWidget {
 
 class _LibraryScreenState extends ConsumerState<LibraryScreen>
     with SingleTickerProviderStateMixin {
+  /// Widest the search box gets on a desktop window.
+  static const double _searchFieldMaxWidth = 520;
+
   final Set<String> _selectedUris = <String>{};
   bool _selecting = false;
 
@@ -231,10 +235,19 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
     return Column(
       children: <Widget>[
         if (!foldersTab)
-          LibrarySearchField(
-            controller: _searchController,
-            onChanged: _onQueryChanged,
-            onClear: _clearSearch,
+          // The box is a text input, not content: on a wide window it stops
+          // growing and stays left-aligned under the tabs rather than running
+          // the width of a monitor.
+          Align(
+            alignment: AlignmentDirectional.centerStart,
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: _searchFieldMaxWidth),
+              child: LibrarySearchField(
+                controller: _searchController,
+                onChanged: _onQueryChanged,
+                onClear: _clearSearch,
+              ),
+            ),
           ),
         Expanded(
           child: TabBarView(
@@ -298,29 +311,28 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
         message: 'You can still browse the connected server from Folders.',
       );
     }
-    return ListView.builder(
-      key: const Key('library_artist_list'),
-      itemCount: filtered.length,
-      itemBuilder: (context, index) {
-        final Artist artist = filtered[index];
-        return ArtistTile(
-          artist: artist,
-          onTap: () => context.push(AppRoutes.artistDetailPath(artist.id)),
-        );
-      },
+    return ArtistGrid(
+      artists: filtered,
+      onOpen: (Artist artist) =>
+          context.push(AppRoutes.artistDetailPath(artist.id)),
     );
   }
 
   List<Track> _filteredSongs(List<Track> songs) => filterTracks(songs, _query);
 
   Widget _songsList(List<Track> tracks) {
-    return AlphabetTrackList(
-      tracks: tracks,
-      selectable: true,
-      selectionActive: _selecting,
-      selectedUris: _selectedUris,
-      onSelectStart: _enterSelection,
-      onSelectToggle: _toggle,
+    // Song rows are a single column of text: past [maxContentWidth] the title
+    // and the trailing menu end up a screen apart, so the column stops growing
+    // and centres instead of stretching across a desktop monitor.
+    return AdaptiveContentWidth(
+      child: AlphabetTrackList(
+        tracks: tracks,
+        selectable: true,
+        selectionActive: _selecting,
+        selectedUris: _selectedUris,
+        onSelectStart: _enterSelection,
+        onSelectToggle: _toggle,
+      ),
     );
   }
 

--- a/lib/features/library/widgets/album_grid.dart
+++ b/lib/features/library/widgets/album_grid.dart
@@ -9,22 +9,37 @@ import 'album_grid_card.dart';
 /// why [albumGridColumnCount] never returns fewer than [_minColumns].
 const double _minCardWidth = 200;
 
+/// Widest a card may get before the grid adds a column instead.
+///
+/// This is what keeps a desktop window from reading as a stretched phone: past
+/// this width the extra space buys another album, not a bigger cover. Without
+/// it a 2560 px window rendered six ~400 px cards — the same mobile grid, just
+/// inflated.
+const double _maxCardWidth = 260;
+
 /// Phones (and anything narrower than two comfortable cards) get exactly two
-/// columns; the cap keeps covers from turning into thumbnails on a desktop
-/// window that is very wide.
+/// columns; the upper bound is a sanity stop for absurd widths rather than a
+/// design limit — every monitor Linthra realistically runs on is sized by
+/// [_maxCardWidth] well before it.
 const int _minColumns = 2;
-const int _maxColumns = 6;
+const int _maxColumns = 12;
 
 /// Columns for [width] logical pixels of *content* width — the space left for
 /// the cards themselves, gutters included, after the grid's own padding.
 ///
-/// Two on a phone, and an extra column only once there is genuinely room for
-/// another card at [_minCardWidth]. Pure so the breakpoints can be tested
-/// without pumping a widget.
+/// Two on a phone; a column is added as soon as one more card fits at
+/// [_minCardWidth], and columns keep being added while cards would otherwise
+/// grow past [_maxCardWidth]. Pure so the breakpoints can be tested without
+/// pumping a widget.
 int albumGridColumnCount(double width) {
   if (!width.isFinite || width <= 0) return _minColumns;
+  // As many as still fit at the narrow bound, and as many as it takes to keep
+  // cards under the wide one. The narrow bound wins where they disagree, so a
+  // card is never squeezed below [_minCardWidth] just to add a column.
   final int fits = (width / _minCardWidth).floor();
-  return fits.clamp(_minColumns, _maxColumns);
+  final int dense = (width / _maxCardWidth).ceil();
+  final int columns = dense < fits ? dense : fits;
+  return columns.clamp(_minColumns, _maxColumns);
 }
 
 /// The Albums tab body: a responsive grid of [AlbumGridCard]s.

--- a/lib/features/library/widgets/artist_grid.dart
+++ b/lib/features/library/widgets/artist_grid.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/models/artist.dart';
+import 'artist_tile.dart';
+
+/// Narrowest an artist row may get before the grid drops a column. Below this
+/// the name and the "3 albums • 41 songs" line start to clip on real libraries.
+const double _minRowWidth = 340;
+
+/// Widest a row may get before the grid adds a column instead — the same idea
+/// as the album grid's card cap. A single 2400 px row would put the avatar and
+/// the chevron a screen apart.
+const double _maxRowWidth = 520;
+
+/// One column on a phone; the upper bound is a sanity stop for absurd widths,
+/// not a design limit.
+const int _minColumns = 1;
+const int _maxColumns = 6;
+
+/// Columns for [width] logical pixels of available width.
+///
+/// One on a phone (identical to the single-column list this replaces), and a
+/// column added as soon as another row fits at [_minRowWidth] or rows would
+/// otherwise stretch past [_maxRowWidth]. Pure so the breakpoints can be
+/// asserted without pumping a widget.
+int artistGridColumnCount(double width) {
+  if (!width.isFinite || width <= 0) return _minColumns;
+  final int fits = (width / _minRowWidth).floor();
+  final int dense = (width / _maxRowWidth).ceil();
+  final int columns = dense < fits ? dense : fits;
+  return columns.clamp(_minColumns, _maxColumns);
+}
+
+/// The Artists tab body: [ArtistTile] rows that flow into columns as the window
+/// widens.
+///
+/// At one column this is the list it replaces, row for row — same tile, same
+/// tap and long-press. Wider windows lay the same rows out in two or more
+/// columns instead of stretching each one across the monitor, which is what
+/// made the Artists tab read as a blown-up phone screen on Linux.
+class ArtistGrid extends StatelessWidget {
+  const ArtistGrid({required this.artists, required this.onOpen, super.key});
+
+  final List<Artist> artists;
+  final void Function(Artist artist) onOpen;
+
+  /// Height of one row. [ArtistTile] is a two-line [ListTile], so 72 is its
+  /// natural height — but the grid has to give every cell a fixed extent, so
+  /// scaled-up text gets the room it needs rather than overflowing the cell.
+  static double rowExtent(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final TextScaler scaler = MediaQuery.textScalerOf(context);
+    final double title =
+        scaler.scale(theme.textTheme.titleMedium?.fontSize ?? 16) * _lineHeight;
+    final double subtitle =
+        scaler.scale(theme.textTheme.bodyMedium?.fontSize ?? 14) * _lineHeight;
+    final double text = title + subtitle + AppSpacing.md;
+    return text > _defaultRowExtent ? text : _defaultRowExtent;
+  }
+
+  static const double _lineHeight = 1.35;
+  static const double _defaultRowExtent = 72;
+
+  @override
+  Widget build(BuildContext context) {
+    final double extent = rowExtent(context);
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final int columns = artistGridColumnCount(constraints.maxWidth);
+        final bool single = columns == 1;
+        return GridView.builder(
+          key: const Key('library_artist_list'),
+          // A single column keeps the edge-to-edge list look phones already
+          // have; only the multi-column desktop layout needs gutters.
+          padding: single
+              ? EdgeInsets.zero
+              : const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.sm,
+                  vertical: AppSpacing.sm,
+                ),
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: columns,
+            crossAxisSpacing: single ? 0 : AppSpacing.sm,
+            mainAxisSpacing: 0,
+            mainAxisExtent: extent,
+          ),
+          itemCount: artists.length,
+          itemBuilder: (BuildContext context, int index) {
+            final Artist artist = artists[index];
+            return ArtistTile(
+              artist: artist,
+              onTap: () => onOpen(artist),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../app/dimens.dart';
 import '../../core/models/playback_state.dart';
 import '../../core/models/track.dart';
+import '../../shared/layout/adaptive_layout.dart';
 import '../../shared/widgets/empty_state.dart';
 import 'cast/cast_button.dart';
 import 'cast/cast_providers.dart';
@@ -139,52 +140,124 @@ class _NowPlayingState extends State<_NowPlaying> {
 
   @override
   Widget build(BuildContext context) {
-    final Track track = widget.track;
-    // A tighter side margin lets the artwork breathe wider and gives the
-    // transport controls more room to spread, while the generous gaps below
-    // group the screen into three calm bands: stage · metadata · controls.
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        AppSpacing.md,
-        AppSpacing.sm,
-        AppSpacing.md,
-        AppSpacing.lg,
-      ),
-      child: Column(
-        children: [
-          Expanded(child: _Stage(track: track, showLyrics: _showLyrics)),
-          // Lyrics need the height more than the gap does; the artwork keeps
-          // its generous breathing room.
-          SizedBox(height: _showLyrics ? AppSpacing.md : AppSpacing.xl),
-          // In lyrics mode the three-line metadata block collapses to a single
-          // quiet line, handing the difference to the lyrics above without
-          // losing track of what is playing.
-          if (_showLyrics)
-            _CompactTrackLine(
-              title: track.title,
-              artistName: track.artistName,
-            )
-          else
-            TrackMetadata(
-              title: track.title,
-              artistName: track.artistName,
-              albumName: track.albumName,
-            ),
-          SizedBox(height: _showLyrics ? AppSpacing.md : AppSpacing.lg),
-          // The only part of the screen that follows the live, high-frequency
-          // playback state — kept separate so the stage, metadata, and the
-          // blurred background above never rebuild on a position tick. It stays
-          // exactly where it is in both modes, so play/pause, skip, and seek are
-          // never further away for reading lyrics.
-          const _LiveControls(),
-          const SizedBox(height: AppSpacing.md),
-          NowPlayingActions(
-            track: track,
-            lyricsVisible: _showLyrics,
-            onToggleLyrics: () => setState(() => _showLyrics = !_showLyrics),
+    return AdaptiveLayoutBuilder(
+      builder: (
+        BuildContext context,
+        BoxConstraints constraints,
+        WindowSizeClass sizeClass,
+      ) {
+        // Width alone decides, so the same window is laid out the same way on
+        // any platform — and the side-by-side layout is the *more* forgiving of
+        // the two vertically, since the cover shrinks beside the controls
+        // instead of stacking on top of them.
+        final bool wide = sizeClass.isAtLeast(WindowSizeClass.expanded);
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(
+            AppSpacing.md,
+            AppSpacing.sm,
+            AppSpacing.md,
+            AppSpacing.lg,
           ),
-        ],
+          child: wide ? _wideLayout() : _stackedLayout(),
+        );
+      },
+    );
+  }
+
+  /// Desktop-width Now Playing: the cover holds one side while metadata,
+  /// transport and actions sit on the other — and lyrics open *beside* the
+  /// cover instead of replacing it, which is the whole point of the extra
+  /// width. Same widgets, same `_showLyrics`, same playback state as the
+  /// stacked layout; only the arrangement differs.
+  Widget _wideLayout() {
+    final Track track = widget.track;
+    return Center(
+      child: ConstrainedBox(
+        // Ultrawide windows stop stretching the two columns apart here.
+        constraints: const BoxConstraints(maxWidth: maxPaneLayoutWidth),
+        child: Row(
+          children: <Widget>[
+            Expanded(
+              flex: 5,
+              child: Center(child: _ArtworkHero(artworkUri: track.artworkUri)),
+            ),
+            const SizedBox(width: AppSpacing.xl),
+            Expanded(
+              flex: 4,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  if (_showLyrics) ...<Widget>[
+                    const Expanded(
+                      child: LyricsBackdrop(child: LyricsView()),
+                    ),
+                    const SizedBox(height: AppSpacing.lg),
+                  ],
+                  TrackMetadata(
+                    title: track.title,
+                    artistName: track.artistName,
+                    albumName: track.albumName,
+                  ),
+                  const SizedBox(height: AppSpacing.lg),
+                  const _LiveControls(),
+                  const SizedBox(height: AppSpacing.md),
+                  NowPlayingActions(
+                    track: track,
+                    lyricsVisible: _showLyrics,
+                    onToggleLyrics: _toggleLyrics,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
+    );
+  }
+
+  void _toggleLyrics() => setState(() => _showLyrics = !_showLyrics);
+
+  /// Phones, and any window without the width (or height) for two columns.
+  ///
+  /// A tighter side margin lets the artwork breathe wider and gives the
+  /// transport controls more room to spread, while the generous gaps below
+  /// group the screen into three calm bands: stage · metadata · controls.
+  Widget _stackedLayout() {
+    final Track track = widget.track;
+    return Column(
+      children: [
+        Expanded(child: _Stage(track: track, showLyrics: _showLyrics)),
+        // Lyrics need the height more than the gap does; the artwork keeps
+        // its generous breathing room.
+        SizedBox(height: _showLyrics ? AppSpacing.md : AppSpacing.xl),
+        // In lyrics mode the three-line metadata block collapses to a single
+        // quiet line, handing the difference to the lyrics above without
+        // losing track of what is playing.
+        if (_showLyrics)
+          _CompactTrackLine(
+            title: track.title,
+            artistName: track.artistName,
+          )
+        else
+          TrackMetadata(
+            title: track.title,
+            artistName: track.artistName,
+            albumName: track.albumName,
+          ),
+        SizedBox(height: _showLyrics ? AppSpacing.md : AppSpacing.lg),
+        // The only part of the screen that follows the live, high-frequency
+        // playback state — kept separate so the stage, metadata, and the
+        // blurred background above never rebuild on a position tick. It stays
+        // exactly where it is in both modes, so play/pause, skip, and seek are
+        // never further away for reading lyrics.
+        const _LiveControls(),
+        const SizedBox(height: AppSpacing.md),
+        NowPlayingActions(
+          track: track,
+          lyricsVisible: _showLyrics,
+          onToggleLyrics: _toggleLyrics,
+        ),
+      ],
     );
   }
 }

--- a/lib/features/playlists/playlists_screen.dart
+++ b/lib/features/playlists/playlists_screen.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../../app/routes.dart';
 import '../../core/models/playlist.dart';
 import '../../data/repositories/playlist_repository_provider.dart';
+import '../../shared/layout/adaptive_layout.dart';
 import '../../shared/widgets/confirm_dialog.dart';
 import '../../shared/widgets/empty_state.dart';
 import '../library/remote_library_refresher.dart';
@@ -52,45 +53,49 @@ class _PlaylistsScreenState extends ConsumerState<PlaylistsScreen> {
         icon: const Icon(Icons.add),
         label: const Text('New playlist'),
       ),
-      body: Column(
-        children: <Widget>[
-          ListTile(
-            leading: CircleAvatar(
-              backgroundColor: accent.withValues(alpha: 0.12),
-              child: Icon(Icons.favorite, color: accent),
+      // Rows of one playlist each: capped and centred on a wide window rather
+      // than stretched edge to edge.
+      body: AdaptiveContentWidth(
+        child: Column(
+          children: <Widget>[
+            ListTile(
+              leading: CircleAvatar(
+                backgroundColor: accent.withValues(alpha: 0.12),
+                child: Icon(Icons.favorite, color: accent),
+              ),
+              title: const Text('Favorites'),
+              subtitle: const Text('Tracks you’ve liked'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => context.push(AppRoutes.favorites),
             ),
-            title: const Text('Favorites'),
-            subtitle: const Text('Tracks you’ve liked'),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: () => context.push(AppRoutes.favorites),
-          ),
-          const Divider(height: 0),
-          ListTile(
-            leading: CircleAvatar(
-              backgroundColor: accent.withValues(alpha: 0.12),
-              child: Icon(Icons.auto_awesome, color: accent),
+            const Divider(height: 0),
+            ListTile(
+              leading: CircleAvatar(
+                backgroundColor: accent.withValues(alpha: 0.12),
+                child: Icon(Icons.auto_awesome, color: accent),
+              ),
+              title: const Text('Smart mixes'),
+              subtitle: const Text('Made by Linthra'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => context.push(AppRoutes.smartMixes),
             ),
-            title: const Text('Smart mixes'),
-            subtitle: const Text('Made by Linthra'),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: () => context.push(AppRoutes.smartMixes),
-          ),
-          const Divider(height: 0),
-          Expanded(
-            child: playlists.when(
-              loading: () => const Center(child: CircularProgressIndicator()),
-              error: (_, __) => const _PlaylistsError(),
-              data: (List<Playlist> items) => items.isEmpty
-                  ? _PlaylistsEmpty(serverConnected: serverConnected)
-                  : ListView.builder(
-                      padding: const EdgeInsets.only(bottom: 88),
-                      itemCount: items.length,
-                      itemBuilder: (context, index) =>
-                          _PlaylistTile(playlist: items[index]),
-                    ),
+            const Divider(height: 0),
+            Expanded(
+              child: playlists.when(
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (_, __) => const _PlaylistsError(),
+                data: (List<Playlist> items) => items.isEmpty
+                    ? _PlaylistsEmpty(serverConnected: serverConnected)
+                    : ListView.builder(
+                        padding: const EdgeInsets.only(bottom: 88),
+                        itemCount: items.length,
+                        itemBuilder: (context, index) =>
+                            _PlaylistTile(playlist: items[index]),
+                      ),
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/settings/hub/settings_detail_scaffold.dart
+++ b/lib/features/settings/hub/settings_detail_scaffold.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../app/dimens.dart';
+import '../../../shared/layout/adaptive_layout.dart';
 
 /// The shared frame for a Settings category page (the screen a hub row opens).
 ///
@@ -25,9 +26,14 @@ class SettingsDetailScaffold extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: Text(title)),
-      body: ListView(
-        padding: const EdgeInsets.all(AppSpacing.md),
-        children: children,
+      // Same cap as the hub, so a category page doesn't jump to a different
+      // column width when it opens on a desktop window.
+      body: AdaptiveContentWidth(
+        maxWidth: maxFormWidth,
+        child: ListView(
+          padding: const EdgeInsets.all(AppSpacing.md),
+          children: children,
+        ),
       ),
     );
   }

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import '../../app/dimens.dart';
 import '../../app/routes.dart';
 import '../../core/app_info.dart';
+import '../../shared/layout/adaptive_layout.dart';
 import '../appearance/selected_logo_mark.dart';
 import 'hub/settings_category_tile.dart';
 
@@ -19,67 +20,73 @@ class SettingsScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
-      body: ListView(
-        padding: const EdgeInsets.all(AppSpacing.md),
-        children: <Widget>[
-          const _BrandHeader(),
-          const SizedBox(height: AppSpacing.md),
-          SettingsCategoryTile(
-            icon: Icons.hub_outlined,
-            title: 'Connections',
-            subtitle: 'Jellyfin, Plex, Navidrome/Subsonic, local files',
-            onTap: () => context.push(AppRoutes.settingsConnections),
-          ),
-          const SizedBox(height: AppSpacing.md),
-          SettingsCategoryTile(
-            icon: Icons.play_circle_outline,
-            title: 'Music & playback',
-            subtitle: 'Default source and playback behaviour',
-            onTap: () => context.push(AppRoutes.settingsPlayback),
-          ),
-          const SizedBox(height: AppSpacing.md),
-          SettingsCategoryTile(
-            icon: Icons.sd_storage_outlined,
-            title: 'Cache & data',
-            subtitle: 'Smart pre-cache and cache size',
-            onTap: () => context.push(AppRoutes.settingsCache),
-          ),
-          const SizedBox(height: AppSpacing.md),
-          SettingsCategoryTile(
-            icon: Icons.download_outlined,
-            title: 'Offline & downloads',
-            subtitle: 'Mobile data and offline downloads',
-            onTap: () => context.push(AppRoutes.settingsDownloads),
-          ),
-          const SizedBox(height: AppSpacing.md),
-          SettingsCategoryTile(
-            icon: Icons.palette_outlined,
-            title: 'Appearance',
-            subtitle: 'App icon and in-app branding',
-            onTap: () => context.push(AppRoutes.settingsAppearance),
-          ),
-          const SizedBox(height: AppSpacing.md),
-          SettingsCategoryTile(
-            icon: Icons.auto_awesome_outlined,
-            title: 'Welcome tour',
-            subtitle: 'Replay the Linthra introduction and music-source guide',
-            onTap: () => context.push(AppRoutes.onboardingReplay),
-          ),
-          const SizedBox(height: AppSpacing.md),
-          SettingsCategoryTile(
-            icon: Icons.help_outline,
-            title: 'Diagnostics & support',
-            subtitle: 'Report a bug, copy diagnostics',
-            onTap: () => context.push(AppRoutes.settingsDiagnostics),
-          ),
-          const SizedBox(height: AppSpacing.md),
-          SettingsCategoryTile(
-            icon: Icons.info_outline,
-            title: 'About',
-            subtitle: 'Version, support, and project links',
-            onTap: () => context.push(AppRoutes.settingsAbout),
-          ),
-        ],
+      // A settings row is a label and a control; on a wide window the column
+      // stops growing and centres rather than pulling the two apart.
+      body: AdaptiveContentWidth(
+        maxWidth: maxFormWidth,
+        child: ListView(
+          padding: const EdgeInsets.all(AppSpacing.md),
+          children: <Widget>[
+            const _BrandHeader(),
+            const SizedBox(height: AppSpacing.md),
+            SettingsCategoryTile(
+              icon: Icons.hub_outlined,
+              title: 'Connections',
+              subtitle: 'Jellyfin, Plex, Navidrome/Subsonic, local files',
+              onTap: () => context.push(AppRoutes.settingsConnections),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            SettingsCategoryTile(
+              icon: Icons.play_circle_outline,
+              title: 'Music & playback',
+              subtitle: 'Default source and playback behaviour',
+              onTap: () => context.push(AppRoutes.settingsPlayback),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            SettingsCategoryTile(
+              icon: Icons.sd_storage_outlined,
+              title: 'Cache & data',
+              subtitle: 'Smart pre-cache and cache size',
+              onTap: () => context.push(AppRoutes.settingsCache),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            SettingsCategoryTile(
+              icon: Icons.download_outlined,
+              title: 'Offline & downloads',
+              subtitle: 'Mobile data and offline downloads',
+              onTap: () => context.push(AppRoutes.settingsDownloads),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            SettingsCategoryTile(
+              icon: Icons.palette_outlined,
+              title: 'Appearance',
+              subtitle: 'App icon and in-app branding',
+              onTap: () => context.push(AppRoutes.settingsAppearance),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            SettingsCategoryTile(
+              icon: Icons.auto_awesome_outlined,
+              title: 'Welcome tour',
+              subtitle:
+                  'Replay the Linthra introduction and music-source guide',
+              onTap: () => context.push(AppRoutes.onboardingReplay),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            SettingsCategoryTile(
+              icon: Icons.help_outline,
+              title: 'Diagnostics & support',
+              subtitle: 'Report a bug, copy diagnostics',
+              onTap: () => context.push(AppRoutes.settingsDiagnostics),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            SettingsCategoryTile(
+              icon: Icons.info_outline,
+              title: 'About',
+              subtitle: 'Version, support, and project links',
+              onTap: () => context.push(AppRoutes.settingsAbout),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/shared/layout/adaptive_layout.dart
+++ b/lib/shared/layout/adaptive_layout.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/widgets.dart';
+
+/// How much horizontal room a surface actually has to lay itself out in.
+///
+/// Linthra adapts on *width*, not on `Platform.isLinux`: a 700 px Linux window
+/// and a large foldable want the same layout, and a feature widget should not
+/// have to know which OS it is drawn on to make that call. The desktop shell
+/// (rail, dividers) already eats part of the window, so the classes are meant
+/// to be resolved from the constraints a widget is given — see
+/// [AdaptiveLayoutBuilder] — rather than from the raw window size.
+///
+/// The thresholds follow Material's window size classes, with the compact and
+/// medium ones kept exactly where Android already behaves, so nothing about the
+/// phone layout moves.
+enum WindowSizeClass {
+  /// Phones, and Linux windows narrow enough that one column is still right.
+  compact,
+
+  /// Small desktop windows, tablets, landscape phones: room for a second
+  /// column of list rows, not yet for a second pane.
+  medium,
+
+  /// A normal desktop window (1280×720 and up): room for a real two-pane
+  /// composition beside the navigation rail.
+  expanded,
+
+  /// 1920 and beyond, including ultrawide. Content is capped and centred here
+  /// rather than stretched, so text lines stay readable.
+  large;
+
+  /// Whether this class is at least [other] wide, so callers can ask
+  /// `sizeClass.isAtLeast(WindowSizeClass.expanded)` instead of comparing
+  /// enum indices by hand.
+  bool isAtLeast(WindowSizeClass other) => index >= other.index;
+}
+
+/// Lower bound of [WindowSizeClass.medium].
+const double mediumWindowWidth = 600;
+
+/// Lower bound of [WindowSizeClass.expanded]: the width where a second pane
+/// starts to pay for itself next to the navigation rail.
+const double expandedWindowWidth = 1000;
+
+/// Lower bound of [WindowSizeClass.large].
+const double largeWindowWidth = 1600;
+
+/// Widest a single column of text or list rows is allowed to get.
+///
+/// Rows stretched across a 2560 px monitor put the title and the trailing
+/// action a screen apart and read badly; capping and centring keeps them
+/// scannable without leaving the desktop looking empty.
+const double maxContentWidth = 1100;
+
+/// Widest a settings form or card stack is allowed to get. Narrower than
+/// [maxContentWidth]: a settings row is a label and a control, and pulling the
+/// two apart across a monitor is exactly what makes a desktop app look like a
+/// stretched phone.
+const double maxFormWidth = 840;
+
+/// Widest a two-pane composition is allowed to get before it stops growing and
+/// centres instead. Generous enough that 1920 is used in full.
+const double maxPaneLayoutWidth = 1800;
+
+/// The size class for [width] logical pixels of available width.
+///
+/// Pure, so the breakpoints can be asserted without pumping a widget. A
+/// non-finite or non-positive width (an unbounded or not-yet-measured box)
+/// falls back to [WindowSizeClass.compact], which is the layout that works
+/// everywhere.
+WindowSizeClass windowSizeClassFor(double width) {
+  if (!width.isFinite || width <= 0) return WindowSizeClass.compact;
+  if (width >= largeWindowWidth) return WindowSizeClass.large;
+  if (width >= expandedWindowWidth) return WindowSizeClass.expanded;
+  if (width >= mediumWindowWidth) return WindowSizeClass.medium;
+  return WindowSizeClass.compact;
+}
+
+/// Builds against the [WindowSizeClass] of the box the widget is given.
+///
+/// Prefer this over reading `MediaQuery.sizeOf(context)`: inside the desktop
+/// shell a feature screen is narrower than the window by the width of the
+/// navigation rail, and a sheet or split pane is narrower still.
+class AdaptiveLayoutBuilder extends StatelessWidget {
+  const AdaptiveLayoutBuilder({required this.builder, super.key});
+
+  final Widget Function(
+    BuildContext context,
+    BoxConstraints constraints,
+    WindowSizeClass sizeClass,
+  ) builder;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) => builder(
+          context, constraints, windowSizeClassFor(constraints.maxWidth)),
+    );
+  }
+}
+
+/// Caps a single column of content at [maxWidth] and centres it.
+///
+/// A no-op below the cap, so phones and narrow windows are untouched; it only
+/// engages once a window is wide enough that a full-bleed column would be hard
+/// to read.
+class AdaptiveContentWidth extends StatelessWidget {
+  const AdaptiveContentWidth({
+    required this.child,
+    this.maxWidth = maxContentWidth,
+    super.key,
+  });
+
+  final Widget child;
+  final double maxWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.topCenter,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: maxWidth),
+        child: child,
+      ),
+    );
+  }
+}

--- a/test/features/library/album_grid_test.dart
+++ b/test/features/library/album_grid_test.dart
@@ -134,8 +134,36 @@ void main() {
       expect(albumGridColumnCount(800), 4);
     });
 
-    test('columns are capped so covers never shrink to thumbnails', () {
-      expect(albumGridColumnCount(4000), 6);
+    test('desktop widths add columns instead of inflating covers', () {
+      // Content widths for the common Linux windows, minus the navigation rail
+      // and the grid's own padding. Each keeps cards in the 200–260 band rather
+      // than stretching six mobile-sized cards across the monitor.
+      expect(albumGridColumnCount(1168), 5); // 1280x720
+      expect(albumGridColumnCount(1808), 7); // 1920x1080
+      expect(albumGridColumnCount(2448), 10); // 2560x1440
+      expect(albumGridColumnCount(3120), 12); // ultrawide
+    });
+
+    test('a card is never squeezed below its minimum to add a column', () {
+      for (final double width in <double>[
+        328,
+        560,
+        900,
+        1168,
+        1808,
+        2448,
+        3120,
+      ]) {
+        expect(
+          width / albumGridColumnCount(width),
+          greaterThanOrEqualTo(160),
+          reason: 'cards stay readable at $width',
+        );
+      }
+    });
+
+    test('columns stop climbing at an absurd width', () {
+      expect(albumGridColumnCount(40000), 12);
     });
 
     test('a degenerate width still renders two columns', () {
@@ -193,6 +221,47 @@ void main() {
       );
 
       expect(_firstRow(tester).length, greaterThan(2));
+    });
+
+    testWidgets('a desktop window keeps covers card-sized, not inflated',
+        (tester) async {
+      await _pumpAlbums(
+        tester,
+        tracks: _manyAlbums(),
+        size: const Size(1920, 1080),
+      );
+
+      final List<Rect> row = _firstRow(tester);
+      // Six albums across a 1920 window: all on one row, none of them the
+      // ~400 px slab a capped mobile grid produced here.
+      expect(row.length, 6);
+      for (final Rect card in row) {
+        expect(card.width, lessThan(300));
+        expect(card.width, greaterThan(180));
+      }
+      expect(row.last.right, lessThanOrEqualTo(1920));
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('resizing from phone to desktop reflows without overflow',
+        (tester) async {
+      await _pumpAlbums(tester, tracks: _manyAlbums());
+      expect(_firstRow(tester).length, 2);
+
+      for (final Size size in <Size>[
+        const Size(800, 720),
+        const Size(1280, 720),
+        const Size(2560, 1440),
+        const Size(3440, 1440),
+        const Size(390, 844),
+      ]) {
+        tester.view.physicalSize = size;
+        await tester.pumpAndSettle();
+        expect(tester.takeException(), isNull, reason: 'at $size');
+        final List<Rect> row = _firstRow(tester);
+        expect(row.last.right, lessThanOrEqualTo(size.width),
+            reason: 'at $size');
+      }
     });
 
     testWidgets('tapping a card opens that album', (tester) async {

--- a/test/features/library/artist_grid_test.dart
+++ b/test/features/library/artist_grid_test.dart
@@ -1,0 +1,215 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:linthra/app/routes.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/in_memory_playlist_store.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/data/repositories/playlist_repository_provider.dart';
+import 'package:linthra/features/library/artist_detail_screen.dart';
+import 'package:linthra/features/library/library_screen.dart';
+import 'package:linthra/features/library/widgets/artist_grid.dart';
+import 'package:linthra/features/library/widgets/artist_tile.dart';
+import 'package:linthra/features/player/player_providers.dart';
+
+import '../player/fake_playback_controller.dart';
+import 'fake_music_library_repository.dart';
+
+/// Six artists, enough rows to tell one column from two or three. No artwork
+/// anywhere, so the tests never reach for the network.
+List<Track> _artists() => <Track>[
+      for (int i = 0; i < 6; i++)
+        Track(
+          id: 'a$i',
+          title: 'Song $i',
+          uri: 'jellyfin:a$i',
+          artistName: 'Artist $i',
+          albumName: 'Album $i',
+        ),
+    ];
+
+GoRouter _router() {
+  return GoRouter(
+    initialLocation: AppRoutes.library,
+    routes: <RouteBase>[
+      GoRoute(
+        path: AppRoutes.library,
+        builder: (_, __) => const LibraryScreen(),
+      ),
+      GoRoute(
+        path: '/library/artist/:id',
+        builder: (_, GoRouterState s) =>
+            ArtistDetailScreen(artistId: s.pathParameters['id']!),
+      ),
+    ],
+  );
+}
+
+Future<void> _pumpArtists(
+  WidgetTester tester, {
+  Size size = const Size(390, 844),
+  TextScaler textScaler = TextScaler.noScaling,
+}) async {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = size;
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        musicLibraryRepositoryProvider.overrideWithValue(
+          FakeMusicLibraryRepository(tracks: _artists()),
+        ),
+        playlistStoreProvider.overrideWithValue(InMemoryPlaylistStore()),
+        playbackControllerProvider.overrideWithValue(FakePlaybackController()),
+      ],
+      child: MediaQuery(
+        data: MediaQueryData(textScaler: textScaler),
+        child: MaterialApp.router(routerConfig: _router()),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('Artists'));
+  await tester.pumpAndSettle();
+}
+
+/// The artist rows sharing the topmost row of the grid, left to right.
+List<Rect> _firstRow(WidgetTester tester) {
+  final List<Rect> rects = tester.elementList(find.byType(ArtistTile)).map(
+    (Element e) {
+      final RenderBox box = e.renderObject! as RenderBox;
+      return box.localToGlobal(Offset.zero) & box.size;
+    },
+  ).toList();
+  final double top = rects
+      .map((Rect r) => r.top)
+      .reduce((double a, double b) => a < b ? a : b);
+  return <Rect>[
+    for (final Rect r in rects)
+      if (r.top == top) r,
+  ]..sort((Rect a, Rect b) => a.left.compareTo(b.left));
+}
+
+void main() {
+  group('artistGridColumnCount', () {
+    test('a phone stays a single-column list', () {
+      expect(artistGridColumnCount(360), 1);
+      expect(artistGridColumnCount(390), 1);
+      expect(artistGridColumnCount(430), 1);
+    });
+
+    test('a second column only lands once a row still reads', () {
+      expect(artistGridColumnCount(600), 1);
+      expect(artistGridColumnCount(700), 2);
+      expect(artistGridColumnCount(1040), 2);
+    });
+
+    test('desktop widths flow rows into columns', () {
+      expect(artistGridColumnCount(1168), 3); // 1280x720
+      expect(artistGridColumnCount(1808), 4); // 1920x1080
+      expect(artistGridColumnCount(2448), 5); // 2560x1440
+    });
+
+    test('a row is never squeezed below its minimum to add a column', () {
+      for (final double width in <double>[
+        360,
+        700,
+        1168,
+        1808,
+        2448,
+        3300,
+      ]) {
+        expect(
+          width / artistGridColumnCount(width),
+          greaterThanOrEqualTo(300),
+          reason: 'rows stay readable at $width',
+        );
+      }
+    });
+
+    test('a degenerate width still renders one column', () {
+      expect(artistGridColumnCount(0), 1);
+      expect(artistGridColumnCount(-10), 1);
+      expect(artistGridColumnCount(double.infinity), 1);
+    });
+  });
+
+  group('Artists tab', () {
+    testWidgets('a phone shows one artist per row', (tester) async {
+      await _pumpArtists(tester);
+
+      expect(find.byKey(const Key('library_artist_list')), findsOneWidget);
+      expect(_firstRow(tester).length, 1);
+      expect(find.text('Artist 0'), findsOneWidget);
+    });
+
+    testWidgets('a desktop window puts several artists on a row',
+        (tester) async {
+      await _pumpArtists(tester, size: const Size(1920, 1080));
+
+      final List<Rect> row = _firstRow(tester);
+      expect(row.length, greaterThan(2));
+      // No row stretches across the monitor, and none runs off it.
+      for (final Rect tile in row) {
+        expect(tile.width, lessThan(600));
+      }
+      expect(row.last.right, lessThanOrEqualTo(1920));
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('tapping an artist still opens them', (tester) async {
+      await _pumpArtists(tester, size: const Size(1280, 800));
+
+      await tester.tap(find.text('Artist 3'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Play all'), findsOneWidget);
+      expect(find.text('Song 3'), findsOneWidget);
+    });
+
+    testWidgets('long-pressing an artist still offers their songs',
+        (tester) async {
+      await _pumpArtists(tester, size: const Size(1280, 800));
+
+      await tester.longPress(find.text('Artist 1'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add to playlist'), findsOneWidget);
+      expect(find.text('New playlist'), findsOneWidget);
+    });
+
+    testWidgets('scaled-up text gets the room it needs', (tester) async {
+      await _pumpArtists(
+        tester,
+        size: const Size(1280, 800),
+        textScaler: const TextScaler.linear(2.0),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(ArtistTile), findsWidgets);
+    });
+
+    testWidgets('resizing reflows the rows without overflow', (tester) async {
+      await _pumpArtists(tester);
+
+      for (final Size size in <Size>[
+        const Size(800, 720),
+        const Size(1280, 720),
+        const Size(2560, 1440),
+        const Size(3440, 1440),
+        const Size(390, 844),
+      ]) {
+        tester.view.physicalSize = size;
+        await tester.pumpAndSettle();
+        expect(tester.takeException(), isNull, reason: 'at $size');
+        expect(
+          _firstRow(tester).last.right,
+          lessThanOrEqualTo(size.width),
+          reason: 'at $size',
+        );
+      }
+    });
+  });
+}

--- a/test/features/library/detail_desktop_layout_test.dart
+++ b/test/features/library/detail_desktop_layout_test.dart
@@ -1,0 +1,233 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:linthra/app/routes.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/in_memory_playlist_store.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/data/repositories/playlist_repository_provider.dart';
+import 'package:linthra/features/library/album_detail_screen.dart';
+import 'package:linthra/features/library/artist_detail_screen.dart';
+import 'package:linthra/features/library/library_screen.dart';
+import 'package:linthra/features/library/widgets/track_tile.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/player_screen.dart';
+
+import '../player/fake_playback_controller.dart';
+import 'fake_music_library_repository.dart';
+
+/// One artist with two albums, so both detail screens have a header, an album
+/// section and a song list to lay out. No artwork anywhere, so these widget
+/// tests never reach for the network.
+final List<Track> _tracks = <Track>[
+  for (int i = 0; i < 4; i++)
+    Track(
+      id: '$i',
+      title: 'Song $i',
+      uri: 'jellyfin:$i',
+      artistName: 'Daft Punk',
+      albumName: i.isEven ? 'Discovery' : 'Homework',
+      trackNumber: i + 1,
+    ),
+];
+
+GoRouter _router() {
+  return GoRouter(
+    initialLocation: AppRoutes.library,
+    routes: <RouteBase>[
+      GoRoute(
+        path: AppRoutes.library,
+        builder: (_, __) => const LibraryScreen(),
+      ),
+      GoRoute(
+        path: '/library/album/:id',
+        builder: (_, GoRouterState s) =>
+            AlbumDetailScreen(albumId: s.pathParameters['id']!),
+      ),
+      GoRoute(
+        path: '/library/artist/:id',
+        builder: (_, GoRouterState s) =>
+            ArtistDetailScreen(artistId: s.pathParameters['id']!),
+      ),
+      GoRoute(path: AppRoutes.player, builder: (_, __) => const PlayerScreen()),
+    ],
+  );
+}
+
+Future<void> _pumpLibrary(WidgetTester tester, Size size) async {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = size;
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        musicLibraryRepositoryProvider.overrideWithValue(
+          FakeMusicLibraryRepository(tracks: _tracks),
+        ),
+        playlistStoreProvider.overrideWithValue(InMemoryPlaylistStore()),
+        playbackControllerProvider.overrideWithValue(FakePlaybackController()),
+      ],
+      child: MaterialApp.router(routerConfig: _router()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> _openAlbum(WidgetTester tester, Size size) async {
+  await _pumpLibrary(tester, size);
+  await tester.tap(find.text('Albums'));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('Discovery').first);
+  await tester.pumpAndSettle();
+}
+
+Future<void> _openArtist(WidgetTester tester, Size size) async {
+  await _pumpLibrary(tester, size);
+  await tester.tap(find.text('Artists'));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('Daft Punk').first);
+  await tester.pumpAndSettle();
+}
+
+/// Rect of the Play (or Play all) button, which lives in the header on both
+/// screens — a reliable stand-in for "where the header is".
+Rect _headerRect(WidgetTester tester, String playLabel) =>
+    tester.getRect(find.widgetWithText(FilledButton, playLabel));
+
+Rect _firstTrackRect(WidgetTester tester) =>
+    tester.getRect(find.byType(TrackTile).first);
+
+void main() {
+  group('AlbumDetailScreen layout', () {
+    testWidgets('a phone keeps the header above the tracks', (tester) async {
+      await _openAlbum(tester, const Size(390, 844));
+
+      final Rect header = _headerRect(tester, 'Play');
+      final Rect track = _firstTrackRect(tester);
+      expect(header.bottom, lessThanOrEqualTo(track.top));
+      expect(header.left, lessThan(track.right));
+    });
+
+    testWidgets('a desktop window puts the album beside its tracks',
+        (tester) async {
+      await _openAlbum(tester, const Size(1280, 800));
+
+      final Rect header = _headerRect(tester, 'Play');
+      final Rect track = _firstTrackRect(tester);
+      // Side by side: the album pane ends before the track list begins, and
+      // both are visible at once rather than one scrolling the other away.
+      expect(header.right, lessThanOrEqualTo(track.left));
+      expect(track.width, greaterThan(header.width));
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('the album pane stays put while the tracks scroll',
+        (tester) async {
+      await _openAlbum(tester, const Size(1280, 800));
+
+      final Rect before = _headerRect(tester, 'Play');
+      await tester.drag(find.byType(TrackTile).first, const Offset(0, -200));
+      await tester.pumpAndSettle();
+
+      expect(_headerRect(tester, 'Play'), before);
+    });
+
+    testWidgets('Play still queues the album from the desktop pane',
+        (tester) async {
+      await _openAlbum(tester, const Size(1280, 800));
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Play'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PlayerScreen), findsOneWidget);
+    });
+
+    testWidgets('selecting tracks drops back to the single column',
+        (tester) async {
+      await _openAlbum(tester, const Size(1280, 800));
+
+      await tester.longPress(find.text('Song 0'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('1 selected'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, 'Play'), findsNothing);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('resizing across the breakpoint keeps the album on screen',
+        (tester) async {
+      await _openAlbum(tester, const Size(390, 844));
+
+      for (final Size size in <Size>[
+        const Size(800, 720),
+        const Size(1280, 720),
+        const Size(1920, 1080),
+        const Size(2560, 1440),
+        const Size(390, 844),
+      ]) {
+        tester.view.physicalSize = size;
+        await tester.pumpAndSettle();
+        expect(tester.takeException(), isNull, reason: 'at $size');
+        expect(find.text('Song 0'), findsOneWidget, reason: 'at $size');
+        expect(
+          _headerRect(tester, 'Play').right,
+          lessThanOrEqualTo(size.width),
+          reason: 'at $size',
+        );
+      }
+    });
+  });
+
+  group('ArtistDetailScreen layout', () {
+    testWidgets('a phone keeps the header above the catalog', (tester) async {
+      await _openArtist(tester, const Size(390, 844));
+
+      expect(
+        _headerRect(tester, 'Play all').bottom,
+        lessThanOrEqualTo(_firstTrackRect(tester).top),
+      );
+    });
+
+    testWidgets('a desktop window puts the artist beside their catalog',
+        (tester) async {
+      await _openArtist(tester, const Size(1280, 800));
+
+      final Rect header = _headerRect(tester, 'Play all');
+      expect(header.right, lessThanOrEqualTo(_firstTrackRect(tester).left));
+      // The albums section still lists both albums beside the artist pane.
+      expect(find.text('Discovery'), findsOneWidget);
+      expect(find.text('Homework'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('selecting songs drops back to the single column',
+        (tester) async {
+      await _openArtist(tester, const Size(1280, 800));
+
+      await tester.longPress(find.text('Song 0'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('1 selected'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, 'Play all'), findsNothing);
+    });
+
+    testWidgets('resizing across the breakpoint keeps the artist on screen',
+        (tester) async {
+      await _openArtist(tester, const Size(1920, 1080));
+
+      for (final Size size in <Size>[
+        const Size(2560, 1440),
+        const Size(800, 720),
+        const Size(390, 844),
+        const Size(1280, 720),
+      ]) {
+        tester.view.physicalSize = size;
+        await tester.pumpAndSettle();
+        expect(tester.takeException(), isNull, reason: 'at $size');
+        expect(find.text('Song 0'), findsOneWidget, reason: 'at $size');
+      }
+    });
+  });
+}

--- a/test/features/player/player_desktop_layout_test.dart
+++ b/test/features/player/player_desktop_layout_test.dart
@@ -1,0 +1,217 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/lyrics.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/lyrics_service.dart';
+import 'package:linthra/features/player/lyrics_providers.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/player_screen.dart';
+import 'package:linthra/features/player/widgets/album_artwork.dart';
+import 'package:linthra/features/player/widgets/lyrics_view.dart';
+import 'package:linthra/features/player/widgets/playback_controls.dart';
+import 'package:linthra/features/player/widgets/track_metadata.dart';
+
+import 'fake_playback_controller.dart';
+
+/// A lyrics backend returning one canned set for the test track.
+class _FakeLyricsService implements LyricsService {
+  _FakeLyricsService(this._lyrics);
+
+  final Lyrics? _lyrics;
+
+  @override
+  Future<Lyrics?> lyricsFor(Track track) async => _lyrics;
+}
+
+/// No artwork, so the cover falls back to its placeholder and nothing here
+/// reaches for the network.
+const Track _track = Track(
+  id: '1',
+  title: 'Song One',
+  uri: '/music/song1.mp3',
+  artistName: 'Artist A',
+  albumName: 'Album B',
+);
+
+const Lyrics _lyrics = Lyrics(
+  lines: <LyricLine>[
+    LyricLine(text: 'First line'),
+    LyricLine(text: 'Second line'),
+  ],
+);
+
+Future<void> _pumpPlayer(
+  WidgetTester tester, {
+  required Size size,
+  Lyrics? lyrics,
+  TextScaler textScaler = TextScaler.noScaling,
+}) async {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = size;
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        playbackControllerProvider.overrideWithValue(
+          FakePlaybackController(
+            initial: const PlaybackState(
+              status: PlaybackStatus.playing,
+              currentTrack: _track,
+            ),
+          ),
+        ),
+        lyricsServiceProvider.overrideWithValue(_FakeLyricsService(lyrics)),
+      ],
+      child: MaterialApp(
+        home: Builder(
+          builder: (BuildContext context) => MediaQuery(
+            data: MediaQuery.of(context).copyWith(textScaler: textScaler),
+            child: const PlayerScreen(),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Rect _artworkRect(WidgetTester tester) =>
+    tester.getRect(find.byType(AlbumArtwork).first);
+
+Rect _controlsRect(WidgetTester tester) =>
+    tester.getRect(find.byType(PlaybackControls));
+
+void main() {
+  group('Now Playing on a phone', () {
+    testWidgets('stacks the cover above the controls', (tester) async {
+      await _pumpPlayer(tester, size: const Size(390, 844));
+
+      expect(
+        _artworkRect(tester).bottom,
+        lessThanOrEqualTo(_controlsRect(tester).top),
+      );
+      expect(find.byType(TrackMetadata), findsOneWidget);
+    });
+
+    testWidgets('lyrics take the cover’s place', (tester) async {
+      await _pumpPlayer(
+        tester,
+        size: const Size(390, 844),
+        lyrics: _lyrics,
+      );
+
+      await tester.tap(find.byTooltip('Lyrics'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(LyricsView), findsOneWidget);
+      expect(find.byType(AlbumArtwork), findsNothing);
+    });
+  });
+
+  group('Now Playing on a desktop window', () {
+    testWidgets('puts the cover beside the metadata and transport',
+        (tester) async {
+      await _pumpPlayer(tester, size: const Size(1280, 800));
+
+      final Rect artwork = _artworkRect(tester);
+      final Rect controls = _controlsRect(tester);
+      expect(artwork.right, lessThanOrEqualTo(controls.left));
+      // The cover is a square cover, not a stretched panel.
+      expect(artwork.width, closeTo(artwork.height, 1));
+      expect(find.text('Song One'), findsOneWidget);
+      expect(find.text('Artist A'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('lyrics open beside the cover instead of replacing it',
+        (tester) async {
+      await _pumpPlayer(
+        tester,
+        size: const Size(1280, 800),
+        lyrics: _lyrics,
+      );
+
+      await tester.tap(find.byTooltip('Lyrics'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(LyricsView), findsOneWidget);
+      // The whole point of the extra width: the cover stays.
+      expect(find.byType(AlbumArtwork), findsWidgets);
+      expect(
+        _artworkRect(tester).right,
+        lessThanOrEqualTo(tester.getRect(find.byType(LyricsView)).left),
+      );
+      // Transport stays where it was, under the lyrics rather than behind them.
+      expect(find.byTooltip('Pause'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('the smallest wide window shrinks the cover, not the transport',
+        (tester) async {
+      // 1280 wide at Linthra's minimum window height: the cover gives up the
+      // height, the controls keep theirs, and nothing overflows.
+      await _pumpPlayer(tester, size: const Size(1280, 600));
+
+      final Rect artwork = _artworkRect(tester);
+      expect(artwork.right, lessThanOrEqualTo(_controlsRect(tester).left));
+      expect(artwork.height, lessThan(600));
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('scaled-up text does not overflow the side-by-side layout',
+        (tester) async {
+      await _pumpPlayer(
+        tester,
+        size: const Size(1280, 800),
+        textScaler: const TextScaler.linear(2.0),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Song One'), findsOneWidget);
+      expect(find.byTooltip('Pause'), findsOneWidget);
+    });
+
+    testWidgets('resizing keeps playback and the lyrics toggle',
+        (tester) async {
+      await _pumpPlayer(
+        tester,
+        size: const Size(1280, 800),
+        lyrics: _lyrics,
+      );
+
+      await tester.tap(find.byTooltip('Lyrics'));
+      await tester.pumpAndSettle();
+
+      for (final Size size in <Size>[
+        const Size(800, 800),
+        const Size(390, 844),
+        const Size(1920, 1080),
+        const Size(3440, 1440),
+      ]) {
+        tester.view.physicalSize = size;
+        await tester.pumpAndSettle();
+        expect(tester.takeException(), isNull, reason: 'at $size');
+        // Same state either side of the breakpoint: still on lyrics, still
+        // playing the same track.
+        expect(find.byType(LyricsView), findsOneWidget, reason: 'at $size');
+        expect(find.byTooltip('Pause'), findsOneWidget, reason: 'at $size');
+      }
+    });
+
+    testWidgets('an ultrawide window stops stretching the two columns apart',
+        (tester) async {
+      await _pumpPlayer(tester, size: const Size(3440, 1440));
+
+      final Rect artwork = _artworkRect(tester);
+      final Rect controls = _controlsRect(tester);
+      // Both columns stay in the middle of the monitor rather than being
+      // pushed to opposite edges.
+      expect(artwork.left, greaterThan(400));
+      expect(controls.right, lessThan(3040));
+      expect(tester.takeException(), isNull);
+    });
+  });
+}

--- a/test/shared/layout/adaptive_layout_test.dart
+++ b/test/shared/layout/adaptive_layout_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/shared/layout/adaptive_layout.dart';
+
+void main() {
+  group('windowSizeClassFor', () {
+    test('phone widths are compact', () {
+      expect(windowSizeClassFor(360), WindowSizeClass.compact);
+      expect(windowSizeClassFor(390), WindowSizeClass.compact);
+      expect(windowSizeClassFor(599), WindowSizeClass.compact);
+    });
+
+    test('a narrow desktop window is medium, not expanded', () {
+      // Linthra's Linux window can be resized down to 420 px, and 800 px is the
+      // narrow-window case the issue asks about: wide enough for denser lists,
+      // not for a second pane.
+      expect(windowSizeClassFor(600), WindowSizeClass.medium);
+      expect(windowSizeClassFor(800), WindowSizeClass.medium);
+      expect(windowSizeClassFor(999), WindowSizeClass.medium);
+    });
+
+    test('common desktop windows are expanded or large', () {
+      expect(windowSizeClassFor(1000), WindowSizeClass.expanded);
+      expect(windowSizeClassFor(1280), WindowSizeClass.expanded);
+      expect(windowSizeClassFor(1599), WindowSizeClass.expanded);
+      expect(windowSizeClassFor(1600), WindowSizeClass.large);
+      expect(windowSizeClassFor(1920), WindowSizeClass.large);
+      expect(windowSizeClassFor(3440), WindowSizeClass.large);
+    });
+
+    test('an unmeasured or unbounded box falls back to compact', () {
+      expect(windowSizeClassFor(0), WindowSizeClass.compact);
+      expect(windowSizeClassFor(-1), WindowSizeClass.compact);
+      expect(windowSizeClassFor(double.infinity), WindowSizeClass.compact);
+      expect(windowSizeClassFor(double.nan), WindowSizeClass.compact);
+    });
+  });
+
+  group('WindowSizeClass.isAtLeast', () {
+    test('orders the classes by width', () {
+      expect(
+        WindowSizeClass.large.isAtLeast(WindowSizeClass.expanded),
+        isTrue,
+      );
+      expect(
+        WindowSizeClass.expanded.isAtLeast(WindowSizeClass.expanded),
+        isTrue,
+      );
+      expect(
+        WindowSizeClass.medium.isAtLeast(WindowSizeClass.expanded),
+        isFalse,
+      );
+      expect(
+        WindowSizeClass.compact.isAtLeast(WindowSizeClass.medium),
+        isFalse,
+      );
+    });
+  });
+
+  group('AdaptiveLayoutBuilder', () {
+    testWidgets('resolves the class from its own box, not the window',
+        (WidgetTester tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(1920, 1080);
+      addTearDown(tester.view.reset);
+
+      late WindowSizeClass outer;
+      late WindowSizeClass inner;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AdaptiveLayoutBuilder(
+            builder: (BuildContext context, BoxConstraints _,
+                WindowSizeClass sizeClass) {
+              outer = sizeClass;
+              // A pane inside the window: the rail and a split make a feature
+              // widget narrower than the monitor, and it has to lay itself out
+              // for the width it actually got.
+              return Align(
+                alignment: Alignment.topLeft,
+                child: SizedBox(
+                  width: 420,
+                  child: AdaptiveLayoutBuilder(
+                    builder: (BuildContext context, BoxConstraints __,
+                        WindowSizeClass paneClass) {
+                      inner = paneClass;
+                      return const SizedBox.shrink();
+                    },
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      expect(outer, WindowSizeClass.large);
+      expect(inner, WindowSizeClass.compact);
+    });
+  });
+
+  group('AdaptiveContentWidth', () {
+    testWidgets('leaves a phone-width column alone',
+        (WidgetTester tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(390, 844);
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AdaptiveContentWidth(
+              child: SizedBox.expand(
+                key: Key('content'),
+                child: ColoredBox(color: Colors.red),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(tester.getSize(find.byKey(const Key('content'))).width, 390);
+    });
+
+    testWidgets('caps and centres a column on a wide window',
+        (WidgetTester tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(2560, 1440);
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AdaptiveContentWidth(
+              child: SizedBox.expand(
+                key: Key('content'),
+                child: ColoredBox(color: Colors.red),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final Rect box = tester.getRect(find.byKey(const Key('content')));
+      expect(box.width, maxContentWidth);
+      // Centred, so the column doesn't hug one edge of the monitor.
+      expect(box.center.dx, closeTo(1280, 0.5));
+    });
+  });
+}


### PR DESCRIPTION
Closes #556.

Even with the desktop shell from #555, the views inside it were still phone views. The album grid capped at six columns and inflated covers to ~400 px on a 2560 window, artist and song rows stretched the full width of a monitor, and Now Playing stacked a huge cover on top of the controls with half the window empty.

Layout now adapts on the width a widget is actually given, not on `Platform.isLinux`.

## The shared piece

`lib/shared/layout/adaptive_layout.dart`:

- `WindowSizeClass` (compact < 600, medium < 1000, expanded < 1600, large) with a pure `windowSizeClassFor(width)`, so breakpoints are unit-testable.
- `AdaptiveLayoutBuilder`, which resolves the class from the widget's own constraints. Inside the desktop shell a screen is narrower than the window by the navigation rail, and a pane is narrower still, so measuring the window would have been wrong.
- `AdaptiveContentWidth`, which caps and centres a single column and is a no-op below the cap.

## What changed per surface

- **Album grid**: cards stay between 200 and 260 px and the grid adds columns instead of inflating covers. 5 across at 1280, 7 at 1920, 10 at 2560, where before every desktop width got the same six mobile-sized cards.
- **Artists**: the same `ArtistTile` rows flow into 2-5 columns instead of one row per monitor width. Tap and long-press behave exactly as before.
- **Songs, playlists, downloads, settings**: one column, capped and centred, so a title and its trailing action never end up a screen apart. Settings uses a tighter cap since a settings row is a label plus a control.
- **Album and artist detail**: at expanded widths, a persistent left pane (cover or portrait, counts, Play and Shuffle) beside the scrolling list, so the cover no longer scrolls away off the top of a long tracklist. Selection mode falls back to the single column. Same tracks list, same selection set, no duplicated state.
- **Now Playing**: at expanded widths the cover sits beside the metadata and transport, and lyrics open next to the cover rather than replacing it. Same `_showLyrics` toggle, same playback state.
- **Library search box**: stops growing at 520 px instead of running the width of the monitor.

Phone layouts are untouched. Every cap is a no-op below 600 px and the two-pane compositions need 1000 px of space inside the shell, which a phone never has. Nothing here branches on platform, so an Android tablet in landscape gets the same benefit.

## Testing

`flutter analyze` clean, `dart format` clean, full suite green (4032 tests).

New and updated tests cover the phone width alongside 1280, 1920, 2560 and ultrawide:

- `test/shared/layout/adaptive_layout_test.dart` - breakpoints, constraint-based resolution, the content cap.
- `test/features/library/album_grid_test.dart` - desktop column counts, cards never squeezed below the readable minimum, a resize sweep with no overflow.
- `test/features/library/artist_grid_test.dart` - column counts, one column on a phone, tap and long-press, 2x text scale, resize sweep.
- `test/features/library/detail_desktop_layout_test.dart` - two panes side by side, the pane staying put while the list scrolls, Play still queueing, selection dropping to one column, resize sweeps.
- `test/features/player/player_desktop_layout_test.dart` - cover beside the transport, lyrics beside the cover, the smallest wide window, 2x text scale, resize keeping playback and the lyrics toggle, ultrawide not pulling the columns apart.

Docs: a new "How the desktop layout adapts" section in `docs/linux-desktop.md`, next to "How platform selection works", since this is the one thing that deliberately does not branch on `HostPlatform`.

## Not in scope

No new music-source features, no MPRIS or tray integration, no packaging changes, no new Flatpak permissions, no visual rebrand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013KsBgSxCDk7J5TQXtXSY2X

---
_Generated by [Claude Code](https://claude.ai/code/session_013KsBgSxCDk7J5TQXtXSY2X)_