### PR TITLE
fix(ci): wait for the packaged window's X properties in the Flatpak smoke

### DIFF
--- a/scripts/flatpak_launch_smoke.sh
+++ b/scripts/flatpak_launch_smoke.sh
@@ -79,6 +79,56 @@ xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' \
       xwininfo -root -tree 2>/dev/null | grep -F "\"$WINDOW_TITLE\":" | head -n 1 || true
     }
 
+    # Read one X property off the window, first line only: xprop renders
+    # _NET_WM_ICON as ASCII art of the icon, and all these checks need is the
+    # header line.
+    window_property() {
+      xprop -id "$1" "$2" 2>&1 | head -n 1 || true
+    }
+
+    # Wait for an X property to appear on the window, because the window shows
+    # up in the X tree before it carries all of them.
+    #
+    # GTK sets them in one pass through gtk_window_realize(), but not at one
+    # moment. The title and the WM_CLASS pair are attributes of the
+    # gdk_window_new() call that creates the window, so they are on it from its
+    # first instant. The icon is set last: gtk_window_realize_icon() runs at the
+    # end of the same function, and it first has to resolve the icon name
+    # through the icon theme (which round-trips to the X server for the theme
+    # name, flushing everything queued before it) and then decode the PNGs it
+    # finds. On a cold Flatpak install that lookup is slow enough to be visible,
+    # and xwininfo/xprop are separate X clients that see the window as soon as
+    # it exists.
+    #
+    # Sampling once therefore reads a real window mid-realize and can miss an
+    # icon that lands a few milliseconds later. That is a race in this smoke
+    # test, not in the app, and it failed the Flatpak build on main. Poll to the
+    # same deadline as the window itself instead: an icon that never resolves
+    # still fails, which is the regression this guards.
+    wait_for_property() {
+      local window_id="$1"
+      local property="$2"
+      local deadline=$((SECONDS + TIMEOUT_SECONDS))
+      local value
+
+      while :; do
+        value="$(window_property "$window_id" "$property")"
+        case "$value" in
+          "" | *"not found"*) ;;
+          *)
+            printf "%s\n" "$value"
+            return 0
+            ;;
+        esac
+
+        (( SECONDS < deadline )) || break
+        sleep 0.25
+      done
+
+      printf "%s\n" "$value"
+      return 1
+    }
+
     # Close the app and wait for its window to actually leave the X server, so
     # the next launch cannot match a window left behind by the previous one.
     stop_app() {
@@ -105,9 +155,10 @@ xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' \
     #                 the value the desktop entry StartupWMClass= declares.
     #   _NET_WM_ICON  is the icon the window itself carries. GTK attaches it from the icon name
     #                 the runner sets as the default, so its presence proves the
-    #                 hicolor SVG the Flatpak installed actually resolves from
-    #                 inside the sandbox. Without it every task switcher and panel
-    #                 falls back to a generic icon.
+    #                 hicolor icons the Flatpak installed actually resolve from
+    #                 inside the sandbox (#558: the rasters, since gdk-pixbuf has
+    #                 no SVG loader there). Without it every task switcher and
+    #                 panel falls back to a generic icon.
     launch_and_check() {
       local what="$1"
       local app_pid deadline line window_id wm_class expected icon status
@@ -147,7 +198,7 @@ xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' \
 
       window_id="$(printf "%s\n" "$line" | awk "{print \$1}")"
 
-      wm_class="$(xprop -id "$window_id" WM_CLASS 2>&1 || true)"
+      wm_class="$(wait_for_property "$window_id" WM_CLASS)" || true
       expected="WM_CLASS(STRING) = \"$APP_ID\", \"$APP_ID\""
       if [ "$wm_class" != "$expected" ]; then
         printf "FAIL: the %s window does not identify as %s (%s).\n" \
@@ -160,20 +211,16 @@ xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' \
       fi
       printf "PASS: %s\n" "$wm_class"
 
-      # Only the first line: all that matters is that the property exists, and
-      # xprop renders the rest of it as ASCII art of the icon.
-      icon="$(xprop -id "$window_id" _NET_WM_ICON 2>&1 | head -n 1 || true)"
-      case "$icon" in
-        *"not found"*|"")
-          printf "FAIL: the %s window carries no _NET_WM_ICON (%s), so the\n" \
-            "$WINDOW_TITLE" "$what" >&2
-          printf "      installed %s icon did not resolve inside the sandbox.\n" \
-            "$APP_ID" >&2
-          cat "$log_file" >&2
-          stop_app "$app_pid"
-          return 1
-          ;;
-      esac
+      # All that matters is that the property exists at all.
+      if ! icon="$(wait_for_property "$window_id" _NET_WM_ICON)"; then
+        printf "FAIL: the %s window carries no _NET_WM_ICON after %ss (%s), so\n" \
+          "$WINDOW_TITLE" "$TIMEOUT_SECONDS" "$what" >&2
+        printf "      the installed %s icon did not resolve inside the sandbox.\n" \
+          "$APP_ID" >&2
+        cat "$log_file" >&2
+        stop_app "$app_pid"
+        return 1
+      fi
       printf "PASS: %s window carries _NET_WM_ICON (%s).\n" "$WINDOW_TITLE" "$icon"
 
       stop_app "$app_pid"

--- a/test/tooling/flatpak_launch_smoke_test.dart
+++ b/test/tooling/flatpak_launch_smoke_test.dart
@@ -35,7 +35,7 @@ void main() {
   // both of these are readable as X properties on the packaged app.
   test('launch smoke holds the packaged window to the application id', () {
     expect(smoke, contains('xprop is not installed'));
-    expect(smoke, contains(r'xprop -id "$window_id" WM_CLASS'));
+    expect(smoke, contains(r'wait_for_property "$window_id" WM_CLASS'));
     expect(
       smoke,
       contains(r'expected="WM_CLASS(STRING) = \"$APP_ID\", \"$APP_ID\""'),
@@ -43,8 +43,20 @@ void main() {
   });
 
   test('launch smoke requires the packaged window to carry its icon', () {
-    expect(smoke, contains(r'xprop -id "$window_id" _NET_WM_ICON'));
+    expect(smoke, contains(r'wait_for_property "$window_id" _NET_WM_ICON'));
     expect(smoke, contains('carries no _NET_WM_ICON'));
+  });
+
+  // The window enters the X tree before GTK has finished realizing it: the
+  // title and WM_CLASS come from gdk_window_new(), while the icon is set at the
+  // end of gtk_window_realize() after the icon-theme lookup. Reading a property
+  // once raced that gap and failed the Flatpak build on main, so every property
+  // read has to poll to the same deadline as the window itself.
+  test('launch smoke waits for window properties instead of sampling once', () {
+    expect(smoke, contains('wait_for_property()'));
+    expect(smoke, contains(r'xprop -id "$1" "$2"'));
+    expect(smoke, contains(r'local deadline=$((SECONDS + TIMEOUT_SECONDS))'));
+    expect(smoke, contains(r'(( SECONDS < deadline )) || break'));
   });
 
   test('launch smoke re-checks identity after a close and reopen', () {


### PR DESCRIPTION
Fixes the red Flatpak build on main ([run 34057805436](https://github.com/TheZupZup/Linthra/actions/runs/34057805436)).

## What happened

The build, export and install all succeeded. The launch smoke failed on:

```
PASS: packaged io.github.thezupzup.linthra opened a Linthra window (first launch).
PASS: WM_CLASS(STRING) = "io.github.thezupzup.linthra", "io.github.thezupzup.linthra"
FAIL: the Linthra window carries no _NET_WM_ICON (first launch)
```

The same packaging passed 26 minutes earlier on the release branch, with `_NET_WM_ICON(CARDINAL) = Icon (48 x 48)`. Between 3c885d0 (last green Flatpak run on main) and 0b628c8 nothing under `flatpak/`, `linux/` or `tool/branding/` changed except the metainfo release entry and the version bump. So this was the smoke test racing the app, not a packaging regression.

## Why it raced

The window enters the X tree before it carries all of its properties:

- the title and the WM_CLASS pair are attributes of the `gdk_window_new()` call that creates the window, so they are on it from its first instant
- the icon is set last. `gtk_window_realize_icon()` runs at the end of `gtk_window_realize()`, and it first resolves the icon name through the icon theme (which round-trips to the X server for the theme name, flushing everything queued before it) and then decodes the PNGs it finds

On a cold Flatpak install that lookup takes long enough to observe, and `xwininfo`/`xprop` are separate X clients that see the window as soon as it exists. A single sample lands mid-realize and reads a real window whose icon is a few milliseconds away. Both CI runs sampled at the same point (~0.45s after launch, right after the poll loop's `sleep 0.5`), which is why it is a coin flip.

## The change

`scripts/flatpak_launch_smoke.sh` now polls for each X property to the same deadline the window itself already gets, instead of reading it once:

- `window_property()` reads one property, first line only
- `wait_for_property()` retries until the property appears or `TIMEOUT_SECONDS` passes
- both WM_CLASS and `_NET_WM_ICON` go through it, and the icon failure message now says how long it waited

An icon that never resolves still fails the smoke, which is the #558 regression this check exists for.

Also corrects the comment above `launch_and_check`: since #558 the property comes from the installed rasters, not the scalable SVG, because gdk-pixbuf in the runtime has no SVG loader.

## Testing

- `python3 scripts/check_linux_runner.py` and `python3 test/tooling/check_linux_runner_test.py` (83 tests) pass
- `bash -n` on the script
- Ran the inner smoke logic against stub `xwininfo`/`xprop`/`flatpak`: with the icon landing 1.5s after the window it now passes (it failed before this change), and with an icon that never lands it still fails with the expected message
- `test/tooling/flatpak_launch_smoke_test.dart` guardrails updated for the new call shapes, plus a new test pinning the polling so nobody reintroduces the single sample. No Dart toolchain in this environment, so each `contains` literal was verified against the script directly; CI runs the suite.

The real proof is the Flatpak workflow on this PR, which runs the smoke end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk9khyZXtTWK3WBh2F9Tuq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk9khyZXtTWK3WBh2F9Tuq)_