### PR TITLE
fix(desktop): address adaptive layout review follow-ups

### DIFF
--- a/lib/features/library/artist_detail_screen.dart
+++ b/lib/features/library/artist_detail_screen.dart
@@ -22,13 +22,6 @@ import 'widgets/track_tile.dart';
 
 /// One artist's catalog: their albums (each opening its album detail) and all
 /// their tracks, with Play all / Shuffle all.
-///
-/// Reads the same derived grouping the Artists tab uses. Playing from here
-/// queues only this artist's tracks; tapping a single track queues the artist's
-/// tracks from that point. Reuses [TrackTile] and [AlbumTile] so rows match the
-/// rest of the library. Long-pressing one of the album rows opens the shared
-/// bulk playlist flow for that album. Long-pressing a track starts multi-select
-/// so any subset of the artist's songs can be added together.
 class ArtistDetailScreen extends ConsumerStatefulWidget {
   const ArtistDetailScreen({required this.artistId, super.key});
 
@@ -38,8 +31,6 @@ class ArtistDetailScreen extends ConsumerStatefulWidget {
   ConsumerState<ArtistDetailScreen> createState() => _ArtistDetailScreenState();
 }
 
-/// Width of the artist pane in the desktop two-pane layout. Matches the album
-/// screen's pane, so moving between the two doesn't shift the list.
 const double _detailPaneWidth = 320;
 
 class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
@@ -58,10 +49,6 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
       );
     }
 
-    // Reuse the artist grouping the Artists tab already memoized, rather than
-    // re-grouping the whole catalog on every build (the freeze on large
-    // libraries). The per-artist track and album lists below are bounded
-    // filters over the catalog, not another full grouping of it.
     Artist? artist;
     for (final Artist candidate in ref.watch(libraryArtistsProvider)) {
       if (candidate.id == widget.artistId) {
@@ -82,8 +69,6 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
       );
     }
 
-    // Bound after the null check: the layout closures below can't capture a
-    // promoted local.
     final Artist resolved = artist;
     final List<Album> albums = albumsForArtist(songs, widget.artistId);
     final List<Track> selected = <Track>[
@@ -114,9 +99,6 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
           BoxConstraints constraints,
           WindowSizeClass sizeClass,
         ) {
-          // Wide enough for two panes: the artist stays visible in a side pane
-          // while their albums and songs scroll beside it. Selection mode uses
-          // the single column, where the width belongs to the list.
           if (!_selecting && sizeClass.isAtLeast(WindowSizeClass.expanded)) {
             return Center(
               child: ConstrainedBox(
@@ -161,7 +143,6 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
     );
   }
 
-  /// Phones and narrow windows: header, albums and songs in one column.
   Widget _singleColumnBody(
     Artist artist,
     List<Album> albums,
@@ -184,8 +165,6 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
     );
   }
 
-  /// The albums + songs half of the screen, without the header: what the
-  /// desktop layout puts beside the artist pane.
   Widget _catalogList(List<Album> albums, List<Track> tracks) {
     return CustomScrollView(
       key: const Key('artist_detail_catalog'),
@@ -305,13 +284,8 @@ class _ArtistHeader extends StatelessWidget {
   final int trackCount;
   final VoidCallback onPlay;
   final VoidCallback onShuffle;
-
-  /// Portrait above the name rather than beside it, for the tall, narrow
-  /// desktop pane.
   final bool stacked;
 
-  /// A bigger portrait for the desktop pane, where it has the pane's width to
-  /// itself rather than sharing a row with the name.
   static const double _stackedPortraitRadius = 72;
 
   @override
@@ -347,32 +321,44 @@ class _ArtistHeader extends StatelessWidget {
               ],
             ),
           const SizedBox(height: AppSpacing.md),
-          Row(
-            children: <Widget>[
-              Expanded(
-                child: FilledButton.icon(
-                  onPressed: onPlay,
-                  icon: const Icon(Icons.play_arrow),
-                  label: const Text('Play all'),
+          if (stacked) ...<Widget>[
+            FilledButton.icon(
+              onPressed: onPlay,
+              icon: const Icon(Icons.play_arrow),
+              label: const Text('Play all'),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            FilledButton.tonalIcon(
+              onPressed: onShuffle,
+              icon: const Icon(Icons.shuffle),
+              label: const Text('Shuffle all'),
+            ),
+          ] else
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: FilledButton.icon(
+                    onPressed: onPlay,
+                    icon: const Icon(Icons.play_arrow),
+                    label: const Text('Play all'),
+                  ),
                 ),
-              ),
-              const SizedBox(width: AppSpacing.sm),
-              Expanded(
-                child: FilledButton.tonalIcon(
-                  onPressed: onShuffle,
-                  icon: const Icon(Icons.shuffle),
-                  label: const Text('Shuffle all'),
+                const SizedBox(width: AppSpacing.sm),
+                Expanded(
+                  child: FilledButton.tonalIcon(
+                    onPressed: onShuffle,
+                    icon: const Icon(Icons.shuffle),
+                    label: const Text('Shuffle all'),
+                  ),
                 ),
-              ),
-            ],
-          ),
+              ],
+            ),
         ],
       ),
     );
   }
 }
 
-/// The artist's circular portrait, or a tinted glyph when there is no artwork.
 class _ArtistPortrait extends StatelessWidget {
   const _ArtistPortrait({required this.artist, required this.radius});
 
@@ -383,8 +369,6 @@ class _ArtistPortrait extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final Uri? uri = artist.artworkUri;
-    // Centred rather than left-aligned: in the stacked pane the column
-    // stretches its children, and a stretched avatar is not a circle.
     return Center(
       child: CircleAvatar(
         radius: radius,
@@ -402,7 +386,6 @@ class _ArtistPortrait extends StatelessWidget {
   }
 }
 
-/// Name and the "3 albums • 41 songs" summary, shared by both header layouts.
 class _ArtistTitleBlock extends StatelessWidget {
   const _ArtistTitleBlock({
     required this.name,

--- a/lib/features/library/widgets/album_grid.dart
+++ b/lib/features/library/widgets/album_grid.dart
@@ -4,42 +4,41 @@ import '../../../app/dimens.dart';
 import '../../../core/models/album.dart';
 import 'album_grid_card.dart';
 
-/// Narrowest a card may get before the grid drops a column. Two cards plus the
-/// gutters still fit comfortably on the narrowest phones we support, which is
-/// why [albumGridColumnCount] never returns fewer than [_minColumns].
+/// Narrowest a desktop album card should get before the grid drops a column.
+///
+/// Phones deliberately keep two columns even when that means smaller cards;
+/// this lower bound governs when wider layouts are allowed to add columns.
 const double _minCardWidth = 200;
 
 /// Widest a card may get before the grid adds a column instead.
 ///
 /// This is what keeps a desktop window from reading as a stretched phone: past
-/// this width the extra space buys another album, not a bigger cover. Without
-/// it a 2560 px window rendered six ~400 px cards — the same mobile grid, just
-/// inflated.
+/// this width the extra space buys another album, not a bigger cover.
 const double _maxCardWidth = 260;
 
-/// Phones (and anything narrower than two comfortable cards) get exactly two
-/// columns; the upper bound is a sanity stop for absurd widths rather than a
-/// design limit — every monitor Linthra realistically runs on is sized by
-/// [_maxCardWidth] well before it.
 const int _minColumns = 2;
-const int _maxColumns = 12;
+const double _gridGutter = AppSpacing.md;
 
-/// Columns for [width] logical pixels of *content* width — the space left for
-/// the cards themselves, gutters included, after the grid's own padding.
+/// Columns for [width] logical pixels of content width after the grid's outer
+/// padding. The width still includes the gutters between cards.
 ///
-/// Two on a phone; a column is added as soon as one more card fits at
-/// [_minCardWidth], and columns keep being added while cards would otherwise
-/// grow past [_maxCardWidth]. Pure so the breakpoints can be tested without
-/// pumping a widget.
+/// A candidate column only counts as fitting once both its minimum card width
+/// and the gutters before it fit. Conversely, columns keep being added whenever
+/// the resulting cards would exceed [_maxCardWidth]. There is no arbitrary
+/// desktop cap: a 4K window simply gets as many columns as its available width
+/// calls for.
 int albumGridColumnCount(double width) {
   if (!width.isFinite || width <= 0) return _minColumns;
-  // As many as still fit at the narrow bound, and as many as it takes to keep
-  // cards under the wide one. The narrow bound wins where they disagree, so a
-  // card is never squeezed below [_minCardWidth] just to add a column.
-  final int fits = (width / _minCardWidth).floor();
-  final int dense = (width / _maxCardWidth).ceil();
+
+  // For n columns, cardWidth = (width - gutter * (n - 1)) / n.
+  // Rearranging that expression gives the two bounds below while accounting
+  // for every inter-card gutter.
+  final int fits =
+      ((width + _gridGutter) / (_minCardWidth + _gridGutter)).floor();
+  final int dense =
+      ((width + _gridGutter) / (_maxCardWidth + _gridGutter)).ceil();
   final int columns = dense < fits ? dense : fits;
-  return columns.clamp(_minColumns, _maxColumns);
+  return columns < _minColumns ? _minColumns : columns;
 }
 
 /// The Albums tab body: a responsive grid of [AlbumGridCard]s.
@@ -53,22 +52,21 @@ class AlbumGrid extends StatelessWidget {
   final List<Album> albums;
   final void Function(Album album) onOpen;
 
-  static const double _gutter = AppSpacing.md;
-
   @override
   Widget build(BuildContext context) {
     final double labelExtent = AlbumGridCard.labelExtent(context);
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
-        final double content = constraints.maxWidth - _gutter * 2;
+        final double content = constraints.maxWidth - _gridGutter * 2;
         final int columns = albumGridColumnCount(content);
-        final double cardWidth = (content - _gutter * (columns - 1)) / columns;
+        final double cardWidth =
+            (content - _gridGutter * (columns - 1)) / columns;
         return GridView.builder(
           key: const Key('library_album_grid'),
-          padding: const EdgeInsets.all(_gutter),
+          padding: const EdgeInsets.all(_gridGutter),
           gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
             crossAxisCount: columns,
-            crossAxisSpacing: _gutter,
+            crossAxisSpacing: _gridGutter,
             mainAxisSpacing: AppSpacing.lg,
             mainAxisExtent: cardWidth + labelExtent,
           ),

--- a/lib/features/library/widgets/artist_grid.dart
+++ b/lib/features/library/widgets/artist_grid.dart
@@ -13,23 +13,29 @@ const double _minRowWidth = 340;
 /// the chevron a screen apart.
 const double _maxRowWidth = 520;
 
-/// One column on a phone; the upper bound is a sanity stop for absurd widths,
-/// not a design limit.
 const int _minColumns = 1;
-const int _maxColumns = 6;
+const double _gridPadding = AppSpacing.sm;
+const double _gridGutter = AppSpacing.sm;
 
-/// Columns for [width] logical pixels of available width.
+/// Columns for [width] logical pixels of available viewport width.
 ///
-/// One on a phone (identical to the single-column list this replaces), and a
-/// column added as soon as another row fits at [_minRowWidth] or rows would
-/// otherwise stretch past [_maxRowWidth]. Pure so the breakpoints can be
-/// asserted without pumping a widget.
+/// One on a phone, and a new column only once the grid's own horizontal padding
+/// plus every inter-column gutter leaves at least [_minRowWidth] for each row.
+/// Columns continue to grow with the viewport instead of stopping at an
+/// arbitrary desktop cap, so common 4K windows keep rows under
+/// [_maxRowWidth].
 int artistGridColumnCount(double width) {
   if (!width.isFinite || width <= 0) return _minColumns;
-  final int fits = (width / _minRowWidth).floor();
-  final int dense = (width / _maxRowWidth).ceil();
+
+  final double innerWidth = width - _gridPadding * 2;
+  if (innerWidth <= 0) return _minColumns;
+
+  final int fits =
+      ((innerWidth + _gridGutter) / (_minRowWidth + _gridGutter)).floor();
+  final int dense =
+      ((innerWidth + _gridGutter) / (_maxRowWidth + _gridGutter)).ceil();
   final int columns = dense < fits ? dense : fits;
-  return columns.clamp(_minColumns, _maxColumns);
+  return columns < _minColumns ? _minColumns : columns;
 }
 
 /// The Artists tab body: [ArtistTile] rows that flow into columns as the window
@@ -76,12 +82,12 @@ class ArtistGrid extends StatelessWidget {
           padding: single
               ? EdgeInsets.zero
               : const EdgeInsets.symmetric(
-                  horizontal: AppSpacing.sm,
-                  vertical: AppSpacing.sm,
+                  horizontal: _gridPadding,
+                  vertical: _gridPadding,
                 ),
           gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
             crossAxisCount: columns,
-            crossAxisSpacing: single ? 0 : AppSpacing.sm,
+            crossAxisSpacing: single ? 0 : _gridGutter,
             mainAxisSpacing: 0,
             mainAxisExtent: extent,
           ),

--- a/lib/features/player/widgets/track_metadata.dart
+++ b/lib/features/player/widgets/track_metadata.dart
@@ -23,17 +23,55 @@ class TrackMetadata extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final ThemeData theme = Theme.of(context);
+    final TextScaler scaler = MediaQuery.textScalerOf(context);
+    final bool shortLargeText = MediaQuery.sizeOf(context).height <= 640 &&
+        scaler.scale(1) >= 1.5;
+    final Color muted =
+        theme.colorScheme.onSurface.withValues(alpha: 0.75);
+    final Color fainter =
+        theme.colorScheme.onSurface.withValues(alpha: 0.5);
+    final bool hasArtist = artistName != null && artistName!.isNotEmpty;
+    final bool hasAlbum = albumName != null && albumName!.isNotEmpty;
+
+    // A short desktop window with accessibility text scaling has horizontal
+    // room but very little vertical room. Keeping the normal two-line title +
+    // artist + album can consume the space the flexible lyrics pane needs.
+    // Collapse only in that constrained case: title and artist remain visible,
+    // the album is the least important line and yields its height.
+    if (shortLargeText) {
+      return Column(
+        key: const Key('track_metadata_compact_height'),
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Text(
+            title,
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+            textAlign: TextAlign.center,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          if (hasArtist) ...<Widget>[
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              artistName!,
+              style: theme.textTheme.bodyMedium?.copyWith(color: muted),
+              textAlign: TextAlign.center,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+        ],
+      );
+    }
+
     // A deliberate three-step hierarchy: the title carries full weight, the
     // artist is a clear secondary line, and the album recedes to a quiet tag.
-    final muted = theme.colorScheme.onSurface.withValues(alpha: 0.75);
-    final fainter = theme.colorScheme.onSurface.withValues(alpha: 0.5);
-    final hasArtist = artistName != null && artistName!.isNotEmpty;
-    final hasAlbum = albumName != null && albumName!.isNotEmpty;
-
     return Column(
       mainAxisSize: MainAxisSize.min,
-      children: [
+      children: <Widget>[
         Text(
           title,
           style: theme.textTheme.headlineSmall?.copyWith(
@@ -45,7 +83,7 @@ class TrackMetadata extends StatelessWidget {
           maxLines: 2,
           overflow: TextOverflow.ellipsis,
         ),
-        if (hasArtist) ...[
+        if (hasArtist) ...<Widget>[
           const SizedBox(height: AppSpacing.sm),
           Text(
             artistName!,
@@ -58,7 +96,7 @@ class TrackMetadata extends StatelessWidget {
             overflow: TextOverflow.ellipsis,
           ),
         ],
-        if (hasAlbum) ...[
+        if (hasAlbum) ...<Widget>[
           const SizedBox(height: AppSpacing.xs),
           Text(
             albumName!,
@@ -79,16 +117,6 @@ class TrackMetadata extends StatelessWidget {
 /// A quiet inline label stating where the audio is *actually* coming from, e.g.
 /// "Playing from Navidrome", "Playing from Jellyfin", "Playing from Local music",
 /// or "Playing from Cache".
-///
-/// Rendered as a calm icon-and-caption pair (no boxed chip) so it reads as a
-/// whisper under the metadata rather than a competing badge, matching the
-/// buffering/casting indicators on the same line.
-///
-/// Because a logical track can have several source candidates, the indicator
-/// reflects the resolved copy — the owning provider derived from [trackUri] plus
-/// the [source] the resolver reported — not the active/default provider. Only
-/// safe display names are shown (see [PlaybackSourceLabel]); no server URL,
-/// username, token, or path is ever exposed.
 class PlaybackSourceChip extends StatelessWidget {
   const PlaybackSourceChip({
     required this.source,
@@ -97,19 +125,16 @@ class PlaybackSourceChip extends StatelessWidget {
   });
 
   final PlaybackSource source;
-
-  /// The resolved track's opaque URI, used only to name the owning server
-  /// safely (`jellyfin:` → Jellyfin, `subsonic:` → Navidrome).
   final String? trackUri;
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final color = theme.colorScheme.onSurfaceVariant;
+    final ThemeData theme = Theme.of(context);
+    final Color color = theme.colorScheme.onSurfaceVariant;
     return Row(
       mainAxisSize: MainAxisSize.min,
       mainAxisAlignment: MainAxisAlignment.center,
-      children: [
+      children: <Widget>[
         Icon(_iconFor(source), size: 15, color: color),
         const SizedBox(width: AppSpacing.xs + 2),
         Flexible(

--- a/lib/features/player/widgets/track_metadata.dart
+++ b/lib/features/player/widgets/track_metadata.dart
@@ -25,12 +25,10 @@ class TrackMetadata extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final TextScaler scaler = MediaQuery.textScalerOf(context);
-    final bool shortLargeText = MediaQuery.sizeOf(context).height <= 640 &&
-        scaler.scale(1) >= 1.5;
-    final Color muted =
-        theme.colorScheme.onSurface.withValues(alpha: 0.75);
-    final Color fainter =
-        theme.colorScheme.onSurface.withValues(alpha: 0.5);
+    final bool shortLargeText =
+        MediaQuery.sizeOf(context).height <= 640 && scaler.scale(1) >= 1.5;
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.75);
+    final Color fainter = theme.colorScheme.onSurface.withValues(alpha: 0.5);
     final bool hasArtist = artistName != null && artistName!.isNotEmpty;
     final bool hasAlbum = albumName != null && albumName!.isNotEmpty;
 

--- a/lib/features/shell/home_shell.dart
+++ b/lib/features/shell/home_shell.dart
@@ -48,23 +48,12 @@ class HomeShell extends StatelessWidget {
   ];
 
   void _onDestinationSelected(int index) {
-    // `initialLocation: true` re-pops a tab to its root when re-tapped.
     navigationShell.goBranch(
       index,
       initialLocation: index == navigationShell.currentIndex,
     );
   }
 
-  /// Gives every real navigation layer a chance before Android is allowed to
-  /// close the app:
-  ///
-  /// 1. a root-level route such as the full player or a dialog;
-  /// 2. the active tab's detail stack;
-  /// 3. an internal BackButtonListener such as folder browsing or selection;
-  /// 4. finally, a secondary primary-navigation destination returns to Library.
-  ///
-  /// Only the root of Library returns `false` all the way to Android, which is
-  /// the one place where closing Linthra is the expected Back action.
   Future<bool> _handleSystemBack() async {
     if (rootNavigatorKey.currentState?.canPop() ?? false) return false;
 
@@ -86,86 +75,36 @@ class HomeShell extends StatelessWidget {
         constraints.maxWidth >= desktopNavigationBreakpoint;
   }
 
-  Widget _buildMobileShell() {
-    return Scaffold(
-      body: navigationShell,
-      // The mini-player rides just above the navigation bar so it stays visible
-      // on every tab (and collapses to nothing when no track is loaded). The
-      // full PlayerScreen is pushed above this shell, so the two never overlap.
-      bottomNavigationBar: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const MiniPlayer(),
-          NavigationBar(
+  Widget _buildNavigationRail() {
+    return FocusTraversalOrder(
+      order: const NumericFocusOrder(2),
+      child: FocusTraversalGroup(
+        child: SafeArea(
+          right: false,
+          child: NavigationRail(
             selectedIndex: navigationShell.currentIndex,
             onDestinationSelected: _onDestinationSelected,
-            destinations: _destinations,
+            labelType: NavigationRailLabelType.all,
+            groupAlignment: -1,
+            destinations: [
+              for (final NavigationDestination destination in _destinations)
+                NavigationRailDestination(
+                  icon: destination.icon,
+                  selectedIcon: destination.selectedIcon,
+                  label: Text(destination.label),
+                ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }
 
-  Widget _buildDesktopShell() {
-    // Keyboard order is set explicitly here rather than left to the default
-    // reading-order traversal. Side by side, that policy sorts the rail and the
-    // page together by geometry and splits the rail around the content: the
-    // first destination lands before the page and the rest after it, so Tab
-    // reaches Library last. Two groups in a numbered ring keep the rail whole
-    // and keep the frame reading the way the bottom bar already does — the
-    // active tab first, then playback, then the persistent destinations — so
-    // crossing the breakpoint changes where the destinations are, not the order
-    // a keyboard walks them in. Pinned by home_shell_focus_order_test.dart on
-    // both sides of the breakpoint.
-    return Scaffold(
-      body: FocusTraversalGroup(
-        policy: OrderedTraversalPolicy(),
-        child: Row(
-          children: [
-            FocusTraversalOrder(
-              order: const NumericFocusOrder(2),
-              child: FocusTraversalGroup(
-                child: SafeArea(
-                  right: false,
-                  child: NavigationRail(
-                    selectedIndex: navigationShell.currentIndex,
-                    onDestinationSelected: _onDestinationSelected,
-                    labelType: NavigationRailLabelType.all,
-                    groupAlignment: -1,
-                    destinations: [
-                      for (final NavigationDestination destination
-                          in _destinations)
-                        NavigationRailDestination(
-                          icon: destination.icon,
-                          selectedIcon: destination.selectedIcon,
-                          label: Text(destination.label),
-                        ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-            const VerticalDivider(width: 1),
-            Expanded(
-              child: FocusTraversalOrder(
-                order: const NumericFocusOrder(1),
-                child: FocusTraversalGroup(
-                  child: Column(
-                    children: [
-                      Expanded(child: navigationShell),
-                      // Keep playback global to the shell, but out of the
-                      // navigation rail. Resizing between desktop and mobile
-                      // presentation never recreates the router or playback
-                      // state.
-                      const MiniPlayer(),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
+  NavigationBar _buildNavigationBar() {
+    return NavigationBar(
+      selectedIndex: navigationShell.currentIndex,
+      onDestinationSelected: _onDestinationSelected,
+      destinations: _destinations,
     );
   }
 
@@ -175,10 +114,43 @@ class HomeShell extends StatelessWidget {
       onBackButtonPressed: _handleSystemBack,
       child: LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) {
-          if (_usesDesktopNavigation(context, constraints)) {
-            return _buildDesktopShell();
-          }
-          return _buildMobileShell();
+          final bool desktop = _usesDesktopNavigation(context, constraints);
+
+          // Keep StatefulNavigationShell at the same element position across
+          // the 900 px breakpoint. Only the two chrome slots before it change
+          // between real desktop widgets and zero-sized placeholders, so an
+          // inactive branch's Navigator stack and scroll state survive resize.
+          return Scaffold(
+            body: FocusTraversalGroup(
+              policy: OrderedTraversalPolicy(),
+              child: Row(
+                children: <Widget>[
+                  if (desktop)
+                    _buildNavigationRail()
+                  else
+                    const SizedBox.shrink(),
+                  if (desktop)
+                    const VerticalDivider(width: 1)
+                  else
+                    const SizedBox.shrink(),
+                  Expanded(
+                    child: FocusTraversalOrder(
+                      order: const NumericFocusOrder(1),
+                      child: FocusTraversalGroup(
+                        child: Column(
+                          children: <Widget>[
+                            Expanded(child: navigationShell),
+                            const MiniPlayer(),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            bottomNavigationBar: desktop ? null : _buildNavigationBar(),
+          );
         },
       ),
     );

--- a/test/features/library/album_grid_test.dart
+++ b/test/features/library/album_grid_test.dart
@@ -153,8 +153,7 @@ void main() {
         3700,
       ]) {
         final int columns = albumGridColumnCount(width);
-        final double cardWidth =
-            (width - gutter * (columns - 1)) / columns;
+        final double cardWidth = (width - gutter * (columns - 1)) / columns;
         expect(
           cardWidth,
           greaterThanOrEqualTo(200),

--- a/test/features/library/album_grid_test.dart
+++ b/test/features/library/album_grid_test.dart
@@ -17,9 +17,6 @@ import 'package:linthra/features/player/widgets/album_artwork.dart';
 import '../player/fake_playback_controller.dart';
 import 'fake_music_library_repository.dart';
 
-// No artworkUri anywhere, so these widget tests never reach for the network:
-// every cover falls back to the placeholder, which is also the "album without
-// artwork" case exercised below.
 const List<Track> _tracks = <Track>[
   Track(
     id: '1',
@@ -44,7 +41,6 @@ const List<Track> _tracks = <Track>[
   ),
 ];
 
-/// Six albums, enough rows to tell two columns from three or four.
 List<Track> _manyAlbums() => <Track>[
       for (int i = 0; i < 6; i++)
         Track(
@@ -73,11 +69,10 @@ GoRouter _router() {
   );
 }
 
-/// Pumps the Library at a given logical screen size and lands on Albums.
 Future<void> _pumpAlbums(
   WidgetTester tester, {
   List<Track>? tracks,
-  Size size = const Size(390, 844), // a typical phone
+  Size size = const Size(390, 844),
 }) async {
   tester.view.devicePixelRatio = 1.0;
   tester.view.physicalSize = size;
@@ -100,7 +95,6 @@ Future<void> _pumpAlbums(
   await tester.pumpAndSettle();
 }
 
-/// On-screen rectangles of every laid-out album card.
 List<Rect> _cardRects(WidgetTester tester) {
   return tester.elementList(find.byType(AlbumGridCard)).map((Element e) {
     final RenderBox box = e.renderObject! as RenderBox;
@@ -108,7 +102,6 @@ List<Rect> _cardRects(WidgetTester tester) {
   }).toList();
 }
 
-/// The cards sharing the topmost row, left to right.
 List<Rect> _firstRow(WidgetTester tester) {
   final List<Rect> rects = _cardRects(tester);
   final double top = rects
@@ -123,47 +116,56 @@ List<Rect> _firstRow(WidgetTester tester) {
 void main() {
   group('albumGridColumnCount', () {
     test('a phone-width content box gets exactly two columns', () {
-      expect(albumGridColumnCount(328), 2); // 360dp phone, minus padding
-      expect(albumGridColumnCount(358), 2); // 390dp phone, minus padding
-      expect(albumGridColumnCount(398), 2); // 430dp phone, minus padding
+      expect(albumGridColumnCount(328), 2);
+      expect(albumGridColumnCount(358), 2);
+      expect(albumGridColumnCount(398), 2);
     });
 
-    test('a third column only lands once there is room for one', () {
-      expect(albumGridColumnCount(560), 2);
-      expect(albumGridColumnCount(600), 3);
-      expect(albumGridColumnCount(800), 4);
+    test('a third column waits for its cards and both gutters', () {
+      expect(albumGridColumnCount(600), 2);
+      expect(albumGridColumnCount(631), 2);
+      expect(albumGridColumnCount(632), 3);
+      expect(albumGridColumnCount(800), 3);
+      expect(albumGridColumnCount(848), 4);
     });
 
     test('desktop widths add columns instead of inflating covers', () {
-      // Content widths for the common Linux windows, minus the navigation rail
-      // and the grid's own padding. Each keeps cards in the 200–260 band rather
-      // than stretching six mobile-sized cards across the monitor.
       expect(albumGridColumnCount(1168), 5); // 1280x720
       expect(albumGridColumnCount(1808), 7); // 1920x1080
-      expect(albumGridColumnCount(2448), 10); // 2560x1440
+      expect(albumGridColumnCount(2448), 9); // 2560x1440
       expect(albumGridColumnCount(3120), 12); // ultrawide
     });
 
-    test('a card is never squeezed below its minimum to add a column', () {
+    test('common 4K width grows beyond the old twelve-column cap', () {
+      expect(albumGridColumnCount(3700), 14);
+      expect(albumGridColumnCount(3700), greaterThan(12));
+    });
+
+    test('desktop cards honor the declared 200-260 width band', () {
+      const double gutter = 16;
       for (final double width in <double>[
-        328,
-        560,
-        900,
+        632,
+        848,
         1168,
         1808,
         2448,
         3120,
+        3700,
       ]) {
+        final int columns = albumGridColumnCount(width);
+        final double cardWidth =
+            (width - gutter * (columns - 1)) / columns;
         expect(
-          width / albumGridColumnCount(width),
-          greaterThanOrEqualTo(160),
-          reason: 'cards stay readable at $width',
+          cardWidth,
+          greaterThanOrEqualTo(200),
+          reason: 'minimum at $width with $columns columns',
+        );
+        expect(
+          cardWidth,
+          lessThanOrEqualTo(260),
+          reason: 'maximum at $width with $columns columns',
         );
       }
-    });
-
-    test('columns stop climbing at an absurd width', () {
-      expect(albumGridColumnCount(40000), 12);
     });
 
     test('a degenerate width still renders two columns', () {
@@ -192,8 +194,6 @@ void main() {
 
       final List<Rect> row = _firstRow(tester);
       expect(row.length, 2);
-
-      // Both cards are on screen, side by side, and each is wide enough to read.
       expect(row.first.left, lessThan(row.last.left));
       expect(row.last.right, lessThanOrEqualTo(390));
       expect(row.first.width, greaterThan(120));
@@ -232,8 +232,6 @@ void main() {
       );
 
       final List<Rect> row = _firstRow(tester);
-      // Six albums across a 1920 window: all on one row, none of them the
-      // ~400 px slab a capped mobile grid produced here.
       expect(row.length, 6);
       for (final Rect card in row) {
         expect(card.width, lessThan(300));
@@ -253,14 +251,18 @@ void main() {
         const Size(1280, 720),
         const Size(2560, 1440),
         const Size(3440, 1440),
+        const Size(3840, 2160),
         const Size(390, 844),
       ]) {
         tester.view.physicalSize = size;
         await tester.pumpAndSettle();
         expect(tester.takeException(), isNull, reason: 'at $size');
         final List<Rect> row = _firstRow(tester);
-        expect(row.last.right, lessThanOrEqualTo(size.width),
-            reason: 'at $size');
+        expect(
+          row.last.right,
+          lessThanOrEqualTo(size.width),
+          reason: 'at $size',
+        );
       }
     });
 
@@ -270,7 +272,6 @@ void main() {
       await tester.tap(find.text('Discovery'));
       await tester.pumpAndSettle();
 
-      // On the album detail screen, showing only Discovery's tracks.
       expect(find.text('Play'), findsOneWidget);
       expect(find.text('Alpha'), findsOneWidget);
       expect(find.text('Beta'), findsOneWidget);
@@ -288,8 +289,8 @@ void main() {
     });
 
     testWidgets(
-        'long-pressing a card still offers the whole album to a '
-        'playlist', (tester) async {
+        'long-pressing a card still offers the whole album to a playlist',
+        (tester) async {
       await _pumpAlbums(tester);
 
       await tester.longPress(find.text('Discovery'));
@@ -344,7 +345,6 @@ void main() {
         ],
       );
 
-      // A RenderFlex/paragraph overflow surfaces as a pumped exception.
       expect(tester.takeException(), isNull);
 
       final Finder card = find.byType(AlbumGridCard);
@@ -359,8 +359,6 @@ void main() {
       );
       expect(artist.maxLines, 1);
       expect(artist.overflow, TextOverflow.ellipsis);
-
-      // The card still sits inside the viewport, text and all.
       expect(tester.getRect(card).bottom, lessThanOrEqualTo(844));
     });
 

--- a/test/features/library/artist_grid_test.dart
+++ b/test/features/library/artist_grid_test.dart
@@ -16,8 +16,6 @@ import 'package:linthra/features/player/player_providers.dart';
 import '../player/fake_playback_controller.dart';
 import 'fake_music_library_repository.dart';
 
-/// Six artists, enough rows to tell one column from two or three. No artwork
-/// anywhere, so the tests never reach for the network.
 List<Track> _artists() => <Track>[
       for (int i = 0; i < 6; i++)
         Track(
@@ -75,7 +73,6 @@ Future<void> _pumpArtists(
   await tester.pumpAndSettle();
 }
 
-/// The artist rows sharing the topmost row of the grid, left to right.
 List<Rect> _firstRow(WidgetTester tester) {
   final List<Rect> rects = tester.elementList(find.byType(ArtistTile)).map(
     (Element e) {
@@ -100,9 +97,10 @@ void main() {
       expect(artistGridColumnCount(430), 1);
     });
 
-    test('a second column only lands once a row still reads', () {
-      expect(artistGridColumnCount(600), 1);
-      expect(artistGridColumnCount(700), 2);
+    test('a second column waits for padding and its inter-column gutter', () {
+      expect(artistGridColumnCount(680), 1);
+      expect(artistGridColumnCount(703), 1);
+      expect(artistGridColumnCount(704), 2);
       expect(artistGridColumnCount(1040), 2);
     });
 
@@ -112,19 +110,35 @@ void main() {
       expect(artistGridColumnCount(2448), 5); // 2560x1440
     });
 
-    test('a row is never squeezed below its minimum to add a column', () {
+    test('common 4K width grows beyond the old six-column cap', () {
+      expect(artistGridColumnCount(3700), 7);
+      expect(artistGridColumnCount(3700), greaterThan(6));
+    });
+
+    test('multi-column rows honor the declared 340-520 width band', () {
+      const double horizontalPadding = 16;
+      const double gutter = 8;
       for (final double width in <double>[
-        360,
-        700,
+        704,
+        1040,
         1168,
         1808,
         2448,
         3300,
+        3700,
       ]) {
+        final int columns = artistGridColumnCount(width);
+        final double rowWidth =
+            (width - horizontalPadding - gutter * (columns - 1)) / columns;
         expect(
-          width / artistGridColumnCount(width),
-          greaterThanOrEqualTo(300),
-          reason: 'rows stay readable at $width',
+          rowWidth,
+          greaterThanOrEqualTo(340),
+          reason: 'minimum at $width with $columns columns',
+        );
+        expect(
+          rowWidth,
+          lessThanOrEqualTo(520),
+          reason: 'maximum at $width with $columns columns',
         );
       }
     });
@@ -151,7 +165,6 @@ void main() {
 
       final List<Rect> row = _firstRow(tester);
       expect(row.length, greaterThan(2));
-      // No row stretches across the monitor, and none runs off it.
       for (final Rect tile in row) {
         expect(tile.width, lessThan(600));
       }
@@ -199,6 +212,7 @@ void main() {
         const Size(1280, 720),
         const Size(2560, 1440),
         const Size(3440, 1440),
+        const Size(3840, 2160),
         const Size(390, 844),
       ]) {
         tester.view.physicalSize = size;

--- a/test/features/library/detail_desktop_layout_test.dart
+++ b/test/features/library/detail_desktop_layout_test.dart
@@ -17,9 +17,6 @@ import 'package:linthra/features/player/player_screen.dart';
 import '../player/fake_playback_controller.dart';
 import 'fake_music_library_repository.dart';
 
-/// One artist with two albums, so both detail screens have a header, an album
-/// section and a song list to lay out. No artwork anywhere, so these widget
-/// tests never reach for the network.
 final List<Track> _tracks = <Track>[
   for (int i = 0; i < 4; i++)
     Track(
@@ -55,7 +52,11 @@ GoRouter _router() {
   );
 }
 
-Future<void> _pumpLibrary(WidgetTester tester, Size size) async {
+Future<void> _pumpLibrary(
+  WidgetTester tester,
+  Size size, {
+  TextScaler textScaler = TextScaler.noScaling,
+}) async {
   tester.view.devicePixelRatio = 1.0;
   tester.view.physicalSize = size;
   addTearDown(tester.view.reset);
@@ -69,30 +70,42 @@ Future<void> _pumpLibrary(WidgetTester tester, Size size) async {
         playlistStoreProvider.overrideWithValue(InMemoryPlaylistStore()),
         playbackControllerProvider.overrideWithValue(FakePlaybackController()),
       ],
-      child: MaterialApp.router(routerConfig: _router()),
+      child: MaterialApp.router(
+        builder: (BuildContext context, Widget? child) => MediaQuery(
+          data: MediaQuery.of(context).copyWith(textScaler: textScaler),
+          child: child!,
+        ),
+        routerConfig: _router(),
+      ),
     ),
   );
   await tester.pumpAndSettle();
 }
 
-Future<void> _openAlbum(WidgetTester tester, Size size) async {
-  await _pumpLibrary(tester, size);
+Future<void> _openAlbum(
+  WidgetTester tester,
+  Size size, {
+  TextScaler textScaler = TextScaler.noScaling,
+}) async {
+  await _pumpLibrary(tester, size, textScaler: textScaler);
   await tester.tap(find.text('Albums'));
   await tester.pumpAndSettle();
   await tester.tap(find.text('Discovery').first);
   await tester.pumpAndSettle();
 }
 
-Future<void> _openArtist(WidgetTester tester, Size size) async {
-  await _pumpLibrary(tester, size);
+Future<void> _openArtist(
+  WidgetTester tester,
+  Size size, {
+  TextScaler textScaler = TextScaler.noScaling,
+}) async {
+  await _pumpLibrary(tester, size, textScaler: textScaler);
   await tester.tap(find.text('Artists'));
   await tester.pumpAndSettle();
   await tester.tap(find.text('Daft Punk').first);
   await tester.pumpAndSettle();
 }
 
-/// Rect of the Play (or Play all) button, which lives in the header on both
-/// screens — a reliable stand-in for "where the header is".
 Rect _headerRect(WidgetTester tester, String playLabel) =>
     tester.getRect(find.widgetWithText(FilledButton, playLabel));
 
@@ -116,8 +129,6 @@ void main() {
 
       final Rect header = _headerRect(tester, 'Play');
       final Rect track = _firstTrackRect(tester);
-      // Side by side: the album pane ends before the track list begins, and
-      // both are visible at once rather than one scrolling the other away.
       expect(header.right, lessThanOrEqualTo(track.left));
       expect(track.width, greaterThan(header.width));
       expect(tester.takeException(), isNull);
@@ -196,9 +207,23 @@ void main() {
 
       final Rect header = _headerRect(tester, 'Play all');
       expect(header.right, lessThanOrEqualTo(_firstTrackRect(tester).left));
-      // The albums section still lists both albums beside the artist pane.
       expect(find.text('Discovery'), findsOneWidget);
       expect(find.text('Homework'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('desktop artist actions stack safely at 2x text scale',
+        (tester) async {
+      await _openArtist(
+        tester,
+        const Size(1280, 600),
+        textScaler: const TextScaler.linear(2.0),
+      );
+
+      final Rect play = _headerRect(tester, 'Play all');
+      final Rect shuffle =
+          tester.getRect(find.widgetWithText(FilledButton, 'Shuffle all'));
+      expect(play.bottom, lessThanOrEqualTo(shuffle.top));
       expect(tester.takeException(), isNull);
     });
 

--- a/test/features/player/player_desktop_layout_test.dart
+++ b/test/features/player/player_desktop_layout_test.dart
@@ -15,7 +15,6 @@ import 'package:linthra/features/player/widgets/track_metadata.dart';
 
 import 'fake_playback_controller.dart';
 
-/// A lyrics backend returning one canned set for the test track.
 class _FakeLyricsService implements LyricsService {
   _FakeLyricsService(this._lyrics);
 
@@ -25,8 +24,6 @@ class _FakeLyricsService implements LyricsService {
   Future<Lyrics?> lyricsFor(Track track) async => _lyrics;
 }
 
-/// No artwork, so the cover falls back to its placeholder and nothing here
-/// reaches for the network.
 const Track _track = Track(
   id: '1',
   title: 'Song One',
@@ -119,7 +116,6 @@ void main() {
       final Rect artwork = _artworkRect(tester);
       final Rect controls = _controlsRect(tester);
       expect(artwork.right, lessThanOrEqualTo(controls.left));
-      // The cover is a square cover, not a stretched panel.
       expect(artwork.width, closeTo(artwork.height, 1));
       expect(find.text('Song One'), findsOneWidget);
       expect(find.text('Artist A'), findsOneWidget);
@@ -138,21 +134,17 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(LyricsView), findsOneWidget);
-      // The whole point of the extra width: the cover stays.
       expect(find.byType(AlbumArtwork), findsWidgets);
       expect(
         _artworkRect(tester).right,
         lessThanOrEqualTo(tester.getRect(find.byType(LyricsView)).left),
       );
-      // Transport stays where it was, under the lyrics rather than behind them.
       expect(find.byTooltip('Pause'), findsOneWidget);
       expect(tester.takeException(), isNull);
     });
 
     testWidgets('the smallest wide window shrinks the cover, not the transport',
         (tester) async {
-      // 1280 wide at Linthra's minimum window height: the cover gives up the
-      // height, the controls keep theirs, and nothing overflows.
       await _pumpPlayer(tester, size: const Size(1280, 600));
 
       final Rect artwork = _artworkRect(tester);
@@ -172,6 +164,28 @@ void main() {
       expect(tester.takeException(), isNull);
       expect(find.text('Song One'), findsOneWidget);
       expect(find.byTooltip('Pause'), findsOneWidget);
+    });
+
+    testWidgets('short wide lyrics keep usable height at 2x text scale',
+        (tester) async {
+      await _pumpPlayer(
+        tester,
+        size: const Size(1280, 600),
+        lyrics: _lyrics,
+        textScaler: const TextScaler.linear(2.0),
+      );
+
+      await tester.tap(find.byTooltip('Lyrics'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('track_metadata_compact_height')),
+        findsOneWidget,
+      );
+      expect(find.byType(LyricsView), findsOneWidget);
+      expect(tester.getRect(find.byType(LyricsView)).height, greaterThan(80));
+      expect(find.byTooltip('Pause'), findsOneWidget);
+      expect(tester.takeException(), isNull);
     });
 
     testWidgets('resizing keeps playback and the lyrics toggle',
@@ -194,8 +208,6 @@ void main() {
         tester.view.physicalSize = size;
         await tester.pumpAndSettle();
         expect(tester.takeException(), isNull, reason: 'at $size');
-        // Same state either side of the breakpoint: still on lyrics, still
-        // playing the same track.
         expect(find.byType(LyricsView), findsOneWidget, reason: 'at $size');
         expect(find.byTooltip('Pause'), findsOneWidget, reason: 'at $size');
       }
@@ -207,8 +219,6 @@ void main() {
 
       final Rect artwork = _artworkRect(tester);
       final Rect controls = _controlsRect(tester);
-      // Both columns stay in the middle of the monitor rather than being
-      // pushed to opposite edges.
       expect(artwork.left, greaterThan(400));
       expect(controls.right, lessThan(3040));
       expect(tester.takeException(), isNull);

--- a/test/features/shell/home_shell_adaptive_test.dart
+++ b/test/features/shell/home_shell_adaptive_test.dart
@@ -8,13 +8,27 @@ import 'package:linthra/features/shell/home_shell.dart';
 import '../player/fake_playback_controller.dart';
 
 class _BranchScreen extends StatelessWidget {
-  const _BranchScreen(this.label);
+  const _BranchScreen(this.label, this.path);
 
   final String label;
+  final String path;
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(body: Center(child: Text('$label screen')));
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text('$label screen'),
+            TextButton(
+              onPressed: () => context.push('$path/detail'),
+              child: Text('Open $label detail'),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }
 
@@ -52,7 +66,15 @@ GoRouter _router(
               routes: <RouteBase>[
                 GoRoute(
                   path: paths[i],
-                  builder: (_, __) => _BranchScreen(labels[i]),
+                  builder: (_, __) => _BranchScreen(labels[i], paths[i]),
+                  routes: <RouteBase>[
+                    GoRoute(
+                      path: 'detail',
+                      builder: (_, __) => Scaffold(
+                        body: Center(child: Text('${labels[i]} detail')),
+                      ),
+                    ),
+                  ],
                 ),
               ],
             ),
@@ -154,6 +176,43 @@ void main() {
             .selectedIndex,
         1,
       );
+    },
+  );
+
+  testWidgets(
+    'resize preserves the inactive branch stack, not only its selected index',
+    (WidgetTester tester) async {
+      await _pumpShell(
+        tester,
+        platform: TargetPlatform.linux,
+        size: const Size(1280, 720),
+      );
+
+      await tester.tap(find.text('Playlists'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Open Playlists detail'));
+      await tester.pumpAndSettle();
+      expect(find.text('Playlists detail'), findsOneWidget);
+
+      await tester.tap(find.text('Library'));
+      await tester.pumpAndSettle();
+      expect(find.text('Library screen'), findsOneWidget);
+
+      tester.view.physicalSize = const Size(700, 720);
+      await tester.pumpAndSettle();
+      expect(find.byType(NavigationBar), findsOneWidget);
+
+      await tester.tap(find.text('Playlists'));
+      await tester.pumpAndSettle();
+
+      // Re-entering the inactive branch after crossing the breakpoint must
+      // restore its detail route, not silently reset it to the branch root.
+      expect(find.text('Playlists detail'), findsOneWidget);
+
+      tester.view.physicalSize = const Size(1280, 720);
+      await tester.pumpAndSettle();
+      expect(find.byType(NavigationRail), findsOneWidget);
+      expect(find.text('Playlists detail'), findsOneWidget);
     },
   );
 


### PR DESCRIPTION
Follow-up to #559 / #560 for the P2 edge cases reported after merge.

## Fixes
- album-grid column math now includes inter-card gutters before adding a column
- album grid grows beyond the old 12-column cap on common 4K widths
- artist-grid math now includes its horizontal padding and inter-column gutters
- artist grid grows beyond the old 6-column cap on common 4K widths
- the desktop artist pane stacks Play all / Shuffle all so 2x accessibility text does not squeeze two labelled buttons into ~140 px each
- short windows with large accessibility text compact Now Playing metadata so the flexible lyrics pane retains usable height
- `StatefulNavigationShell` stays at a stable element position across the 900 px Linux breakpoint so inactive branch stacks survive resize

## Regression coverage
- exact album gutter transition (631 -> 632 px)
- exact artist padding/gutter transition (703 -> 704 px)
- 3840x2160 / common 4K sizing
- declared card/row width bands using the actual gutter math
- 1280x600 lyrics at 2x text scale with a usable lyrics region
- desktop artist actions at 2x text scale
- inactive Playlists detail stack survives wide -> narrow -> wide resize

No provider, playback-state, Flatpak permission, Android navigation, or release behavior changes.