### PR TITLE
fix(linux): stop mpv creating an on-disk packet cache (#405)

### DIFF
--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -206,9 +206,27 @@ source-specific player exists and credentials remain in the existing resolver.
 (and wired in through a `dependency_overrides` path entry) rather than pulled
 from pub.dev. The local delta is two hunks that add
 `JustAudioMediaKit.mpvProperties`, an optional map of libmpv properties applied
-at player creation, so the headless CI smoke target can force `ao=alsa` where
-there is no PipeWire/Pulse device. Production sets nothing, so the libmpv calls
-are identical to the published package's.
+at player creation. Linthra uses it for the defaults below, and the headless CI
+smoke target layers `ao=alsa` on top where there is no PipeWire/Pulse device.
+
+### libmpv properties Linthra sets
+
+`linuxMpvProperties` in `lib/core/services/linux_playback_controller.dart` is
+the one place these live, and `resolveLinuxMpvProperties` merges anything a
+caller already set on top of them.
+
+| Property | Value | Why |
+| --- | --- | --- |
+| `cache-on-disk` | `no` | media_kit turns mpv's on-disk demuxer cache on for every player (`'cache-on-disk': 'yes'`, media_kit 1.2.6 `lib/src/player/native/player/real.dart`). That suits a video player buffering gigabytes; Linthra streams audio and manages its own offline downloads. Where mpv cannot create its temporary file — a sandbox, or a cache directory it cannot write — it logs `[lavf] Failed to create cache temporary file.` and `[lavf] Failed to create file cache.` on every stream ([#405](https://github.com/thezupzup/linthra/issues/405)). |
+
+Only the temporary on-disk packet file is turned off. media_kit's `cache=yes`
+stays, so memory and network buffering behave as before, and Linthra's own
+download/offline cache is a separate mechanism that this does not touch.
+
+Ordering matters and is not accidental: media_kit applies its own defaults while
+the player initializes, and `just_audio_media_kit` applies `mpvProperties`
+afterwards through `NativePlayer.setProperty`, which awaits that initialization.
+The Linthra values therefore land last.
 
 `third_party/just_audio_media_kit/PATCHES.md` records the exact upstream
 version and archive digest, what is and isn't vendored, and how to refresh it.

--- a/lib/core/services/linux_playback_controller.dart
+++ b/lib/core/services/linux_playback_controller.dart
@@ -10,6 +10,39 @@ import 'playback_candidate_source.dart';
 
 typedef LinuxPlaybackBackendRegistration = void Function();
 
+/// The libmpv properties Linthra always applies on Linux.
+///
+/// media_kit turns mpv's on-disk demuxer cache on for every player it creates
+/// (`'cache-on-disk': 'yes'` in media_kit 1.2.6,
+/// `lib/src/player/native/player/real.dart`). That is a reasonable default for
+/// a video player buffering gigabytes to disk, and the wrong one here: Linthra
+/// streams audio, and it manages its own offline downloads separately. When mpv
+/// cannot create the temporary file it wants, libmpv logs
+/// `[lavf] Failed to create cache temporary file.` followed by
+/// `[lavf] Failed to create file cache.` on every stream (#405).
+///
+/// `cache-on-disk=no` turns off exactly that temporary on-disk packet file.
+/// media_kit's `cache=yes` is deliberately left alone, so normal memory and
+/// network buffering are unchanged, as is Linthra's own download/offline cache.
+///
+/// Ordering is what makes this work: media_kit applies its own defaults while
+/// the player initializes, and just_audio_media_kit applies this map afterwards
+/// through `NativePlayer.setProperty`, which awaits that initialization. The
+/// override therefore lands last.
+const Map<String, String> linuxMpvProperties = <String, String>{
+  'cache-on-disk': 'no',
+};
+
+/// [linuxMpvProperties] with anything a caller already configured layered on
+/// top.
+///
+/// The headless audio smoke sets `ao=alsa` before it builds a controller
+/// (`tool/linux_audio_backend_smoke.dart`). Merging rather than assigning keeps
+/// that working *and* keeps the smoke honest: it exercises the same cache
+/// configuration production uses, with only the output device swapped.
+Map<String, String> resolveLinuxMpvProperties(Map<String, String> configured) =>
+    <String, String>{...linuxMpvProperties, ...configured};
+
 /// Registers just_audio's Linux implementation once for this process.
 ///
 /// Registration is synchronous, so the success flag cannot race another call
@@ -31,6 +64,8 @@ class LinuxPlaybackBackendInitializer {
 
   static void _registerDefaultBackend() {
     JustAudioMediaKit.title = 'Linthra';
+    JustAudioMediaKit.mpvProperties =
+        resolveLinuxMpvProperties(JustAudioMediaKit.mpvProperties);
     JustAudioMediaKit.ensureInitialized(linux: true, windows: false);
   }
 }

--- a/test/core/services/linux_playback_controller_test.dart
+++ b/test/core/services/linux_playback_controller_test.dart
@@ -94,6 +94,36 @@ class _Resolver implements PlayableUriResolver {
 Track _track(String id, String uri) => Track(id: id, title: id, uri: uri);
 
 void main() {
+  group('linuxMpvProperties', () {
+    test('turns off mpv\'s on-disk packet cache', () {
+      expect(resolveLinuxMpvProperties(const {})['cache-on-disk'], 'no');
+    });
+
+    test('never disables mpv caching wholesale', () {
+      // media_kit sets `cache=yes`; only the on-disk packet file is the
+      // problem, so a broad `cache=no` would cost normal network buffering.
+      expect(
+        resolveLinuxMpvProperties(const {}).keys,
+        <String>['cache-on-disk'],
+      );
+    });
+
+    test('keeps what a caller already configured, and adds the defaults', () {
+      // The headless audio smoke picks the output device this way.
+      final resolved = resolveLinuxMpvProperties(const {'ao': 'alsa'});
+
+      expect(resolved['ao'], 'alsa');
+      expect(resolved['cache-on-disk'], 'no');
+    });
+
+    test('lets an explicit caller value win over a default', () {
+      expect(
+        resolveLinuxMpvProperties(const {'cache-on-disk': 'yes'}),
+        containsPair('cache-on-disk', 'yes'),
+      );
+    });
+  });
+
   group('LinuxPlaybackBackendInitializer', () {
     test('registers the backend exactly once after successful initialization',
         () {

--- a/third_party/just_audio_media_kit/PATCHES.md
+++ b/third_party/just_audio_media_kit/PATCHES.md
@@ -1,8 +1,9 @@
 # Vendored `just_audio_media_kit`
 
-Linthra vendors this package so the headless Linux audio smoke test can force
-libmpv onto a specific audio output. Everything here is upstream source except
-the two hunks in [`upstream.patch`](upstream.patch).
+Linthra vendors this package for one reason: upstream has no public hook for
+setting extra libmpv options at player creation, and Linthra needs one on two
+paths — production playback and the headless audio smoke test. Everything here
+is upstream source except the two hunks in [`upstream.patch`](upstream.patch).
 
 ## Provenance
 
@@ -38,8 +39,9 @@ Two hunks, ten added lines, no deletions:
    identical `prefetch-playlist` call upstream already makes.
 
 Nothing else changes: no new dependency, no new I/O, no new process or library
-loading, and with the map left empty (production) the generated libmpv calls
-are byte-for-byte what upstream makes.
+loading. With the map left empty the generated libmpv calls are byte-for-byte
+what upstream makes; Linthra does not leave it empty (see below), so the
+difference from upstream is exactly the properties it sets and nothing more.
 
 ### Why
 
@@ -50,9 +52,19 @@ set on each libmpv instance before playback starts. Upstream exposes
 `setProperty` internally but has no public hook for extra mpv options at player
 creation (unlike `prefetchPlaylist`).
 
-Only `tool/linux_audio_backend_smoke.dart` sets it (`{'ao': 'alsa'}`). No
-shipped code path does, so production playback resolves exactly as the hosted
-package did.
+### Who sets it
+
+**Two callers, and production is one of them.** This hook is *not* CI-only —
+removing it breaks shipped playback behaviour, not just a test.
+
+| Caller | Sets | Why |
+| --- | --- | --- |
+| `lib/core/services/linux_playback_controller.dart` (`linuxMpvProperties`) | `cache-on-disk=no` | media_kit turns mpv's on-disk demuxer cache on for every player; Linthra streams audio and manages its own offline cache, and mpv logs `[lavf] Failed to create file cache.` on every stream where it cannot write the temporary file ([#405](https://github.com/thezupzup/linthra/issues/405)). |
+| `tool/linux_audio_backend_smoke.dart` | `ao=alsa` | The headless CI case described above. |
+
+The smoke target layers its value on top of the production defaults rather than
+replacing them (`resolveLinuxMpvProperties` merges), so CI exercises the same
+cache configuration production uses, with only the output device swapped.
 
 ## Auditing this directory
 
@@ -73,6 +85,12 @@ set). CI runs it on every PR.
 2. Replace every file listed in `upstream.sha256` with the new upstream copy and
    regenerate that manifest from the pristine tree.
 3. Re-apply the two hunks (`git apply upstream.patch`, or by hand if they moved)
-   and regenerate `upstream.patch` from the pristine-vs-vendored diff.
+   and regenerate `upstream.patch` from the pristine-vs-vendored diff. **Do not
+   drop them because upstream gained something similar** without checking both
+   callers in *Who sets it* first: production playback depends on this hook, so
+   losing it is a silent behaviour change, not a test-only regression.
 4. Update the table above, refresh `pubspec.lock`, and run
    `./scripts/check_vendored_packages.sh`.
+5. If upstream ever adds its own public hook for player-creation properties,
+   move both callers onto it and drop the patch — that is the outcome this
+   vendoring exists to make unnecessary.

--- a/third_party/just_audio_media_kit/lib/just_audio_media_kit.dart
+++ b/third_party/just_audio_media_kit/lib/just_audio_media_kit.dart
@@ -50,8 +50,8 @@ class JustAudioMediaKit extends JustAudioPlatform {
 
   /// Optional libmpv properties applied to each [Player] after creation.
   ///
-  /// Linthra leaves this empty in production. The headless Linux audio smoke
-  /// target sets `ao=alsa` so CI can route output through an ALSA null device.
+  /// Linthra sets its Linux defaults here (see `linuxMpvProperties`); the
+  /// headless audio smoke layers `ao=alsa` on top for an ALSA null device.
   static Map<String, String> mpvProperties = const {};
 
   static final _logger = Logger('JustAudioMediaKit');

--- a/third_party/just_audio_media_kit/upstream.patch
+++ b/third_party/just_audio_media_kit/upstream.patch
@@ -6,8 +6,8 @@
  
 +  /// Optional libmpv properties applied to each [Player] after creation.
 +  ///
-+  /// Linthra leaves this empty in production. The headless Linux audio smoke
-+  /// target sets `ao=alsa` so CI can route output through an ALSA null device.
++  /// Linthra sets its Linux defaults here (see `linuxMpvProperties`); the
++  /// headless audio smoke layers `ao=alsa` on top for an ALSA null device.
 +  static Map<String, String> mpvProperties = const {};
 +
    static final _logger = Logger('JustAudioMediaKit');


### PR DESCRIPTION
Fixes #405.

## Root cause

Not a guess, and not what the issue title assumed. media_kit sets mpv's on-disk demuxer cache **on** for every player it creates:

```dart
// media_kit 1.2.6, lib/src/player/native/player/real.dart:2400
'cache': 'yes',
'cache-on-disk': 'yes',
```

mpv's own default for `cache-on-disk` is `no`. So this is media_kit's choice, sensible for a video player buffering gigabytes to disk and wrong for Linthra, which streams audio and manages its own offline downloads. When mpv cannot create the temporary file it wants, libmpv logs on every stream:

```
[lavf] Failed to create cache temporary file.
[lavf] Failed to create file cache.
```

## How it was verified

Reproduced against mpv 0.37 directly, no guessing at which cache path fails:

```
$ mpv --no-config --cache=yes --cache-on-disk=yes \
      --demuxer-cache-dir=/proc/definitely-not-writable silence.wav
[lavf] Failed to create cache temporary file.
[lavf] Failed to create file cache.

$ mpv --no-config --cache=yes --cache-on-disk=no \
      --demuxer-cache-dir=/proc/definitely-not-writable silence.wav
(silent)
```

With a writable cache dir it is silent either way, which lines up with the warning showing up in restricted environments (a sandbox, or a cache directory the app cannot write) rather than on every machine.

## The fix

`cache-on-disk=no` through the existing `JustAudioMediaKit.mpvProperties` seam, from a single named `linuxMpvProperties` map in `lib/core/services/linux_playback_controller.dart`.

- Only the temporary on-disk packet file is turned off. media_kit's `cache=yes` stays, so memory and network buffering behave exactly as before.
- Linthra's own download/offline cache is a separate mechanism and is untouched.
- No broad `cache=no`, and a test guards against one creeping in.
- No filesystem permissions were widened anywhere.

Ordering is what makes it stick: media_kit applies its defaults while the player initializes, and `just_audio_media_kit` applies `mpvProperties` afterwards through `NativePlayer.setProperty`, which awaits that initialization.

`resolveLinuxMpvProperties` merges instead of assigning, so `tool/linux_audio_backend_smoke.dart` keeps its `ao=alsa` and now runs against the same cache configuration production uses, with only the output device swapped.

## Checks

- `dart format --set-exit-if-changed` clean
- `flutter analyze`: no issues
- `flutter test`: 4054 passing
- `scripts/check_vendored_packages.sh --no-analyze`: vendored tree still upstream + patch (the vendored doc comment and `upstream.patch` were updated together)

## Still needs real hardware

I can reproduce the mpv behaviour but not a real Linthra playback session here (no libmpv runtime, no audio device, no server). Before this closes #405, someone should confirm on a real Linux box that the warning is gone and that Jellyfin, Navidrome/Subsonic and Plex streams still buffer and play normally. That is the one acceptance criterion I cannot tick from CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvJnixf94LEa7BYmBRV54m

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvJnixf94LEa7BYmBRV54m)_