### PR TITLE
fix(android): scan the SAF library off the platform thread (#346)

### DIFF
--- a/.github/workflows/android-debug-apk.yml
+++ b/.github/workflows/android-debug-apk.yml
@@ -39,6 +39,16 @@ jobs:
       - name: Install dependencies
         run: flutter pub get --enforce-lockfile
 
+      # Cheap, Flutter-independent, and it runs before the build because the
+      # regression it guards against would build perfectly: a method-channel
+      # handler that does its work inline blocks Android's platform thread and
+      # only shows up as an ANR on a real music library (#346).
+      - name: Check Android channel threading
+        run: python3 scripts/check_android_channel_threading.py
+
+      - name: Test the Android channel threading tooling
+        run: python3 test/tooling/check_android_channel_threading_test.py
+
       - name: Build debug APK
         run: flutter build apk --debug
 

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
@@ -75,6 +75,11 @@ class MainActivity : AudioServiceActivity() {
                     // walk was never reached. Returning the tree URI routes the
                     // scan through SafDocumentScanner instead.
                     "pickFolderTree" -> startFolderPick(result)
+                    // Walks the picked tree and returns its audio documents.
+                    // The scan itself runs off this (platform) thread — see
+                    // PlatformChannelWorker — so this branch only queues it and
+                    // returns; `result` is answered back on the platform thread
+                    // once the walk finishes.
                     "listAudioDocuments" -> {
                         val treeUri = call.argument<String>("treeUri")
                         if (treeUri == null) {

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
@@ -100,6 +100,15 @@ class MainActivity : AudioServiceActivity() {
                                 .listAudioDocuments(treeUri, result)
                         }
                     }
+                    // Stop the walk in flight without starting another: the
+                    // user forgot the folder or switched to MediaStore, so
+                    // nothing is waiting on its result and it should stop
+                    // burning content-resolver I/O. One atomic swap, so it
+                    // answers here rather than on the worker.
+                    "cancelScan" -> {
+                        safDocumentScanner.cancelScan()
+                        result.success(null)
+                    }
                     "hasPersistedPermission" -> {
                         val treeUri = call.argument<String>("treeUri")
                         if (treeUri == null) {

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
@@ -44,11 +44,12 @@ class MainActivity : AudioServiceActivity() {
     }
 
     // Walks the picked SAF tree and reads sidecar lyrics from it. One instance
-    // for the activity, not one per call: it holds the cancellation flag of the
-    // walk in flight, and a fresh scanner per request would have nothing to
-    // cancel — the superseded walk would keep the shared worker thread and the
-    // newly picked folder would wait it out (#346). Application-scoped so it
-    // never retains this activity.
+    // for the activity rather than one per channel call, like every other
+    // channel here. Superseding an in-flight walk does not depend on this: the
+    // cancellation flag lives in SafDocumentScanner's companion object, process-
+    // scoped like the worker thread it frees, so it survives this activity being
+    // recreated mid-scan the same way the pending folder pick below does (#346).
+    // Application-scoped so it never retains this activity.
     private val safDocumentScanner by lazy {
         SafDocumentScanner(applicationContext)
     }

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
@@ -43,6 +43,16 @@ class MainActivity : AudioServiceActivity() {
         InstallHistoryChannel(applicationContext)
     }
 
+    // Walks the picked SAF tree and reads sidecar lyrics from it. One instance
+    // for the activity, not one per call: it holds the cancellation flag of the
+    // walk in flight, and a fresh scanner per request would have nothing to
+    // cancel — the superseded walk would keep the shared worker thread and the
+    // newly picked folder would wait it out (#346). Application-scoped so it
+    // never retains this activity.
+    private val safDocumentScanner by lazy {
+        SafDocumentScanner(applicationContext)
+    }
+
     // Optional device-wide local-library path. Unlike SAF, this uses Android's
     // explicit Music and audio runtime permission and MediaStore. Kept on its
     // own channel so broad-library access is auditable separately from targeted
@@ -85,7 +95,7 @@ class MainActivity : AudioServiceActivity() {
                         if (treeUri == null) {
                             result.error("bad_args", "treeUri is required", null)
                         } else {
-                            SafDocumentScanner(applicationContext)
+                            safDocumentScanner
                                 .listAudioDocuments(treeUri, result)
                         }
                     }
@@ -95,7 +105,7 @@ class MainActivity : AudioServiceActivity() {
                             result.error("bad_args", "treeUri is required", null)
                         } else {
                             result.success(
-                                SafDocumentScanner(applicationContext)
+                                safDocumentScanner
                                     .hasPersistedPermission(treeUri),
                             )
                         }
@@ -114,7 +124,7 @@ class MainActivity : AudioServiceActivity() {
                             )
                         } else {
                             result.success(
-                                SafDocumentScanner(applicationContext)
+                                safDocumentScanner
                                     .readSidecarText(uri, extension),
                             )
                         }

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
@@ -75,6 +75,11 @@ class MainActivity : AudioServiceActivity() {
                     // walk was never reached. Returning the tree URI routes the
                     // scan through SafDocumentScanner instead.
                     "pickFolderTree" -> startFolderPick(result)
+                    // Walks the picked tree and returns its audio documents.
+                    // The scan itself runs off this (platform) thread — see
+                    // PlatformChannelWorker — so this branch only queues it and
+                    // returns; `result` is encoded and answered from the worker
+                    // once the walk finishes.
                     "listAudioDocuments" -> {
                         val treeUri = call.argument<String>("treeUri")
                         if (treeUri == null) {

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/PlatformChannelWorker.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/PlatformChannelWorker.kt
@@ -1,0 +1,65 @@
+package io.github.thezupzup.linthra
+
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+
+/**
+ * Runs one piece of blocking method-channel work off the platform thread and
+ * delivers its outcome from that worker thread.
+ *
+ * Flutter invokes a `MethodChannel` handler on the platform (main) thread.
+ * Doing the work *inside* the handler therefore blocks the UI for as long as it
+ * takes — fine
+ * for reading a flag, not fine for walking a music library through the content
+ * resolver (#346). This is the seam between the two: [submit] hands the work to
+ * a background thread and invokes exactly one callback there. Flutter permits
+ * `MethodChannel.Result` replies from any thread, which also keeps the channel
+ * codec's potentially large success-envelope encoding off the platform thread.
+ *
+ * The background executor is a single shared daemon thread, deliberately:
+ *
+ *  * two scans of the same tree at once would only make the content resolver
+ *    slower and could double the artwork extraction work, so they queue instead;
+ *  * one long-lived thread costs nothing between scans, and a scan started just
+ *    before the process dies cannot hold it open.
+ *
+ * The executor is injectable so the threading boundary can be exercised
+ * without a device. Production takes the default.
+ */
+class PlatformChannelWorker(
+    private val background: Executor = SHARED_BACKGROUND,
+) {
+
+    /**
+     * Runs [work] on the background executor, then calls exactly one of
+     * [onSuccess] or [onFailure] on that same worker thread.
+     *
+     * Only [Exception] is caught. An [Error] (an OOM on a very large library,
+     * say) is left to the default handler rather than being reported as an
+     * ordinary channel failure the Dart side would treat as "this folder is
+     * unreadable".
+     */
+    fun <T> submit(
+        work: () -> T,
+        onSuccess: (T) -> Unit,
+        onFailure: (Exception) -> Unit,
+    ) {
+        background.execute {
+            val value =
+                try {
+                    work()
+                } catch (e: Exception) {
+                    onFailure(e)
+                    return@execute
+                }
+            onSuccess(value)
+        }
+    }
+
+    companion object {
+        private val SHARED_BACKGROUND: Executor =
+            Executors.newSingleThreadExecutor { runnable ->
+                Thread(runnable, "linthra-channel-work").apply { isDaemon = true }
+            }
+    }
+}

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/PlatformChannelWorker.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/PlatformChannelWorker.kt
@@ -1,0 +1,75 @@
+package io.github.thezupzup.linthra
+
+import android.os.Handler
+import android.os.Looper
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+
+/**
+ * Runs one piece of blocking method-channel work off the platform thread and
+ * delivers its outcome back on the platform thread.
+ *
+ * Flutter invokes a `MethodChannel` handler on the platform (main) thread and
+ * requires `MethodChannel.Result` to be answered there too. Doing the work
+ * *inside* the handler therefore blocks the UI for as long as it takes — fine
+ * for reading a flag, not fine for walking a music library through the content
+ * resolver (#346). This is the seam between the two: [submit] hands the work to
+ * a background thread and posts exactly one callback back to the main looper.
+ *
+ * The background executor is a single shared daemon thread, deliberately:
+ *
+ *  * two scans of the same tree at once would only make the content resolver
+ *    slower and could double the artwork extraction work, so they queue instead;
+ *  * one long-lived thread costs nothing between scans, and a scan started just
+ *    before the process dies cannot hold it open.
+ *
+ * Both executors are injectable so the threading boundary can be exercised
+ * without a device. Production takes the defaults.
+ */
+class PlatformChannelWorker(
+    private val background: Executor = SHARED_BACKGROUND,
+    private val platform: Executor = PlatformThreadExecutor,
+) {
+
+    /**
+     * Runs [work] on the background executor, then calls exactly one of
+     * [onSuccess] or [onFailure] on the platform thread.
+     *
+     * Only [Exception] is caught. An [Error] (an OOM on a very large library,
+     * say) is left to the default handler rather than being reported as an
+     * ordinary channel failure the Dart side would treat as "this folder is
+     * unreadable".
+     */
+    fun <T> submit(
+        work: () -> T,
+        onSuccess: (T) -> Unit,
+        onFailure: (Exception) -> Unit,
+    ) {
+        background.execute {
+            val value =
+                try {
+                    work()
+                } catch (e: Exception) {
+                    platform.execute { onFailure(e) }
+                    return@execute
+                }
+            platform.execute { onSuccess(value) }
+        }
+    }
+
+    /** Posts to the main looper, which is where Flutter wants channel replies. */
+    private object PlatformThreadExecutor : Executor {
+        private val handler = Handler(Looper.getMainLooper())
+
+        override fun execute(command: Runnable) {
+            handler.post(command)
+        }
+    }
+
+    companion object {
+        private val SHARED_BACKGROUND: Executor =
+            Executors.newSingleThreadExecutor { runnable ->
+                Thread(runnable, "linthra-channel-work").apply { isDaemon = true }
+            }
+    }
+}

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
@@ -10,6 +10,8 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.security.MessageDigest
 import java.util.ArrayDeque
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Walks a user-picked Storage Access Framework tree URI through the content
@@ -40,22 +42,52 @@ class SafDocumentScanner(
 ) {
 
     /**
+     * The cancellation flag of the walk currently queued or running, if any.
+     *
+     * Scans share one worker thread, so a second one waits for the first. That
+     * is right while both are wanted and wrong the moment the first is not: a
+     * user who picks a different folder mid-scan would otherwise watch the new
+     * one sit "loading" for however long the abandoned walk still had to run.
+     * Superseding sets this flag, the walk notices between folders, and the
+     * thread frees up for the selection the user actually made.
+     */
+    private val currentScan = AtomicReference<AtomicBoolean?>(null)
+
+    /**
      * Lists audio documents under [treeUri], reporting back through [result].
      *
-     * The walk runs on [PlatformChannelWorker]'s background thread and [result]
-     * and the result is encoded and answered there, so a real library — thousands of
+     * The walk runs on [PlatformChannelWorker]'s background thread, and [result]
+     * is encoded and answered there too, so a real library — thousands of
      * content-resolver queries plus a [MediaMetadataRetriever] open per file —
      * never blocks the UI (#346). This returns as soon as the work is queued.
+     *
+     * Starting a scan supersedes any earlier one: the older walk stops at its
+     * next folder boundary instead of making this one wait out a scan the user
+     * already moved on from.
      */
     fun listAudioDocuments(treeUri: String, result: MethodChannel.Result) {
+        // Supersede whatever was queued or running before answering this one.
+        val cancelled = AtomicBoolean(false)
+        currentScan.getAndSet(cancelled)?.set(true)
+
         worker.submit(
-            work = { walk(Uri.parse(treeUri)) },
+            work = { walk(Uri.parse(treeUri), cancelled) },
             onSuccess = { documents -> result.success(documents) },
             onFailure = { error ->
                 // A revoked or never-granted tree is a clear "no access"; every
                 // other failure stays a generic read error, so no provider
                 // message (which could carry a path) reaches the Dart side.
-                if (error is SecurityException) {
+                if (error is ScanSuperseded) {
+                    // Only ever reached by a scan a newer one replaced, and the
+                    // Dart side drops a superseded response on every path
+                    // (LibraryController's generation guard), so this reports
+                    // what happened rather than pretending the folder failed.
+                    result.error(
+                        "saf_superseded",
+                        "A newer scan replaced this one.",
+                        null,
+                    )
+                } else if (error is SecurityException) {
                     result.error(
                         "saf_permission",
                         "No access to the selected folder.",
@@ -160,7 +192,7 @@ class SafDocumentScanner(
         }
     }
 
-    private fun walk(treeUri: Uri): Map<String, Any?> {
+    private fun walk(treeUri: Uri, cancelled: AtomicBoolean): Map<String, Any?> {
         // Persist the grant when possible so a folder picked once can still be
         // scanned after a restart; harmless (and ignored) when not persistable.
         try {
@@ -183,6 +215,9 @@ class SafDocumentScanner(
         val queue = ArrayDeque<String>()
         queue.add(DocumentsContract.getTreeDocumentId(treeUri))
         while (queue.isNotEmpty()) {
+            // Checked per folder rather than per file: it bounds the wait to one
+            // directory listing without adding a check to the hot path.
+            if (cancelled.get()) throw ScanSuperseded()
             val parentDocId = queue.poll()
             val childrenUri =
                 DocumentsContract.buildChildDocumentsUriUsingTree(treeUri, parentDocId)
@@ -397,6 +432,9 @@ class SafDocumentScanner(
         val bytes = digest.digest(uri.toString().toByteArray(Charsets.UTF_8))
         return bytes.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
     }
+
+    /** Raised inside [walk] when a newer scan superseded this one. */
+    private class ScanSuperseded : Exception()
 
     companion object {
         private val AUDIO_EXTENSIONS =

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
@@ -28,18 +28,48 @@ import java.util.ArrayDeque
  * walk, so one bad subtree can't zero out an otherwise-readable library. A
  * total access denial (a revoked grant) still surfaces as a SecurityException
  * so the user sees a clear "no access" message instead of a silent empty.
+ *
+ * Threading: the walk is blocking and proportional to the library, so it runs
+ * on [PlatformChannelWorker]'s background thread rather than on the platform
+ * thread Flutter calls the channel handler on (#346). The cheap calls
+ * ([hasPersistedPermission], [readSidecarText]) still answer inline.
  */
-class SafDocumentScanner(private val context: Context) {
+class SafDocumentScanner(
+    private val context: Context,
+    private val worker: PlatformChannelWorker = PlatformChannelWorker(),
+) {
 
-    /** Lists audio documents under [treeUri], reporting back through [result]. */
+    /**
+     * Lists audio documents under [treeUri], reporting back through [result].
+     *
+     * The walk runs on [PlatformChannelWorker]'s background thread and [result]
+     * and the result is encoded and answered there, so a real library — thousands of
+     * content-resolver queries plus a [MediaMetadataRetriever] open per file —
+     * never blocks the UI (#346). This returns as soon as the work is queued.
+     */
     fun listAudioDocuments(treeUri: String, result: MethodChannel.Result) {
-        try {
-            result.success(walk(Uri.parse(treeUri)))
-        } catch (e: SecurityException) {
-            result.error("saf_permission", "No access to the selected folder.", null)
-        } catch (e: Exception) {
-            result.error("saf_failed", "Failed to read the selected folder.", null)
-        }
+        worker.submit(
+            work = { walk(Uri.parse(treeUri)) },
+            onSuccess = { documents -> result.success(documents) },
+            onFailure = { error ->
+                // A revoked or never-granted tree is a clear "no access"; every
+                // other failure stays a generic read error, so no provider
+                // message (which could carry a path) reaches the Dart side.
+                if (error is SecurityException) {
+                    result.error(
+                        "saf_permission",
+                        "No access to the selected folder.",
+                        null,
+                    )
+                } else {
+                    result.error(
+                        "saf_failed",
+                        "Failed to read the selected folder.",
+                        null,
+                    )
+                }
+            },
+        )
     }
 
     /**

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
@@ -48,8 +48,10 @@ class SafDocumentScanner(
      * is right while both are wanted and wrong the moment the first is not: a
      * user who picks a different folder mid-scan would otherwise watch the new
      * one sit "loading" for however long the abandoned walk still had to run.
-     * Superseding sets this flag, the walk notices between folders, and the
-     * thread frees up for the selection the user actually made.
+     * Superseding sets this flag, the walk notices at its next file, and the
+     * thread frees up for the selection the user actually made. This is why
+     * `MainActivity` keeps one scanner instead of building one per request:
+     * a fresh instance would have no in-flight walk to cancel.
      */
     private val currentScan = AtomicReference<AtomicBoolean?>(null)
 
@@ -62,8 +64,9 @@ class SafDocumentScanner(
      * never blocks the UI (#346). This returns as soon as the work is queued.
      *
      * Starting a scan supersedes any earlier one: the older walk stops at its
-     * next folder boundary instead of making this one wait out a scan the user
-     * already moved on from.
+     * next file instead of making this one wait out a scan the user already
+     * moved on from. That needs one scanner for the whole channel rather than
+     * one per request, which is why `MainActivity` holds it.
      */
     fun listAudioDocuments(treeUri: String, result: MethodChannel.Result) {
         // Supersede whatever was queued or running before answering this one.
@@ -215,8 +218,8 @@ class SafDocumentScanner(
         val queue = ArrayDeque<String>()
         queue.add(DocumentsContract.getTreeDocumentId(treeUri))
         while (queue.isNotEmpty()) {
-            // Checked per folder rather than per file: it bounds the wait to one
-            // directory listing without adding a check to the hot path.
+            // Checked here and once more per entry below, so a superseded walk
+            // stops within one file's work rather than one folder's.
             if (cancelled.get()) throw ScanSuperseded()
             val parentDocId = queue.poll()
             val childrenUri =
@@ -250,6 +253,12 @@ class SafDocumentScanner(
                 isRoot = false
                 cursor.use { c ->
                     while (c.moveToNext()) {
+                        // Also checked per entry, not only per folder: the
+                        // common shape is one flat Music folder holding every
+                        // track, so the outer loop runs once and a per-folder
+                        // check alone would not interrupt anything. This is the
+                        // loop that opens a MediaMetadataRetriever per file.
+                        if (cancelled.get()) throw ScanSuperseded()
                         val docId = c.getString(0) ?: continue
                         val name = c.getString(1) ?: continue
                         val mime = c.getString(2)

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
@@ -40,21 +40,6 @@ class SafDocumentScanner(
     private val context: Context,
     private val worker: PlatformChannelWorker = PlatformChannelWorker(),
 ) {
-
-    /**
-     * The cancellation flag of the walk currently queued or running, if any.
-     *
-     * Scans share one worker thread, so a second one waits for the first. That
-     * is right while both are wanted and wrong the moment the first is not: a
-     * user who picks a different folder mid-scan would otherwise watch the new
-     * one sit "loading" for however long the abandoned walk still had to run.
-     * Superseding sets this flag, the walk notices at its next file, and the
-     * thread frees up for the selection the user actually made. This is why
-     * `MainActivity` keeps one scanner instead of building one per request:
-     * a fresh instance would have no in-flight walk to cancel.
-     */
-    private val currentScan = AtomicReference<AtomicBoolean?>(null)
-
     /**
      * Lists audio documents under [treeUri], reporting back through [result].
      *
@@ -65,8 +50,9 @@ class SafDocumentScanner(
      *
      * Starting a scan supersedes any earlier one: the older walk stops at its
      * next file instead of making this one wait out a scan the user already
-     * moved on from. That needs one scanner for the whole channel rather than
-     * one per request, which is why `MainActivity` holds it.
+     * moved on from. The flag that does it is process-scoped (see [currentScan])
+     * because the worker thread it frees is, so this holds across a scanner
+     * rebuilt with a recreated activity.
      */
     fun listAudioDocuments(treeUri: String, result: MethodChannel.Result) {
         // Supersede whatever was queued or running before answering this one.
@@ -298,6 +284,16 @@ class SafDocumentScanner(
                         }
                     }
                 }
+            } catch (e: ScanSuperseded) {
+                // Cancellation is not a read failure. Without this clause the
+                // per-entry check in the cursor loop above lands in the generic
+                // catch, is counted as one unreadable subtree, and the walk
+                // carries on to answer a partial success. The Dart side would
+                // then decode a response of thousands of entries only to discard
+                // it, while the scan the user is actually waiting for keeps
+                // queueing. Rethrow so the worker answers the small
+                // saf_superseded error instead.
+                throw e
             } catch (e: SecurityException) {
                 // A total access denial must surface as a clear error, not a
                 // silent empty — rethrow so listAudioDocuments reports it.
@@ -446,6 +442,32 @@ class SafDocumentScanner(
     private class ScanSuperseded : Exception()
 
     companion object {
+        /**
+         * The cancellation flag of the walk currently queued or running, if any.
+         *
+         * Scans share one worker thread, so a second one waits for the first.
+         * That is right while both are wanted and wrong the moment the first is
+         * not: a user who picks a different folder mid-scan would otherwise
+         * watch the new one sit "loading" for however long the abandoned walk
+         * still had to run. Superseding sets this flag, the walk notices at its
+         * next file, and the thread frees up for the selection the user
+         * actually made.
+         *
+         * Process-scoped, deliberately, because the thread it frees is:
+         * [PlatformChannelWorker]'s executor outlives any one activity, so a
+         * flag that did not would stop cancelling exactly when the activity is
+         * recreated mid-scan ("Don't keep activities", a low-memory reclaim
+         * while the audio service keeps the process alive, a config change
+         * outside the manifest's list; the same recreation `MainActivity`'s
+         * pending folder pick already has to survive). The new activity's
+         * scanner would hold an empty flag, the obsolete walk would keep the
+         * worker thread, and the folder the user just picked would wait it out.
+         *
+         * Only ever read and written through [AtomicReference.getAndSet] here,
+         * so two scans racing from different threads still hand off cleanly.
+         */
+        private val currentScan = AtomicReference<AtomicBoolean?>(null)
+
         private val AUDIO_EXTENSIONS =
             listOf(".mp3", ".flac", ".m4a", ".aac", ".ogg", ".opus", ".wav")
 

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
@@ -28,18 +28,48 @@ import java.util.ArrayDeque
  * walk, so one bad subtree can't zero out an otherwise-readable library. A
  * total access denial (a revoked grant) still surfaces as a SecurityException
  * so the user sees a clear "no access" message instead of a silent empty.
+ *
+ * Threading: the walk is blocking and proportional to the library, so it runs
+ * on [PlatformChannelWorker]'s background thread rather than on the platform
+ * thread Flutter calls the channel handler on (#346). The cheap calls
+ * ([hasPersistedPermission], [readSidecarText]) still answer inline.
  */
-class SafDocumentScanner(private val context: Context) {
+class SafDocumentScanner(
+    private val context: Context,
+    private val worker: PlatformChannelWorker = PlatformChannelWorker(),
+) {
 
-    /** Lists audio documents under [treeUri], reporting back through [result]. */
+    /**
+     * Lists audio documents under [treeUri], reporting back through [result].
+     *
+     * The walk runs on [PlatformChannelWorker]'s background thread and [result]
+     * is answered on the platform thread, so a real library — thousands of
+     * content-resolver queries plus a [MediaMetadataRetriever] open per file —
+     * never blocks the UI (#346). This returns as soon as the work is queued.
+     */
     fun listAudioDocuments(treeUri: String, result: MethodChannel.Result) {
-        try {
-            result.success(walk(Uri.parse(treeUri)))
-        } catch (e: SecurityException) {
-            result.error("saf_permission", "No access to the selected folder.", null)
-        } catch (e: Exception) {
-            result.error("saf_failed", "Failed to read the selected folder.", null)
-        }
+        worker.submit(
+            work = { walk(Uri.parse(treeUri)) },
+            onSuccess = { documents -> result.success(documents) },
+            onFailure = { error ->
+                // A revoked or never-granted tree is a clear "no access"; every
+                // other failure stays a generic read error, so no provider
+                // message (which could carry a path) reaches the Dart side.
+                if (error is SecurityException) {
+                    result.error(
+                        "saf_permission",
+                        "No access to the selected folder.",
+                        null,
+                    )
+                } else {
+                    result.error(
+                        "saf_failed",
+                        "Failed to read the selected folder.",
+                        null,
+                    )
+                }
+            },
+        )
     }
 
     /**

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
@@ -94,6 +94,25 @@ class SafDocumentScanner(
     }
 
     /**
+     * Stops the walk that is queued or running, if any, without starting one.
+     *
+     * [listAudioDocuments] already supersedes its predecessor, which covers a
+     * user picking a different folder. It does not cover abandoning the scan
+     * outright: forgetting the folder, or switching to the device-wide
+     * MediaStore library. Those only invalidate the Dart-side result, so
+     * without this the abandoned walk keeps opening a MediaMetadataRetriever
+     * and extracting artwork for the rest of a library nobody is waiting for,
+     * competing with the MediaStore traversal that just started for the same
+     * content-resolver I/O.
+     *
+     * Cheap (one atomic swap), so it answers on the calling thread. Safe to
+     * call when nothing is running: there is simply no flag to trip.
+     */
+    fun cancelScan() {
+        currentScan.getAndSet(null)?.set(true)
+    }
+
+    /**
      * Whether the app currently holds a persisted *read* grant for [treeUri] —
      * the diagnostic that tells "no music found" apart from a lost folder grant
      * (e.g. after a reboot, or a removable SD card that was remounted).

--- a/docs/local-music.md
+++ b/docs/local-music.md
@@ -81,9 +81,15 @@ read a user-chosen folder is the **Storage Access Framework (SAF)**:
    there too. A real library means thousands of
    content-resolver queries plus a `MediaMetadataRetriever` open per file, so
    scanning inline would freeze the UI and eventually trip an ANR. Two scans
-   queue rather than run at once. `scripts/check_android_channel_threading.py`
-   guards the boundary, because a walk that drifts back onto the platform thread
-   still compiles and still passes every test.
+   never run at once. Picking a second folder mid-scan **supersedes** the first
+   rather than queueing behind it: the abandoned walk stops at its next file and
+   answers `saf_superseded`, so the folder you just chose starts right away
+   instead of waiting out a scan you already moved on from. That flag is
+   process-scoped, so it keeps working if Android recreates the activity
+   mid-scan. `scripts/check_android_channel_threading.py` guards both the thread
+   boundary and the cancellation, because a walk that drifts back onto the
+   platform thread, or a supersede that quietly stops superseding, still
+   compiles and still passes every test.
 
 This is why a raw path like `/storage/emulated/0/Music/...` is the wrong thing to
 store — it looks fine but can't be read under scoped storage. If you selected a

--- a/docs/local-music.md
+++ b/docs/local-music.md
@@ -84,9 +84,10 @@ read a user-chosen folder is the **Storage Access Framework (SAF)**:
    never run at once. Picking a second folder mid-scan **supersedes** the first
    rather than queueing behind it: the abandoned walk stops at its next file and
    answers `saf_superseded`, so the folder you just chose starts right away
-   instead of waiting out a scan you already moved on from. That flag is
-   process-scoped, so it keeps working if Android recreates the activity
-   mid-scan. `scripts/check_android_channel_threading.py` guards both the thread
+   instead of waiting out a scan you already moved on from. Forgetting the
+   folder or switching to the device-wide library cancels it the same way, even
+   though neither starts a replacement scan. That flag is process-scoped, so it
+   keeps working if Android recreates the activity mid-scan. `scripts/check_android_channel_threading.py` guards both the thread
    boundary and the cancellation, because a walk that drifts back onto the
    platform thread, or a supersede that quietly stops superseding, still
    compiles and still passes every test.

--- a/docs/local-music.md
+++ b/docs/local-music.md
@@ -76,6 +76,14 @@ read a user-chosen folder is the **Storage Access Framework (SAF)**:
    descending into subfolders. One unreadable subfolder is skipped and counted,
    not fatal; a totally unreadable selected folder surfaces a clear error rather
    than a silent empty result.
+4. That walk runs **off the platform (main) thread**, on `PlatformChannelWorker`'s
+   single background thread, and the method-channel reply is encoded and sent
+   there too. A real library means thousands of
+   content-resolver queries plus a `MediaMetadataRetriever` open per file, so
+   scanning inline would freeze the UI and eventually trip an ANR. Two scans
+   queue rather than run at once. `scripts/check_android_channel_threading.py`
+   guards the boundary, because a walk that drifts back onto the platform thread
+   still compiles and still passes every test.
 
 This is why a raw path like `/storage/emulated/0/Music/...` is the wrong thing to
 store — it looks fine but can't be read under scoped storage. If you selected a

--- a/docs/local-music.md
+++ b/docs/local-music.md
@@ -76,6 +76,14 @@ read a user-chosen folder is the **Storage Access Framework (SAF)**:
    descending into subfolders. One unreadable subfolder is skipped and counted,
    not fatal; a totally unreadable selected folder surfaces a clear error rather
    than a silent empty result.
+4. That walk runs **off the platform (main) thread**, on `PlatformChannelWorker`'s
+   single background thread, and the method-channel reply is posted back to the
+   platform thread where Flutter needs it. A real library means thousands of
+   content-resolver queries plus a `MediaMetadataRetriever` open per file, so
+   scanning inline would freeze the UI and eventually trip an ANR. Two scans
+   queue rather than run at once. `scripts/check_android_channel_threading.py`
+   guards the boundary, because a walk that drifts back onto the platform thread
+   still compiles and still passes every test.
 
 This is why a raw path like `/storage/emulated/0/Music/...` is the wrong thing to
 store — it looks fine but can't be read under scoped storage. If you selected a

--- a/lib/core/sources/local/method_channel_saf_document_lister.dart
+++ b/lib/core/sources/local/method_channel_saf_document_lister.dart
@@ -51,6 +51,20 @@ class MethodChannelSafDocumentLister implements SafDocumentLister {
     return parseScanResult(result);
   }
 
+  @override
+  Future<void> cancelScan() async {
+    if (!Platform.isAndroid) return;
+    try {
+      await _channel.invokeMethod<void>('cancelScan');
+    } on MissingPluginException {
+      // An older native build with no cancel handler: the walk finishes on its
+      // own and the generation guard drops it, exactly as before.
+    } on PlatformException {
+      // Nothing to cancel, or the native side refused. There is no result to
+      // salvage here and no user-visible outcome, so this stays silent.
+    }
+  }
+
   /// Parses the native `listAudioDocuments` reply into a [SafScanResult].
   ///
   /// Pure and public so the parsing — the part with real logic — is unit-testable

--- a/lib/core/sources/local/saf_document_lister.dart
+++ b/lib/core/sources/local/saf_document_lister.dart
@@ -87,6 +87,19 @@ class SafUnsupportedException implements Exception {
 ///  - throws a `FolderScanException` when traversal is available but fails.
 abstract interface class SafDocumentLister {
   Future<SafScanResult> listAudioDocuments(String treeUri);
+
+  /// Stops the walk in flight, if any, without starting another.
+  ///
+  /// Starting a scan already supersedes the one before it, which covers the
+  /// user picking a different folder. This covers abandoning the scan instead:
+  /// forgetting the folder, or switching to the device-wide library. Without
+  /// it the native walk runs to completion for a result nobody will read,
+  /// competing for content-resolver I/O with whatever replaced it.
+  ///
+  /// Best-effort and never throws: a platform that cannot cancel simply has
+  /// nothing to stop, and the Dart-side generation guard still discards the
+  /// result either way.
+  Future<void> cancelScan();
 }
 
 /// The default [SafDocumentLister] for platforms without native SAF traversal
@@ -100,4 +113,7 @@ class UnsupportedSafDocumentLister implements SafDocumentLister {
   Future<SafScanResult> listAudioDocuments(String treeUri) async {
     throw const SafUnsupportedException();
   }
+
+  @override
+  Future<void> cancelScan() async {}
 }

--- a/lib/features/library/library_controller.dart
+++ b/lib/features/library/library_controller.dart
@@ -13,17 +13,23 @@ import 'local_scan_report_provider.dart';
 /// Drives the Library screen: loads tracks from the [MusicLibraryRepository]
 /// and exposes them as a [LibraryState].
 class LibraryController extends Notifier<LibraryState> {
+  int _catalogGeneration = 0;
+
   @override
   LibraryState build() {
     _load();
     return const LibraryState.loading();
   }
 
-  Future<void> refresh() => _load();
+  Future<void> refresh() {
+    _catalogGeneration++;
+    return _load();
+  }
 
   /// Scans a filesystem folder, SAF tree, or Android device-wide MediaStore
   /// selection, persists the discovered tracks, then reloads the catalog.
   Future<void> scanFolder(String folderPath) async {
+    final int generation = ++_catalogGeneration;
     state = const LibraryState.loading();
     final FolderLocation location = FolderLocation.parse(folderPath);
     try {
@@ -35,6 +41,10 @@ class LibraryController extends Notifier<LibraryState> {
         metadataReader: ref.read(localMetadataReaderProvider),
       );
       final LocalScan scan = await source.scanTracks();
+      // A SAF scan can take long enough for the user to forget this source or
+      // start a scan of another one. Never let that obsolete result repopulate
+      // or replace the catalog chosen by the newer action.
+      if (generation != _catalogGeneration) return;
       final repository = ref.read(musicLibraryRepositoryProvider);
       await repository.upsertCatalog(
         sourceId: source.id,
@@ -45,6 +55,7 @@ class LibraryController extends Notifier<LibraryState> {
       ref.read(localScanReportProvider.notifier).record(scan.report);
       await _load();
     } on FolderScanException catch (error) {
+      if (generation != _catalogGeneration) return;
       ref.read(localScanReportProvider.notifier).record(
             LocalScanReport.failure(
               folderSelected: folderPath.isNotEmpty,
@@ -61,6 +72,7 @@ class LibraryController extends Notifier<LibraryState> {
           );
       state = LibraryState.error(error.message);
     } catch (_) {
+      if (generation != _catalogGeneration) return;
       ref.read(localScanReportProvider.notifier).record(
             LocalScanReport.failure(
               folderSelected: folderPath.isNotEmpty,

--- a/lib/features/library/library_controller.dart
+++ b/lib/features/library/library_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/catalog/library_grouping.dart';
@@ -28,9 +30,23 @@ class LibraryController extends Notifier<LibraryState> {
 
   /// Supersedes pending local scans when the user changes or forgets a source.
   /// Call this before the first asynchronous part of the source mutation.
+  ///
+  /// Bumping the generations makes an in-flight scan's result unusable, but on
+  /// Android it does not stop the native SAF walk producing it: that keeps
+  /// opening a metadata retriever and extracting artwork for the rest of an
+  /// abandoned library, competing for content-resolver I/O with whatever the
+  /// user switched to. Starting another scan already supersedes the walk ahead
+  /// of it; forgetting the folder or switching to the device-wide library does
+  /// not start one, so ask the scanner to stop directly.
+  ///
+  /// Deliberately not awaited: this must stay synchronous so callers can
+  /// invalidate before their first `await`, and cancellation is best-effort on
+  /// every platform. The generation guard remains the thing that makes the
+  /// result safe; this only saves the work.
   void invalidatePendingScans() {
     _scanGeneration++;
     _loadGeneration++;
+    unawaited(ref.read(safDocumentListerProvider).cancelScan());
   }
 
   /// Waits for already-started local writes before persisting a source change.

--- a/lib/features/library/library_controller.dart
+++ b/lib/features/library/library_controller.dart
@@ -28,16 +28,21 @@ class LibraryController extends Notifier<LibraryState> {
   /// Reloading the shared catalog must not cancel an unrelated local scan.
   Future<void> refresh() => _load();
 
-  /// Supersedes pending local scans when the user changes or forgets a source.
-  /// Call this before the first asynchronous part of the source mutation.
+  /// Supersedes pending local scans when the user changes or forgets a source,
+  /// and when one starts. Call this before the first asynchronous part of the
+  /// source mutation.
   ///
   /// Bumping the generations makes an in-flight scan's result unusable, but on
   /// Android it does not stop the native SAF walk producing it: that keeps
   /// opening a metadata retriever and extracting artwork for the rest of an
   /// abandoned library, competing for content-resolver I/O with whatever the
-  /// user switched to. Starting another scan already supersedes the walk ahead
-  /// of it; forgetting the folder or switching to the device-wide library does
-  /// not start one, so ask the scanner to stop directly.
+  /// user switched to.
+  ///
+  /// Only a new `listAudioDocuments` supersedes a walk natively, so every other
+  /// way to abandon one needs this: forgetting the folder, clearing the local
+  /// catalog, and starting a scan of the device-wide library (which goes to
+  /// MediaStore, never through the SAF channel). This is why the bump lives
+  /// here rather than being written out at each call site.
   ///
   /// Deliberately not awaited: this must stay synchronous so callers can
   /// invalidate before their first `await`, and cancellation is best-effort on
@@ -91,8 +96,13 @@ class LibraryController extends Notifier<LibraryState> {
   /// Returns this operation's report, or null if it was superseded. Callers
   /// must not infer success from the last globally recorded scan report.
   Future<LocalScanReport?> scanFolderWithReport(String folderPath) async {
-    final int generation = ++_scanGeneration;
-    _loadGeneration++;
+    // Through invalidatePendingScans, so starting a scan also stops the native
+    // walk it replaces. A SAF-to-SAF switch would supersede on its own (the
+    // next listAudioDocuments trips the old flag), but switching to the
+    // device-wide library never calls that, and the abandoned SAF walk would
+    // otherwise do metadata and artwork I/O for the whole MediaStore traversal.
+    invalidatePendingScans();
+    final int generation = _scanGeneration;
     state = const LibraryState.loading();
     final FolderLocation location = FolderLocation.parse(folderPath);
     try {

--- a/lib/features/library/library_controller.dart
+++ b/lib/features/library/library_controller.dart
@@ -13,7 +13,9 @@ import 'local_scan_report_provider.dart';
 /// Drives the Library screen: loads tracks from the [MusicLibraryRepository]
 /// and exposes them as a [LibraryState].
 class LibraryController extends Notifier<LibraryState> {
-  int _catalogGeneration = 0;
+  int _scanGeneration = 0;
+  int _loadGeneration = 0;
+  Future<void> _localMutationTail = Future<void>.value();
 
   @override
   LibraryState build() {
@@ -21,15 +23,60 @@ class LibraryController extends Notifier<LibraryState> {
     return const LibraryState.loading();
   }
 
-  Future<void> refresh() {
-    _catalogGeneration++;
-    return _load();
+  /// Reloading the shared catalog must not cancel an unrelated local scan.
+  Future<void> refresh() => _load();
+
+  /// Supersedes pending local scans when the user changes or forgets a source.
+  /// Call this before the first asynchronous part of the source mutation.
+  void invalidatePendingScans() {
+    _scanGeneration++;
+    _loadGeneration++;
+  }
+
+  /// Waits for already-started local writes before persisting a source change.
+  /// Invalidation happens first, so pending walks cannot enqueue a new write.
+  Future<void> waitForLocalMutations() => _localMutationTail;
+
+  /// Serializes local catalog writes, including forget. A scan may finish its
+  /// walk while a previous write is pending; its generation is checked again
+  /// inside this queue so obsolete results cannot commit after a clear.
+  Future<T> _serializeLocalMutation<T>(Future<T> Function() operation) {
+    final Future<T> result = _localMutationTail.then((_) => operation());
+    _localMutationTail = result.then<void>(
+      (_) {},
+      onError: (Object _, StackTrace __) {},
+    );
+    return result;
+  }
+
+  /// Clears only the local source, after any already-started local write.
+  /// A new scan started after this action can still populate the catalog.
+  Future<void> clearLocalCatalog() {
+    invalidatePendingScans();
+    return _serializeLocalMutation(() async {
+      await ref.read(musicLibraryRepositoryProvider).upsertCatalog(
+            sourceId: const LocalMusicSource(folderPath: null).id,
+            tracks: const [],
+            albums: const [],
+            artists: const [],
+          );
+      ref.read(localScanReportProvider.notifier).clear();
+      await _load();
+    });
   }
 
   /// Scans a filesystem folder, SAF tree, or Android device-wide MediaStore
   /// selection, persists the discovered tracks, then reloads the catalog.
+  /// Kept as a void-returning API for existing Library screen callers.
   Future<void> scanFolder(String folderPath) async {
-    final int generation = ++_catalogGeneration;
+    await scanFolderWithReport(folderPath);
+  }
+
+  /// Returns this operation's report, or null if it was superseded. Callers
+  /// must not infer success from the last globally recorded scan report.
+  Future<LocalScanReport?> scanFolderWithReport(String folderPath) async {
+    final int generation = ++_scanGeneration;
+    _loadGeneration++;
     state = const LibraryState.loading();
     final FolderLocation location = FolderLocation.parse(folderPath);
     try {
@@ -41,47 +88,55 @@ class LibraryController extends Notifier<LibraryState> {
         metadataReader: ref.read(localMetadataReaderProvider),
       );
       final LocalScan scan = await source.scanTracks();
-      // A SAF scan can take long enough for the user to forget this source or
-      // start a scan of another one. Never let that obsolete result repopulate
-      // or replace the catalog chosen by the newer action.
-      if (generation != _catalogGeneration) return;
-      final repository = ref.read(musicLibraryRepositoryProvider);
-      await repository.upsertCatalog(
-        sourceId: source.id,
-        tracks: scan.tracks,
-        albums: groupAlbums(scan.tracks),
-        artists: groupArtists(scan.tracks),
-      );
-      ref.read(localScanReportProvider.notifier).record(scan.report);
-      await _load();
+      if (generation != _scanGeneration) return null;
+
+      return await _serializeLocalMutation<LocalScanReport?>(() async {
+        // Check at commit time, not merely when the filesystem walk finishes.
+        if (generation != _scanGeneration) return null;
+        final repository = ref.read(musicLibraryRepositoryProvider);
+        await repository.upsertCatalog(
+          sourceId: source.id,
+          tracks: scan.tracks,
+          albums: groupAlbums(scan.tracks),
+          artists: groupArtists(scan.tracks),
+        );
+        // A newer action may have started while the write was awaiting I/O.
+        // Its queued write will run after this one; do not publish stale status.
+        if (generation != _scanGeneration) return null;
+        ref.read(localScanReportProvider.notifier).record(scan.report);
+        await _load();
+        return generation == _scanGeneration ? scan.report : null;
+      });
     } on FolderScanException catch (error) {
-      if (generation != _catalogGeneration) return;
-      ref.read(localScanReportProvider.notifier).record(
-            LocalScanReport.failure(
-              folderSelected: folderPath.isNotEmpty,
-              isContentUri: location.isContentUri,
-              isDeviceLibrary: location.isAndroidMediaStore,
-              error: location.isAndroidMediaStore
-                  ? error.code == 'permission_denied'
-                      ? LocalScanError.mediaPermission
-                      : LocalScanError.unexpected
-                  : location.isContentUri
-                      ? LocalScanError.safTraversal
-                      : LocalScanError.folderUnavailable,
-            ),
-          );
+      if (generation != _scanGeneration) return null;
+      final report = LocalScanReport.failure(
+        folderSelected: folderPath.isNotEmpty,
+        isContentUri: location.isContentUri,
+        isDeviceLibrary: location.isAndroidMediaStore,
+        error: location.isAndroidMediaStore
+            ? error.code == 'permission_denied'
+                ? LocalScanError.mediaPermission
+                : LocalScanError.unexpected
+            : location.isContentUri
+                ? LocalScanError.safTraversal
+                : LocalScanError.folderUnavailable,
+      );
+      ref.read(localScanReportProvider.notifier).record(report);
+      _loadGeneration++;
       state = LibraryState.error(error.message);
+      return report;
     } catch (_) {
-      if (generation != _catalogGeneration) return;
-      ref.read(localScanReportProvider.notifier).record(
-            LocalScanReport.failure(
-              folderSelected: folderPath.isNotEmpty,
-              isContentUri: location.isContentUri,
-              isDeviceLibrary: location.isAndroidMediaStore,
-              error: LocalScanError.unexpected,
-            ),
-          );
+      if (generation != _scanGeneration) return null;
+      final report = LocalScanReport.failure(
+        folderSelected: folderPath.isNotEmpty,
+        isContentUri: location.isContentUri,
+        isDeviceLibrary: location.isAndroidMediaStore,
+        error: LocalScanError.unexpected,
+      );
+      ref.read(localScanReportProvider.notifier).record(report);
+      _loadGeneration++;
       state = const LibraryState.error(_scanFailedMessage);
+      return report;
     }
   }
 
@@ -94,13 +149,18 @@ class LibraryController extends Notifier<LibraryState> {
       'folder.';
 
   Future<void> _load() async {
+    final int generation = ++_loadGeneration;
     state = const LibraryState.loading();
     try {
       final tracks =
           await ref.read(musicLibraryRepositoryProvider).getAllTracks();
-      state = LibraryState.loaded(tracks);
+      if (generation == _loadGeneration) {
+        state = LibraryState.loaded(tracks);
+      }
     } catch (_) {
-      state = const LibraryState.error(_loadFailedMessage);
+      if (generation == _loadGeneration) {
+        state = const LibraryState.error(_loadFailedMessage);
+      }
     }
   }
 }

--- a/lib/features/library/selected_folder_controller.dart
+++ b/lib/features/library/selected_folder_controller.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../data/repositories/selected_music_folder_repository_provider.dart';
+import 'library_controller.dart';
 import 'library_providers.dart';
 
 /// Owns the user's chosen local-music location: a folder path/SAF URI, or an
@@ -25,6 +26,10 @@ class SelectedFolderController extends AsyncNotifier<String?> {
   /// Used by Android's explicit device-wide MediaStore mode.
   Future<void> setAndPersist(String location) async {
     if (location.isEmpty) return;
+    // A source change supersedes pending scans before persistence can yield.
+    final library = ref.read(libraryControllerProvider.notifier);
+    library.invalidatePendingScans();
+    await library.waitForLocalMutations();
     await ref
         .read(selectedMusicFolderRepositoryProvider)
         .setSelectedFolder(location);
@@ -33,6 +38,9 @@ class SelectedFolderController extends AsyncNotifier<String?> {
 
   /// Forgets the current selection.
   Future<void> clear() async {
+    final library = ref.read(libraryControllerProvider.notifier);
+    library.invalidatePendingScans();
+    await library.waitForLocalMutations();
     await ref.read(selectedMusicFolderRepositoryProvider).clearSelectedFolder();
     state = const AsyncData<String?>(null);
   }

--- a/lib/features/settings/source/local_music_controller.dart
+++ b/lib/features/settings/source/local_music_controller.dart
@@ -2,10 +2,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/sources/local/android_media_library.dart';
 import '../../../core/sources/local/folder_location.dart';
-import '../../../core/sources/local/local_music_source.dart';
 import '../../../core/sources/local/local_scan_report.dart';
 import '../../../data/repositories/host_platform_provider.dart';
-import '../../../data/repositories/music_library_repository_provider.dart';
 import '../../library/library_controller.dart';
 import '../../library/library_providers.dart';
 import '../../library/local_scan_report_provider.dart';
@@ -106,16 +104,14 @@ class LocalMusicController extends Notifier<LocalMusicActionState> {
   }
 
   Future<void> forget() async {
+    final library = ref.read(libraryControllerProvider.notifier);
+    // Invalidate immediately, before the first await. The selection controller
+    // also invalidates source changes, and clearLocalCatalog serializes the
+    // actual clear after any already-started local catalog write.
+    library.invalidatePendingScans();
     state = const LocalMusicActionState(busy: true);
     await ref.read(selectedFolderControllerProvider.notifier).clear();
-    await ref.read(musicLibraryRepositoryProvider).upsertCatalog(
-      sourceId: const LocalMusicSource(folderPath: null).id,
-      tracks: const [],
-      albums: const [],
-      artists: const [],
-    );
-    ref.read(localScanReportProvider.notifier).clear();
-    await ref.read(libraryControllerProvider.notifier).refresh();
+    await library.clearLocalCatalog();
     state = const LocalMusicActionState(
       message: 'Local music forgotten. Your files were not deleted.',
     );
@@ -124,8 +120,11 @@ class LocalMusicController extends Notifier<LocalMusicActionState> {
   /// Scans [folder], turns the resulting report into the card's status line,
   /// and hands the report back so a caller can act on the outcome.
   Future<LocalScanReport?> _scan(String folder) async {
-    await ref.read(libraryControllerProvider.notifier).scanFolder(folder);
-    final report = ref.read(localScanReportProvider);
+    // Use this operation's result, never the last globally recorded report:
+    // a superseded scan must not look successful or persist a source switch.
+    final report = await ref
+        .read(libraryControllerProvider.notifier)
+        .scanFolderWithReport(folder);
     final FolderLocation location = FolderLocation.parse(folder);
     if (report == null) {
       state = const LocalMusicActionState();

--- a/scripts/check_android_channel_threading.py
+++ b/scripts/check_android_channel_threading.py
@@ -3,8 +3,9 @@
 
 This is a narrow, offline source tripwire, not a Kotlin compiler or a proof of
 thread safety. It checks that the expensive walk is evaluated inside the work
-lambda submitted to the real background worker, and that result encoding stays
-on that worker. A token appearing somewhere in the same method is not enough.
+lambda submitted to the real background worker, that result encoding stays on
+that worker, and that superseding a queued scan keeps working. A token appearing
+somewhere in the same method is not enough.
 
     python3 scripts/check_android_channel_threading.py
 """
@@ -30,7 +31,6 @@ KOTLIN = (
 )
 WORKER_FILE = "PlatformChannelWorker.kt"
 SCANNER_FILE = "SafDocumentScanner.kt"
-ACTIVITY_FILE = "MainActivity.kt"
 SCAN_METHOD = "listAudioDocuments"
 SCAN_WORK = "walk"
 
@@ -233,38 +233,65 @@ def check_scanner(directory: Path, failures: list[str]) -> None:
         failures.append(f"{SCANNER_FILE}: expected exactly one worker submission")
 
 
-def check_scanner_is_shared(directory: Path, failures: list[str]) -> None:
-    """One scanner for the channel, so a new scan can cancel the one in flight.
+def companion_span(code: str) -> tuple[int, int] | None:
+    match = re.search(r"\bcompanion\s+object\s*\{", code)
+    if match is None:
+        return None
+    return balanced_span(code, match.end() - 1)
 
-    Constructing `SafDocumentScanner(...)` per request is the natural thing to
-    write and it silently disables cancellation: the fresh instance holds no
-    in-flight walk, so the superseded one keeps the shared worker thread and the
-    folder the user just picked waits it out. Nothing fails, nothing logs, the
-    scan simply takes as long as the one it replaced.
+
+def check_cancellation(directory: Path, failures: list[str]) -> None:
+    """Superseding a queued scan has to keep working, and it fails quietly.
+
+    Two ways to break it that both compile, pass every test, and read like a
+    tidy-up in review:
+
+    1. Moving `currentScan` out of the companion object onto the instance. It
+       looks like ordinary state, but the thread it frees is process-wide, so an
+       instance flag stops cancelling the moment the activity is recreated
+       mid-scan and the new scanner comes up holding nothing.
+    2. Dropping the `ScanSuperseded` rethrow from the walk's per-folder catch.
+       Cancellation is then counted as one unreadable subtree, the walk finishes
+       and answers a partial success, and the replacement scan keeps waiting.
+
+    Neither logs anything. The scan just takes as long as the one it replaced.
     """
-    source = code_only(read(directory, ACTIVITY_FILE, failures))
+    source = code_only(read(directory, SCANNER_FILE, failures))
     if not source:
         return
 
-    constructions = occurrences(source, rf"\b{re.escape(SCANNER_FILE[:-3])}\s*\(")
-    if len(constructions) != 1:
+    flag = occurrences(source, r"\bval\s+currentScan\b")
+    if not flag:
+        failures.append(f"{SCANNER_FILE}: no currentScan flag to supersede a walk")
+        return
+    companion = companion_span(source)
+    if companion is None or outside(flag, companion):
         failures.append(
-            f"{ACTIVITY_FILE}: expected exactly one SafDocumentScanner construction, "
-            f"found {len(constructions)} — a scanner built per request has no "
-            "in-flight walk to cancel (#346)"
+            f"{SCANNER_FILE}: currentScan must live in the companion object, "
+            "process-scoped like the worker thread it frees. An activity "
+            "recreated mid-scan otherwise brings up a scanner with an empty flag "
+            "and nothing to cancel (#346)"
         )
+
+    walk = function_span(source, SCAN_WORK)
+    if walk is None:
+        failures.append(f"{SCANNER_FILE}: no {SCAN_WORK}() to check")
+        return
+    body = source[walk[0] : walk[1]]
+    if not occurrences(body, r"\bthrow\s+ScanSuperseded\s*\("):
+        failures.append(f"{SCANNER_FILE}: {SCAN_WORK}() never acts on cancellation")
         return
 
-    # The single construction has to be the stored one, not a call site that
-    # happens to be alone today.
-    if not re.search(
-        r"\bval\s+\w+\s+by\s+lazy\s*\{[^}]*SafDocumentScanner\s*\(",
-        source,
-        re.DOTALL,
+    # The rethrow has to come before the catch-all, or Kotlin never reaches it.
+    superseded = re.search(r"\bcatch\s*\(\s*\w+\s*:\s*ScanSuperseded\s*\)", body)
+    catch_all = re.search(r"\bcatch\s*\(\s*\w+\s*:\s*Exception\s*\)", body)
+    if catch_all is not None and (
+        superseded is None or superseded.start() > catch_all.start()
     ):
         failures.append(
-            f"{ACTIVITY_FILE}: the SafDocumentScanner must be held for the "
-            "activity (a `by lazy` property), not built at a call site"
+            f"{SCANNER_FILE}: {SCAN_WORK}() must rethrow ScanSuperseded before its "
+            "catch-all, or a superseded scan is counted as an unreadable subtree "
+            "and answers a partial success instead (#346)"
         )
 
 
@@ -272,7 +299,7 @@ def check(directory: Path) -> list[str]:
     failures: list[str] = []
     check_worker(directory, failures)
     check_scanner(directory, failures)
-    check_scanner_is_shared(directory, failures)
+    check_cancellation(directory, failures)
     return failures
 
 

--- a/scripts/check_android_channel_threading.py
+++ b/scripts/check_android_channel_threading.py
@@ -159,6 +159,18 @@ def outside(positions: list[int], span: tuple[int, int]) -> bool:
     return any(not (span[0] <= position < span[1]) for position in positions)
 
 
+def within(positions: list[int], span: tuple[int, int]) -> bool:
+    return any(span[0] <= position < span[1] for position in positions)
+
+
+# Ways to hand a lambda to some other thread. Nesting a callback in one of
+# these inside the background task puts the reply back where it started.
+REDISPATCH = (
+    r"\b(?:\w+\s*\.\s*(?:execute|post|postDelayed|postAtTime|submit|schedule)"
+    r"|runOnUiThread|runBlocking)\s*\{"
+)
+
+
 def check_worker(directory: Path, failures: list[str]) -> None:
     source = code_only(read(directory, WORKER_FILE, failures))
     if not source:
@@ -192,7 +204,25 @@ def check_worker(directory: Path, failures: list[str]) -> None:
                 f"{WORKER_FILE}: callbacks must stay inside the background executor "
                 "so MethodChannel encoding cannot stall the platform thread"
             )
-            break
+            return
+
+    # Lexically inside the task is not the same as running on its thread. Handing
+    # a callback to another executor or to the main looper reads like a careful
+    # fix ("replies belong on the platform thread") and puts the codec's
+    # success-envelope encoding of a whole library back where it started.
+    inner = body[task[0] : task[1]]
+    for match in re.finditer(REDISPATCH, inner):
+        nested = balanced_span(inner, match.end() - 1)
+        if nested is None:
+            continue
+        for callback in ("onSuccess", "onFailure"):
+            if within(occurrences(inner, rf"\b{callback}\s*\("), nested):
+                failures.append(
+                    f"{WORKER_FILE}: {callback}() is dispatched to another thread "
+                    "from inside the background task. The reply must be encoded on "
+                    "the worker, not handed back to the platform thread (#346)"
+                )
+                return
 
 
 def check_scanner(directory: Path, failures: list[str]) -> None:
@@ -240,6 +270,50 @@ def companion_span(code: str) -> tuple[int, int] | None:
     return balanced_span(code, match.end() - 1)
 
 
+def check_supersede_handoff(source: str, failures: list[str]) -> None:
+    """The flag only supersedes if the scan actually swaps and trips it.
+
+    Declaring `currentScan` proves nothing on its own: drop the one-line
+    `getAndSet(...)?.set(true)` from the scan and every walk keeps an unset flag,
+    so a replacement queues behind the obsolete one exactly as before. Require
+    the swap, the trip of what it replaced, and that the new flag reaches the
+    submitted walk.
+    """
+    span = function_span(source, SCAN_METHOD)
+    if span is None:
+        return
+    body = source[span[0] : span[1]]
+
+    swap = re.search(r"\bcurrentScan\s*\.\s*getAndSet\s*\(", body)
+    arguments = None if swap is None else balanced_span(body, swap.end() - 1)
+    if arguments is None:
+        failures.append(
+            f"{SCANNER_FILE}: {SCAN_METHOD}() must swap the new flag into "
+            "currentScan, or nothing is ever superseded (#346)"
+        )
+        return
+    if not re.match(r"\s*\??\s*\.\s*set\s*\(\s*true\s*\)", body[arguments[1] + 1 :]):
+        failures.append(
+            f"{SCANNER_FILE}: the walk currentScan.getAndSet() replaced must be "
+            "tripped right there (`?.set(true)`), or the superseded scan runs on"
+        )
+
+    # The flag that was swapped in has to be the one the walk watches.
+    flag = body[arguments[0] : arguments[1]].strip()
+    if re.fullmatch(r"\w+", flag):
+        submit = call_span(body, "worker.submit")
+        work = (
+            None if submit is None else lambda_span(body[submit[0] : submit[1]], "work")
+        )
+        if submit is not None and work is not None:
+            work_in_body = (submit[0] + work[0], submit[0] + work[1])
+            if not within(occurrences(body, rf"\b{re.escape(flag)}\b"), work_in_body):
+                failures.append(
+                    f"{SCANNER_FILE}: the flag swapped into currentScan never "
+                    "reaches the submitted walk, so setting it cancels nothing"
+                )
+
+
 def check_cancellation(directory: Path, failures: list[str]) -> None:
     """Superseding a queued scan has to keep working, and it fails quietly.
 
@@ -273,14 +347,33 @@ def check_cancellation(directory: Path, failures: list[str]) -> None:
             "and nothing to cancel (#346)"
         )
 
+    check_supersede_handoff(source, failures)
+
     walk = function_span(source, SCAN_WORK)
     if walk is None:
         failures.append(f"{SCANNER_FILE}: no {SCAN_WORK}() to check")
         return
     body = source[walk[0] : walk[1]]
-    if not occurrences(body, r"\bthrow\s+ScanSuperseded\s*\("):
+    throws = occurrences(body, r"\bthrow\s+ScanSuperseded\s*\(")
+    if not throws:
         failures.append(f"{SCANNER_FILE}: {SCAN_WORK}() never acts on cancellation")
         return
+
+    # A folder-boundary check alone is not cancellation for the common library
+    # shape: one flat Music folder is a single outer iteration whose cursor loop
+    # opens a MediaMetadataRetriever per track. Deleting the per-entry check
+    # leaves the outer one in place and looks like it still works.
+    loop = re.search(r"\bwhile\s*\(\s*\w+\s*\.\s*moveToNext\s*\(\s*\)\s*\)\s*\{", body)
+    if loop is None:
+        failures.append(f"{SCANNER_FILE}: no cursor loop in {SCAN_WORK}() to check")
+    else:
+        cursor = balanced_span(body, loop.end() - 1)
+        if cursor is None or not within(throws, cursor):
+            failures.append(
+                f"{SCANNER_FILE}: {SCAN_WORK}() must check cancellation inside the "
+                "cursor loop, not only per folder. A flat Music folder is one "
+                "outer iteration and would otherwise run to completion (#346)"
+            )
 
     # The rethrow has to come before the catch-all, or Kotlin never reaches it.
     superseded = re.search(r"\bcatch\s*\(\s*\w+\s*:\s*ScanSuperseded\s*\)", body)

--- a/scripts/check_android_channel_threading.py
+++ b/scripts/check_android_channel_threading.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""check_android_channel_threading.py — keep the SAF scan off the main thread.
+
+Flutter calls a `MethodChannel` handler on Android's platform (main) thread, and
+`MethodChannel.Result` has to be answered there too. That pairing makes it very
+easy to write a handler that quietly blocks the UI: the code reads like ordinary
+straight-line Kotlin, it compiles, and on the developer's twelve-track test
+folder it returns instantly. It only hurts on a real library, on a slow
+provider, or on an SD card — where it becomes an ANR (#346).
+
+Nothing in the build catches that. Lint has no opinion about how long a channel
+handler runs, and a regression would look like a simplification: delete the
+worker, call `walk()` directly, tests still pass. So the boundary is asserted
+here instead.
+
+Three things have to hold, and each is checked against the sources rather than
+duplicated:
+
+    the worker exists          <- PlatformChannelWorker.kt runs work on an
+                                  Executor and posts replies to the main looper
+    the scan uses it           <- SafDocumentScanner.listAudioDocuments submits
+                                  the walk instead of running it inline
+    nothing answers inline     <- listAudioDocuments contains no direct
+                                  result.success(walk(...)) call
+
+The last one is the shape the bug had before the fix, so it is worth naming
+explicitly rather than inferring from the other two.
+
+This is deliberately a text check, not a parse: it has to run anywhere (no
+Android SDK, no Gradle, no network), the same way check_linux_runner.py does for
+the desktop runner. It is not a substitute for reading the code — it is a
+tripwire for the specific silent regression.
+
+    python3 scripts/check_android_channel_threading.py
+
+Exits 0 when every claim holds, 1 with the failures listed otherwise.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+KOTLIN = (
+    ROOT
+    / "android"
+    / "app"
+    / "src"
+    / "main"
+    / "kotlin"
+    / "io"
+    / "github"
+    / "thezupzup"
+    / "linthra"
+)
+
+WORKER_FILE = "PlatformChannelWorker.kt"
+SCANNER_FILE = "SafDocumentScanner.kt"
+
+# The channel method whose work is heavy enough to matter, and the private
+# function that does that work.
+SCAN_METHOD = "listAudioDocuments"
+SCAN_WORK = "walk"
+
+
+def read(directory: Path, name: str, failures: list[str]) -> str:
+    """Returns the text of ``directory/name``, or "" (recording why) if absent."""
+    path = directory / name
+    if not path.is_file():
+        failures.append(f"{name}: missing (expected at {path})")
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def strip_comments(source: str) -> str:
+    """Drops // and /* */ comments so a mention in prose is never a match.
+
+    Every claim below is about code that runs. KDoc on these files talks about
+    `walk`, `result.success` and the main thread by name, so checking the raw
+    text would pass on a file whose comments still describe a fix its code no
+    longer has.
+    """
+    source = re.sub(r"/\*.*?\*/", "", source, flags=re.DOTALL)
+    return re.sub(r"//[^\n]*", "", source)
+
+
+def function_body(source: str, name: str) -> str | None:
+    """Returns the brace-balanced body of ``fun name(...)``, or None.
+
+    Tolerates a type-parameter list (``fun <T> submit(``), which the worker has.
+    """
+    match = re.search(rf"\bfun\s+(?:<[^>]*>\s*)?{re.escape(name)}\s*\(", source)
+    if match is None:
+        return None
+    opening = source.find("{", match.end())
+    if opening == -1:
+        return None
+    depth = 0
+    for index in range(opening, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening + 1 : index]
+    return None
+
+
+def check_worker(directory: Path, failures: list[str]) -> None:
+    """The worker really moves work off the caller and back to the main looper."""
+    source = strip_comments(read(directory, WORKER_FILE, failures))
+    if not source:
+        return
+
+    if "java.util.concurrent.Executor" not in source:
+        failures.append(
+            f"{WORKER_FILE}: no Executor import — work has to leave the caller's "
+            "thread on something"
+        )
+    if "Looper.getMainLooper()" not in source or "handler.post(" not in source:
+        failures.append(
+            f"{WORKER_FILE}: replies are not posted to the main looper "
+            "(Handler(Looper.getMainLooper()) + post), which Flutter requires "
+            "for MethodChannel.Result"
+        )
+
+    body = function_body(source, "submit")
+    if body is None:
+        failures.append(f"{WORKER_FILE}: no submit() to hand work to")
+        return
+    if "background.execute" not in body:
+        failures.append(
+            f"{WORKER_FILE}: submit() does not run its work on the background executor"
+        )
+    if "platform.execute" not in body:
+        failures.append(
+            f"{WORKER_FILE}: submit() does not deliver its callbacks on the "
+            "platform executor"
+        )
+
+
+def check_scanner(directory: Path, failures: list[str]) -> None:
+    """The scan is submitted to the worker, and never answered inline."""
+    source = strip_comments(read(directory, SCANNER_FILE, failures))
+    if not source:
+        return
+
+    if "PlatformChannelWorker" not in source:
+        failures.append(
+            f"{SCANNER_FILE}: does not use PlatformChannelWorker, so the walk "
+            "runs on whichever thread calls it"
+        )
+
+    body = function_body(source, SCAN_METHOD)
+    if body is None:
+        failures.append(f"{SCANNER_FILE}: no {SCAN_METHOD}() to check")
+        return
+
+    if "worker.submit(" not in body:
+        failures.append(
+            f"{SCANNER_FILE}: {SCAN_METHOD}() does not submit its work to the "
+            "worker — the walk is back on the platform thread (#346)"
+        )
+
+    # The pre-fix shape: the whole walk evaluated as the argument to a reply,
+    # i.e. on the caller's thread. Whitespace-tolerant so reformatting the call
+    # does not hide it.
+    inline = re.compile(
+        rf"result\s*\.\s*success\s*\(\s*{re.escape(SCAN_WORK)}\s*\(",
+        re.DOTALL,
+    )
+    if inline.search(body):
+        failures.append(
+            f"{SCANNER_FILE}: {SCAN_METHOD}() answers with {SCAN_WORK}() inline, "
+            "which runs the whole library walk on the platform thread (#346)"
+        )
+
+
+def check(directory: Path) -> list[str]:
+    """Runs every claim against the Kotlin in [directory]. Empty list = passing."""
+    failures: list[str] = []
+    check_worker(directory, failures)
+    check_scanner(directory, failures)
+    return failures
+
+
+def main() -> int:
+    failures = check(KOTLIN)
+    if failures:
+        print("Android channel threading check FAILED:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+    print("Android channel threading check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_android_channel_threading.py
+++ b/scripts/check_android_channel_threading.py
@@ -31,6 +31,7 @@ KOTLIN = (
 )
 WORKER_FILE = "PlatformChannelWorker.kt"
 SCANNER_FILE = "SafDocumentScanner.kt"
+ACTIVITY_FILE = "MainActivity.kt"
 SCAN_METHOD = "listAudioDocuments"
 CANCEL_METHOD = "cancelScan"
 SCAN_WORK = "walk"
@@ -44,12 +45,16 @@ def read(directory: Path, name: str, failures: list[str]) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def code_only(source: str) -> str:
-    """Mask comments and Kotlin string/char literals, retaining offsets.
+def code_only(source: str, mask_strings: bool = True) -> str:
+    """Mask comments and (by default) Kotlin string/char literals, keeping offsets.
 
     Braces, parentheses and fake calls inside prose must not affect nesting.
     Kotlin block comments can nest, and triple-quoted strings can contain both
     quotes and braces. This intentionally does not try to parse Kotlin syntax.
+
+    Pass mask_strings=False when the literal itself is the thing being checked,
+    such as a `when` arm's method name. Strings are still scanned past either
+    way, so a `//` inside one never opens a comment.
     """
     result = list(source)
     i = 0
@@ -82,7 +87,8 @@ def code_only(source: str) -> str:
         elif source.startswith('"""', i):
             end = source.find('"""', i + 3)
             i = n if end < 0 else end + 3
-            mask(start, i)
+            if mask_strings:
+                mask(start, i)
         elif source[i] in ('"', "'"):
             quote = source[i]
             i += 1
@@ -95,7 +101,8 @@ def code_only(source: str) -> str:
                 else:
                     i += 1
             i = min(i, n)
-            mask(start, i)
+            if mask_strings:
+                mask(start, i)
         else:
             i += 1
     return "".join(result)
@@ -299,20 +306,27 @@ def check_supersede_handoff(source: str, failures: list[str]) -> None:
             "tripped right there (`?.set(true)`), or the superseded scan runs on"
         )
 
-    # The flag that was swapped in has to be the one the walk watches.
+    # The flag that was swapped in has to be the one the walk watches. Anything
+    # but a named local is rejected rather than skipped: swapping a fresh
+    # `AtomicBoolean(false)` in reads fine and leaves the walk watching a flag
+    # nothing holds a reference to, which is unverifiable here and wrong anyway.
     flag = body[arguments[0] : arguments[1]].strip()
-    if re.fullmatch(r"\w+", flag):
-        submit = call_span(body, "worker.submit")
-        work = (
-            None if submit is None else lambda_span(body[submit[0] : submit[1]], "work")
+    if not re.fullmatch(r"\w+", flag):
+        failures.append(
+            f"{SCANNER_FILE}: currentScan must be handed the named flag this "
+            f"scan passes to the walk, not `{flag}`. Anything else leaves the "
+            "walk watching a flag no later scan can reach (#346)"
         )
-        if submit is not None and work is not None:
-            work_in_body = (submit[0] + work[0], submit[0] + work[1])
-            if not within(occurrences(body, rf"\b{re.escape(flag)}\b"), work_in_body):
-                failures.append(
-                    f"{SCANNER_FILE}: the flag swapped into currentScan never "
-                    "reaches the submitted walk, so setting it cancels nothing"
-                )
+        return
+    submit = call_span(body, "worker.submit")
+    work = None if submit is None else lambda_span(body[submit[0] : submit[1]], "work")
+    if submit is not None and work is not None:
+        work_in_body = (submit[0] + work[0], submit[0] + work[1])
+        if not within(occurrences(body, rf"\b{re.escape(flag)}\b"), work_in_body):
+            failures.append(
+                f"{SCANNER_FILE}: the flag swapped into currentScan never "
+                "reaches the submitted walk, so setting it cancels nothing"
+            )
 
 
 def check_cancellation(directory: Path, failures: list[str]) -> None:
@@ -370,6 +384,8 @@ def check_cancellation(directory: Path, failures: list[str]) -> None:
             "through currentScan, or it cancels nothing"
         )
 
+    check_cancel_is_reachable(directory, failures)
+
     walk = function_span(source, SCAN_WORK)
     if walk is None:
         failures.append(f"{SCANNER_FILE}: no {SCAN_WORK}() to check")
@@ -406,6 +422,40 @@ def check_cancellation(directory: Path, failures: list[str]) -> None:
             f"{SCANNER_FILE}: {SCAN_WORK}() must rethrow ScanSuperseded before its "
             "catch-all, or a superseded scan is counted as an unreadable subtree "
             "and answers a partial success instead (#346)"
+        )
+
+
+def check_cancel_is_reachable(directory: Path, failures: list[str]) -> None:
+    """A cancel the channel does not route to is a cancel that never runs.
+
+    Dart calls `cancelScan` on the SAF channel. Drop that branch from the
+    handler and the call falls to `notImplemented`, which Dart receives as a
+    MissingPluginException and deliberately swallows (an older native build is
+    a supported case). So nothing throws, nothing logs, and abandoned walks
+    quietly run to completion again.
+    """
+    # Comments masked, string literals kept: the branch label is a literal.
+    source = code_only(read(directory, ACTIVITY_FILE, failures), mask_strings=False)
+    if not source:
+        return
+
+    branch = re.search(rf'"{CANCEL_METHOD}"\s*->', source)
+    if branch is None:
+        failures.append(
+            f'{ACTIVITY_FILE}: the SAF channel does not route "{CANCEL_METHOD}", '
+            "so Dart gets notImplemented and the walk is never cancelled (#346)"
+        )
+        return
+
+    # It has to reach the scanner, not just exist. The branch body is the rest
+    # of the `when` arm, so bound the search at the next arm.
+    rest = source[branch.end() :]
+    end = re.search(r'^\s*(?:"[^"]*"|else)\s*->', rest, re.MULTILINE)
+    arm = rest[: end.start()] if end else rest
+    if not re.search(rf"\.\s*{CANCEL_METHOD}\s*\(", arm):
+        failures.append(
+            f'{ACTIVITY_FILE}: the "{CANCEL_METHOD}" branch must call '
+            f"{CANCEL_METHOD}() on the scanner"
         )
 
 

--- a/scripts/check_android_channel_threading.py
+++ b/scripts/check_android_channel_threading.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""check_android_channel_threading.py — keep the SAF scan off the main thread.
+
+Flutter calls a `MethodChannel` handler on Android's platform (main) thread. It
+is therefore easy to write a handler that quietly blocks the UI: the code reads like ordinary
+straight-line Kotlin, it compiles, and on the developer's twelve-track test
+folder it returns instantly. It only hurts on a real library, on a slow
+provider, or on an SD card — where it becomes an ANR (#346).
+
+Nothing in the build catches that. Lint has no opinion about how long a channel
+handler runs, and a regression would look like a simplification: delete the
+worker, call `walk()` directly, tests still pass. So the boundary is asserted
+here instead.
+
+Three things have to hold, and each is checked against the sources rather than
+duplicated:
+
+    the worker exists          <- PlatformChannelWorker.kt runs the work and
+                                  callbacks inside an Executor task
+    the scan uses it           <- SafDocumentScanner.listAudioDocuments submits
+                                  the walk instead of running it inline
+    nothing answers inline     <- listAudioDocuments contains no direct
+                                  result.success(walk(...)) call
+
+The last one is the shape the bug had before the fix, so it is worth naming
+explicitly rather than inferring from the other two.
+
+This is deliberately a text check, not a parse: it has to run anywhere (no
+Android SDK, no Gradle, no network), the same way check_linux_runner.py does for
+the desktop runner. It is not a substitute for reading the code — it is a
+tripwire for the specific silent regression.
+
+    python3 scripts/check_android_channel_threading.py
+
+Exits 0 when every claim holds, 1 with the failures listed otherwise.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+KOTLIN = (
+    ROOT
+    / "android"
+    / "app"
+    / "src"
+    / "main"
+    / "kotlin"
+    / "io"
+    / "github"
+    / "thezupzup"
+    / "linthra"
+)
+
+WORKER_FILE = "PlatformChannelWorker.kt"
+SCANNER_FILE = "SafDocumentScanner.kt"
+
+# The channel method whose work is heavy enough to matter, and the private
+# function that does that work.
+SCAN_METHOD = "listAudioDocuments"
+SCAN_WORK = "walk"
+
+
+def read(directory: Path, name: str, failures: list[str]) -> str:
+    """Returns the text of ``directory/name``, or "" (recording why) if absent."""
+    path = directory / name
+    if not path.is_file():
+        failures.append(f"{name}: missing (expected at {path})")
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def strip_comments(source: str) -> str:
+    """Drops // and /* */ comments so a mention in prose is never a match.
+
+    Every claim below is about code that runs. KDoc on these files talks about
+    `walk`, `result.success` and the main thread by name, so checking the raw
+    text would pass on a file whose comments still describe a fix its code no
+    longer has.
+    """
+    source = re.sub(r"/\*.*?\*/", "", source, flags=re.DOTALL)
+    return re.sub(r"//[^\n]*", "", source)
+
+
+def function_body(source: str, name: str) -> str | None:
+    """Returns the brace-balanced body of ``fun name(...)``, or None.
+
+    Tolerates a type-parameter list (``fun <T> submit(``), which the worker has.
+    """
+    match = re.search(rf"\bfun\s+(?:<[^>]*>\s*)?{re.escape(name)}\s*\(", source)
+    if match is None:
+        return None
+    opening = source.find("{", match.end())
+    if opening == -1:
+        return None
+    depth = 0
+    for index in range(opening, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening + 1 : index]
+    return None
+
+
+def trailing_lambda_body(source: str, call: str) -> str | None:
+    """Returns the brace-balanced trailing lambda passed to ``call``."""
+    match = re.search(rf"\b{re.escape(call)}\s*\{{", source)
+    if match is None:
+        return None
+    opening = source.find("{", match.start())
+    depth = 0
+    for index in range(opening, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening + 1 : index]
+    return None
+
+
+def check_worker(directory: Path, failures: list[str]) -> None:
+    """The worker really evaluates work and callbacks off the caller thread."""
+    source = strip_comments(read(directory, WORKER_FILE, failures))
+    if not source:
+        return
+
+    if "java.util.concurrent.Executor" not in source:
+        failures.append(
+            f"{WORKER_FILE}: no Executor import — work has to leave the caller's "
+            "thread on something"
+        )
+    body = function_body(source, "submit")
+    if body is None:
+        failures.append(f"{WORKER_FILE}: no submit() to hand work to")
+        return
+    task = trailing_lambda_body(body, "background.execute")
+    if task is None:
+        failures.append(
+            f"{WORKER_FILE}: submit() does not run its work on the background executor"
+        )
+        return
+    if not re.search(r"\bwork\s*\(\s*\)", task):
+        failures.append(
+            f"{WORKER_FILE}: work() is evaluated outside the background executor"
+        )
+    if not re.search(r"\bonSuccess\s*\(", task) or not re.search(
+        r"\bonFailure\s*\(", task
+    ):
+        failures.append(
+            f"{WORKER_FILE}: callbacks must stay inside the background executor "
+            "so MethodChannel encoding cannot stall the platform thread"
+        )
+
+
+def check_scanner(directory: Path, failures: list[str]) -> None:
+    """The scan is submitted to the worker, and never answered inline."""
+    source = strip_comments(read(directory, SCANNER_FILE, failures))
+    if not source:
+        return
+
+    if "PlatformChannelWorker" not in source:
+        failures.append(
+            f"{SCANNER_FILE}: does not use PlatformChannelWorker, so the walk "
+            "runs on whichever thread calls it"
+        )
+
+    body = function_body(source, SCAN_METHOD)
+    if body is None:
+        failures.append(f"{SCANNER_FILE}: no {SCAN_METHOD}() to check")
+        return
+
+    if "worker.submit(" not in body:
+        failures.append(
+            f"{SCANNER_FILE}: {SCAN_METHOD}() does not submit its work to the "
+            "worker — the walk is back on the platform thread (#346)"
+        )
+
+    # The pre-fix shape: the whole walk evaluated as the argument to a reply,
+    # i.e. on the caller's thread. Whitespace-tolerant so reformatting the call
+    # does not hide it.
+    inline = re.compile(
+        rf"result\s*\.\s*success\s*\(\s*{re.escape(SCAN_WORK)}\s*\(",
+        re.DOTALL,
+    )
+    if inline.search(body):
+        failures.append(
+            f"{SCANNER_FILE}: {SCAN_METHOD}() answers with {SCAN_WORK}() inline, "
+            "which runs the whole library walk on the platform thread (#346)"
+        )
+
+
+def check(directory: Path) -> list[str]:
+    """Runs every claim against the Kotlin in [directory]. Empty list = passing."""
+    failures: list[str] = []
+    check_worker(directory, failures)
+    check_scanner(directory, failures)
+    return failures
+
+
+def main() -> int:
+    failures = check(KOTLIN)
+    if failures:
+        print("Android channel threading check FAILED:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+    print("Android channel threading check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_android_channel_threading.py
+++ b/scripts/check_android_channel_threading.py
@@ -30,6 +30,7 @@ KOTLIN = (
 )
 WORKER_FILE = "PlatformChannelWorker.kt"
 SCANNER_FILE = "SafDocumentScanner.kt"
+ACTIVITY_FILE = "MainActivity.kt"
 SCAN_METHOD = "listAudioDocuments"
 SCAN_WORK = "walk"
 
@@ -232,10 +233,46 @@ def check_scanner(directory: Path, failures: list[str]) -> None:
         failures.append(f"{SCANNER_FILE}: expected exactly one worker submission")
 
 
+def check_scanner_is_shared(directory: Path, failures: list[str]) -> None:
+    """One scanner for the channel, so a new scan can cancel the one in flight.
+
+    Constructing `SafDocumentScanner(...)` per request is the natural thing to
+    write and it silently disables cancellation: the fresh instance holds no
+    in-flight walk, so the superseded one keeps the shared worker thread and the
+    folder the user just picked waits it out. Nothing fails, nothing logs, the
+    scan simply takes as long as the one it replaced.
+    """
+    source = code_only(read(directory, ACTIVITY_FILE, failures))
+    if not source:
+        return
+
+    constructions = occurrences(source, rf"\b{re.escape(SCANNER_FILE[:-3])}\s*\(")
+    if len(constructions) != 1:
+        failures.append(
+            f"{ACTIVITY_FILE}: expected exactly one SafDocumentScanner construction, "
+            f"found {len(constructions)} — a scanner built per request has no "
+            "in-flight walk to cancel (#346)"
+        )
+        return
+
+    # The single construction has to be the stored one, not a call site that
+    # happens to be alone today.
+    if not re.search(
+        r"\bval\s+\w+\s+by\s+lazy\s*\{[^}]*SafDocumentScanner\s*\(",
+        source,
+        re.DOTALL,
+    ):
+        failures.append(
+            f"{ACTIVITY_FILE}: the SafDocumentScanner must be held for the "
+            "activity (a `by lazy` property), not built at a call site"
+        )
+
+
 def check(directory: Path) -> list[str]:
     failures: list[str] = []
     check_worker(directory, failures)
     check_scanner(directory, failures)
+    check_scanner_is_shared(directory, failures)
     return failures
 
 

--- a/scripts/check_android_channel_threading.py
+++ b/scripts/check_android_channel_threading.py
@@ -1,38 +1,12 @@
 #!/usr/bin/env python3
-"""check_android_channel_threading.py — keep the SAF scan off the main thread.
+"""Guard the SAF method-channel threading boundary (#346).
 
-Flutter calls a `MethodChannel` handler on Android's platform (main) thread. It
-is therefore easy to write a handler that quietly blocks the UI: the code reads like ordinary
-straight-line Kotlin, it compiles, and on the developer's twelve-track test
-folder it returns instantly. It only hurts on a real library, on a slow
-provider, or on an SD card — where it becomes an ANR (#346).
-
-Nothing in the build catches that. Lint has no opinion about how long a channel
-handler runs, and a regression would look like a simplification: delete the
-worker, call `walk()` directly, tests still pass. So the boundary is asserted
-here instead.
-
-Three things have to hold, and each is checked against the sources rather than
-duplicated:
-
-    the worker exists          <- PlatformChannelWorker.kt runs the work and
-                                  callbacks inside an Executor task
-    the scan uses it           <- SafDocumentScanner.listAudioDocuments submits
-                                  the walk instead of running it inline
-    nothing answers inline     <- listAudioDocuments contains no direct
-                                  result.success(walk(...)) call
-
-The last one is the shape the bug had before the fix, so it is worth naming
-explicitly rather than inferring from the other two.
-
-This is deliberately a text check, not a parse: it has to run anywhere (no
-Android SDK, no Gradle, no network), the same way check_linux_runner.py does for
-the desktop runner. It is not a substitute for reading the code — it is a
-tripwire for the specific silent regression.
+This is a narrow, offline source tripwire, not a Kotlin compiler or a proof of
+thread safety. It checks that the expensive walk is evaluated inside the work
+lambda submitted to the real background worker, and that result encoding stays
+on that worker. A token appearing somewhere in the same method is not enough.
 
     python3 scripts/check_android_channel_threading.py
-
-Exits 0 when every claim holds, 1 with the failures listed otherwise.
 """
 
 from __future__ import annotations
@@ -43,29 +17,16 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 KOTLIN = (
-    ROOT
-    / "android"
-    / "app"
-    / "src"
-    / "main"
-    / "kotlin"
-    / "io"
-    / "github"
-    / "thezupzup"
-    / "linthra"
+    ROOT / "android" / "app" / "src" / "main" / "kotlin"
+    / "io" / "github" / "thezupzup" / "linthra"
 )
-
 WORKER_FILE = "PlatformChannelWorker.kt"
 SCANNER_FILE = "SafDocumentScanner.kt"
-
-# The channel method whose work is heavy enough to matter, and the private
-# function that does that work.
 SCAN_METHOD = "listAudioDocuments"
 SCAN_WORK = "walk"
 
 
 def read(directory: Path, name: str, failures: list[str]) -> str:
-    """Returns the text of ``directory/name``, or "" (recording why) if absent."""
     path = directory / name
     if not path.is_file():
         failures.append(f"{name}: missing (expected at {path})")
@@ -73,132 +34,191 @@ def read(directory: Path, name: str, failures: list[str]) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def strip_comments(source: str) -> str:
-    """Drops // and /* */ comments so a mention in prose is never a match.
+def code_only(source: str) -> str:
+    """Mask comments and Kotlin string/char literals, retaining offsets.
 
-    Every claim below is about code that runs. KDoc on these files talks about
-    `walk`, `result.success` and the main thread by name, so checking the raw
-    text would pass on a file whose comments still describe a fix its code no
-    longer has.
+    Braces, parentheses and fake calls inside prose must not affect nesting.
+    Kotlin block comments can nest, and triple-quoted strings can contain both
+    quotes and braces. This intentionally does not try to parse Kotlin syntax.
     """
-    source = re.sub(r"/\*.*?\*/", "", source, flags=re.DOTALL)
-    return re.sub(r"//[^\n]*", "", source)
+    result = list(source)
+    i = 0
+    n = len(source)
+
+    def mask(start: int, end: int) -> None:
+        for j in range(start, end):
+            if source[j] not in "\r\n":
+                result[j] = " "
+
+    while i < n:
+        start = i
+        if source.startswith("//", i):
+            end = source.find("\n", i)
+            i = n if end < 0 else end
+            mask(start, i)
+        elif source.startswith("/*", i):
+            depth = 1
+            i += 2
+            while i < n and depth:
+                if source.startswith("/*", i):
+                    depth += 1
+                    i += 2
+                elif source.startswith("*/", i):
+                    depth -= 1
+                    i += 2
+                else:
+                    i += 1
+            mask(start, i)
+        elif source.startswith('"""', i):
+            end = source.find('"""', i + 3)
+            i = n if end < 0 else end + 3
+            mask(start, i)
+        elif source[i] in ('"', "'"):
+            quote = source[i]
+            i += 1
+            while i < n:
+                if source[i] == "\\":
+                    i += 2
+                elif source[i] == quote:
+                    i += 1
+                    break
+                else:
+                    i += 1
+            i = min(i, n)
+            mask(start, i)
+        else:
+            i += 1
+    return "".join(result)
 
 
-def function_body(source: str, name: str) -> str | None:
-    """Returns the brace-balanced body of ``fun name(...)``, or None.
-
-    Tolerates a type-parameter list (``fun <T> submit(``), which the worker has.
-    """
-    match = re.search(rf"\bfun\s+(?:<[^>]*>\s*)?{re.escape(name)}\s*\(", source)
-    if match is None:
+def balanced_span(code: str, opening: int) -> tuple[int, int] | None:
+    """Return the inside of one balanced pair, using masked source offsets."""
+    pairs = {"{": "}", "(": ")"}
+    if opening >= len(code) or code[opening] not in pairs:
         return None
-    opening = source.find("{", match.end())
-    if opening == -1:
-        return None
-    depth = 0
-    for index in range(opening, len(source)):
-        char = source[index]
-        if char == "{":
-            depth += 1
-        elif char == "}":
-            depth -= 1
-            if depth == 0:
-                return source[opening + 1 : index]
+    stack = [pairs[code[opening]]]
+    for i in range(opening + 1, len(code)):
+        char = code[i]
+        if char in pairs:
+            stack.append(pairs[char])
+        elif stack and char == stack[-1]:
+            stack.pop()
+            if not stack:
+                return opening + 1, i
     return None
 
 
-def trailing_lambda_body(source: str, call: str) -> str | None:
-    """Returns the brace-balanced trailing lambda passed to ``call``."""
-    match = re.search(rf"\b{re.escape(call)}\s*\{{", source)
+def function_span(code: str, name: str) -> tuple[int, int] | None:
+    match = re.search(
+        rf"\bfun\s+(?:<[^>]*>\s*)?{re.escape(name)}\s*\(", code
+    )
     if match is None:
         return None
-    opening = source.find("{", match.start())
-    depth = 0
-    for index in range(opening, len(source)):
-        char = source[index]
-        if char == "{":
-            depth += 1
-        elif char == "}":
-            depth -= 1
-            if depth == 0:
-                return source[opening + 1 : index]
-    return None
+    parameters = balanced_span(code, match.end() - 1)
+    if parameters is None:
+        return None
+    opening = code.find("{", parameters[1] + 1)
+    return balanced_span(code, opening) if opening >= 0 else None
+
+
+def call_span(code: str, name: str) -> tuple[int, int] | None:
+    pattern = re.escape(name).replace(r"\.", r"\s*\.\s*")
+    match = re.search(rf"\b{pattern}\s*\(", code)
+    if match is None:
+        return None
+    return balanced_span(code, match.end() - 1)
+
+
+def lambda_span(code: str, name: str) -> tuple[int, int] | None:
+    match = re.search(rf"\b{re.escape(name)}\s*=\s*\{{", code)
+    if match is None:
+        return None
+    return balanced_span(code, match.end() - 1)
+
+
+def trailing_lambda_span(code: str, name: str) -> tuple[int, int] | None:
+    pattern = re.escape(name).replace(r"\.", r"\s*\.\s*")
+    match = re.search(rf"\b{pattern}\s*\{{", code)
+    if match is None:
+        return None
+    return balanced_span(code, match.end() - 1)
+
+
+def occurrences(code: str, pattern: str) -> list[int]:
+    return [match.start() for match in re.finditer(pattern, code)]
+
+
+def outside(positions: list[int], span: tuple[int, int]) -> bool:
+    return any(not (span[0] <= position < span[1]) for position in positions)
 
 
 def check_worker(directory: Path, failures: list[str]) -> None:
-    """The worker really evaluates work and callbacks off the caller thread."""
-    source = strip_comments(read(directory, WORKER_FILE, failures))
+    source = code_only(read(directory, WORKER_FILE, failures))
     if not source:
         return
-
     if "java.util.concurrent.Executor" not in source:
-        failures.append(
-            f"{WORKER_FILE}: no Executor import — work has to leave the caller's "
-            "thread on something"
-        )
-    body = function_body(source, "submit")
-    if body is None:
+        failures.append(f"{WORKER_FILE}: no Executor import")
+    if not re.search(r"background\s*:\s*Executor\s*=\s*SHARED_BACKGROUND", source):
+        failures.append(f"{WORKER_FILE}: production must use the background executor")
+    if not re.search(r"Executors\s*\.\s*newSingleThreadExecutor\s*\{", source):
+        failures.append(f"{WORKER_FILE}: no real background thread factory")
+    span = function_span(source, "submit")
+    if span is None:
         failures.append(f"{WORKER_FILE}: no submit() to hand work to")
         return
-    task = trailing_lambda_body(body, "background.execute")
+    body = source[span[0]:span[1]]
+    task = trailing_lambda_span(body, "background.execute")
     if task is None:
-        failures.append(
-            f"{WORKER_FILE}: submit() does not run its work on the background executor"
-        )
+        failures.append(f"{WORKER_FILE}: submit() does not run on the background executor")
         return
-    if not re.search(r"\bwork\s*\(\s*\)", task):
-        failures.append(
-            f"{WORKER_FILE}: work() is evaluated outside the background executor"
-        )
-    if not re.search(r"\bonSuccess\s*\(", task) or not re.search(
-        r"\bonFailure\s*\(", task
-    ):
-        failures.append(
-            f"{WORKER_FILE}: callbacks must stay inside the background executor "
-            "so MethodChannel encoding cannot stall the platform thread"
-        )
+    work_calls = occurrences(body, r"\bwork\s*\(\s*\)")
+    if not work_calls or outside(work_calls, task):
+        failures.append(f"{WORKER_FILE}: work() is evaluated outside the background executor")
+    for callback in ("onSuccess", "onFailure"):
+        calls = occurrences(body, rf"\b{callback}\s*\(")
+        if not calls or outside(calls, task):
+            failures.append(
+                f"{WORKER_FILE}: callbacks must stay inside the background executor "
+                "so MethodChannel encoding cannot stall the platform thread"
+            )
+            break
 
 
 def check_scanner(directory: Path, failures: list[str]) -> None:
-    """The scan is submitted to the worker, and never answered inline."""
-    source = strip_comments(read(directory, SCANNER_FILE, failures))
+    source = code_only(read(directory, SCANNER_FILE, failures))
     if not source:
         return
-
     if "PlatformChannelWorker" not in source:
-        failures.append(
-            f"{SCANNER_FILE}: does not use PlatformChannelWorker, so the walk "
-            "runs on whichever thread calls it"
-        )
-
-    body = function_body(source, SCAN_METHOD)
-    if body is None:
+        failures.append(f"{SCANNER_FILE}: does not use PlatformChannelWorker")
+    span = function_span(source, SCAN_METHOD)
+    if span is None:
         failures.append(f"{SCANNER_FILE}: no {SCAN_METHOD}() to check")
         return
-
-    if "worker.submit(" not in body:
+    body = source[span[0]:span[1]]
+    submit = call_span(body, "worker.submit")
+    if submit is None:
+        failures.append(f"{SCANNER_FILE}: {SCAN_METHOD}() does not submit its work to the worker")
+        return
+    arguments = body[submit[0]:submit[1]]
+    work = lambda_span(arguments, "work")
+    if work is None:
+        failures.append(f"{SCANNER_FILE}: submitted work must contain the scan invocation")
+        return
+    work_in_body = (submit[0] + work[0], submit[0] + work[1])
+    walk_calls = occurrences(body, rf"\b{re.escape(SCAN_WORK)}\s*\(")
+    if not walk_calls or outside(walk_calls, work_in_body):
         failures.append(
-            f"{SCANNER_FILE}: {SCAN_METHOD}() does not submit its work to the "
-            "worker — the walk is back on the platform thread (#346)"
+            f"{SCANNER_FILE}: {SCAN_WORK}() must be evaluated inside the submitted "
+            "work lambda, never eagerly on the platform thread (#346)"
         )
-
-    # The pre-fix shape: the whole walk evaluated as the argument to a reply,
-    # i.e. on the caller's thread. Whitespace-tolerant so reformatting the call
-    # does not hide it.
-    inline = re.compile(
-        rf"result\s*\.\s*success\s*\(\s*{re.escape(SCAN_WORK)}\s*\(",
-        re.DOTALL,
-    )
-    if inline.search(body):
-        failures.append(
-            f"{SCANNER_FILE}: {SCAN_METHOD}() answers with {SCAN_WORK}() inline, "
-            "which runs the whole library walk on the platform thread (#346)"
-        )
+    # A second reply or another submission cannot hide an eager walk.
+    if outside(occurrences(body, r"\bresult\s*\.\s*success\s*\("), submit):
+        failures.append(f"{SCANNER_FILE}: result.success() must not answer inline")
+    if len(occurrences(body, r"\bworker\s*\.\s*submit\s*\(")) != 1:
+        failures.append(f"{SCANNER_FILE}: expected exactly one worker submission")
 
 
 def check(directory: Path) -> list[str]:
-    """Runs every claim against the Kotlin in [directory]. Empty list = passing."""
     failures: list[str] = []
     check_worker(directory, failures)
     check_scanner(directory, failures)

--- a/scripts/check_android_channel_threading.py
+++ b/scripts/check_android_channel_threading.py
@@ -32,6 +32,7 @@ KOTLIN = (
 WORKER_FILE = "PlatformChannelWorker.kt"
 SCANNER_FILE = "SafDocumentScanner.kt"
 SCAN_METHOD = "listAudioDocuments"
+CANCEL_METHOD = "cancelScan"
 SCAN_WORK = "walk"
 
 
@@ -348,6 +349,26 @@ def check_cancellation(directory: Path, failures: list[str]) -> None:
         )
 
     check_supersede_handoff(source, failures)
+
+    # Starting a scan supersedes the one before it, which covers picking a
+    # different folder. Abandoning the scan outright (forget the folder, switch
+    # to MediaStore) starts nothing, so it needs its own way in. Dropping this
+    # method leaves the Dart generation guard still discarding the result, so
+    # nothing breaks visibly; the walk just keeps burning content-resolver I/O.
+    cancel = function_span(source, CANCEL_METHOD)
+    if cancel is None:
+        failures.append(
+            f"{SCANNER_FILE}: no {CANCEL_METHOD}() for a scan that is abandoned "
+            "rather than replaced (#346)"
+        )
+    elif not re.search(
+        r"\bcurrentScan\s*\.\s*getAndSet\s*\([^)]*\)\s*\??\s*\.\s*set\s*\(\s*true\s*\)",
+        source[cancel[0] : cancel[1]],
+    ):
+        failures.append(
+            f"{SCANNER_FILE}: {CANCEL_METHOD}() must trip the walk in flight "
+            "through currentScan, or it cancels nothing"
+        )
 
     walk = function_span(source, SCAN_WORK)
     if walk is None:

--- a/scripts/verify_android.sh
+++ b/scripts/verify_android.sh
@@ -78,6 +78,14 @@ main() {
   # diagnostics fixture carrying real private data.
   run_step "secret & privacy scan" "$REPO_ROOT/scripts/check_secrets.sh"
 
+  # Also Flutter-independent, and the reason it is a check at all: a library
+  # walk that drifts back onto the platform thread still compiles and still
+  # passes every test — it only shows up as an ANR on a real library (#346).
+  run_step "Android channel threading" \
+    python3 scripts/check_android_channel_threading.py
+  run_step "Android channel threading tooling tests" \
+    python3 test/tooling/check_android_channel_threading_test.py
+
   if android_sdk_available; then
     run_step "flutter build apk --debug" "$FLUTTER" build apk --debug
   else

--- a/test/core/sources/local/fake_saf_document_lister.dart
+++ b/test/core/sources/local/fake_saf_document_lister.dart
@@ -24,6 +24,7 @@ class FakeSafDocumentLister implements SafDocumentLister {
   final bool unsupported;
   final Object? error;
   String? requestedTreeUri;
+  int cancellations = 0;
 
   @override
   Future<SafScanResult> listAudioDocuments(String treeUri) async {
@@ -41,5 +42,10 @@ class FakeSafDocumentLister implements SafDocumentLister {
       foldersVisited: foldersVisited,
       readFailures: readFailures,
     );
+  }
+
+  @override
+  Future<void> cancelScan() async {
+    cancellations++;
   }
 }

--- a/test/features/library/library_controller_test.dart
+++ b/test/features/library/library_controller_test.dart
@@ -175,7 +175,7 @@ void main() {
       expect(container.read(libraryControllerProvider).tracks, tracks);
     });
 
-    test('refresh invalidates a scan that is still in flight', () async {
+    test('explicit source invalidation discards an in-flight scan', () async {
       final repository = InMemoryMusicLibraryRepository();
       final scanner = _DeferredAudioFileScanner();
       final container = _scanContainer(
@@ -185,6 +185,7 @@ void main() {
       final controller = container.read(libraryControllerProvider.notifier);
 
       final Future<void> scan = controller.scanFolder('/forgotten');
+      controller.invalidatePendingScans();
       await controller.refresh();
       scanner.requests['/forgotten']!.complete(<String>[
         '/forgotten/ShouldNotReturn.mp3',
@@ -193,6 +194,27 @@ void main() {
 
       expect(await repository.getAllTracks(), isEmpty);
       expect(container.read(libraryControllerProvider).tracks, isEmpty);
+    });
+
+    test('an unrelated catalog refresh does not cancel a local scan', () async {
+      final repository = InMemoryMusicLibraryRepository();
+      final scanner = _DeferredAudioFileScanner();
+      final container = _scanContainer(
+        repository: repository,
+        scanner: scanner,
+      );
+      final controller = container.read(libraryControllerProvider.notifier);
+
+      final scan = controller.scanFolderWithReport('/music');
+      await controller.refresh();
+      scanner.requests['/music']!.complete(<String>['/music/One.mp3']);
+      final report = await scan;
+
+      expect(report, isNotNull);
+      expect(report!.hadError, isFalse);
+      expect(report.importedTracks, 1);
+      expect(await repository.getAllTracks(), hasLength(1));
+      expect(container.read(localScanReportProvider), same(report));
     });
 
     test(

--- a/test/features/library/library_controller_test.dart
+++ b/test/features/library/library_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/track.dart';
@@ -35,11 +37,19 @@ class _NeverReadable implements DirectoryReadability {
   Future<bool> canList(String path) async => false;
 }
 
+class _DeferredAudioFileScanner implements AudioFileScanner {
+  final Map<String, Completer<List<String>>> requests =
+      <String, Completer<List<String>>>{};
+
+  @override
+  Future<List<String>> listFiles(String folder) {
+    return (requests[folder] ??= Completer<List<String>>()).future;
+  }
+}
+
 ProviderContainer _containerWith(FakeMusicLibraryRepository repository) {
   final container = ProviderContainer(
-    overrides: [
-      musicLibraryRepositoryProvider.overrideWithValue(repository),
-    ],
+    overrides: [musicLibraryRepositoryProvider.overrideWithValue(repository)],
   );
   addTearDown(container.dispose);
   return container;
@@ -93,25 +103,30 @@ void main() {
       expect(state.isEmpty, isTrue);
     });
 
-    test('surfaces a friendly, leak-free error when the repository throws',
-        () async {
-      // A raw store failure (a corrupt-db or filesystem error on device) must
-      // not leak its text — the user sees one clean, actionable line instead.
-      final container = _containerWith(
-        FakeMusicLibraryRepository(
-          error: Exception('FileSystemException: /data/.../db errno = 13'),
-        ),
-      );
+    test(
+      'surfaces a friendly, leak-free error when the repository throws',
+      () async {
+        // A raw store failure (a corrupt-db or filesystem error on device) must
+        // not leak its text — the user sees one clean, actionable line instead.
+        final container = _containerWith(
+          FakeMusicLibraryRepository(
+            error: Exception('FileSystemException: /data/.../db errno = 13'),
+          ),
+        );
 
-      await container.read(libraryControllerProvider.notifier).refresh();
+        await container.read(libraryControllerProvider.notifier).refresh();
 
-      final state = container.read(libraryControllerProvider);
-      expect(state.status, LibraryStatus.error);
-      expect(state.errorMessage, contains("Couldn't open your music library"));
-      // The raw exception text never reaches the UI.
-      expect(state.errorMessage, isNot(contains('errno')));
-      expect(state.errorMessage, isNot(contains('Exception')));
-    });
+        final state = container.read(libraryControllerProvider);
+        expect(state.status, LibraryStatus.error);
+        expect(
+          state.errorMessage,
+          contains("Couldn't open your music library"),
+        );
+        // The raw exception text never reaches the UI.
+        expect(state.errorMessage, isNot(contains('errno')));
+        expect(state.errorMessage, isNot(contains('Exception')));
+      },
+    );
 
     test('scanFolder persists discovered tracks and reloads', () async {
       final repository = InMemoryMusicLibraryRepository();
@@ -139,28 +154,71 @@ void main() {
       expect(await repository.getAllTracks(), hasLength(2));
     });
 
-    test('scanFolder shows a friendly message for an unexpected scan failure',
-        () async {
-      // A raw scanner failure (a dart:io permission error on device, say) must
-      // not leak its text — the user sees one clean, actionable line instead.
+    test('an obsolete scan cannot overwrite a newer source scan', () async {
+      final repository = InMemoryMusicLibraryRepository();
+      final scanner = _DeferredAudioFileScanner();
       final container = _scanContainer(
-        repository: InMemoryMusicLibraryRepository(),
-        scanner: FakeAudioFileScanner(
-          error: Exception('FileSystemException: errno = 13'),
-        ),
+        repository: repository,
+        scanner: scanner,
       );
+      final controller = container.read(libraryControllerProvider.notifier);
 
-      await container
-          .read(libraryControllerProvider.notifier)
-          .scanFolder('/missing');
+      final Future<void> oldScan = controller.scanFolder('/old');
+      final Future<void> newScan = controller.scanFolder('/new');
+      scanner.requests['/new']!.complete(<String>['/new/New.mp3']);
+      await newScan;
+      scanner.requests['/old']!.complete(<String>['/old/Old.mp3']);
+      await oldScan;
 
-      final state = container.read(libraryControllerProvider);
-      expect(state.status, LibraryStatus.error);
-      expect(state.errorMessage, contains("Couldn't scan that folder"));
-      // The raw exception text never reaches the UI.
-      expect(state.errorMessage, isNot(contains('errno')));
-      expect(state.errorMessage, isNot(contains('Exception')));
+      final tracks = await repository.getAllTracks();
+      expect(tracks.map((track) => track.title), <String>['New']);
+      expect(container.read(libraryControllerProvider).tracks, tracks);
     });
+
+    test('refresh invalidates a scan that is still in flight', () async {
+      final repository = InMemoryMusicLibraryRepository();
+      final scanner = _DeferredAudioFileScanner();
+      final container = _scanContainer(
+        repository: repository,
+        scanner: scanner,
+      );
+      final controller = container.read(libraryControllerProvider.notifier);
+
+      final Future<void> scan = controller.scanFolder('/forgotten');
+      await controller.refresh();
+      scanner.requests['/forgotten']!.complete(<String>[
+        '/forgotten/ShouldNotReturn.mp3',
+      ]);
+      await scan;
+
+      expect(await repository.getAllTracks(), isEmpty);
+      expect(container.read(libraryControllerProvider).tracks, isEmpty);
+    });
+
+    test(
+      'scanFolder shows a friendly message for an unexpected scan failure',
+      () async {
+        // A raw scanner failure (a dart:io permission error on device, say) must
+        // not leak its text — the user sees one clean, actionable line instead.
+        final container = _scanContainer(
+          repository: InMemoryMusicLibraryRepository(),
+          scanner: FakeAudioFileScanner(
+            error: Exception('FileSystemException: errno = 13'),
+          ),
+        );
+
+        await container
+            .read(libraryControllerProvider.notifier)
+            .scanFolder('/missing');
+
+        final state = container.read(libraryControllerProvider);
+        expect(state.status, LibraryStatus.error);
+        expect(state.errorMessage, contains("Couldn't scan that folder"));
+        // The raw exception text never reaches the UI.
+        expect(state.errorMessage, isNot(contains('errno')));
+        expect(state.errorMessage, isNot(contains('Exception')));
+      },
+    );
 
     test('scanFolder surfaces a FolderScanException message verbatim',
         () async {
@@ -253,23 +311,25 @@ void main() {
       expect(state.tracks.map((t) => t.title), <String>['One']);
     });
 
-    test('scanFolder surfaces a clean error for an unscannable content URI',
-        () async {
-      final container = _scanContainer(
-        repository: InMemoryMusicLibraryRepository(),
-        scanner: const PlatformAudioFileScanner(),
-      );
+    test(
+      'scanFolder surfaces a clean error for an unscannable content URI',
+      () async {
+        final container = _scanContainer(
+          repository: InMemoryMusicLibraryRepository(),
+          scanner: const PlatformAudioFileScanner(),
+        );
 
-      const folderUri = 'content://com.android.providers.downloads.documents/'
-          'tree/raw%3A';
-      await container
-          .read(libraryControllerProvider.notifier)
-          .scanFolder(folderUri);
+        const folderUri = 'content://com.android.providers.downloads.documents/'
+            'tree/raw%3A';
+        await container
+            .read(libraryControllerProvider.notifier)
+            .scanFolder(folderUri);
 
-      final state = container.read(libraryControllerProvider);
-      expect(state.status, LibraryStatus.error);
-      expect(state.errorMessage, contains('Storage Access Framework'));
-    });
+        final state = container.read(libraryControllerProvider);
+        expect(state.status, LibraryStatus.error);
+        expect(state.errorMessage, contains('Storage Access Framework'));
+      },
+    );
 
     test(
         'scanFolder surfaces a clean error when a resolved content URI is '
@@ -299,43 +359,45 @@ void main() {
       expect(state.errorMessage, contains('not letting it read'));
     });
 
-    test('a folder Linthra can no longer reach keeps the catalog intact',
-        () async {
-      // The recoverable-source case (#438/#414): a selected folder that has
-      // gone away — an unplugged drive, a deleted folder, a revoked Flatpak
-      // portal document — must leave the already-indexed tracks alone. Wiping
-      // them would turn a "reselect the folder" problem into a lost library.
-      // The scan report recorder is a process-wide static; keep this test's
-      // report from leaking into the next one.
-      addTearDown(LocalScanDiagnostics.reset);
-      final repository = InMemoryMusicLibraryRepository();
-      await repository.upsertCatalog(
-        sourceId: 'local',
-        tracks: <Track>[_track('a'), _track('b')],
-        albums: const [],
-        artists: const [],
-      );
-      final container = _scanContainer(
-        repository: repository,
-        scanner: FakeAudioFileScanner(
-          error: const FolderScanException(
-            "Linthra couldn't find the selected folder.",
+    test(
+      'a folder Linthra can no longer reach keeps the catalog intact',
+      () async {
+        // The recoverable-source case (#438/#414): a selected folder that has
+        // gone away — an unplugged drive, a deleted folder, a revoked Flatpak
+        // portal document — must leave the already-indexed tracks alone. Wiping
+        // them would turn a "reselect the folder" problem into a lost library.
+        // The scan report recorder is a process-wide static; keep this test's
+        // report from leaking into the next one.
+        addTearDown(LocalScanDiagnostics.reset);
+        final repository = InMemoryMusicLibraryRepository();
+        await repository.upsertCatalog(
+          sourceId: 'local',
+          tracks: <Track>[_track('a'), _track('b')],
+          albums: const [],
+          artists: const [],
+        );
+        final container = _scanContainer(
+          repository: repository,
+          scanner: FakeAudioFileScanner(
+            error: const FolderScanException(
+              "Linthra couldn't find the selected folder.",
+            ),
           ),
-        ),
-      );
+        );
 
-      await container
-          .read(libraryControllerProvider.notifier)
-          .scanFolder('/home/me/Music');
+        await container
+            .read(libraryControllerProvider.notifier)
+            .scanFolder('/home/me/Music');
 
-      final state = container.read(libraryControllerProvider);
-      expect(state.status, LibraryStatus.error);
-      expect(await repository.getAllTracks(), hasLength(2));
-      // Recorded as a folder-availability failure, not as an Android SAF one,
-      // so a desktop diagnostics report says what actually happened.
-      final report = container.read(localScanReportProvider);
-      expect(report?.error, LocalScanError.folderUnavailable);
-      expect(report?.isContentUri, isFalse);
-    });
+        final state = container.read(libraryControllerProvider);
+        expect(state.status, LibraryStatus.error);
+        expect(await repository.getAllTracks(), hasLength(2));
+        // Recorded as a folder-availability failure, not as an Android SAF one,
+        // so a desktop diagnostics report says what actually happened.
+        final report = container.read(localScanReportProvider);
+        expect(report?.error, LocalScanError.folderUnavailable);
+        expect(report?.isContentUri, isFalse);
+      },
+    );
   });
 }

--- a/test/features/library/library_scan_concurrency_test.dart
+++ b/test/features/library/library_scan_concurrency_test.dart
@@ -8,6 +8,7 @@ import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/platform/host_platform.dart';
 import 'package:linthra/core/sources/local/android_media_library.dart';
 import 'package:linthra/core/sources/local/audio_file_scanner.dart';
+import 'package:linthra/core/sources/local/folder_location.dart';
 import 'package:linthra/core/sources/local/local_scan_diagnostics.dart';
 import 'package:linthra/core/sources/local/saf_document_lister.dart';
 import 'package:linthra/data/repositories/host_platform_provider.dart';
@@ -122,6 +123,27 @@ void main() {
     controller.invalidatePendingScans();
 
     expect(lister.cancellations, 1);
+  });
+
+  test('starting a MediaStore scan stops the SAF walk it supersedes', () async {
+    // Switching to the device library never calls listAudioDocuments, so
+    // nothing supersedes the SAF walk natively. Without cancelling here it
+    // keeps doing metadata and artwork I/O for the whole MediaStore traversal.
+    final library = InMemoryMusicLibraryRepository();
+    final lister = FakeSafDocumentLister();
+    final container = _container(
+      library: library,
+      scanner: _DeferredScanner(),
+      extra: [safDocumentListerProvider.overrideWithValue(lister)],
+    );
+    final controller = container.read(libraryControllerProvider.notifier);
+
+    await controller.scanFolderWithReport(
+      FolderLocation.androidMediaStoreAudio,
+    );
+
+    expect(lister.cancellations, 1);
+    expect(lister.requestedTreeUri, isNull);
   });
 
   test('clearing the local catalog also stops the walk feeding it', () async {

--- a/test/features/library/library_scan_concurrency_test.dart
+++ b/test/features/library/library_scan_concurrency_test.dart
@@ -1,0 +1,240 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/album.dart';
+import 'package:linthra/core/models/artist.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/core/sources/local/android_media_library.dart';
+import 'package:linthra/core/sources/local/audio_file_scanner.dart';
+import 'package:linthra/core/sources/local/local_scan_diagnostics.dart';
+import 'package:linthra/core/sources/local/saf_document_lister.dart';
+import 'package:linthra/data/repositories/host_platform_provider.dart';
+import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
+import 'package:linthra/data/repositories/in_memory_selected_music_folder_repository.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/data/repositories/selected_music_folder_repository_provider.dart';
+import 'package:linthra/features/library/library_controller.dart';
+import 'package:linthra/features/library/library_providers.dart';
+import 'package:linthra/features/library/local_scan_report_provider.dart';
+import 'package:linthra/features/library/selected_folder_controller.dart';
+import 'package:linthra/features/settings/source/local_music_controller.dart';
+
+import 'fake_audio_file_scanner.dart';
+
+class _DeferredScanner implements AudioFileScanner {
+  final requests = <String, Completer<List<String>>>{};
+
+  @override
+  Future<List<String>> listFiles(String folder) =>
+      (requests[folder] ??= Completer<List<String>>()).future;
+}
+
+/// Delays the first nonempty local write, then performs it only when released.
+/// This exposes the race between a started upsert and a later forget/switch.
+class _DeferredWriteRepository extends InMemoryMusicLibraryRepository {
+  final writeStarted = Completer<void>();
+  final releaseWrite = Completer<void>();
+  bool _delayed = false;
+
+  @override
+  Future<void> upsertCatalog({
+    required String sourceId,
+    required List<Track> tracks,
+    required List<Album> albums,
+    required List<Artist> artists,
+  }) async {
+    if (sourceId == 'local' && tracks.isNotEmpty && !_delayed) {
+      _delayed = true;
+      writeStarted.complete();
+      await releaseWrite.future;
+    }
+    await super.upsertCatalog(
+      sourceId: sourceId,
+      tracks: tracks,
+      albums: albums,
+      artists: artists,
+    );
+  }
+}
+
+class _DeferredMediaLibrary implements AndroidMediaLibrary {
+  final started = Completer<void>();
+  final result = Completer<SafScanResult>();
+
+  @override
+  Future<AndroidMusicPermissionStatus> permissionStatus() async =>
+      AndroidMusicPermissionStatus.allowed;
+
+  @override
+  Future<AndroidMusicPermissionStatus> requestPermission() async =>
+      AndroidMusicPermissionStatus.allowed;
+
+  @override
+  Future<void> openAppSettings() async {}
+
+  @override
+  Future<SafScanResult> listDeviceAudio() {
+    if (!started.isCompleted) started.complete();
+    return result.future;
+  }
+}
+
+ProviderContainer _container({
+  required InMemoryMusicLibraryRepository library,
+  required AudioFileScanner scanner,
+  InMemorySelectedMusicFolderRepository? selected,
+  List<Override> extra = const [],
+}) {
+  final container = ProviderContainer(overrides: [
+    musicLibraryRepositoryProvider.overrideWithValue(library),
+    audioFileScannerProvider.overrideWithValue(scanner),
+    selectedMusicFolderRepositoryProvider.overrideWithValue(
+      selected ?? InMemorySelectedMusicFolderRepository(),
+    ),
+    ...extra,
+  ]);
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  setUp(LocalScanDiagnostics.reset);
+  tearDown(LocalScanDiagnostics.reset);
+
+  test('a superseded scan returns null, not the previous successful report',
+      () async {
+    final library = InMemoryMusicLibraryRepository();
+    final scanner = _DeferredScanner();
+    final container = _container(library: library, scanner: scanner);
+    final controller = container.read(libraryControllerProvider.notifier);
+
+    final first = controller.scanFolderWithReport('/first');
+    scanner.requests['/first']!.complete(['/first/First.mp3']);
+    final previous = await first;
+    expect(previous?.importedTracks, 1);
+
+    final stale = controller.scanFolderWithReport('/stale');
+    controller.invalidatePendingScans();
+    scanner.requests['/stale']!.complete(['/stale/Stale.mp3']);
+    expect(await stale, isNull);
+    expect(container.read(localScanReportProvider), same(previous));
+    expect((await library.getAllTracks()).single.title, 'First');
+  });
+
+  test('forget invalidates a walk before it can enqueue a catalog write',
+      () async {
+    final library = InMemoryMusicLibraryRepository();
+    final scanner = _DeferredScanner();
+    final selected =
+        InMemorySelectedMusicFolderRepository(initialFolder: '/music');
+    final container = _container(
+      library: library,
+      scanner: scanner,
+      selected: selected,
+    );
+    await container.read(selectedFolderControllerProvider.future);
+    final controller = container.read(libraryControllerProvider.notifier);
+
+    final scan = controller.scanFolderWithReport('/music');
+    await container.read(localMusicControllerProvider.notifier).forget();
+    scanner.requests['/music']!.complete(['/music/ShouldNotReturn.mp3']);
+    expect(await scan, isNull);
+    expect(await library.getAllTracks(), isEmpty);
+    expect(container.read(localScanReportProvider), isNull);
+    expect(await selected.getSelectedFolder(), isNull);
+  });
+
+  test('forget waits for a started write and clears it without resurrection',
+      () async {
+    final library = _DeferredWriteRepository();
+    final scanner = FakeAudioFileScanner(files: ['/music/Old.mp3']);
+    final selected =
+        InMemorySelectedMusicFolderRepository(initialFolder: '/music');
+    final container = _container(
+      library: library,
+      scanner: scanner,
+      selected: selected,
+    );
+    await container.read(selectedFolderControllerProvider.future);
+    final controller = container.read(libraryControllerProvider.notifier);
+
+    final scan = controller.scanFolderWithReport('/music');
+    await library.writeStarted.future;
+    final forget =
+        container.read(localMusicControllerProvider.notifier).forget();
+    await Future<void>.delayed(Duration.zero);
+    expect(library.releaseWrite.isCompleted, isFalse);
+    library.releaseWrite.complete();
+    expect(await scan, isNull);
+    await forget;
+
+    expect(await library.getAllTracks(), isEmpty);
+    expect(container.read(localScanReportProvider), isNull);
+    expect(await selected.getSelectedFolder(), isNull);
+  });
+
+  test('a source change waits for an already-started local write', () async {
+    final library = _DeferredWriteRepository();
+    final selected =
+        InMemorySelectedMusicFolderRepository(initialFolder: '/old');
+    final container = _container(
+      library: library,
+      scanner: FakeAudioFileScanner(files: ['/old/Old.mp3']),
+      selected: selected,
+    );
+    await container.read(selectedFolderControllerProvider.future);
+    final controller = container.read(libraryControllerProvider.notifier);
+
+    final scan = controller.scanFolderWithReport('/old');
+    await library.writeStarted.future;
+    final change = container
+        .read(selectedFolderControllerProvider.notifier)
+        .setAndPersist('/new');
+    await Future<void>.delayed(Duration.zero);
+    expect(await selected.getSelectedFolder(), '/old');
+    library.releaseWrite.complete();
+    expect(await scan, isNull);
+    await change;
+    expect(await selected.getSelectedFolder(), '/new');
+  });
+
+  test('a canceled MediaStore switch cannot reuse an old report', () async {
+    final library = InMemoryMusicLibraryRepository();
+    final media = _DeferredMediaLibrary();
+    final selected =
+        InMemorySelectedMusicFolderRepository(initialFolder: '/old');
+    final container = _container(
+      library: library,
+      scanner: FakeAudioFileScanner(files: ['/old/Old.mp3']),
+      selected: selected,
+      extra: [
+        hostPlatformProvider.overrideWithValue(HostPlatform.android),
+        androidMediaLibraryProvider.overrideWithValue(media),
+      ],
+    );
+    await container.read(selectedFolderControllerProvider.future);
+    final controller = container.read(libraryControllerProvider.notifier);
+    final previous = await controller.scanFolderWithReport('/old');
+    expect(previous?.importedTracks, 1);
+
+    final local = container.read(localMusicControllerProvider.notifier);
+    final switching = local.useAllDeviceMusic();
+    await media.started.future;
+    await local.forget();
+    media.result.complete(const SafScanResult(
+      documents: [SafAudioDocument(
+        uri: 'content://media/external/audio/media/7',
+        name: 'New.mp3',
+        mimeType: 'audio/mpeg',
+      )],
+      filesVisited: 1,
+    ));
+    await switching;
+
+    expect(await selected.getSelectedFolder(), isNull);
+    expect(await library.getAllTracks(), isEmpty);
+    expect(container.read(localScanReportProvider), isNull);
+  });
+}

--- a/test/features/library/library_scan_concurrency_test.dart
+++ b/test/features/library/library_scan_concurrency_test.dart
@@ -21,6 +21,7 @@ import 'package:linthra/features/library/local_scan_report_provider.dart';
 import 'package:linthra/features/library/selected_folder_controller.dart';
 import 'package:linthra/features/settings/source/local_music_controller.dart';
 
+import '../../core/sources/local/fake_saf_document_lister.dart';
 import 'fake_audio_file_scanner.dart';
 
 class _DeferredScanner implements AudioFileScanner {
@@ -102,6 +103,58 @@ ProviderContainer _container({
 void main() {
   setUp(LocalScanDiagnostics.reset);
   tearDown(LocalScanDiagnostics.reset);
+
+  test('abandoning a source stops the native walk, not just its result',
+      () async {
+    // Forgetting the folder or switching to the device library never starts
+    // another scan, so nothing supersedes the walk in flight. Without an
+    // explicit cancel it runs to completion opening a metadata retriever per
+    // file, for a result the generation guard is going to throw away.
+    final library = InMemoryMusicLibraryRepository();
+    final lister = FakeSafDocumentLister();
+    final container = _container(
+      library: library,
+      scanner: _DeferredScanner(),
+      extra: [safDocumentListerProvider.overrideWithValue(lister)],
+    );
+    final controller = container.read(libraryControllerProvider.notifier);
+
+    controller.invalidatePendingScans();
+
+    expect(lister.cancellations, 1);
+  });
+
+  test('clearing the local catalog also stops the walk feeding it', () async {
+    final library = InMemoryMusicLibraryRepository();
+    final lister = FakeSafDocumentLister();
+    final container = _container(
+      library: library,
+      scanner: _DeferredScanner(),
+      extra: [safDocumentListerProvider.overrideWithValue(lister)],
+    );
+    final controller = container.read(libraryControllerProvider.notifier);
+
+    await controller.clearLocalCatalog();
+
+    expect(lister.cancellations, 1);
+  });
+
+  test('a plain refresh does not cancel an unrelated scan', () async {
+    // refresh() reloads the shared catalog; it is not a source change and must
+    // leave a running local scan alone.
+    final library = InMemoryMusicLibraryRepository();
+    final lister = FakeSafDocumentLister();
+    final container = _container(
+      library: library,
+      scanner: _DeferredScanner(),
+      extra: [safDocumentListerProvider.overrideWithValue(lister)],
+    );
+    final controller = container.read(libraryControllerProvider.notifier);
+
+    await controller.refresh();
+
+    expect(lister.cancellations, 0);
+  });
 
   test('a superseded scan returns null, not the previous successful report',
       () async {

--- a/test/tooling/check_android_channel_threading_test.py
+++ b/test/tooling/check_android_channel_threading_test.py
@@ -104,6 +104,8 @@ class SafDocumentScanner(
     private val worker: PlatformChannelWorker = PlatformChannelWorker(),
 ) {
     fun listAudioDocuments(treeUri: String, result: MethodChannel.Result) {
+        val cancelled = AtomicBoolean(false)
+        currentScan.getAndSet(cancelled)?.set(true)
 """
     + SUBMITTING_SCAN
     + """
@@ -322,6 +324,52 @@ class CheckerTest(unittest.TestCase):
             "            // } catch (e: ScanSuperseded) { throw e\n",
         )
         self.assertCaught(self.check(scanner=scanner), "before its catch-all")
+
+    def test_deleting_the_supersede_handoff_is_caught(self):
+        # currentScan declared but never swapped: every walk keeps an unset flag.
+        scanner = GOOD_SCANNER.replace(
+            "        currentScan.getAndSet(cancelled)?.set(true)\n", ""
+        )
+        self.assertCaught(self.check(scanner=scanner), "must swap the new flag")
+
+    def test_a_swap_that_never_trips_the_old_flag_is_caught(self):
+        scanner = GOOD_SCANNER.replace(
+            "currentScan.getAndSet(cancelled)?.set(true)",
+            "currentScan.getAndSet(cancelled)",
+        )
+        self.assertCaught(self.check(scanner=scanner), "must be tripped right there")
+
+    def test_a_flag_that_never_reaches_the_walk_is_caught(self):
+        # Swapped and tripped, but the walk watches a different one.
+        scanner = GOOD_SCANNER.replace(
+            "walk(Uri.parse(treeUri), cancelled)",
+            "walk(Uri.parse(treeUri), AtomicBoolean(false))",
+        )
+        self.assertCaught(self.check(scanner=scanner), "never reaches the submitted")
+
+    def test_cancellation_only_at_the_folder_boundary_is_caught(self):
+        # The regression the per-entry check exists for: a flat Music folder is
+        # one outer iteration, so the folder check alone interrupts nothing.
+        scanner = GOOD_SCANNER.replace(
+            "                        if (cancelled.get()) throw ScanSuperseded()\n", ""
+        )
+        self.assertCaught(self.check(scanner=scanner), "inside the cursor loop")
+
+    def test_a_callback_redispatched_to_another_executor_is_caught(self):
+        # Lexically inside the task, but back on the platform thread: this is the
+        # shape a "replies belong on the main thread" fix would take.
+        worker = GOOD_WORKER.replace(
+            "                    onFailure(e)",
+            "                    platform.execute { onFailure(e) }",
+        )
+        self.assertCaught(self.check(worker=worker), "dispatched to another thread")
+
+    def test_a_callback_posted_to_the_main_looper_is_caught(self):
+        worker = GOOD_WORKER.replace(
+            "            onSuccess(value)",
+            "            handler.post { onSuccess(value) }",
+        )
+        self.assertCaught(self.check(worker=worker), "dispatched to another thread")
 
 
 if __name__ == "__main__":

--- a/test/tooling/check_android_channel_threading_test.py
+++ b/test/tooling/check_android_channel_threading_test.py
@@ -125,17 +125,42 @@ class SafDocumentScanner(
 )
 
 
+GOOD_ACTIVITY = """package io.github.thezupzup.linthra
+
+class MainActivity : AudioServiceActivity() {
+    private val safDocumentScanner by lazy {
+        SafDocumentScanner(applicationContext)
+    }
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        when (call.method) {
+            "listAudioDocuments" -> safDocumentScanner.listAudioDocuments(treeUri, result)
+            "cancelScan" -> {
+                safDocumentScanner.cancelScan()
+                result.success(null)
+            }
+            "hasPersistedPermission" ->
+                result.success(safDocumentScanner.hasPersistedPermission(treeUri))
+            else -> result.notImplemented()
+        }
+    }
+}
+"""
+
+
 class CheckerTest(unittest.TestCase):
     def check(
         self,
         *,
         worker: str = GOOD_WORKER,
         scanner: str = GOOD_SCANNER,
+        activity: str = GOOD_ACTIVITY,
     ):
         with tempfile.TemporaryDirectory() as raw:
             directory = Path(raw)
             (directory / checker.WORKER_FILE).write_text(worker, encoding="utf-8")
             (directory / checker.SCANNER_FILE).write_text(scanner, encoding="utf-8")
+            (directory / checker.ACTIVITY_FILE).write_text(activity, encoding="utf-8")
             return checker.check(directory)
 
     def assertCaught(self, failures: list[str], needle: str) -> None:
@@ -153,6 +178,9 @@ class CheckerTest(unittest.TestCase):
             directory = Path(raw)
             (directory / checker.SCANNER_FILE).write_text(
                 GOOD_SCANNER, encoding="utf-8"
+            )
+            (directory / checker.ACTIVITY_FILE).write_text(
+                GOOD_ACTIVITY, encoding="utf-8"
             )
             self.assertCaught(checker.check(directory), "missing")
 
@@ -392,6 +420,49 @@ class CheckerTest(unittest.TestCase):
             "        currentScan.getAndSet(null)?.set(true)\n", ""
         )
         self.assertCaught(self.check(scanner=scanner), "must trip the walk in flight")
+
+    def test_a_non_identifier_flag_in_the_swap_is_caught(self):
+        # Swapped and tripped, but with a fresh flag nothing else holds: the
+        # walk watches `cancelled` and no later scan can ever reach it.
+        scanner = GOOD_SCANNER.replace(
+            "currentScan.getAndSet(cancelled)?.set(true)",
+            "currentScan.getAndSet(AtomicBoolean(false))?.set(true)",
+        )
+        self.assertCaught(self.check(scanner=scanner), "must be handed the named flag")
+
+    def test_a_cancel_the_channel_does_not_route_is_caught(self):
+        # Dart calls "cancelScan"; without the branch it gets notImplemented,
+        # which the binding deliberately swallows as an older native build.
+        activity = GOOD_ACTIVITY.replace(
+            """            "cancelScan" -> {
+                safDocumentScanner.cancelScan()
+                result.success(null)
+            }
+""",
+            "",
+        )
+        self.assertCaught(self.check(activity=activity), "does not route")
+
+    def test_a_cancel_branch_that_calls_nothing_is_caught(self):
+        activity = GOOD_ACTIVITY.replace(
+            "                safDocumentScanner.cancelScan()\n", ""
+        )
+        self.assertCaught(self.check(activity=activity), "must call cancelScan()")
+
+    def test_a_commented_out_cancel_branch_does_not_count(self):
+        activity = GOOD_ACTIVITY.replace(
+            '            "cancelScan" -> {', '            // "cancelScan" -> {'
+        )
+        self.assertCaught(self.check(activity=activity), "does not route")
+
+    def test_a_missing_activity_is_caught(self):
+        with tempfile.TemporaryDirectory() as raw:
+            directory = Path(raw)
+            (directory / checker.WORKER_FILE).write_text(GOOD_WORKER, encoding="utf-8")
+            (directory / checker.SCANNER_FILE).write_text(
+                GOOD_SCANNER, encoding="utf-8"
+            )
+            self.assertCaught(checker.check(directory), "missing")
 
 
 if __name__ == "__main__":

--- a/test/tooling/check_android_channel_threading_test.py
+++ b/test/tooling/check_android_channel_threading_test.py
@@ -92,12 +92,41 @@ class SafDocumentScanner(
 )
 
 
+GOOD_ACTIVITY = """package io.github.thezupzup.linthra
+
+class MainActivity : AudioServiceActivity() {
+    // One scanner for the channel: it holds the cancellation flag of the walk
+    // in flight, and a fresh one per request would have nothing to cancel.
+    private val safDocumentScanner by lazy {
+        SafDocumentScanner(applicationContext)
+    }
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        when (call.method) {
+            "listAudioDocuments" -> safDocumentScanner.listAudioDocuments(treeUri, result)
+            "hasPersistedPermission" ->
+                result.success(safDocumentScanner.hasPersistedPermission(treeUri))
+            "readSidecarText" ->
+                result.success(safDocumentScanner.readSidecarText(uri, extension))
+        }
+    }
+}
+"""
+
+
 class CheckerTest(unittest.TestCase):
-    def check(self, *, worker: str = GOOD_WORKER, scanner: str = GOOD_SCANNER):
+    def check(
+        self,
+        *,
+        worker: str = GOOD_WORKER,
+        scanner: str = GOOD_SCANNER,
+        activity: str = GOOD_ACTIVITY,
+    ):
         with tempfile.TemporaryDirectory() as raw:
             directory = Path(raw)
             (directory / checker.WORKER_FILE).write_text(worker, encoding="utf-8")
             (directory / checker.SCANNER_FILE).write_text(scanner, encoding="utf-8")
+            (directory / checker.ACTIVITY_FILE).write_text(activity, encoding="utf-8")
             return checker.check(directory)
 
     def assertCaught(self, failures: list[str], needle: str) -> None:
@@ -113,18 +142,23 @@ class CheckerTest(unittest.TestCase):
     def test_a_missing_worker_file_is_caught(self):
         with tempfile.TemporaryDirectory() as raw:
             directory = Path(raw)
-            (directory / checker.SCANNER_FILE).write_text(GOOD_SCANNER, encoding="utf-8")
+            (directory / checker.SCANNER_FILE).write_text(
+                GOOD_SCANNER, encoding="utf-8"
+            )
+            (directory / checker.ACTIVITY_FILE).write_text(
+                GOOD_ACTIVITY, encoding="utf-8"
+            )
             self.assertCaught(checker.check(directory), "missing")
 
     def test_the_pre_fix_shape_is_caught(self):
-        inline = '        result.success(walk(Uri.parse(treeUri)))'
+        inline = "        result.success(walk(Uri.parse(treeUri)))"
         self.assertCaught(
             self.check(scanner=GOOD_SCANNER.replace(SUBMITTING_SCAN, inline)),
             "does not submit",
         )
 
     def test_a_reformatted_inline_reply_is_caught(self):
-        inline = '        result . success (\n walk(Uri.parse(treeUri))\n )'
+        inline = "        result . success (\n walk(Uri.parse(treeUri))\n )"
         self.assertCaught(
             self.check(scanner=GOOD_SCANNER.replace(SUBMITTING_SCAN, inline)),
             "does not submit",
@@ -154,14 +188,19 @@ class CheckerTest(unittest.TestCase):
         self.assertCaught(self.check(worker=worker), "work() is evaluated outside")
 
     def test_callbacks_outside_the_executor_are_caught(self):
-        worker = GOOD_WORKER.replace("                    onFailure(e)", "                    throw e").replace(
-            "            onSuccess(value)", "            value\n        }\n        onSuccess(work())"
+        worker = GOOD_WORKER.replace(
+            "                    onFailure(e)", "                    throw e"
+        ).replace(
+            "            onSuccess(value)",
+            "            value\n        }\n        onSuccess(work())",
         )
         self.assertCaught(self.check(worker=worker), "callbacks must stay inside")
 
     def test_a_renamed_scan_method_is_caught(self):
         self.assertCaught(
-            self.check(scanner=GOOD_SCANNER.replace("fun listAudioDocuments", "fun listAudio")),
+            self.check(
+                scanner=GOOD_SCANNER.replace("fun listAudioDocuments", "fun listAudio")
+            ),
             "no listAudioDocuments()",
         )
 
@@ -202,25 +241,67 @@ class CheckerTest(unittest.TestCase):
         self.assertCaught(self.check(scanner=scanner), "must not answer inline")
 
     def test_a_second_submission_is_caught(self):
-        scanner = GOOD_SCANNER.replace(SUBMITTING_SCAN, SUBMITTING_SCAN + "\n" + SUBMITTING_SCAN)
+        scanner = GOOD_SCANNER.replace(
+            SUBMITTING_SCAN, SUBMITTING_SCAN + "\n" + SUBMITTING_SCAN
+        )
         self.assertCaught(self.check(scanner=scanner), "exactly one")
 
     def test_a_synchronous_production_executor_is_caught(self):
-        worker = GOOD_WORKER.replace("newSingleThreadExecutor", "newSingleThreadExecutorRemoved")
+        worker = GOOD_WORKER.replace(
+            "newSingleThreadExecutor", "newSingleThreadExecutorRemoved"
+        )
         self.assertCaught(self.check(worker=worker), "background thread factory")
 
     def test_comments_and_strings_cannot_fake_calls(self):
-        worker = GOOD_WORKER.replace("                    work()", '                    "work()"')
+        worker = GOOD_WORKER.replace(
+            "                    work()", '                    "work()"'
+        )
         self.assertCaught(self.check(worker=worker), "work() is evaluated outside")
 
     def test_nested_comments_and_raw_strings_do_not_break_nesting(self):
         scanner = GOOD_SCANNER.replace(
             SUBMITTING_SCAN,
-            '        /* outer { /* inner ) } */ still } */\n'
+            "        /* outer { /* inner ) } */ still } */\n"
             '        val prose = """{ ) worker.submit(work = { walk() })"""\n'
             + SUBMITTING_SCAN,
         )
         self.assertEqual(self.check(scanner=scanner), [])
+
+    def test_a_scanner_built_per_request_is_caught(self):
+        # The shape that silently disabled cancellation: each request gets a
+        # fresh instance, so there is never an in-flight walk to supersede.
+        activity = GOOD_ACTIVITY.replace(
+            "safDocumentScanner.listAudioDocuments(treeUri, result)",
+            "SafDocumentScanner(applicationContext)"
+            ".listAudioDocuments(treeUri, result)",
+        )
+        self.assertCaught(self.check(activity=activity), "exactly one")
+
+    def test_a_scanner_built_at_a_call_site_is_caught(self):
+        # Exactly one construction, but not a stored one: cancellation state
+        # still dies with the call.
+        activity = GOOD_ACTIVITY.replace(
+            """    private val safDocumentScanner by lazy {
+        SafDocumentScanner(applicationContext)
+    }
+
+""",
+            "",
+        ).replace(
+            "safDocumentScanner.listAudioDocuments(treeUri, result)",
+            "SafDocumentScanner(applicationContext)"
+            ".listAudioDocuments(treeUri, result)",
+        )
+        self.assertCaught(self.check(activity=activity), "held for the")
+
+    def test_a_missing_activity_is_caught(self):
+        with tempfile.TemporaryDirectory() as raw:
+            directory = Path(raw)
+            (directory / checker.WORKER_FILE).write_text(GOOD_WORKER, encoding="utf-8")
+            (directory / checker.SCANNER_FILE).write_text(
+                GOOD_SCANNER, encoding="utf-8"
+            )
+            self.assertCaught(checker.check(directory), "missing")
 
 
 if __name__ == "__main__":

--- a/test/tooling/check_android_channel_threading_test.py
+++ b/test/tooling/check_android_channel_threading_test.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/check_android_channel_threading.py (#346).
+
+    python3 test/tooling/check_android_channel_threading_test.py
+
+The checker exists to notice one silent regression: the SAF library walk drifting
+back onto Android's platform thread, where it becomes an ANR on a real library.
+That regression compiles, passes every test in the repo, and reads like a
+simplification in review, so the tests here are "take a good checkout, break
+exactly one thing, expect it to be caught".
+
+They run against a synthetic Kotlin fixture rather than the real files, because a
+fixture is the only way to prove the checker *fails* when it should. One test
+does run against the real repository, since "the checker passes on the actual
+Kotlin" is what the CI step cares about.
+
+Everything is offline. No network, no Gradle, no Android SDK, no repository
+writes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+
+
+def _load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load("check_android_channel_threading", "check_android_channel_threading.py")
+
+
+GOOD_WORKER = """package io.github.thezupzup.linthra
+
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+
+/** Runs blocking channel work off the platform thread. */
+class PlatformChannelWorker(
+    private val background: Executor = SHARED_BACKGROUND,
+) {
+    fun <T> submit(
+        work: () -> T,
+        onSuccess: (T) -> Unit,
+        onFailure: (Exception) -> Unit,
+    ) {
+        background.execute {
+            val value =
+                try {
+                    work()
+                } catch (e: Exception) {
+                    onFailure(e)
+                    return@execute
+                }
+            onSuccess(value)
+        }
+    }
+
+    companion object {
+        private val SHARED_BACKGROUND: Executor =
+            Executors.newSingleThreadExecutor { runnable ->
+                Thread(runnable, "linthra-channel-work").apply { isDaemon = true }
+            }
+    }
+}
+"""
+
+SUBMITTING_SCAN = """        worker.submit(
+            work = { walk(Uri.parse(treeUri)) },
+            onSuccess = { documents -> result.success(documents) },
+            onFailure = { error ->
+                if (error is SecurityException) {
+                    result.error("saf_permission", "No access.", null)
+                } else {
+                    result.error("saf_failed", "Failed to read.", null)
+                }
+            },
+        )"""
+
+GOOD_SCANNER = (
+    """package io.github.thezupzup.linthra
+
+import android.content.Context
+import android.net.Uri
+import io.flutter.plugin.common.MethodChannel
+
+class SafDocumentScanner(
+    private val context: Context,
+    private val worker: PlatformChannelWorker = PlatformChannelWorker(),
+) {
+    /** Walks the tree off the platform thread. */
+    fun listAudioDocuments(treeUri: String, result: MethodChannel.Result) {
+"""
+    + SUBMITTING_SCAN
+    + """
+    }
+
+    fun hasPersistedPermission(treeUri: String): Boolean = true
+
+    private fun walk(treeUri: Uri): Map<String, Any?> = emptyMap()
+}
+"""
+)
+
+
+class CheckerTest(unittest.TestCase):
+    def check(self, *, worker: str = GOOD_WORKER, scanner: str = GOOD_SCANNER):
+        """Runs the checker over a throwaway Kotlin directory."""
+        with tempfile.TemporaryDirectory() as raw:
+            directory = Path(raw)
+            (directory / checker.WORKER_FILE).write_text(worker, encoding="utf-8")
+            (directory / checker.SCANNER_FILE).write_text(scanner, encoding="utf-8")
+            return checker.check(directory)
+
+    def assertCaught(self, failures: list[str], needle: str) -> None:
+        self.assertTrue(failures, "expected the checker to fail, it passed")
+        self.assertIn(needle, "\n".join(failures))
+
+    def test_a_good_pair_passes(self):
+        self.assertEqual(self.check(), [])
+
+    def test_the_real_kotlin_passes(self):
+        # The claim the CI step is actually making.
+        self.assertEqual(checker.check(checker.KOTLIN), [])
+
+    def test_a_missing_worker_file_is_caught(self):
+        with tempfile.TemporaryDirectory() as raw:
+            directory = Path(raw)
+            (directory / checker.SCANNER_FILE).write_text(
+                GOOD_SCANNER, encoding="utf-8"
+            )
+            self.assertCaught(checker.check(directory), "missing")
+
+    def test_the_pre_fix_shape_is_caught(self):
+        # Exactly how the scan looked before #346: the whole walk evaluated as
+        # the argument to the reply, on the caller's thread.
+        inline = """        try {
+            result.success(walk(Uri.parse(treeUri)))
+        } catch (e: Exception) {
+            result.error("saf_failed", "Failed to read.", null)
+        }"""
+        scanner = GOOD_SCANNER.replace(SUBMITTING_SCAN, inline)
+        self.assertCaught(self.check(scanner=scanner), "inline")
+
+    def test_a_reformatted_inline_reply_is_still_caught(self):
+        inline = """        result . success (
+            walk( Uri.parse(treeUri) )
+        )"""
+        scanner = GOOD_SCANNER.replace(SUBMITTING_SCAN, inline)
+        self.assertCaught(self.check(scanner=scanner), "inline")
+
+    def test_dropping_the_worker_from_the_scan_is_caught(self):
+        scanner = GOOD_SCANNER.replace("worker.submit(", "runNow(")
+        self.assertCaught(self.check(scanner=scanner), "does not submit")
+
+    def test_a_commented_out_submit_does_not_satisfy_the_checker(self):
+        # A file whose comments still describe the fix, whose code no longer
+        # has it. Checking raw text would pass this.
+        scanner = GOOD_SCANNER.replace(
+            "worker.submit(", "// worker.submit(\n        runNow("
+        )
+        self.assertCaught(self.check(scanner=scanner), "does not submit")
+
+    def test_a_worker_that_never_leaves_the_caller_thread_is_caught(self):
+        worker = GOOD_WORKER.replace("background.execute {", "run {")
+        self.assertCaught(self.check(worker=worker), "background executor")
+
+    def test_work_evaluated_before_the_executor_is_caught(self):
+        worker = GOOD_WORKER.replace(
+            "        background.execute {\n            val value =",
+            "        val eager = work()\n        background.execute {\n            val value =",
+        ).replace("                    work()", "                    eager")
+        self.assertCaught(self.check(worker=worker), "work() is evaluated outside")
+
+    def test_callbacks_outside_the_executor_are_caught(self):
+        worker = GOOD_WORKER.replace(
+            "                    onFailure(e)", "                    throw e"
+        ).replace(
+            "            onSuccess(value)",
+            "            value\n        }\n        onSuccess(work())",
+        )
+        self.assertCaught(self.check(worker=worker), "callbacks must stay inside")
+
+    def test_a_renamed_scan_method_is_caught(self):
+        scanner = GOOD_SCANNER.replace("fun listAudioDocuments", "fun listAudio")
+        self.assertCaught(self.check(scanner=scanner), "no listAudioDocuments()")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/tooling/check_android_channel_threading_test.py
+++ b/test/tooling/check_android_channel_threading_test.py
@@ -1,21 +1,9 @@
 #!/usr/bin/env python3
-"""Unit tests for scripts/check_android_channel_threading.py (#346).
+"""Mutation tests for the SAF threading tripwire (#346).
 
-    python3 test/tooling/check_android_channel_threading_test.py
-
-The checker exists to notice one silent regression: the SAF library walk drifting
-back onto Android's platform thread, where it becomes an ANR on a real library.
-That regression compiles, passes every test in the repo, and reads like a
-simplification in review, so the tests here are "take a good checkout, break
-exactly one thing, expect it to be caught".
-
-They run against a synthetic Kotlin fixture rather than the real files, because a
-fixture is the only way to prove the checker *fails* when it should. One test
-does run against the real repository, since "the checker passes on the actual
-Kotlin" is what the CI step cares about.
-
-Everything is offline. No network, no Gradle, no Android SDK, no repository
-writes.
+The synthetic fixtures deliberately move the walk outside the submitted work,
+including the regression that #570's previous checker failed to detect.
+Everything runs offline without an Android SDK or Gradle.
 """
 
 from __future__ import annotations
@@ -41,13 +29,9 @@ def _load(name: str, filename: str):
 
 checker = _load("check_android_channel_threading", "check_android_channel_threading.py")
 
-
 GOOD_WORKER = """package io.github.thezupzup.linthra
-
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
-
-/** Runs blocking channel work off the platform thread. */
 class PlatformChannelWorker(
     private val background: Executor = SHARED_BACKGROUND,
 ) {
@@ -67,7 +51,6 @@ class PlatformChannelWorker(
             onSuccess(value)
         }
     }
-
     companion object {
         private val SHARED_BACKGROUND: Executor =
             Executors.newSingleThreadExecutor { runnable ->
@@ -91,24 +74,18 @@ SUBMITTING_SCAN = """        worker.submit(
 
 GOOD_SCANNER = (
     """package io.github.thezupzup.linthra
-
 import android.content.Context
 import android.net.Uri
 import io.flutter.plugin.common.MethodChannel
-
 class SafDocumentScanner(
     private val context: Context,
     private val worker: PlatformChannelWorker = PlatformChannelWorker(),
 ) {
-    /** Walks the tree off the platform thread. */
     fun listAudioDocuments(treeUri: String, result: MethodChannel.Result) {
 """
     + SUBMITTING_SCAN
     + """
     }
-
-    fun hasPersistedPermission(treeUri: String): Boolean = true
-
     private fun walk(treeUri: Uri): Map<String, Any?> = emptyMap()
 }
 """
@@ -117,7 +94,6 @@ class SafDocumentScanner(
 
 class CheckerTest(unittest.TestCase):
     def check(self, *, worker: str = GOOD_WORKER, scanner: str = GOOD_SCANNER):
-        """Runs the checker over a throwaway Kotlin directory."""
         with tempfile.TemporaryDirectory() as raw:
             directory = Path(raw)
             (directory / checker.WORKER_FILE).write_text(worker, encoding="utf-8")
@@ -132,50 +108,43 @@ class CheckerTest(unittest.TestCase):
         self.assertEqual(self.check(), [])
 
     def test_the_real_kotlin_passes(self):
-        # The claim the CI step is actually making.
         self.assertEqual(checker.check(checker.KOTLIN), [])
 
     def test_a_missing_worker_file_is_caught(self):
         with tempfile.TemporaryDirectory() as raw:
             directory = Path(raw)
-            (directory / checker.SCANNER_FILE).write_text(
-                GOOD_SCANNER, encoding="utf-8"
-            )
+            (directory / checker.SCANNER_FILE).write_text(GOOD_SCANNER, encoding="utf-8")
             self.assertCaught(checker.check(directory), "missing")
 
     def test_the_pre_fix_shape_is_caught(self):
-        # Exactly how the scan looked before #346: the whole walk evaluated as
-        # the argument to the reply, on the caller's thread.
-        inline = """        try {
-            result.success(walk(Uri.parse(treeUri)))
-        } catch (e: Exception) {
-            result.error("saf_failed", "Failed to read.", null)
-        }"""
-        scanner = GOOD_SCANNER.replace(SUBMITTING_SCAN, inline)
-        self.assertCaught(self.check(scanner=scanner), "inline")
+        inline = '        result.success(walk(Uri.parse(treeUri)))'
+        self.assertCaught(
+            self.check(scanner=GOOD_SCANNER.replace(SUBMITTING_SCAN, inline)),
+            "does not submit",
+        )
 
-    def test_a_reformatted_inline_reply_is_still_caught(self):
-        inline = """        result . success (
-            walk( Uri.parse(treeUri) )
-        )"""
-        scanner = GOOD_SCANNER.replace(SUBMITTING_SCAN, inline)
-        self.assertCaught(self.check(scanner=scanner), "inline")
+    def test_a_reformatted_inline_reply_is_caught(self):
+        inline = '        result . success (\n walk(Uri.parse(treeUri))\n )'
+        self.assertCaught(
+            self.check(scanner=GOOD_SCANNER.replace(SUBMITTING_SCAN, inline)),
+            "does not submit",
+        )
 
     def test_dropping_the_worker_from_the_scan_is_caught(self):
-        scanner = GOOD_SCANNER.replace("worker.submit(", "runNow(")
-        self.assertCaught(self.check(scanner=scanner), "does not submit")
-
-    def test_a_commented_out_submit_does_not_satisfy_the_checker(self):
-        # A file whose comments still describe the fix, whose code no longer
-        # has it. Checking raw text would pass this.
-        scanner = GOOD_SCANNER.replace(
-            "worker.submit(", "// worker.submit(\n        runNow("
+        self.assertCaught(
+            self.check(scanner=GOOD_SCANNER.replace("worker.submit(", "runNow(")),
+            "does not submit",
         )
+
+    def test_a_commented_out_submit_is_not_a_submission(self):
+        scanner = GOOD_SCANNER.replace("worker.submit(", "// worker.submit(\n runNow(")
         self.assertCaught(self.check(scanner=scanner), "does not submit")
 
     def test_a_worker_that_never_leaves_the_caller_thread_is_caught(self):
-        worker = GOOD_WORKER.replace("background.execute {", "run {")
-        self.assertCaught(self.check(worker=worker), "background executor")
+        self.assertCaught(
+            self.check(worker=GOOD_WORKER.replace("background.execute {", "run {")),
+            "background executor",
+        )
 
     def test_work_evaluated_before_the_executor_is_caught(self):
         worker = GOOD_WORKER.replace(
@@ -185,17 +154,73 @@ class CheckerTest(unittest.TestCase):
         self.assertCaught(self.check(worker=worker), "work() is evaluated outside")
 
     def test_callbacks_outside_the_executor_are_caught(self):
-        worker = GOOD_WORKER.replace(
-            "                    onFailure(e)", "                    throw e"
-        ).replace(
-            "            onSuccess(value)",
-            "            value\n        }\n        onSuccess(work())",
+        worker = GOOD_WORKER.replace("                    onFailure(e)", "                    throw e").replace(
+            "            onSuccess(value)", "            value\n        }\n        onSuccess(work())"
         )
         self.assertCaught(self.check(worker=worker), "callbacks must stay inside")
 
     def test_a_renamed_scan_method_is_caught(self):
-        scanner = GOOD_SCANNER.replace("fun listAudioDocuments", "fun listAudio")
-        self.assertCaught(self.check(scanner=scanner), "no listAudioDocuments()")
+        self.assertCaught(
+            self.check(scanner=GOOD_SCANNER.replace("fun listAudioDocuments", "fun listAudio")),
+            "no listAudioDocuments()",
+        )
+
+    def test_eager_walk_then_submitted_value_is_caught(self):
+        scanner = GOOD_SCANNER.replace(
+            SUBMITTING_SCAN,
+            "        val documents = walk(Uri.parse(treeUri))\n"
+            + SUBMITTING_SCAN.replace("walk(Uri.parse(treeUri))", "documents"),
+        )
+        self.assertCaught(self.check(scanner=scanner), "inside the submitted work")
+
+    def test_eager_walk_with_another_valid_work_lambda_is_caught(self):
+        scanner = GOOD_SCANNER.replace(
+            SUBMITTING_SCAN,
+            "        val eager = walk(Uri.parse(treeUri))\n" + SUBMITTING_SCAN,
+        )
+        self.assertCaught(self.check(scanner=scanner), "inside the submitted work")
+
+    def test_walk_after_submission_is_caught(self):
+        scanner = GOOD_SCANNER.replace(
+            SUBMITTING_SCAN, SUBMITTING_SCAN + "\n        walk(Uri.parse(treeUri))"
+        )
+        self.assertCaught(self.check(scanner=scanner), "inside the submitted work")
+
+    def test_work_in_a_comment_cannot_hide_an_eager_walk(self):
+        scanner = GOOD_SCANNER.replace(
+            SUBMITTING_SCAN,
+            "        val documents = walk(Uri.parse(treeUri))\n"
+            "        // work = { walk(Uri.parse(treeUri)) }\n"
+            + SUBMITTING_SCAN.replace("walk(Uri.parse(treeUri))", "documents"),
+        )
+        self.assertCaught(self.check(scanner=scanner), "inside the submitted work")
+
+    def test_a_second_inline_success_is_caught(self):
+        scanner = GOOD_SCANNER.replace(
+            SUBMITTING_SCAN, SUBMITTING_SCAN + "\n        result.success(emptyMap())"
+        )
+        self.assertCaught(self.check(scanner=scanner), "must not answer inline")
+
+    def test_a_second_submission_is_caught(self):
+        scanner = GOOD_SCANNER.replace(SUBMITTING_SCAN, SUBMITTING_SCAN + "\n" + SUBMITTING_SCAN)
+        self.assertCaught(self.check(scanner=scanner), "exactly one")
+
+    def test_a_synchronous_production_executor_is_caught(self):
+        worker = GOOD_WORKER.replace("newSingleThreadExecutor", "newSingleThreadExecutorRemoved")
+        self.assertCaught(self.check(worker=worker), "background thread factory")
+
+    def test_comments_and_strings_cannot_fake_calls(self):
+        worker = GOOD_WORKER.replace("                    work()", '                    "work()"')
+        self.assertCaught(self.check(worker=worker), "work() is evaluated outside")
+
+    def test_nested_comments_and_raw_strings_do_not_break_nesting(self):
+        scanner = GOOD_SCANNER.replace(
+            SUBMITTING_SCAN,
+            '        /* outer { /* inner ) } */ still } */\n'
+            '        val prose = """{ ) worker.submit(work = { walk() })"""\n'
+            + SUBMITTING_SCAN,
+        )
+        self.assertEqual(self.check(scanner=scanner), [])
 
 
 if __name__ == "__main__":

--- a/test/tooling/check_android_channel_threading_test.py
+++ b/test/tooling/check_android_channel_threading_test.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/check_android_channel_threading.py (#346).
+
+    python3 test/tooling/check_android_channel_threading_test.py
+
+The checker exists to notice one silent regression: the SAF library walk drifting
+back onto Android's platform thread, where it becomes an ANR on a real library.
+That regression compiles, passes every test in the repo, and reads like a
+simplification in review, so the tests here are "take a good checkout, break
+exactly one thing, expect it to be caught".
+
+They run against a synthetic Kotlin fixture rather than the real files, because a
+fixture is the only way to prove the checker *fails* when it should. One test
+does run against the real repository, since "the checker passes on the actual
+Kotlin" is what the CI step cares about.
+
+Everything is offline. No network, no Gradle, no Android SDK, no repository
+writes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+
+
+def _load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load("check_android_channel_threading", "check_android_channel_threading.py")
+
+
+GOOD_WORKER = """package io.github.thezupzup.linthra
+
+import android.os.Handler
+import android.os.Looper
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+
+/** Runs blocking channel work off the platform thread. */
+class PlatformChannelWorker(
+    private val background: Executor = SHARED_BACKGROUND,
+    private val platform: Executor = PlatformThreadExecutor,
+) {
+    fun <T> submit(
+        work: () -> T,
+        onSuccess: (T) -> Unit,
+        onFailure: (Exception) -> Unit,
+    ) {
+        background.execute {
+            val value =
+                try {
+                    work()
+                } catch (e: Exception) {
+                    platform.execute { onFailure(e) }
+                    return@execute
+                }
+            platform.execute { onSuccess(value) }
+        }
+    }
+
+    private object PlatformThreadExecutor : Executor {
+        private val handler = Handler(Looper.getMainLooper())
+
+        override fun execute(command: Runnable) {
+            handler.post(command)
+        }
+    }
+
+    companion object {
+        private val SHARED_BACKGROUND: Executor =
+            Executors.newSingleThreadExecutor { runnable ->
+                Thread(runnable, "linthra-channel-work").apply { isDaemon = true }
+            }
+    }
+}
+"""
+
+SUBMITTING_SCAN = """        worker.submit(
+            work = { walk(Uri.parse(treeUri)) },
+            onSuccess = { documents -> result.success(documents) },
+            onFailure = { error ->
+                if (error is SecurityException) {
+                    result.error("saf_permission", "No access.", null)
+                } else {
+                    result.error("saf_failed", "Failed to read.", null)
+                }
+            },
+        )"""
+
+GOOD_SCANNER = (
+    """package io.github.thezupzup.linthra
+
+import android.content.Context
+import android.net.Uri
+import io.flutter.plugin.common.MethodChannel
+
+class SafDocumentScanner(
+    private val context: Context,
+    private val worker: PlatformChannelWorker = PlatformChannelWorker(),
+) {
+    /** Walks the tree off the platform thread. */
+    fun listAudioDocuments(treeUri: String, result: MethodChannel.Result) {
+"""
+    + SUBMITTING_SCAN
+    + """
+    }
+
+    fun hasPersistedPermission(treeUri: String): Boolean = true
+
+    private fun walk(treeUri: Uri): Map<String, Any?> = emptyMap()
+}
+"""
+)
+
+
+class CheckerTest(unittest.TestCase):
+    def check(self, *, worker: str = GOOD_WORKER, scanner: str = GOOD_SCANNER):
+        """Runs the checker over a throwaway Kotlin directory."""
+        with tempfile.TemporaryDirectory() as raw:
+            directory = Path(raw)
+            (directory / checker.WORKER_FILE).write_text(worker, encoding="utf-8")
+            (directory / checker.SCANNER_FILE).write_text(scanner, encoding="utf-8")
+            return checker.check(directory)
+
+    def assertCaught(self, failures: list[str], needle: str) -> None:
+        self.assertTrue(failures, "expected the checker to fail, it passed")
+        self.assertIn(needle, "\n".join(failures))
+
+    def test_a_good_pair_passes(self):
+        self.assertEqual(self.check(), [])
+
+    def test_the_real_kotlin_passes(self):
+        # The claim the CI step is actually making.
+        self.assertEqual(checker.check(checker.KOTLIN), [])
+
+    def test_a_missing_worker_file_is_caught(self):
+        with tempfile.TemporaryDirectory() as raw:
+            directory = Path(raw)
+            (directory / checker.SCANNER_FILE).write_text(
+                GOOD_SCANNER, encoding="utf-8"
+            )
+            self.assertCaught(checker.check(directory), "missing")
+
+    def test_the_pre_fix_shape_is_caught(self):
+        # Exactly how the scan looked before #346: the whole walk evaluated as
+        # the argument to the reply, on the caller's thread.
+        inline = """        try {
+            result.success(walk(Uri.parse(treeUri)))
+        } catch (e: Exception) {
+            result.error("saf_failed", "Failed to read.", null)
+        }"""
+        scanner = GOOD_SCANNER.replace(SUBMITTING_SCAN, inline)
+        self.assertCaught(self.check(scanner=scanner), "inline")
+
+    def test_a_reformatted_inline_reply_is_still_caught(self):
+        inline = """        result . success (
+            walk( Uri.parse(treeUri) )
+        )"""
+        scanner = GOOD_SCANNER.replace(SUBMITTING_SCAN, inline)
+        self.assertCaught(self.check(scanner=scanner), "inline")
+
+    def test_dropping_the_worker_from_the_scan_is_caught(self):
+        scanner = GOOD_SCANNER.replace("worker.submit(", "runNow(")
+        self.assertCaught(self.check(scanner=scanner), "does not submit")
+
+    def test_a_commented_out_submit_does_not_satisfy_the_checker(self):
+        # A file whose comments still describe the fix, whose code no longer
+        # has it. Checking raw text would pass this.
+        scanner = GOOD_SCANNER.replace(
+            "worker.submit(", "// worker.submit(\n        runNow("
+        )
+        self.assertCaught(self.check(scanner=scanner), "does not submit")
+
+    def test_a_worker_that_never_leaves_the_caller_thread_is_caught(self):
+        worker = GOOD_WORKER.replace("background.execute {", "run {")
+        self.assertCaught(self.check(worker=worker), "background executor")
+
+    def test_a_worker_that_replies_off_the_platform_thread_is_caught(self):
+        worker = GOOD_WORKER.replace(
+            "platform.execute { onSuccess(value) }", "onSuccess(value)"
+        ).replace("platform.execute { onFailure(e) }", "onFailure(e)")
+        self.assertCaught(self.check(worker=worker), "platform executor")
+
+    def test_losing_the_main_looper_post_is_caught(self):
+        worker = GOOD_WORKER.replace("handler.post(command)", "command.run()")
+        self.assertCaught(self.check(worker=worker), "main looper")
+
+    def test_a_renamed_scan_method_is_caught(self):
+        scanner = GOOD_SCANNER.replace("fun listAudioDocuments", "fun listAudio")
+        self.assertCaught(self.check(scanner=scanner), "no listAudioDocuments()")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/tooling/check_android_channel_threading_test.py
+++ b/test/tooling/check_android_channel_threading_test.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Mutation tests for the SAF threading tripwire (#346).
 
-The synthetic fixtures deliberately move the walk outside the submitted work,
-including the regression that #570's previous checker failed to detect.
-Everything runs offline without an Android SDK or Gradle.
+The synthetic fixtures deliberately break one thing each: the walk moved
+outside the submitted work (including the regression that #570's previous
+checker failed to detect), and the two quiet ways scan cancellation stops
+working. Everything runs offline without an Android SDK or Gradle.
 """
 
 from __future__ import annotations
@@ -61,7 +62,7 @@ class PlatformChannelWorker(
 """
 
 SUBMITTING_SCAN = """        worker.submit(
-            work = { walk(Uri.parse(treeUri)) },
+            work = { walk(Uri.parse(treeUri), cancelled) },
             onSuccess = { documents -> result.success(documents) },
             onFailure = { error ->
                 if (error is SecurityException) {
@@ -71,6 +72,27 @@ SUBMITTING_SCAN = """        worker.submit(
                 }
             },
         )"""
+
+GOOD_WALK = """    private fun walk(treeUri: Uri, cancelled: AtomicBoolean): Map<String, Any?> {
+        while (queue.isNotEmpty()) {
+            if (cancelled.get()) throw ScanSuperseded()
+            try {
+                cursor.use { c ->
+                    while (c.moveToNext()) {
+                        if (cancelled.get()) throw ScanSuperseded()
+                    }
+                }
+            } catch (e: ScanSuperseded) {
+                throw e
+            } catch (e: SecurityException) {
+                throw e
+            } catch (e: Exception) {
+                readFailures++
+            }
+        }
+        return emptyMap()
+    }
+"""
 
 GOOD_SCANNER = (
     """package io.github.thezupzup.linthra
@@ -86,32 +108,15 @@ class SafDocumentScanner(
     + SUBMITTING_SCAN
     + """
     }
-    private fun walk(treeUri: Uri): Map<String, Any?> = emptyMap()
+"""
+    + GOOD_WALK
+    + """    private class ScanSuperseded : Exception()
+    companion object {
+        private val currentScan = AtomicReference<AtomicBoolean?>(null)
+    }
 }
 """
 )
-
-
-GOOD_ACTIVITY = """package io.github.thezupzup.linthra
-
-class MainActivity : AudioServiceActivity() {
-    // One scanner for the channel: it holds the cancellation flag of the walk
-    // in flight, and a fresh one per request would have nothing to cancel.
-    private val safDocumentScanner by lazy {
-        SafDocumentScanner(applicationContext)
-    }
-
-    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
-        when (call.method) {
-            "listAudioDocuments" -> safDocumentScanner.listAudioDocuments(treeUri, result)
-            "hasPersistedPermission" ->
-                result.success(safDocumentScanner.hasPersistedPermission(treeUri))
-            "readSidecarText" ->
-                result.success(safDocumentScanner.readSidecarText(uri, extension))
-        }
-    }
-}
-"""
 
 
 class CheckerTest(unittest.TestCase):
@@ -120,13 +125,11 @@ class CheckerTest(unittest.TestCase):
         *,
         worker: str = GOOD_WORKER,
         scanner: str = GOOD_SCANNER,
-        activity: str = GOOD_ACTIVITY,
     ):
         with tempfile.TemporaryDirectory() as raw:
             directory = Path(raw)
             (directory / checker.WORKER_FILE).write_text(worker, encoding="utf-8")
             (directory / checker.SCANNER_FILE).write_text(scanner, encoding="utf-8")
-            (directory / checker.ACTIVITY_FILE).write_text(activity, encoding="utf-8")
             return checker.check(directory)
 
     def assertCaught(self, failures: list[str], needle: str) -> None:
@@ -145,20 +148,17 @@ class CheckerTest(unittest.TestCase):
             (directory / checker.SCANNER_FILE).write_text(
                 GOOD_SCANNER, encoding="utf-8"
             )
-            (directory / checker.ACTIVITY_FILE).write_text(
-                GOOD_ACTIVITY, encoding="utf-8"
-            )
             self.assertCaught(checker.check(directory), "missing")
 
     def test_the_pre_fix_shape_is_caught(self):
-        inline = "        result.success(walk(Uri.parse(treeUri)))"
+        inline = "        result.success(walk(Uri.parse(treeUri), cancelled))"
         self.assertCaught(
             self.check(scanner=GOOD_SCANNER.replace(SUBMITTING_SCAN, inline)),
             "does not submit",
         )
 
     def test_a_reformatted_inline_reply_is_caught(self):
-        inline = "        result . success (\n walk(Uri.parse(treeUri))\n )"
+        inline = "        result . success (\n walk(Uri.parse(treeUri), cancelled)\n )"
         self.assertCaught(
             self.check(scanner=GOOD_SCANNER.replace(SUBMITTING_SCAN, inline)),
             "does not submit",
@@ -207,30 +207,36 @@ class CheckerTest(unittest.TestCase):
     def test_eager_walk_then_submitted_value_is_caught(self):
         scanner = GOOD_SCANNER.replace(
             SUBMITTING_SCAN,
-            "        val documents = walk(Uri.parse(treeUri))\n"
-            + SUBMITTING_SCAN.replace("walk(Uri.parse(treeUri))", "documents"),
+            "        val documents = walk(Uri.parse(treeUri), cancelled)\n"
+            + SUBMITTING_SCAN.replace(
+                "walk(Uri.parse(treeUri), cancelled)", "documents"
+            ),
         )
         self.assertCaught(self.check(scanner=scanner), "inside the submitted work")
 
     def test_eager_walk_with_another_valid_work_lambda_is_caught(self):
         scanner = GOOD_SCANNER.replace(
             SUBMITTING_SCAN,
-            "        val eager = walk(Uri.parse(treeUri))\n" + SUBMITTING_SCAN,
+            "        val eager = walk(Uri.parse(treeUri), cancelled)\n"
+            + SUBMITTING_SCAN,
         )
         self.assertCaught(self.check(scanner=scanner), "inside the submitted work")
 
     def test_walk_after_submission_is_caught(self):
         scanner = GOOD_SCANNER.replace(
-            SUBMITTING_SCAN, SUBMITTING_SCAN + "\n        walk(Uri.parse(treeUri))"
+            SUBMITTING_SCAN,
+            SUBMITTING_SCAN + "\n        walk(Uri.parse(treeUri), cancelled)",
         )
         self.assertCaught(self.check(scanner=scanner), "inside the submitted work")
 
     def test_work_in_a_comment_cannot_hide_an_eager_walk(self):
         scanner = GOOD_SCANNER.replace(
             SUBMITTING_SCAN,
-            "        val documents = walk(Uri.parse(treeUri))\n"
-            "        // work = { walk(Uri.parse(treeUri)) }\n"
-            + SUBMITTING_SCAN.replace("walk(Uri.parse(treeUri))", "documents"),
+            "        val documents = walk(Uri.parse(treeUri), cancelled)\n"
+            "        // work = { walk(Uri.parse(treeUri), cancelled) }\n"
+            + SUBMITTING_SCAN.replace(
+                "walk(Uri.parse(treeUri), cancelled)", "documents"
+            ),
         )
         self.assertCaught(self.check(scanner=scanner), "inside the submitted work")
 
@@ -267,41 +273,55 @@ class CheckerTest(unittest.TestCase):
         )
         self.assertEqual(self.check(scanner=scanner), [])
 
-    def test_a_scanner_built_per_request_is_caught(self):
-        # The shape that silently disabled cancellation: each request gets a
-        # fresh instance, so there is never an in-flight walk to supersede.
-        activity = GOOD_ACTIVITY.replace(
-            "safDocumentScanner.listAudioDocuments(treeUri, result)",
-            "SafDocumentScanner(applicationContext)"
-            ".listAudioDocuments(treeUri, result)",
-        )
-        self.assertCaught(self.check(activity=activity), "exactly one")
-
-    def test_a_scanner_built_at_a_call_site_is_caught(self):
-        # Exactly one construction, but not a stored one: cancellation state
-        # still dies with the call.
-        activity = GOOD_ACTIVITY.replace(
-            """    private val safDocumentScanner by lazy {
-        SafDocumentScanner(applicationContext)
+    def test_an_instance_scoped_cancellation_flag_is_caught(self):
+        # Compiles and works until the activity is recreated mid-scan, at which
+        # point the new scanner's flag is empty and nothing cancels.
+        scanner = GOOD_SCANNER.replace(
+            """    companion object {
+        private val currentScan = AtomicReference<AtomicBoolean?>(null)
     }
-
 """,
             "",
         ).replace(
-            "safDocumentScanner.listAudioDocuments(treeUri, result)",
-            "SafDocumentScanner(applicationContext)"
-            ".listAudioDocuments(treeUri, result)",
+            "class SafDocumentScanner(",
+            "private val currentScan = AtomicReference<AtomicBoolean?>(null)\n"
+            "class SafDocumentScanner(",
         )
-        self.assertCaught(self.check(activity=activity), "held for the")
+        self.assertCaught(self.check(scanner=scanner), "companion object")
 
-    def test_a_missing_activity_is_caught(self):
-        with tempfile.TemporaryDirectory() as raw:
-            directory = Path(raw)
-            (directory / checker.WORKER_FILE).write_text(GOOD_WORKER, encoding="utf-8")
-            (directory / checker.SCANNER_FILE).write_text(
-                GOOD_SCANNER, encoding="utf-8"
-            )
-            self.assertCaught(checker.check(directory), "missing")
+    def test_a_missing_cancellation_flag_is_caught(self):
+        scanner = GOOD_SCANNER.replace("val currentScan", "val unusedScan")
+        self.assertCaught(self.check(scanner=scanner), "no currentScan")
+
+    def test_dropping_the_superseded_rethrow_is_caught(self):
+        # The quiet one: cancellation becomes "one unreadable subtree" and the
+        # walk answers a partial success instead of saf_superseded.
+        scanner = GOOD_SCANNER.replace(
+            "            } catch (e: ScanSuperseded) {\n                throw e\n", ""
+        )
+        self.assertCaught(self.check(scanner=scanner), "before its catch-all")
+
+    def test_a_superseded_catch_after_the_catch_all_is_caught(self):
+        # Present but unreachable: Kotlin matches the catch-all first.
+        scanner = GOOD_SCANNER.replace(
+            "            } catch (e: ScanSuperseded) {\n                throw e\n", ""
+        ).replace(
+            "            } catch (e: Exception) {\n                readFailures++\n",
+            "            } catch (e: Exception) {\n                readFailures++\n"
+            "            } catch (e: ScanSuperseded) {\n                throw e\n",
+        )
+        self.assertCaught(self.check(scanner=scanner), "before its catch-all")
+
+    def test_a_walk_that_never_checks_cancellation_is_caught(self):
+        scanner = GOOD_SCANNER.replace("throw ScanSuperseded()", "continue")
+        self.assertCaught(self.check(scanner=scanner), "never acts on cancellation")
+
+    def test_a_commented_out_rethrow_does_not_count(self):
+        scanner = GOOD_SCANNER.replace(
+            "            } catch (e: ScanSuperseded) {\n                throw e\n",
+            "            // } catch (e: ScanSuperseded) { throw e\n",
+        )
+        self.assertCaught(self.check(scanner=scanner), "before its catch-all")
 
 
 if __name__ == "__main__":

--- a/test/tooling/check_android_channel_threading_test.py
+++ b/test/tooling/check_android_channel_threading_test.py
@@ -111,6 +111,10 @@ class SafDocumentScanner(
     + """
     }
 """
+    + """    fun cancelScan() {
+        currentScan.getAndSet(null)?.set(true)
+    }
+"""
     + GOOD_WALK
     + """    private class ScanSuperseded : Exception()
     companion object {
@@ -370,6 +374,24 @@ class CheckerTest(unittest.TestCase):
             "            handler.post { onSuccess(value) }",
         )
         self.assertCaught(self.check(worker=worker), "dispatched to another thread")
+
+    def test_a_missing_cancel_entry_point_is_caught(self):
+        # Forgetting the folder starts no replacement scan, so without this the
+        # abandoned walk runs to completion and nothing looks broken.
+        scanner = GOOD_SCANNER.replace(
+            """    fun cancelScan() {
+        currentScan.getAndSet(null)?.set(true)
+    }
+""",
+            "",
+        )
+        self.assertCaught(self.check(scanner=scanner), "no cancelScan()")
+
+    def test_a_cancel_that_trips_nothing_is_caught(self):
+        scanner = GOOD_SCANNER.replace(
+            "        currentScan.getAndSet(null)?.set(true)\n", ""
+        )
+        self.assertCaught(self.check(scanner=scanner), "must trip the walk in flight")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #346. Supersedes #570, whose rework is merged in here.

## The problem

Flutter calls a `MethodChannel` handler on Android's platform (main) thread. `SafDocumentScanner.listAudioDocuments` was doing the whole walk inside the handler:

```kotlin
result.success(walk(Uri.parse(treeUri)))
```

That is one content-resolver query per folder, plus a `MediaMetadataRetriever` open and an artwork extraction per audio file, all on the UI thread. Instant on a twelve-track test folder. On a real library, a slow provider, or an SD card, it freezes the UI and eventually trips an ANR.

## The fix

`PlatformChannelWorker` is the seam: it runs blocking channel work on a background thread and answers the reply from there.

- The scan submits its work to it. `hasPersistedPermission`, `readSidecarText` and `cancelScan` are cheap and still answer inline, keeping this focused on the heavy path as the issue asked.
- One shared single background thread, deliberately: two scans of the same tree at once would only slow the content resolver down and double the artwork extraction. The thread is a daemon, so a scan started just before the process dies cannot hold it open.
- The reply is encoded on the worker, not posted back to the main looper. `FlutterJNI.invokePlatformMessageResponseCallback` guards its own state with a `ReentrantReadWriteLock` and has no `ensureRunningOnMainThread` assertion, so answering off-thread is supported, and it keeps envelope encoding of a large library off the UI thread too.
- Only `Exception` is caught. An `Error` (an OOM on a very large library) goes to the default handler rather than reaching Dart as "this folder is unreadable".
- Error mapping is otherwise unchanged: `SecurityException` still becomes `saf_permission`, everything else `saf_failed`, and no provider message (which could carry a path) crosses the channel.

No permission model change: same SAF tree grant, no MediaStore, no broad storage access, and no rewrite of the walk itself.

## Cancellation, so an abandoned walk stops costing something

Moving the walk off the UI thread is what makes Settings reachable mid-scan, and with one shared thread the next scan used to queue behind all of the previous one. So a walk nobody is waiting for now stops:

- A cancellation flag lives in `SafDocumentScanner`'s companion object. A new `listAudioDocuments` swaps its own in and trips the one it replaced. It is process-scoped on purpose, matching `PlatformChannelWorker`'s executor: the flag's job is to free that thread, so it has to outlive any one activity. An instance field would stop cancelling exactly when Android recreates the activity mid-scan, the same recreation `MainActivity`'s pending folder pick already has to survive.
- Only a new `listAudioDocuments` supersedes natively, so every other way to abandon a walk goes through `cancelScan()`: forgetting the folder, clearing the local catalog, and starting a scan of the device-wide library (which goes to MediaStore and never touches the SAF channel). `LibraryController.invalidatePendingScans()` owns that, and `scanFolderWithReport` bumps its generations through it, so starting a scan cancels the one it replaces whatever kind it is.
- `walk()` checks the flag per entry inside the cursor loop, not only per folder. A flat Music folder is a single outer iteration, so a per-folder check alone would leave the common case uninterruptible.
- The `ScanSuperseded` throw is rethrown ahead of the walk's catch-all. Without that it would be counted as one unreadable subtree and the walk would carry on to answer a partial success, which Dart then has to decode in full before discarding.
- The superseded scan answers a small `saf_superseded` error rather than going silent, so the Dart side always settles.

Cancellation is best-effort on every platform, and never awaited so callers can still invalidate before their first `await`. The `_scanGeneration` guard is what makes a stale result safe, on every path (success, `FolderScanException`, and the generic catch); cancellation only saves the work.

## The regression check

The failure mode here is silent. Delete the worker, call `walk()` directly, and it compiles, passes every test in the repo, and reads like a simplification in review. Nothing in the build has an opinion about how long a channel handler runs, or about whether cancellation still cancels.

So `scripts/check_android_channel_threading.py` asserts the boundary, the same way `check_linux_runner.py` asserts the desktop runner's identity:

- the worker really moves work off the caller, both callbacks stay inside the executor, and neither is re-dispatched from in there to another executor or the main looper (which would put envelope encoding back on the platform thread while still reading as "inside `background.execute`"),
- `walk()` is evaluated inside the submitted work lambda, not eagerly before it,
- `listAudioDocuments` contains no inline `result.success(...)`,
- `currentScan` is declared in the companion object, not on the instance,
- `listAudioDocuments` swaps a *named* flag into it, trips the one it replaced, and hands that same flag to the walk (an argument it cannot verify is rejected, not skipped),
- `cancelScan()` exists, trips `currentScan`, and `MainActivity` actually routes the channel call to it,
- `walk()` checks cancellation inside the cursor's `moveToNext` loop, not only at the folder boundary,
- `walk()` rethrows `ScanSuperseded` before its catch-all, where Kotlin can actually reach it.

It masks comments and string literals first, so a file whose KDoc still describes the fix but whose code lost it does not pass. Where the literal *is* the thing being checked (a `when` arm's method name) it masks comments only, still scanning past strings so a `//` inside one cannot open a comment.

`test/tooling/check_android_channel_threading_test.py` proves the checker fails when it should: 39 cases that each break one thing in a synthetic fixture, plus one that runs against the real Kotlin. Wired into `scripts/verify_android.sh` and the Android debug APK workflow.

Worth stating the limit, since a source-level check cannot do better: it catches the shapes a real refactor would take, not a callback smuggled through an arbitrary indirection.

## Checks

- `python3 scripts/check_android_channel_threading.py`: passes
- `python3 test/tooling/check_android_channel_threading_test.py`: 39 passing
- `scripts/verify_android.sh`: passes (APK build skipped here, no SDK; CI builds it)
- `ruff check` / `ruff format --check` over `scripts tool tools`: clean
- `dart format --set-exit-if-changed .`: clean
- `flutter analyze`: no issues
- `flutter test`: 4066 passing
- `scripts/check_secrets.sh`: clean

## What I could not run

No Android SDK in this environment, so the Kotlin is **not compiled** here and there is no on-device run. Worth a look at before merge:

- a real scan of a large folder on a device: the library should still import identically, and the UI should stay responsive while it runs
- picking a second folder mid-scan should switch over quickly instead of waiting out the first
- forgetting the folder, or switching to the device library, mid-scan: the old walk should stop rather than run to completion in the background

A JVM unit test for `PlatformChannelWorker` would be the natural companion to this, but the repo has no Kotlin test source set or JUnit dependency yet. Adding one is a build-config change I would rather not make blind, so I left it out. Happy to do it as a follow-up if you want the test infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvJnixf94LEa7BYmBRV54m