### PR TITLE
feat(player): put the transport on the now-playing bar and Folders in the nav

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -7,6 +7,7 @@ import '../features/downloads/downloads_screen.dart';
 import '../features/favorites/favorites_screen.dart';
 import '../features/library/album_detail_screen.dart';
 import '../features/library/artist_detail_screen.dart';
+import '../features/library/folders_screen.dart';
 import '../features/library/library_screen.dart';
 import '../features/onboarding/onboarding_controller.dart';
 import '../features/onboarding/onboarding_screen.dart';
@@ -35,6 +36,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
   final List<GlobalKey<NavigatorState>> branchNavigatorKeys =
       <GlobalKey<NavigatorState>>[
     GlobalKey<NavigatorState>(debugLabel: 'libraryBranch'),
+    GlobalKey<NavigatorState>(debugLabel: 'foldersBranch'),
     GlobalKey<NavigatorState>(debugLabel: 'playlistsBranch'),
     GlobalKey<NavigatorState>(debugLabel: 'downloadsBranch'),
     GlobalKey<NavigatorState>(debugLabel: 'settingsBranch'),
@@ -91,6 +93,15 @@ final appRouterProvider = Provider<GoRouter>((ref) {
             navigatorKey: branchNavigatorKeys[1],
             routes: [
               GoRoute(
+                path: AppRoutes.folders,
+                builder: (context, state) => const FoldersScreen(),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            navigatorKey: branchNavigatorKeys[2],
+            routes: [
+              GoRoute(
                 path: AppRoutes.playlists,
                 builder: (context, state) => const PlaylistsScreen(),
                 routes: [
@@ -121,7 +132,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
             ],
           ),
           StatefulShellBranch(
-            navigatorKey: branchNavigatorKeys[2],
+            navigatorKey: branchNavigatorKeys[3],
             routes: [
               GoRoute(
                 path: AppRoutes.downloads,
@@ -130,7 +141,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
             ],
           ),
           StatefulShellBranch(
-            navigatorKey: branchNavigatorKeys[3],
+            navigatorKey: branchNavigatorKeys[4],
             routes: [
               GoRoute(
                 path: AppRoutes.settings,

--- a/lib/app/routes.dart
+++ b/lib/app/routes.dart
@@ -28,6 +28,11 @@ abstract final class AppRoutes {
   static String artistDetailPath(String id) =>
       '$artistDetail/${Uri.encodeComponent(id)}';
 
+  /// Server folder browsing (Jellyfin, Navidrome/Subsonic), a top-level
+  /// destination of its own so a folder you were deep inside is still open when
+  /// you come back to it from another tab.
+  static const String folders = '/folders';
+
   static const String playlists = '/playlists';
 
   /// Liked tracks, reached from the Playlists tab. A child of [playlists] so it

--- a/lib/features/library/folders_screen.dart
+++ b/lib/features/library/folders_screen.dart
@@ -1,26 +1,35 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../app/dimens.dart';
-import '../../../core/models/music_folder.dart';
-import '../../../core/services/folder_browsable_music_source.dart';
-import '../../../shared/widgets/empty_state.dart';
-import '../folder_browser_providers.dart';
-import 'track_tile.dart';
+import '../../app/dimens.dart';
+import '../../core/models/music_folder.dart';
+import '../../core/services/folder_browsable_music_source.dart';
+import '../../shared/widgets/empty_state.dart';
+import 'folder_browser_providers.dart';
+import 'widgets/track_tile.dart';
 
 /// Browses the real directory hierarchy exposed by Jellyfin and
 /// Navidrome/Subsonic, one level at a time.
 ///
-/// Navigation stays inside the Library tab. Android's system Back first walks
-/// up the folder trail; only at the roots does it leave the screen.
-class FolderBrowserTab extends ConsumerStatefulWidget {
-  const FolderBrowserTab({super.key});
+/// A top-level destination beside Library, Playlists, Downloads and Settings,
+/// with its own navigation branch — so a folder you were three levels deep in
+/// is still open when you come back to it from another tab.
+///
+/// The hierarchy is fetched on demand, so this does not require the directory
+/// tree to be persisted or recursively synced first. With no folder-capable
+/// server connected it shows an empty state pointing at Connections rather
+/// than disappearing, so the feature is discoverable before it is usable.
+///
+/// Android's system Back first walks up the folder trail; only at the roots
+/// does it leave the screen.
+class FoldersScreen extends ConsumerStatefulWidget {
+  const FoldersScreen({super.key});
 
   @override
-  ConsumerState<FolderBrowserTab> createState() => _FolderBrowserTabState();
+  ConsumerState<FoldersScreen> createState() => _FoldersScreenState();
 }
 
-class _FolderBrowserTabState extends ConsumerState<FolderBrowserTab> {
+class _FoldersScreenState extends ConsumerState<FoldersScreen> {
   final List<_FolderLocation> _trail = <_FolderLocation>[];
 
   @override
@@ -28,9 +37,16 @@ class _FolderBrowserTabState extends ConsumerState<FolderBrowserTab> {
     final List<FolderBrowsableMusicSource> sources =
         ref.watch(folderBrowsableSourcesProvider);
 
+    return Scaffold(
+      appBar: AppBar(title: const Text('Folders')),
+      body: _body(sources),
+    );
+  }
+
+  Widget _body(List<FolderBrowsableMusicSource> sources) {
     if (_trail.isNotEmpty &&
         !sources.any((source) => source.id == _trail.last.sourceId)) {
-      // A sign-out can happen while this tab is open. Return to roots on the
+      // A sign-out can happen while this screen is open. Return to roots on the
       // next frame instead of trying to fetch with a session that no longer
       // exists (and never mutate state during build).
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -39,49 +55,41 @@ class _FolderBrowserTabState extends ConsumerState<FolderBrowserTab> {
       return const Center(child: CircularProgressIndicator());
     }
 
-    // BackButtonListener talks directly to the Router used by go_router. A
-    // nested PopScope inside TabBarView is not reliable on every Android back
-    // implementation, while this listener can consume the physical/system
-    // Back event before the app's root route is closed.
+    if (_trail.isEmpty) {
+      // Nothing to intercept at the roots, so no listener is registered and
+      // Back behaves exactly as it does on the other top-level destinations.
+      return _FolderRoots(sources: sources, onOpen: _openRoot);
+    }
+
+    // BackButtonListener talks directly to the Router used by go_router, and
+    // can consume the physical/system Back event before the app's root route
+    // is closed — which a nested PopScope does not do reliably on every
+    // Android back implementation.
     return BackButtonListener(
       onBackButtonPressed: _handleSystemBack,
-      child: _trail.isEmpty
-          ? _FolderRoots(
-              sources: sources,
-              onOpen: _openRoot,
-            )
-          : _FolderContents(
-              location: _trail.last,
-              onBack: _goBack,
-              onOpen: _openChild,
-            ),
+      child: _FolderContents(
+        location: _trail.last,
+        onBack: _goBack,
+        onOpen: _openChild,
+      ),
     );
   }
 
-  /// Consumes Android Back only when this TabBarView page is actually visible
-  /// and there is a folder level to leave. TabBarView keeps neighbouring pages
-  /// alive off-screen, so visibility is checked from the rendered page bounds;
-  /// otherwise a hidden Folders tab could swallow Back while viewing Songs.
+  /// Consumes Android Back only when this branch is the one on screen and
+  /// there is a folder level to leave.
+  ///
+  /// The shell keeps every branch mounted inside an IndexedStack, so a Folders
+  /// screen sitting three levels deep behind the Library tab would otherwise
+  /// swallow Back while the user is looking at Library. go_router marks the
+  /// inactive branches by disabling their tickers, which is the one signal
+  /// available here that distinguishes "mounted" from "visible" — the branches
+  /// are all laid out at the same offset, so measuring bounds cannot.
   Future<bool> _handleSystemBack() async {
-    if (_trail.isEmpty || !_isVisibleInViewport()) return false;
-    _goBack();
-    return true;
-  }
-
-  bool _isVisibleInViewport() {
-    final RenderObject? renderObject = context.findRenderObject();
-    if (renderObject is! RenderBox ||
-        !renderObject.attached ||
-        !renderObject.hasSize) {
+    if (_trail.isEmpty || !TickerMode.valuesOf(context).enabled) {
       return false;
     }
-
-    final Offset topLeft = renderObject.localToGlobal(Offset.zero);
-    final Size viewport = MediaQuery.sizeOf(context);
-    return topLeft.dx < viewport.width &&
-        topLeft.dx + renderObject.size.width > 0 &&
-        topLeft.dy < viewport.height &&
-        topLeft.dy + renderObject.size.height > 0;
+    _goBack();
+    return true;
   }
 
   void _openRoot(FolderBrowsableMusicSource source, MusicFolder folder) {

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -27,15 +27,14 @@ import 'unified_library_providers.dart';
 import 'widgets/album_grid.dart';
 import 'widgets/alphabet_track_list.dart';
 import 'widgets/artist_grid.dart';
-import 'widgets/folder_browser_tab.dart';
 import 'widgets/library_search_field.dart';
 
-/// Browse the catalog across Songs, Albums, Artists, and provider folders.
+/// Browse the de-duplicated catalog across Songs, Albums and Artists.
 ///
-/// The first three tabs read the de-duplicated local catalog and share one
-/// search box. Folders is an on-demand view of the real hierarchy exposed by a
-/// connected Jellyfin or Navidrome/Subsonic server, so it does not require the
-/// directory tree to be persisted or recursively synced first.
+/// All three tabs read the same local catalog and share one search box. The
+/// server's real directory hierarchy is not here: it lives on its own top-level
+/// [FoldersScreen] destination, so it keeps its place in the tree when you
+/// leave it.
 ///
 /// Songs keeps the long-press multi-select and the A–Z fast-scroller from
 /// before. Switching tabs clears the query, so a search meant for one tab never
@@ -68,7 +67,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 4, vsync: this);
+    _tabController = TabController(length: 3, vsync: this);
     _tabController.addListener(_onTabChanged);
   }
 
@@ -186,7 +185,6 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
         Tab(text: 'Songs'),
         Tab(text: 'Albums'),
         Tab(text: 'Artists'),
-        Tab(text: 'Folders'),
       ],
     );
   }
@@ -223,10 +221,8 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
     }
   }
 
-  /// Catalog search + four browse tabs. Folders performs its own hierarchical
-  /// navigation, so the flat-catalog search field is hidden on that tab.
+  /// Catalog search + the three browse tabs.
   Widget _browseBody(List<Track> songs, List<String> syncingSources) {
-    final bool foldersTab = _tabController.index == 3;
     // A connected folder-capable server (Jellyfin, Navidrome/Subsonic) shows the
     // tabs the moment it connects, so its *first* sync lands here rather than in
     // [_statusBody]. Pass the syncing sources down so the catalog tabs say
@@ -234,21 +230,20 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
     final String? syncHeadline = syncingHeadline(syncingSources);
     return Column(
       children: <Widget>[
-        if (!foldersTab)
-          // The box is a text input, not content: on a wide window it stops
-          // growing and stays left-aligned under the tabs rather than running
-          // the width of a monitor.
-          Align(
-            alignment: AlignmentDirectional.centerStart,
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: _searchFieldMaxWidth),
-              child: LibrarySearchField(
-                controller: _searchController,
-                onChanged: _onQueryChanged,
-                onClear: _clearSearch,
-              ),
+        // The box is a text input, not content: on a wide window it stops
+        // growing and stays left-aligned under the tabs rather than running
+        // the width of a monitor.
+        Align(
+          alignment: AlignmentDirectional.centerStart,
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: _searchFieldMaxWidth),
+            child: LibrarySearchField(
+              controller: _searchController,
+              onChanged: _onQueryChanged,
+              onClear: _clearSearch,
             ),
           ),
+        ),
         Expanded(
           child: TabBarView(
             controller: _tabController,
@@ -256,7 +251,6 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
               _songsTab(songs, syncHeadline),
               _albumsTab(syncHeadline),
               _artistsTab(syncHeadline),
-              const FolderBrowserTab(),
             ],
           ),
         ),

--- a/lib/features/player/mini_player.dart
+++ b/lib/features/player/mini_player.dart
@@ -10,29 +10,50 @@ import '../../core/models/playback_source.dart';
 import '../../core/models/playback_state.dart';
 import '../../core/models/track.dart';
 import '../../core/services/playback_source_label.dart';
+import '../../data/repositories/favorites_repository_provider.dart';
 import '../../shared/widgets/wavy_progress_indicator.dart';
 import 'cast/cast_providers.dart';
+import 'favorites_providers.dart';
 import 'player_providers.dart';
 import 'widgets/album_artwork.dart';
+import 'widgets/queue_sheet.dart';
 
 /// A compact, persistent now-playing bar shown above the bottom navigation on
-/// every main screen (Library / Playlists / Downloads / Settings).
+/// every main screen (Library / Folders / Playlists / Downloads / Settings).
 ///
 /// It renders from [playbackStateProvider] — the same single
 /// [PlaybackController] the full [PlayerScreen] and the media session use — so
 /// it never owns playback state of its own and never disappears when switching
 /// tabs. When nothing is loaded it collapses to zero height. Tapping it opens
-/// the full now-playing screen; the play/pause button delegates straight to the
+/// the full now-playing screen; the transport buttons delegate straight to the
 /// controller. A thin accent progress line rides its top edge, doubling as the
 /// separator from the content above.
+///
+/// How much transport the bar carries depends on how much room it has. A phone
+/// in portrait gets play/pause alone, as it always has; a desktop window gets
+/// the full row — favorite · previous · play/pause · next — centred between the
+/// metadata and the queue button, so skipping a track or liking one never means
+/// opening the full player first.
 class MiniPlayer extends ConsumerWidget {
   const MiniPlayer({super.key});
+
+  // Both thresholds are measured against the bar's content width (the row
+  // inside its horizontal padding), not the window, so they hold wherever the
+  // bar is hosted.
+
+  /// Below this the bar has room for play/pause and nothing else, so it looks
+  /// and behaves exactly as it did before the transport row existed.
+  static const double _favoriteBreakpoint = 360;
+
+  /// At this width — a tablet in landscape, any desktop window — the metadata
+  /// can give up the space the previous/next buttons and the queue button need.
+  static const double _transportBreakpoint = 600;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     // Watch only the current track (id-distinct) and its resolved source, so the
-    // ~5 Hz position ticks rebuild just the thin progress line and the play/pause
-    // button below — not the whole bar (artwork, text) on every screen, every
+    // ~5 Hz position ticks rebuild just the thin progress line and the transport
+    // buttons below — not the whole bar (artwork, text) on every screen, every
     // tick. The source changes only when the track does, so including it adds no
     // tick rebuilds. Falls back to the controller's latest state until the first
     // stream event arrives.
@@ -82,62 +103,51 @@ class MiniPlayer extends ConsumerWidget {
                   padding: const EdgeInsets.symmetric(
                     horizontal: AppSpacing.md,
                   ),
-                  child: Row(
-                    children: [
-                      // The cover carries no information the lines beside it
-                      // don't already say, so it stays out of the reading
-                      // order rather than announcing an image before them.
-                      ExcludeSemantics(
-                        child: SizedBox.square(
-                          dimension: 44,
-                          child: AlbumArtwork(
-                            artworkUri: track.artworkUri,
-                            borderRadius: BorderRadius.circular(AppRadii.sm),
-                          ),
-                        ),
-                      ),
-                      const SizedBox(width: AppSpacing.md),
-                      Expanded(
-                        // One node for the whole metadata block, so the bar
-                        // announces "<title>, <artist> • <source>" once
-                        // instead of three fragments in a row. The play/pause
-                        // button stays outside it and keeps its own node.
-                        child: MergeSemantics(
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                track.title,
-                                style: theme.textTheme.titleSmall?.copyWith(
-                                  fontWeight: FontWeight.w600,
-                                ),
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
+                  child: LayoutBuilder(
+                    builder:
+                        (BuildContext context, BoxConstraints constraints) {
+                      final Widget metadata = _NowPlayingMetadata(
+                        track: track,
+                        subtitle: subtitle,
+                        sourceName: sourceName,
+                        isCasting: isCasting,
+                      );
+
+                      if (constraints.maxWidth >= _transportBreakpoint) {
+                        // Two equally weighted side columns, so the transport
+                        // sits on the window's centre line rather than
+                        // drifting with the length of the track title.
+                        return Row(
+                          children: <Widget>[
+                            Expanded(child: metadata),
+                            _Transport(
+                              track: track,
+                              showFavorite: true,
+                              showSkip: true,
+                            ),
+                            const Expanded(
+                              child: Align(
+                                alignment: AlignmentDirectional.centerEnd,
+                                child: _QueueButton(),
                               ),
-                              if (subtitle != null || sourceName != null)
-                                _MiniSubtitle(
-                                  subtitle: subtitle,
-                                  sourceName: sourceName,
-                                ),
-                            ],
+                            ),
+                          ],
+                        );
+                      }
+
+                      return Row(
+                        children: <Widget>[
+                          Expanded(child: metadata),
+                          const SizedBox(width: AppSpacing.sm),
+                          _Transport(
+                            track: track,
+                            showFavorite:
+                                constraints.maxWidth >= _favoriteBreakpoint,
+                            showSkip: false,
                           ),
-                        ),
-                      ),
-                      if (isCasting) ...[
-                        // Icon-only, and the only thing on the bar that says
-                        // the audio is going somewhere else — so it is named.
-                        Icon(
-                          Icons.cast_connected,
-                          size: 18,
-                          color: theme.colorScheme.primary,
-                          semanticLabel: 'Casting',
-                        ),
-                        const SizedBox(width: AppSpacing.sm),
-                      ],
-                      const SizedBox(width: AppSpacing.sm),
-                      const _PlayPauseButton(),
-                    ],
+                        ],
+                      );
+                    },
                   ),
                 ),
               ),
@@ -153,6 +163,105 @@ class MiniPlayer extends ConsumerWidget {
   static String? _subtitle(Track track) {
     final String label = track.artistAlbumLabel;
     return label.isEmpty ? null : label;
+  }
+}
+
+/// The bar's left column: cover, title, subtitle, and the cast indicator.
+class _NowPlayingMetadata extends StatelessWidget {
+  const _NowPlayingMetadata({
+    required this.track,
+    required this.subtitle,
+    required this.sourceName,
+    required this.isCasting,
+  });
+
+  final Track track;
+  final String? subtitle;
+  final String? sourceName;
+  final bool isCasting;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      children: <Widget>[
+        // The cover carries no information the lines beside it don't already
+        // say, so it stays out of the reading order rather than announcing an
+        // image before them.
+        ExcludeSemantics(
+          child: SizedBox.square(
+            dimension: 44,
+            child: AlbumArtwork(
+              artworkUri: track.artworkUri,
+              borderRadius: BorderRadius.circular(AppRadii.sm),
+            ),
+          ),
+        ),
+        const SizedBox(width: AppSpacing.md),
+        Expanded(
+          // One node for the whole metadata block, so the bar announces
+          // "<title>, <artist> • <source>" once instead of three fragments in
+          // a row. The transport buttons stay outside it and keep their own.
+          child: MergeSemantics(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  track.title,
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                if (subtitle != null || sourceName != null)
+                  _MiniSubtitle(subtitle: subtitle, sourceName: sourceName),
+              ],
+            ),
+          ),
+        ),
+        if (isCasting) ...<Widget>[
+          const SizedBox(width: AppSpacing.sm),
+          // Icon-only, and the only thing on the bar that says the audio is
+          // going somewhere else — so it is named.
+          Icon(
+            Icons.cast_connected,
+            size: 18,
+            color: theme.colorScheme.primary,
+            semanticLabel: 'Casting',
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+/// The bar's transport cluster, sized to the room available:
+/// favorite · previous · play/pause · next when the window allows it, and
+/// play/pause alone on a narrow phone.
+class _Transport extends StatelessWidget {
+  const _Transport({
+    required this.track,
+    required this.showFavorite,
+    required this.showSkip,
+  });
+
+  final Track track;
+  final bool showFavorite;
+  final bool showSkip;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        if (showFavorite) _FavoriteButton(track: track),
+        if (showSkip) const _SkipButton(previous: true),
+        const _PlayPauseButton(),
+        if (showSkip) const _SkipButton(previous: false),
+      ],
+    );
   }
 }
 
@@ -248,8 +357,94 @@ class _MiniProgressBar extends ConsumerWidget {
   }
 }
 
-/// The mini-player's transport control: a spinner while a track loads, then a
-/// play/pause toggle (tinted with the warm accent) that forwards to the
+/// Likes or un-likes whatever is playing, without a trip through the full
+/// player.
+///
+/// The track handed here is the one the controller is actually playing, so it
+/// is already the provider-specific copy a favourite write has to target — no
+/// resolution step is needed the way it is on the now-playing screen, where the
+/// displayed track can come from the unified library instead.
+class _FavoriteButton extends ConsumerWidget {
+  const _FavoriteButton({required this.track});
+
+  final Track track;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    // Keyed by the provider-namespaced uri, so `jellyfin:101` and
+    // `subsonic:101` each reflect their own heart.
+    final bool isFavorite = ref.watch(isFavoriteProvider(track.uri));
+    return IconButton(
+      onPressed: () =>
+          ref.read(favoritesRepositoryProvider).setFavorite(track, !isFavorite),
+      icon: Icon(isFavorite ? Icons.favorite : Icons.favorite_border),
+      iconSize: 22,
+      // The same violet the now-playing screen's heart uses, so a liked track
+      // reads the same on both surfaces.
+      color: isFavorite
+          ? theme.colorScheme.primary
+          : theme.colorScheme.onSurface.withValues(alpha: 0.7),
+      isSelected: isFavorite,
+      tooltip: isFavorite ? 'Remove from favorites' : 'Favorite',
+    );
+  }
+}
+
+/// Previous / next, mirroring the full player's transport: they follow the live
+/// queue and grey out at its ends rather than disappearing, so the bar's layout
+/// doesn't shift as a queue plays out.
+class _SkipButton extends ConsumerWidget {
+  const _SkipButton({required this.previous});
+
+  final bool previous;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final controller = ref.watch(playbackControllerProvider);
+    // Only the one flag this button cares about, so a position tick (or the
+    // other end of the queue changing) doesn't rebuild it.
+    final bool enabled = ref.watch(
+          playbackStateProvider.select(
+            (s) => switch (s.valueOrNull) {
+              null => null,
+              final PlaybackState state =>
+                previous ? state.hasPrevious : state.hasNext,
+            },
+          ),
+        ) ??
+        (previous ? controller.state.hasPrevious : controller.state.hasNext);
+
+    return IconButton(
+      onPressed: enabled
+          ? (previous ? controller.skipToPrevious : controller.skipToNext)
+          : null,
+      icon: Icon(previous ? Icons.skip_previous : Icons.skip_next),
+      iconSize: 26,
+      tooltip: previous ? 'Previous' : 'Next',
+    );
+  }
+}
+
+/// Opens the up-next list. Desktop windows only: it is the one control here
+/// that has somewhere better to live on a phone (the full player's action row).
+class _QueueButton extends StatelessWidget {
+  const _QueueButton();
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      onPressed: () => showQueueSheet(context),
+      icon: const Icon(Icons.queue_music_outlined),
+      iconSize: 22,
+      color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
+      tooltip: 'Queue',
+    );
+  }
+}
+
+/// The mini-player's central transport control: a spinner while a track loads,
+/// then a play/pause toggle (tinted with the warm accent) that forwards to the
 /// controller. Watches the playback status itself so it stays live even though
 /// the bar around it only rebuilds when the track changes.
 class _PlayPauseButton extends ConsumerWidget {

--- a/lib/features/shell/home_shell.dart
+++ b/lib/features/shell/home_shell.dart
@@ -12,7 +12,7 @@ class HomeShell extends StatelessWidget {
     required this.rootNavigatorKey,
     required this.branchNavigatorKeys,
     super.key,
-  }) : assert(branchNavigatorKeys.length == 4);
+  }) : assert(branchNavigatorKeys.length == _destinations.length);
 
   final StatefulNavigationShell navigationShell;
   final GlobalKey<NavigatorState> rootNavigatorKey;
@@ -29,6 +29,14 @@ class HomeShell extends StatelessWidget {
       icon: Icon(Icons.library_music_outlined),
       selectedIcon: Icon(Icons.library_music),
       label: 'Library',
+    ),
+    // Folders sits beside Library rather than inside it: both are ways of
+    // browsing the same collection, and as its own branch the folder trail
+    // survives a trip to another tab.
+    NavigationDestination(
+      icon: Icon(Icons.folder_outlined),
+      selectedIcon: Icon(Icons.folder),
+      label: 'Folders',
     ),
     NavigationDestination(
       icon: Icon(Icons.queue_music_outlined),
@@ -120,30 +128,45 @@ class HomeShell extends StatelessWidget {
           // the 900 px breakpoint. Only the two chrome slots before it change
           // between real desktop widgets and zero-sized placeholders, so an
           // inactive branch's Navigator stack and scroll state survive resize.
+          //
+          // The mini-player sits below the whole frame rather than inside the
+          // content column, so on a desktop window the now-playing bar runs the
+          // full width under the rail — the shape every desktop music player
+          // has. On phones there is no rail, so nothing about it moves.
           return Scaffold(
             body: FocusTraversalGroup(
               policy: OrderedTraversalPolicy(),
-              child: Row(
+              child: Column(
                 children: <Widget>[
-                  if (desktop)
-                    _buildNavigationRail()
-                  else
-                    const SizedBox.shrink(),
-                  if (desktop)
-                    const VerticalDivider(width: 1)
-                  else
-                    const SizedBox.shrink(),
                   Expanded(
-                    child: FocusTraversalOrder(
-                      order: const NumericFocusOrder(1),
-                      child: FocusTraversalGroup(
-                        child: Column(
-                          children: <Widget>[
-                            Expanded(child: navigationShell),
-                            const MiniPlayer(),
-                          ],
+                    child: Row(
+                      children: <Widget>[
+                        if (desktop)
+                          _buildNavigationRail()
+                        else
+                          const SizedBox.shrink(),
+                        if (desktop)
+                          const VerticalDivider(width: 1)
+                        else
+                          const SizedBox.shrink(),
+                        Expanded(
+                          child: FocusTraversalOrder(
+                            order: const NumericFocusOrder(1),
+                            child: FocusTraversalGroup(
+                              child: navigationShell,
+                            ),
+                          ),
                         ),
-                      ),
+                      ],
+                    ),
+                  ),
+                  // Last in the reading order: the bar spans everything above
+                  // it, so a keyboard user reaches it after both the page and
+                  // the destinations, not between them.
+                  FocusTraversalOrder(
+                    order: const NumericFocusOrder(3),
+                    child: FocusTraversalGroup(
+                      child: const MiniPlayer(),
                     ),
                   ),
                 ],

--- a/test/features/library/folders_screen_test.dart
+++ b/test/features/library/folders_screen_test.dart
@@ -1,0 +1,190 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:linthra/core/models/music_folder.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/folder_browsable_music_source.dart';
+import 'package:linthra/features/library/folder_browser_providers.dart';
+import 'package:linthra/features/library/folders_screen.dart';
+import 'package:linthra/features/player/player_providers.dart';
+
+import '../player/fake_playback_controller.dart';
+
+/// Folders is a top-level destination rather than a Library tab, so it has to
+/// stand on its own: it carries its own app bar, it explains itself when no
+/// folder-capable server is connected instead of looking broken, and it still
+/// walks the hierarchy one level at a time.
+class _FakeFolderSource implements FolderBrowsableMusicSource {
+  _FakeFolderSource({
+    required this.id,
+    required this.displayName,
+    required this.roots,
+    this.children = const <String, MusicFolderListing>{},
+  });
+
+  @override
+  final String id;
+
+  @override
+  final String displayName;
+
+  final List<MusicFolder> roots;
+  final Map<String, MusicFolderListing> children;
+
+  @override
+  Future<List<MusicFolder>> fetchRootFolders() async => roots;
+
+  @override
+  Future<MusicFolderListing> fetchFolder(String folderId) async =>
+      children[folderId] ?? MusicFolderListing.empty;
+}
+
+/// The screen registers a [BackButtonListener] while it is inside a folder, so
+/// it has to be hosted under a Router the way the app's shell hosts it.
+GoRouter _router() {
+  return GoRouter(
+    routes: <RouteBase>[
+      GoRoute(path: '/', builder: (_, __) => const FoldersScreen()),
+    ],
+  );
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  List<FolderBrowsableMusicSource> sources =
+      const <FolderBrowsableMusicSource>[],
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        folderBrowsableSourcesProvider.overrideWithValue(sources),
+        playbackControllerProvider.overrideWithValue(FakePlaybackController()),
+      ],
+      child: MaterialApp.router(routerConfig: _router()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('FoldersScreen', () {
+    testWidgets('with nothing connected it says so and names its own bar',
+        (tester) async {
+      await _pump(tester);
+
+      expect(find.widgetWithText(AppBar, 'Folders'), findsOneWidget);
+      expect(find.text('No server folders available'), findsOneWidget);
+      expect(
+        find.textContaining('Connect Jellyfin or Navidrome'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('lists a connected source\'s roots under its name',
+        (tester) async {
+      await _pump(
+        tester,
+        sources: <FolderBrowsableMusicSource>[
+          _FakeFolderSource(
+            id: 'subsonic',
+            displayName: 'Navidrome',
+            roots: const <MusicFolder>[MusicFolder(id: 'r1', name: 'Music')],
+          ),
+        ],
+      );
+
+      expect(find.text('Navidrome'), findsOneWidget);
+      expect(find.text('Music'), findsOneWidget);
+    });
+
+    testWidgets('opening a folder walks into it and Back walks out again',
+        (tester) async {
+      await _pump(
+        tester,
+        sources: <FolderBrowsableMusicSource>[
+          _FakeFolderSource(
+            id: 'subsonic',
+            displayName: 'Navidrome',
+            roots: const <MusicFolder>[MusicFolder(id: 'r1', name: 'Music')],
+            children: const <String, MusicFolderListing>{
+              'r1': MusicFolderListing(
+                folders: <MusicFolder>[
+                  MusicFolder(id: 'c1', name: 'Live Sets')
+                ],
+                tracks: <Track>[
+                  Track(id: 't1', title: 'Opener', uri: 'subsonic:t1'),
+                ],
+              ),
+            },
+          ),
+        ],
+      );
+
+      await tester.tap(find.text('Music'));
+      await tester.pumpAndSettle();
+
+      // One level down: the child folder and the tracks beside it, with the
+      // trail's own header naming where we are and which server it came from.
+      expect(find.text('Live Sets'), findsOneWidget);
+      expect(find.text('Opener'), findsOneWidget);
+      expect(find.byKey(const Key('folder_browser_header')), findsOneWidget);
+
+      await tester.tap(find.byTooltip('Back to previous folder'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Music'), findsOneWidget);
+      expect(find.byKey(const Key('folder_browser_header')), findsNothing);
+    });
+
+    testWidgets('signing the source out returns to the roots', (tester) async {
+      final _FakeFolderSource source = _FakeFolderSource(
+        id: 'subsonic',
+        displayName: 'Navidrome',
+        roots: const <MusicFolder>[MusicFolder(id: 'r1', name: 'Music')],
+        children: const <String, MusicFolderListing>{
+          'r1': MusicFolderListing(
+            folders: <MusicFolder>[MusicFolder(id: 'c1', name: 'Live Sets')],
+          ),
+        },
+      );
+      final ProviderContainer container = ProviderContainer(
+        overrides: <Override>[
+          folderBrowsableSourcesProvider
+              .overrideWith((ref) => ref.watch(_sourcesProvider)),
+          playbackControllerProvider
+              .overrideWithValue(FakePlaybackController()),
+        ],
+      );
+      addTearDown(container.dispose);
+      container.read(_sourcesProvider.notifier).state =
+          <FolderBrowsableMusicSource>[source];
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(routerConfig: _router()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Music'));
+      await tester.pumpAndSettle();
+      expect(find.text('Live Sets'), findsOneWidget);
+
+      // The session goes away while the screen is deep in the trail: it must
+      // fall back to the roots rather than keep fetching with a dead session.
+      container.read(_sourcesProvider.notifier).state =
+          <FolderBrowsableMusicSource>[];
+      await tester.pumpAndSettle();
+
+      expect(find.text('No server folders available'), findsOneWidget);
+    });
+  });
+}
+
+/// Stands in for the connected-sources list so a test can sign a server out
+/// mid-flight.
+final _sourcesProvider = StateProvider<List<FolderBrowsableMusicSource>>((ref) {
+  return const <FolderBrowsableMusicSource>[];
+});

--- a/test/features/player/mini_player_transport_test.dart
+++ b/test/features/player/mini_player_transport_test.dart
@@ -1,0 +1,235 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/favorites_repository_provider.dart';
+import 'package:linthra/features/player/mini_player.dart';
+import 'package:linthra/features/player/player_providers.dart';
+
+import 'fake_playback_controller.dart';
+
+/// The bar is the only playback surface on screen while you browse, so on a
+/// desktop window it carries the whole transport — previous, next, and the
+/// heart — and skipping a track never means opening the full player first.
+///
+/// It is the same widget on a phone, where that row does not fit, so what it
+/// drops as the window narrows is pinned down here too: the controls disappear
+/// in order of how easily they are reached elsewhere, and play/pause never
+/// goes.
+const _track = Track(
+  id: '1',
+  title: 'Song One',
+  uri: 'subsonic:1',
+  artistName: 'Artist A',
+  albumName: 'Album B',
+);
+
+const _next = Track(id: '2', title: 'Song Two', uri: 'subsonic:2');
+
+/// Pumps the bar at [width], the way the shell hosts it: pinned below a page
+/// that fills the rest of the window.
+Future<void> _pump(
+  WidgetTester tester, {
+  required PlaybackState state,
+  required double width,
+}) async {
+  tester.view.devicePixelRatio = 1;
+  tester.view.physicalSize = Size(width, 800);
+  addTearDown(tester.view.resetDevicePixelRatio);
+  addTearDown(tester.view.resetPhysicalSize);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        playbackControllerProvider
+            .overrideWithValue(FakePlaybackController(initial: state)),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(
+          body: SizedBox.expand(),
+          bottomNavigationBar: MiniPlayer(),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// The controller behind the pumped bar, for asserting what a tap reached.
+FakePlaybackController _controller(WidgetTester tester) {
+  return ProviderScope.containerOf(
+    tester.element(find.byType(MiniPlayer)),
+  ).read(playbackControllerProvider) as FakePlaybackController;
+}
+
+void main() {
+  group('MiniPlayer transport', () {
+    testWidgets('a desktop window carries favorite, previous and next',
+        (tester) async {
+      await _pump(
+        tester,
+        width: 1280,
+        state: const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: _track,
+          upNext: <Track>[_next],
+          hasPrevious: true,
+        ),
+      );
+
+      expect(find.byTooltip('Favorite'), findsOneWidget);
+      expect(find.byTooltip('Previous'), findsOneWidget);
+      expect(find.byTooltip('Pause'), findsOneWidget);
+      expect(find.byTooltip('Next'), findsOneWidget);
+      expect(find.byTooltip('Queue'), findsOneWidget);
+    });
+
+    testWidgets('previous and next delegate to the controller', (tester) async {
+      await _pump(
+        tester,
+        width: 1280,
+        state: const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: _track,
+          upNext: <Track>[_next],
+          hasPrevious: true,
+        ),
+      );
+      final FakePlaybackController controller = _controller(tester);
+
+      await tester.tap(find.byTooltip('Next'));
+      expect(controller.skipCount, 1);
+
+      await tester.tap(find.byTooltip('Previous'));
+      expect(controller.previousCount, 1);
+    });
+
+    testWidgets('at the ends of the queue they grey out instead of vanishing',
+        (tester) async {
+      // A single track played on its own: nothing before it, nothing after.
+      await _pump(
+        tester,
+        width: 1280,
+        state: const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: _track,
+        ),
+      );
+
+      // Still on the bar, so the layout does not shift as a queue plays out.
+      expect(find.byTooltip('Previous'), findsOneWidget);
+      expect(find.byTooltip('Next'), findsOneWidget);
+      expect(
+        tester
+            .widget<IconButton>(
+              find.widgetWithIcon(IconButton, Icons.skip_previous),
+            )
+            .onPressed,
+        isNull,
+      );
+      expect(
+        tester
+            .widget<IconButton>(
+              find.widgetWithIcon(IconButton, Icons.skip_next),
+            )
+            .onPressed,
+        isNull,
+      );
+    });
+
+    testWidgets('the heart likes the copy that is actually playing',
+        (tester) async {
+      await _pump(
+        tester,
+        width: 1280,
+        state: const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: _track,
+        ),
+      );
+      final ProviderContainer container = ProviderScope.containerOf(
+        tester.element(find.byType(MiniPlayer)),
+      );
+
+      await tester.tap(find.byTooltip('Favorite'));
+      await tester.pumpAndSettle();
+
+      // Written against the provider-namespaced uri, not the bare id.
+      expect(
+        container.read(favoritesRepositoryProvider).isFavorite('subsonic:1'),
+        isTrue,
+      );
+      // And the bar now offers the other half of the toggle.
+      expect(find.byTooltip('Remove from favorites'), findsOneWidget);
+
+      await tester.tap(find.byTooltip('Remove from favorites'));
+      await tester.pumpAndSettle();
+      expect(
+        container.read(favoritesRepositoryProvider).isFavorite('subsonic:1'),
+        isFalse,
+      );
+    });
+
+    testWidgets('a phone-width bar keeps the heart but drops the skips',
+        (tester) async {
+      await _pump(
+        tester,
+        width: 411,
+        state: const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: _track,
+          upNext: <Track>[_next],
+          hasPrevious: true,
+        ),
+      );
+
+      expect(find.byTooltip('Pause'), findsOneWidget);
+      expect(find.byTooltip('Favorite'), findsOneWidget);
+      expect(find.byTooltip('Previous'), findsNothing);
+      expect(find.byTooltip('Next'), findsNothing);
+      expect(find.byTooltip('Queue'), findsNothing);
+    });
+
+    testWidgets('a very narrow bar is play/pause alone, as it always was',
+        (tester) async {
+      await _pump(
+        tester,
+        width: 320,
+        state: const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: _track,
+          upNext: <Track>[_next],
+          hasPrevious: true,
+        ),
+      );
+
+      expect(find.byTooltip('Pause'), findsOneWidget);
+      expect(find.byTooltip('Favorite'), findsNothing);
+      expect(find.byTooltip('Previous'), findsNothing);
+      expect(find.byTooltip('Next'), findsNothing);
+    });
+
+    testWidgets('the metadata still fits beside a full transport row',
+        (tester) async {
+      await _pump(
+        tester,
+        width: 1280,
+        state: const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: Track(
+            id: '3',
+            title: 'A Title That Runs On Well Past Any Reasonable Length',
+            uri: 'subsonic:3',
+            artistName: 'An Artist With A Similarly Unreasonable Name',
+            albumName: 'And An Album To Match It',
+          ),
+          upNext: <Track>[_next],
+          hasPrevious: true,
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+    });
+  });
+}

--- a/test/features/shell/home_shell_adaptive_test.dart
+++ b/test/features/shell/home_shell_adaptive_test.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/features/player/mini_player.dart';
 import 'package:linthra/features/player/player_providers.dart';
 import 'package:linthra/features/shell/home_shell.dart';
 
@@ -38,12 +41,14 @@ GoRouter _router(
 ) {
   const List<String> paths = <String>[
     '/library',
+    '/folders',
     '/playlists',
     '/downloads',
     '/settings',
   ];
   const List<String> labels = <String>[
     'Library',
+    'Folders',
     'Playlists',
     'Downloads',
     'Settings',
@@ -88,6 +93,7 @@ Future<void> _pumpShell(
   WidgetTester tester, {
   required TargetPlatform platform,
   required Size size,
+  PlaybackState playback = PlaybackState.idle,
 }) async {
   tester.view.devicePixelRatio = 1;
   tester.view.physicalSize = size;
@@ -97,13 +103,15 @@ Future<void> _pumpShell(
   final GlobalKey<NavigatorState> rootKey = GlobalKey<NavigatorState>();
   final List<GlobalKey<NavigatorState>> branchKeys =
       <GlobalKey<NavigatorState>>[
-    for (int i = 0; i < 4; i++) GlobalKey<NavigatorState>(),
+    for (int i = 0; i < 5; i++) GlobalKey<NavigatorState>(),
   ];
 
   await tester.pumpWidget(
     ProviderScope(
       overrides: <Override>[
-        playbackControllerProvider.overrideWithValue(FakePlaybackController()),
+        playbackControllerProvider.overrideWithValue(
+          FakePlaybackController(initial: playback),
+        ),
       ],
       child: MaterialApp.router(
         theme: ThemeData(platform: platform),
@@ -136,7 +144,7 @@ void main() {
         tester
             .widget<NavigationRail>(find.byType(NavigationRail))
             .selectedIndex,
-        1,
+        2,
       );
     },
   );
@@ -162,7 +170,7 @@ void main() {
       expect(find.text('Playlists screen'), findsOneWidget);
       expect(
         tester.widget<NavigationBar>(find.byType(NavigationBar)).selectedIndex,
-        1,
+        2,
       );
 
       tester.view.physicalSize = const Size(1280, 720);
@@ -174,7 +182,7 @@ void main() {
         tester
             .widget<NavigationRail>(find.byType(NavigationRail))
             .selectedIndex,
-        1,
+        2,
       );
     },
   );
@@ -213,6 +221,33 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.byType(NavigationRail), findsOneWidget);
       expect(find.text('Playlists detail'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'the now-playing bar spans the window, under the desktop rail',
+    (WidgetTester tester) async {
+      await _pumpShell(
+        tester,
+        platform: TargetPlatform.linux,
+        size: const Size(1280, 720),
+        playback: const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: Track(id: '1', title: 'Song One', uri: 'subsonic:1'),
+        ),
+      );
+
+      // The bar is the frame's floor, not a footer inside the content column:
+      // it starts at the window's left edge, where the rail is, and runs the
+      // whole width — the shape a desktop music player has.
+      expect(find.byType(NavigationRail), findsOneWidget);
+      final Rect bar = tester.getRect(find.byType(MiniPlayer));
+      expect(bar.left, 0);
+      expect(bar.width, tester.view.physicalSize.width);
+      expect(
+        bar.top,
+        greaterThan(tester.getRect(find.byType(NavigationRail)).top),
+      );
     },
   );
 

--- a/test/features/shell/home_shell_focus_order_test.dart
+++ b/test/features/shell/home_shell_focus_order_test.dart
@@ -82,6 +82,7 @@ GoRouter _router(GlobalKey<NavigatorState> rootKey,
             '/two',
             '/three',
             '/four',
+            '/five',
           ].indexed)
             StatefulShellBranch(
               navigatorKey: branchKeys[i],
@@ -118,7 +119,7 @@ void main() {
     final GlobalKey<NavigatorState> rootKey = GlobalKey<NavigatorState>();
     final List<GlobalKey<NavigatorState>> branchKeys =
         <GlobalKey<NavigatorState>>[
-      for (int i = 0; i < 4; i++) GlobalKey<NavigatorState>(),
+      for (int i = 0; i < 5; i++) GlobalKey<NavigatorState>(),
     ];
     await tester.pumpWidget(
       ProviderScope(
@@ -137,7 +138,7 @@ void main() {
     await tester.pump();
 
     final List<String?> order = <String?>[_focusedLabel(tester)];
-    for (int i = 0; i < 7; i++) {
+    for (int i = 0; i < 8; i++) {
       await tester.sendKeyEvent(LogicalKeyboardKey.tab);
       await tester.pump();
       order.add(_focusedLabel(tester));
@@ -151,6 +152,7 @@ void main() {
     );
     expect(order.skip(4), <String>[
       'Library',
+      'Folders',
       'Playlists',
       'Downloads',
       'Settings',
@@ -161,7 +163,7 @@ void main() {
     final GlobalKey<NavigatorState> rootKey = GlobalKey<NavigatorState>();
     final List<GlobalKey<NavigatorState>> branchKeys =
         <GlobalKey<NavigatorState>>[
-      for (int i = 0; i < 4; i++) GlobalKey<NavigatorState>(),
+      for (int i = 0; i < 5; i++) GlobalKey<NavigatorState>(),
     ];
     await tester.pumpWidget(
       ProviderScope(
@@ -193,7 +195,7 @@ void main() {
     final GlobalKey<NavigatorState> rootKey = GlobalKey<NavigatorState>();
     final List<GlobalKey<NavigatorState>> branchKeys =
         <GlobalKey<NavigatorState>>[
-      for (int i = 0; i < 4; i++) GlobalKey<NavigatorState>(),
+      for (int i = 0; i < 5; i++) GlobalKey<NavigatorState>(),
     ];
     await tester.pumpWidget(
       ProviderScope(
@@ -230,7 +232,7 @@ void main() {
     final GlobalKey<NavigatorState> rootKey = GlobalKey<NavigatorState>();
     final List<GlobalKey<NavigatorState>> branchKeys =
         <GlobalKey<NavigatorState>>[
-      for (int i = 0; i < 4; i++) GlobalKey<NavigatorState>(),
+      for (int i = 0; i < 5; i++) GlobalKey<NavigatorState>(),
     ];
     await tester.pumpWidget(
       ProviderScope(
@@ -254,7 +256,7 @@ void main() {
     await tester.pump();
 
     final List<String?> order = <String?>[_focusedLabel(tester)];
-    for (int i = 0; i < 7; i++) {
+    for (int i = 0; i < 8; i++) {
       await tester.sendKeyEvent(LogicalKeyboardKey.tab);
       await tester.pump();
       order.add(_focusedLabel(tester));
@@ -269,6 +271,7 @@ void main() {
     );
     expect(order.skip(4), <String>[
       'Library',
+      'Folders',
       'Playlists',
       'Downloads',
       'Settings',


### PR DESCRIPTION
Two changes that make the desktop window behave like a music player instead of a library browser with a footer.

Visual preview of both, before writing any of it: https://claude.ai/code/artifact/7f7aa989-8666-4ce3-ac56-e3b6bb139359

## The now-playing bar carries the transport

`MiniPlayer` had one control. It now carries favorite, previous, play/pause and next, centred between the metadata and a queue button, whenever it has the room.

- Previous and next read `hasPrevious` / `hasNext` and call `skipToPrevious` / `skipToNext`, so they follow the live queue and grey out at its ends instead of vanishing (the layout does not shift as a queue plays out).
- The heart writes against the provider-namespaced `Track.uri` of the track the controller is actually playing, so a Navidrome copy and a Jellyfin copy of the same song keep their own state. No resolution step is needed here the way it is on the now-playing screen, since the bar always shows the playing copy.
- Position ticks still only rebuild the progress line and the buttons that care, not the artwork and text.

It is the same widget on Android, so it sheds controls as the window narrows. Thresholds are measured on the bar's content width:

| Content width | Controls |
| --- | --- |
| 600 px and up | favorite · previous · play/pause · next, plus queue |
| 360–600 px | favorite · play/pause |
| under 360 px | play/pause, exactly as before |

## Folders becomes a top-level destination

It was the fourth tab inside Library. It is now its own destination next to Library, Playlists, Downloads and Settings, with its own navigation branch, so a folder you were three levels deep in is still open when you come back from another tab. That did not survive a tab switch before.

With no folder-capable server connected the destination stays and shows the existing empty state pointing at Connections, rather than disappearing. The shell's branches are fixed at build time, and this way the feature is discoverable before it is usable.

`folder_browser_tab.dart` moves to `folders_screen.dart` and grows its own `AppBar`; the in-trail header (back arrow, folder name, source name) is unchanged.

Back handling had to change with it. The shell keeps every branch mounted in an `IndexedStack`, so the old `TabBarView` viewport check no longer tells "mounted" from "visible" — every branch is laid out at the same offset. go_router disables tickers on inactive branches, so the screen reads `TickerMode.valuesOf(context).enabled` instead, and it only registers a `BackButtonListener` while there is a folder level to leave.

## Also

The mini-player moves below the whole frame rather than inside the content column, so on a desktop window it spans the full width under the rail. On phones there is no rail, so nothing about it moves. It is ordered last in the focus traversal, after both the page and the destinations.

## Testing

`dart format`, `flutter analyze` (no issues) and the full suite: 4048 tests, all passing.

New coverage:

- `test/features/player/mini_player_transport_test.dart` — the desktop row, previous/next delegating to the controller, greying out at the queue ends, the heart round-tripping through the repository, and what each narrower width drops.
- `test/features/library/folders_screen_test.dart` — the empty state with nothing connected, roots under a source name, walking in and back out, and falling back to the roots when the source signs out mid-trail.
- `test/features/shell/home_shell_adaptive_test.dart` — a new case pinning the bar to the full window width under the rail; existing cases updated for the fifth destination.
- `test/features/shell/home_shell_focus_order_test.dart` — Folders in the expected traversal order.

Not tested on real hardware: I could not run the Linux desktop build in this environment, so the layout is verified by widget tests rather than by eye.

## Open questions

1. **Folders' position in the rail.** I put it second, right under Library, since both are ways of browsing the same collection. Third, after Playlists, is equally defensible — one line to move.
2. **Heart colour.** I used `colorScheme.primary` (violet) to match the heart on the now-playing screen. The preview showed it in the orange accent; happy to switch if you prefer that.
3. **Play/pause style.** Kept as the existing orange icon button rather than the full player's filled gradient circle, to keep the diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018iLKHE5KdjMbww2McoBtLk

---
_Generated by [Claude Code](https://claude.ai/code/session_018iLKHE5KdjMbww2McoBtLk)_