### PR TITLE
docs(security): add a security policy and a private reporting route

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: true
 contact_links:
+  - name: Report a security vulnerability (private)
+    url: https://github.com/TheZupZup/Linthra/security/advisories/new
+    about: Private Vulnerability Reporting. Please don't put security details in a public issue.
   - name: Jellyfin setup & troubleshooting
     url: https://github.com/thezupzup/linthra/blob/main/docs/jellyfin-compatibility.md
     about: Connection, Cloudflare, and "how to report without leaking secrets" notes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,11 @@ These rules matter a lot for Linthra:
 If your change touches authentication, streaming, diagnostics, or stored
 credentials, mention it in the PR so I know to review that part carefully.
 
+Found a vulnerability? Don't open a public issue. Report it privately through
+[GitHub Private Vulnerability Reporting](https://github.com/TheZupZup/Linthra/security/advisories/new);
+[SECURITY.md](./SECURITY.md) has the details of what's in scope and what to
+expect.
+
 ## Testing
 
 Some bugs only show up on real hardware. If your change touches a real music

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,89 @@
+# Security policy
+
+Thanks for taking the time to look at Linthra's security. Linthra is early alpha,
+built by a small group, and reports are genuinely useful.
+
+## Reporting a vulnerability
+
+**Use GitHub Private Vulnerability Reporting:**
+[report a vulnerability](https://github.com/TheZupZup/Linthra/security/advisories/new).
+
+It is enabled on this repository and is the channel to prefer. The report stays
+private between you and the maintainers until an advisory is published, and it
+gives us a place to discuss details and share fixes before anything is public.
+
+Please **do not** open a public issue for a suspected vulnerability, and do not
+put technical details in one. A public issue asking for a private channel is
+fine, but the report itself belongs in the private advisory.
+
+If Private Vulnerability Reporting is unavailable to you for some reason, say so
+in a public issue without details and we will arrange another private channel.
+
+## What to include
+
+The more of this you can give, the faster a fix lands:
+
+- what the issue is and what an attacker gets out of it
+- affected version or commit, and platform (Android or Linux)
+- steps to reproduce, ideally minimal
+- any proof-of-concept, logs, or screenshots
+
+Please redact your own secrets first: no tokens, passwords, authenticated stream
+URLs, or full private server addresses. A version number and a description are
+usually enough.
+
+## What to expect
+
+Linthra is maintained by volunteers, so these are honest intentions rather than
+a contractual SLA:
+
+- an acknowledgement within about a week
+- an assessment of severity and scope after that
+- a fix in a normal release for most issues, faster for anything actively
+  exploitable
+- credit in the advisory and release notes if you want it, or none if you prefer
+
+We will keep you in the loop while a fix is prepared, and we would appreciate
+the report staying private until the fix ships.
+
+## Supported versions
+
+Linthra is pre-1.0 and moves quickly. Only the **latest release** gets security
+fixes. Older tags, forks, and sideloaded modified builds are out of scope.
+
+## In scope
+
+Anything that breaks Linthra's own promises:
+
+- credential handling: stored server credentials, encrypted-at-rest storage, the
+  GitHub sponsor OAuth device flow
+- leaking secrets into logs, diagnostics, bug reports, or the backup file
+  (see [docs/backup-restore-format.md](./docs/backup-restore-format.md))
+- authenticated stream URLs escaping where they should not
+- the Flatpak sandbox: escapes, or permissions broader than the app needs
+  (see [docs/flatpak-filesystem-audit.md](./docs/flatpak-filesystem-audit.md))
+- Android platform surfaces: exported components, SAF and filesystem access,
+  intent handling
+- the repository and release supply chain: workflows, signing, published
+  artifacts (see [docs/repository-hardening.md](./docs/repository-hardening.md))
+- anything that contradicts [PRIVACY.md](./PRIVACY.md), including unexpected
+  network traffic
+
+## Out of scope
+
+- vulnerabilities in your own Jellyfin, Navidrome, Subsonic, or Plex server
+- issues that need an already-compromised device, a rooted attacker with
+  physical access, or a modified build
+- missing hardening with no demonstrated impact, and automated scanner output
+  with no working reproduction
+- denial of service against your own device
+- the deliberate design choices in [PRIVACY.md](./PRIVACY.md) and
+  [docs/roadmap.md](./docs/roadmap.md), such as Linthra having no backend and no
+  account system
+
+## Other contact
+
+For privacy questions that are not vulnerabilities, see the contact section in
+[PRIVACY.md](./PRIVACY.md). For ordinary bugs, use
+[Settings → Report a bug](./docs/reporting-bugs.md) and the normal issue
+templates.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,8 +16,9 @@ Please **do not** open a public issue for a suspected vulnerability, and do not
 put technical details in one. A public issue asking for a private channel is
 fine, but the report itself belongs in the private advisory.
 
-If Private Vulnerability Reporting is unavailable to you for some reason, say so
-in a public issue without details and we will arrange another private channel.
+If Private Vulnerability Reporting is unavailable to you for some reason, email
+**support@linthra.ca**, which reaches the maintainer directly. Either channel is
+fine; the advisory form is easier to coordinate a fix in.
 
 ## What to include
 
@@ -83,7 +84,7 @@ Anything that breaks Linthra's own promises:
 
 ## Other contact
 
-For privacy questions that are not vulnerabilities, see the contact section in
-[PRIVACY.md](./PRIVACY.md). For ordinary bugs, use
-[Settings → Report a bug](./docs/reporting-bugs.md) and the normal issue
+Same address, support@linthra.ca, for privacy questions that are not
+vulnerabilities (also listed in [PRIVACY.md](./PRIVACY.md)). For ordinary bugs,
+use [Settings → Report a bug](./docs/reporting-bugs.md) and the normal issue
 templates.


### PR DESCRIPTION
## What

Adds a `SECURITY.md` and points the two places people actually look at it.

Linthra had no security policy, so GitHub's Security tab was empty and there was no documented private route for a vulnerability report. That is how #545 ended up as a public issue asking for a private channel. Private Vulnerability Reporting is enabled now, so this makes it the documented route.

## Changes

- `SECURITY.md`: private reporting through PVR first, with support@linthra.ca as the fallback that reaches the maintainer directly. Then what to include (redacted), honest response expectations for a volunteer project, supported versions (latest release only, pre-1.0), and an explicit in-scope / out-of-scope list.
- `.github/ISSUE_TEMPLATE/config.yml`: a contact link to the advisory form, listed first, so it is visible before someone files a public issue.
- `CONTRIBUTING.md`: one paragraph in "Privacy and security" pointing at the policy.

In scope covers what Linthra actually promises: credential storage, authenticated stream URLs leaking into logs/diagnostics/backups, the Flatpak sandbox, Android platform surfaces, and the release supply chain. Out of scope covers your own Jellyfin/Navidrome/Plex server, modified builds, and scanner output with no reproduction.

Docs only, no code. `./scripts/check_secrets.sh` passes.

Refs #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvJnixf94LEa7BYmBRV54m