### PR TITLE
fix(android): keep SAF scan and result encoding off platform thread; prevent stale scan commits

### DIFF
--- a/.github/workflows/android-debug-apk.yml
+++ b/.github/workflows/android-debug-apk.yml
@@ -39,6 +39,16 @@ jobs:
       - name: Install dependencies
         run: flutter pub get --enforce-lockfile
 
+      # Cheap, Flutter-independent, and it runs before the build because the
+      # regression it guards against would build perfectly: a method-channel
+      # handler that does its work inline blocks Android's platform thread and
+      # only shows up as an ANR on a real music library (#346).
+      - name: Check Android channel threading
+        run: python3 scripts/check_android_channel_threading.py
+
+      - name: Test the Android channel threading tooling
+        run: python3 test/tooling/check_android_channel_threading_test.py
+
       - name: Build debug APK
         run: flutter build apk --debug
 

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
@@ -75,6 +75,11 @@ class MainActivity : AudioServiceActivity() {
                     // walk was never reached. Returning the tree URI routes the
                     // scan through SafDocumentScanner instead.
                     "pickFolderTree" -> startFolderPick(result)
+                    // Walks the picked tree and returns its audio documents.
+                    // The scan itself runs off this (platform) thread — see
+                    // PlatformChannelWorker — so this branch only queues it and
+                    // returns; `result` is encoded and answered from the worker
+                    // once the walk finishes.
                     "listAudioDocuments" -> {
                         val treeUri = call.argument<String>("treeUri")
                         if (treeUri == null) {

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/PlatformChannelWorker.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/PlatformChannelWorker.kt
@@ -1,0 +1,65 @@
+package io.github.thezupzup.linthra
+
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+
+/**
+ * Runs one piece of blocking method-channel work off the platform thread and
+ * delivers its outcome from that worker thread.
+ *
+ * Flutter invokes a `MethodChannel` handler on the platform (main) thread.
+ * Doing the work *inside* the handler therefore blocks the UI for as long as it
+ * takes — fine
+ * for reading a flag, not fine for walking a music library through the content
+ * resolver (#346). This is the seam between the two: [submit] hands the work to
+ * a background thread and invokes exactly one callback there. Flutter permits
+ * `MethodChannel.Result` replies from any thread, which also keeps the channel
+ * codec's potentially large success-envelope encoding off the platform thread.
+ *
+ * The background executor is a single shared daemon thread, deliberately:
+ *
+ *  * two scans of the same tree at once would only make the content resolver
+ *    slower and could double the artwork extraction work, so they queue instead;
+ *  * one long-lived thread costs nothing between scans, and a scan started just
+ *    before the process dies cannot hold it open.
+ *
+ * The executor is injectable so the threading boundary can be exercised
+ * without a device. Production takes the default.
+ */
+class PlatformChannelWorker(
+    private val background: Executor = SHARED_BACKGROUND,
+) {
+
+    /**
+     * Runs [work] on the background executor, then calls exactly one of
+     * [onSuccess] or [onFailure] on that same worker thread.
+     *
+     * Only [Exception] is caught. An [Error] (an OOM on a very large library,
+     * say) is left to the default handler rather than being reported as an
+     * ordinary channel failure the Dart side would treat as "this folder is
+     * unreadable".
+     */
+    fun <T> submit(
+        work: () -> T,
+        onSuccess: (T) -> Unit,
+        onFailure: (Exception) -> Unit,
+    ) {
+        background.execute {
+            val value =
+                try {
+                    work()
+                } catch (e: Exception) {
+                    onFailure(e)
+                    return@execute
+                }
+            onSuccess(value)
+        }
+    }
+
+    companion object {
+        private val SHARED_BACKGROUND: Executor =
+            Executors.newSingleThreadExecutor { runnable ->
+                Thread(runnable, "linthra-channel-work").apply { isDaemon = true }
+            }
+    }
+}

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
@@ -28,18 +28,48 @@ import java.util.ArrayDeque
  * walk, so one bad subtree can't zero out an otherwise-readable library. A
  * total access denial (a revoked grant) still surfaces as a SecurityException
  * so the user sees a clear "no access" message instead of a silent empty.
+ *
+ * Threading: the walk is blocking and proportional to the library, so it runs
+ * on [PlatformChannelWorker]'s background thread rather than on the platform
+ * thread Flutter calls the channel handler on (#346). The cheap calls
+ * ([hasPersistedPermission], [readSidecarText]) still answer inline.
  */
-class SafDocumentScanner(private val context: Context) {
+class SafDocumentScanner(
+    private val context: Context,
+    private val worker: PlatformChannelWorker = PlatformChannelWorker(),
+) {
 
-    /** Lists audio documents under [treeUri], reporting back through [result]. */
+    /**
+     * Lists audio documents under [treeUri], reporting back through [result].
+     *
+     * The walk runs on [PlatformChannelWorker]'s background thread and [result]
+     * and the result is encoded and answered there, so a real library — thousands of
+     * content-resolver queries plus a [MediaMetadataRetriever] open per file —
+     * never blocks the UI (#346). This returns as soon as the work is queued.
+     */
     fun listAudioDocuments(treeUri: String, result: MethodChannel.Result) {
-        try {
-            result.success(walk(Uri.parse(treeUri)))
-        } catch (e: SecurityException) {
-            result.error("saf_permission", "No access to the selected folder.", null)
-        } catch (e: Exception) {
-            result.error("saf_failed", "Failed to read the selected folder.", null)
-        }
+        worker.submit(
+            work = { walk(Uri.parse(treeUri)) },
+            onSuccess = { documents -> result.success(documents) },
+            onFailure = { error ->
+                // A revoked or never-granted tree is a clear "no access"; every
+                // other failure stays a generic read error, so no provider
+                // message (which could carry a path) reaches the Dart side.
+                if (error is SecurityException) {
+                    result.error(
+                        "saf_permission",
+                        "No access to the selected folder.",
+                        null,
+                    )
+                } else {
+                    result.error(
+                        "saf_failed",
+                        "Failed to read the selected folder.",
+                        null,
+                    )
+                }
+            },
+        )
     }
 
     /**

--- a/docs/local-music.md
+++ b/docs/local-music.md
@@ -76,6 +76,14 @@ read a user-chosen folder is the **Storage Access Framework (SAF)**:
    descending into subfolders. One unreadable subfolder is skipped and counted,
    not fatal; a totally unreadable selected folder surfaces a clear error rather
    than a silent empty result.
+4. That walk runs **off the platform (main) thread**, on `PlatformChannelWorker`'s
+   single background thread, and the method-channel reply is encoded and sent
+   there too. A real library means thousands of
+   content-resolver queries plus a `MediaMetadataRetriever` open per file, so
+   scanning inline would freeze the UI and eventually trip an ANR. Two scans
+   queue rather than run at once. `scripts/check_android_channel_threading.py`
+   guards the boundary, because a walk that drifts back onto the platform thread
+   still compiles and still passes every test.
 
 This is why a raw path like `/storage/emulated/0/Music/...` is the wrong thing to
 store — it looks fine but can't be read under scoped storage. If you selected a

--- a/lib/features/library/library_controller.dart
+++ b/lib/features/library/library_controller.dart
@@ -13,17 +13,23 @@ import 'local_scan_report_provider.dart';
 /// Drives the Library screen: loads tracks from the [MusicLibraryRepository]
 /// and exposes them as a [LibraryState].
 class LibraryController extends Notifier<LibraryState> {
+  int _catalogGeneration = 0;
+
   @override
   LibraryState build() {
     _load();
     return const LibraryState.loading();
   }
 
-  Future<void> refresh() => _load();
+  Future<void> refresh() {
+    _catalogGeneration++;
+    return _load();
+  }
 
   /// Scans a filesystem folder, SAF tree, or Android device-wide MediaStore
   /// selection, persists the discovered tracks, then reloads the catalog.
   Future<void> scanFolder(String folderPath) async {
+    final int generation = ++_catalogGeneration;
     state = const LibraryState.loading();
     final FolderLocation location = FolderLocation.parse(folderPath);
     try {
@@ -35,6 +41,10 @@ class LibraryController extends Notifier<LibraryState> {
         metadataReader: ref.read(localMetadataReaderProvider),
       );
       final LocalScan scan = await source.scanTracks();
+      // A SAF scan can take long enough for the user to forget this source or
+      // start a scan of another one. Never let that obsolete result repopulate
+      // or replace the catalog chosen by the newer action.
+      if (generation != _catalogGeneration) return;
       final repository = ref.read(musicLibraryRepositoryProvider);
       await repository.upsertCatalog(
         sourceId: source.id,
@@ -45,6 +55,7 @@ class LibraryController extends Notifier<LibraryState> {
       ref.read(localScanReportProvider.notifier).record(scan.report);
       await _load();
     } on FolderScanException catch (error) {
+      if (generation != _catalogGeneration) return;
       ref.read(localScanReportProvider.notifier).record(
             LocalScanReport.failure(
               folderSelected: folderPath.isNotEmpty,
@@ -61,6 +72,7 @@ class LibraryController extends Notifier<LibraryState> {
           );
       state = LibraryState.error(error.message);
     } catch (_) {
+      if (generation != _catalogGeneration) return;
       ref.read(localScanReportProvider.notifier).record(
             LocalScanReport.failure(
               folderSelected: folderPath.isNotEmpty,

--- a/lib/features/library/library_controller.dart
+++ b/lib/features/library/library_controller.dart
@@ -13,7 +13,9 @@ import 'local_scan_report_provider.dart';
 /// Drives the Library screen: loads tracks from the [MusicLibraryRepository]
 /// and exposes them as a [LibraryState].
 class LibraryController extends Notifier<LibraryState> {
-  int _catalogGeneration = 0;
+  int _scanGeneration = 0;
+  int _loadGeneration = 0;
+  Future<void> _localMutationTail = Future<void>.value();
 
   @override
   LibraryState build() {
@@ -21,15 +23,60 @@ class LibraryController extends Notifier<LibraryState> {
     return const LibraryState.loading();
   }
 
-  Future<void> refresh() {
-    _catalogGeneration++;
-    return _load();
+  /// Reloading the shared catalog must not cancel an unrelated local scan.
+  Future<void> refresh() => _load();
+
+  /// Supersedes pending local scans when the user changes or forgets a source.
+  /// Call this before the first asynchronous part of the source mutation.
+  void invalidatePendingScans() {
+    _scanGeneration++;
+    _loadGeneration++;
+  }
+
+  /// Waits for already-started local writes before persisting a source change.
+  /// Invalidation happens first, so pending walks cannot enqueue a new write.
+  Future<void> waitForLocalMutations() => _localMutationTail;
+
+  /// Serializes local catalog writes, including forget. A scan may finish its
+  /// walk while a previous write is pending; its generation is checked again
+  /// inside this queue so obsolete results cannot commit after a clear.
+  Future<T> _serializeLocalMutation<T>(Future<T> Function() operation) {
+    final Future<T> result = _localMutationTail.then((_) => operation());
+    _localMutationTail = result.then<void>(
+      (_) {},
+      onError: (Object _, StackTrace __) {},
+    );
+    return result;
+  }
+
+  /// Clears only the local source, after any already-started local write.
+  /// A new scan started after this action can still populate the catalog.
+  Future<void> clearLocalCatalog() {
+    invalidatePendingScans();
+    return _serializeLocalMutation(() async {
+      await ref.read(musicLibraryRepositoryProvider).upsertCatalog(
+            sourceId: const LocalMusicSource(folderPath: null).id,
+            tracks: const [],
+            albums: const [],
+            artists: const [],
+          );
+      ref.read(localScanReportProvider.notifier).clear();
+      await _load();
+    });
   }
 
   /// Scans a filesystem folder, SAF tree, or Android device-wide MediaStore
   /// selection, persists the discovered tracks, then reloads the catalog.
+  /// Kept as a void-returning API for existing Library screen callers.
   Future<void> scanFolder(String folderPath) async {
-    final int generation = ++_catalogGeneration;
+    await scanFolderWithReport(folderPath);
+  }
+
+  /// Returns this operation's report, or null if it was superseded. Callers
+  /// must not infer success from the last globally recorded scan report.
+  Future<LocalScanReport?> scanFolderWithReport(String folderPath) async {
+    final int generation = ++_scanGeneration;
+    _loadGeneration++;
     state = const LibraryState.loading();
     final FolderLocation location = FolderLocation.parse(folderPath);
     try {
@@ -41,47 +88,55 @@ class LibraryController extends Notifier<LibraryState> {
         metadataReader: ref.read(localMetadataReaderProvider),
       );
       final LocalScan scan = await source.scanTracks();
-      // A SAF scan can take long enough for the user to forget this source or
-      // start a scan of another one. Never let that obsolete result repopulate
-      // or replace the catalog chosen by the newer action.
-      if (generation != _catalogGeneration) return;
-      final repository = ref.read(musicLibraryRepositoryProvider);
-      await repository.upsertCatalog(
-        sourceId: source.id,
-        tracks: scan.tracks,
-        albums: groupAlbums(scan.tracks),
-        artists: groupArtists(scan.tracks),
-      );
-      ref.read(localScanReportProvider.notifier).record(scan.report);
-      await _load();
+      if (generation != _scanGeneration) return null;
+
+      return await _serializeLocalMutation<LocalScanReport?>(() async {
+        // Check at commit time, not merely when the filesystem walk finishes.
+        if (generation != _scanGeneration) return null;
+        final repository = ref.read(musicLibraryRepositoryProvider);
+        await repository.upsertCatalog(
+          sourceId: source.id,
+          tracks: scan.tracks,
+          albums: groupAlbums(scan.tracks),
+          artists: groupArtists(scan.tracks),
+        );
+        // A newer action may have started while the write was awaiting I/O.
+        // Its queued write will run after this one; do not publish stale status.
+        if (generation != _scanGeneration) return null;
+        ref.read(localScanReportProvider.notifier).record(scan.report);
+        await _load();
+        return generation == _scanGeneration ? scan.report : null;
+      });
     } on FolderScanException catch (error) {
-      if (generation != _catalogGeneration) return;
-      ref.read(localScanReportProvider.notifier).record(
-            LocalScanReport.failure(
-              folderSelected: folderPath.isNotEmpty,
-              isContentUri: location.isContentUri,
-              isDeviceLibrary: location.isAndroidMediaStore,
-              error: location.isAndroidMediaStore
-                  ? error.code == 'permission_denied'
-                      ? LocalScanError.mediaPermission
-                      : LocalScanError.unexpected
-                  : location.isContentUri
-                      ? LocalScanError.safTraversal
-                      : LocalScanError.folderUnavailable,
-            ),
-          );
+      if (generation != _scanGeneration) return null;
+      final report = LocalScanReport.failure(
+        folderSelected: folderPath.isNotEmpty,
+        isContentUri: location.isContentUri,
+        isDeviceLibrary: location.isAndroidMediaStore,
+        error: location.isAndroidMediaStore
+            ? error.code == 'permission_denied'
+                ? LocalScanError.mediaPermission
+                : LocalScanError.unexpected
+            : location.isContentUri
+                ? LocalScanError.safTraversal
+                : LocalScanError.folderUnavailable,
+      );
+      ref.read(localScanReportProvider.notifier).record(report);
+      _loadGeneration++;
       state = LibraryState.error(error.message);
+      return report;
     } catch (_) {
-      if (generation != _catalogGeneration) return;
-      ref.read(localScanReportProvider.notifier).record(
-            LocalScanReport.failure(
-              folderSelected: folderPath.isNotEmpty,
-              isContentUri: location.isContentUri,
-              isDeviceLibrary: location.isAndroidMediaStore,
-              error: LocalScanError.unexpected,
-            ),
-          );
+      if (generation != _scanGeneration) return null;
+      final report = LocalScanReport.failure(
+        folderSelected: folderPath.isNotEmpty,
+        isContentUri: location.isContentUri,
+        isDeviceLibrary: location.isAndroidMediaStore,
+        error: LocalScanError.unexpected,
+      );
+      ref.read(localScanReportProvider.notifier).record(report);
+      _loadGeneration++;
       state = const LibraryState.error(_scanFailedMessage);
+      return report;
     }
   }
 
@@ -94,13 +149,18 @@ class LibraryController extends Notifier<LibraryState> {
       'folder.';
 
   Future<void> _load() async {
+    final int generation = ++_loadGeneration;
     state = const LibraryState.loading();
     try {
       final tracks =
           await ref.read(musicLibraryRepositoryProvider).getAllTracks();
-      state = LibraryState.loaded(tracks);
+      if (generation == _loadGeneration) {
+        state = LibraryState.loaded(tracks);
+      }
     } catch (_) {
-      state = const LibraryState.error(_loadFailedMessage);
+      if (generation == _loadGeneration) {
+        state = const LibraryState.error(_loadFailedMessage);
+      }
     }
   }
 }

--- a/lib/features/library/selected_folder_controller.dart
+++ b/lib/features/library/selected_folder_controller.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../data/repositories/selected_music_folder_repository_provider.dart';
+import 'library_controller.dart';
 import 'library_providers.dart';
 
 /// Owns the user's chosen local-music location: a folder path/SAF URI, or an
@@ -25,6 +26,10 @@ class SelectedFolderController extends AsyncNotifier<String?> {
   /// Used by Android's explicit device-wide MediaStore mode.
   Future<void> setAndPersist(String location) async {
     if (location.isEmpty) return;
+    // A source change supersedes pending scans before persistence can yield.
+    final library = ref.read(libraryControllerProvider.notifier);
+    library.invalidatePendingScans();
+    await library.waitForLocalMutations();
     await ref
         .read(selectedMusicFolderRepositoryProvider)
         .setSelectedFolder(location);
@@ -33,6 +38,9 @@ class SelectedFolderController extends AsyncNotifier<String?> {
 
   /// Forgets the current selection.
   Future<void> clear() async {
+    final library = ref.read(libraryControllerProvider.notifier);
+    library.invalidatePendingScans();
+    await library.waitForLocalMutations();
     await ref.read(selectedMusicFolderRepositoryProvider).clearSelectedFolder();
     state = const AsyncData<String?>(null);
   }

--- a/lib/features/settings/source/local_music_controller.dart
+++ b/lib/features/settings/source/local_music_controller.dart
@@ -2,10 +2,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/sources/local/android_media_library.dart';
 import '../../../core/sources/local/folder_location.dart';
-import '../../../core/sources/local/local_music_source.dart';
 import '../../../core/sources/local/local_scan_report.dart';
 import '../../../data/repositories/host_platform_provider.dart';
-import '../../../data/repositories/music_library_repository_provider.dart';
 import '../../library/library_controller.dart';
 import '../../library/library_providers.dart';
 import '../../library/local_scan_report_provider.dart';
@@ -106,16 +104,14 @@ class LocalMusicController extends Notifier<LocalMusicActionState> {
   }
 
   Future<void> forget() async {
+    final library = ref.read(libraryControllerProvider.notifier);
+    // Invalidate immediately, before the first await. The selection controller
+    // also invalidates source changes, and clearLocalCatalog serializes the
+    // actual clear after any already-started local catalog write.
+    library.invalidatePendingScans();
     state = const LocalMusicActionState(busy: true);
     await ref.read(selectedFolderControllerProvider.notifier).clear();
-    await ref.read(musicLibraryRepositoryProvider).upsertCatalog(
-      sourceId: const LocalMusicSource(folderPath: null).id,
-      tracks: const [],
-      albums: const [],
-      artists: const [],
-    );
-    ref.read(localScanReportProvider.notifier).clear();
-    await ref.read(libraryControllerProvider.notifier).refresh();
+    await library.clearLocalCatalog();
     state = const LocalMusicActionState(
       message: 'Local music forgotten. Your files were not deleted.',
     );
@@ -124,8 +120,11 @@ class LocalMusicController extends Notifier<LocalMusicActionState> {
   /// Scans [folder], turns the resulting report into the card's status line,
   /// and hands the report back so a caller can act on the outcome.
   Future<LocalScanReport?> _scan(String folder) async {
-    await ref.read(libraryControllerProvider.notifier).scanFolder(folder);
-    final report = ref.read(localScanReportProvider);
+    // Use this operation's result, never the last globally recorded report:
+    // a superseded scan must not look successful or persist a source switch.
+    final report = await ref
+        .read(libraryControllerProvider.notifier)
+        .scanFolderWithReport(folder);
     final FolderLocation location = FolderLocation.parse(folder);
     if (report == null) {
       state = const LocalMusicActionState();

--- a/scripts/check_android_channel_threading.py
+++ b/scripts/check_android_channel_threading.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""check_android_channel_threading.py — keep the SAF scan off the main thread.
+
+Flutter calls a `MethodChannel` handler on Android's platform (main) thread. It
+is therefore easy to write a handler that quietly blocks the UI: the code reads like ordinary
+straight-line Kotlin, it compiles, and on the developer's twelve-track test
+folder it returns instantly. It only hurts on a real library, on a slow
+provider, or on an SD card — where it becomes an ANR (#346).
+
+Nothing in the build catches that. Lint has no opinion about how long a channel
+handler runs, and a regression would look like a simplification: delete the
+worker, call `walk()` directly, tests still pass. So the boundary is asserted
+here instead.
+
+Three things have to hold, and each is checked against the sources rather than
+duplicated:
+
+    the worker exists          <- PlatformChannelWorker.kt runs the work and
+                                  callbacks inside an Executor task
+    the scan uses it           <- SafDocumentScanner.listAudioDocuments submits
+                                  the walk instead of running it inline
+    nothing answers inline     <- listAudioDocuments contains no direct
+                                  result.success(walk(...)) call
+
+The last one is the shape the bug had before the fix, so it is worth naming
+explicitly rather than inferring from the other two.
+
+This is deliberately a text check, not a parse: it has to run anywhere (no
+Android SDK, no Gradle, no network), the same way check_linux_runner.py does for
+the desktop runner. It is not a substitute for reading the code — it is a
+tripwire for the specific silent regression.
+
+    python3 scripts/check_android_channel_threading.py
+
+Exits 0 when every claim holds, 1 with the failures listed otherwise.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+KOTLIN = (
+    ROOT
+    / "android"
+    / "app"
+    / "src"
+    / "main"
+    / "kotlin"
+    / "io"
+    / "github"
+    / "thezupzup"
+    / "linthra"
+)
+
+WORKER_FILE = "PlatformChannelWorker.kt"
+SCANNER_FILE = "SafDocumentScanner.kt"
+
+# The channel method whose work is heavy enough to matter, and the private
+# function that does that work.
+SCAN_METHOD = "listAudioDocuments"
+SCAN_WORK = "walk"
+
+
+def read(directory: Path, name: str, failures: list[str]) -> str:
+    """Returns the text of ``directory/name``, or "" (recording why) if absent."""
+    path = directory / name
+    if not path.is_file():
+        failures.append(f"{name}: missing (expected at {path})")
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def strip_comments(source: str) -> str:
+    """Drops // and /* */ comments so a mention in prose is never a match.
+
+    Every claim below is about code that runs. KDoc on these files talks about
+    `walk`, `result.success` and the main thread by name, so checking the raw
+    text would pass on a file whose comments still describe a fix its code no
+    longer has.
+    """
+    source = re.sub(r"/\*.*?\*/", "", source, flags=re.DOTALL)
+    return re.sub(r"//[^\n]*", "", source)
+
+
+def function_body(source: str, name: str) -> str | None:
+    """Returns the brace-balanced body of ``fun name(...)``, or None.
+
+    Tolerates a type-parameter list (``fun <T> submit(``), which the worker has.
+    """
+    match = re.search(rf"\bfun\s+(?:<[^>]*>\s*)?{re.escape(name)}\s*\(", source)
+    if match is None:
+        return None
+    opening = source.find("{", match.end())
+    if opening == -1:
+        return None
+    depth = 0
+    for index in range(opening, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening + 1 : index]
+    return None
+
+
+def trailing_lambda_body(source: str, call: str) -> str | None:
+    """Returns the brace-balanced trailing lambda passed to ``call``."""
+    match = re.search(rf"\b{re.escape(call)}\s*\{{", source)
+    if match is None:
+        return None
+    opening = source.find("{", match.start())
+    depth = 0
+    for index in range(opening, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening + 1 : index]
+    return None
+
+
+def check_worker(directory: Path, failures: list[str]) -> None:
+    """The worker really evaluates work and callbacks off the caller thread."""
+    source = strip_comments(read(directory, WORKER_FILE, failures))
+    if not source:
+        return
+
+    if "java.util.concurrent.Executor" not in source:
+        failures.append(
+            f"{WORKER_FILE}: no Executor import — work has to leave the caller's "
+            "thread on something"
+        )
+    body = function_body(source, "submit")
+    if body is None:
+        failures.append(f"{WORKER_FILE}: no submit() to hand work to")
+        return
+    task = trailing_lambda_body(body, "background.execute")
+    if task is None:
+        failures.append(
+            f"{WORKER_FILE}: submit() does not run its work on the background executor"
+        )
+        return
+    if not re.search(r"\bwork\s*\(\s*\)", task):
+        failures.append(
+            f"{WORKER_FILE}: work() is evaluated outside the background executor"
+        )
+    if not re.search(r"\bonSuccess\s*\(", task) or not re.search(
+        r"\bonFailure\s*\(", task
+    ):
+        failures.append(
+            f"{WORKER_FILE}: callbacks must stay inside the background executor "
+            "so MethodChannel encoding cannot stall the platform thread"
+        )
+
+
+def check_scanner(directory: Path, failures: list[str]) -> None:
+    """The scan is submitted to the worker, and never answered inline."""
+    source = strip_comments(read(directory, SCANNER_FILE, failures))
+    if not source:
+        return
+
+    if "PlatformChannelWorker" not in source:
+        failures.append(
+            f"{SCANNER_FILE}: does not use PlatformChannelWorker, so the walk "
+            "runs on whichever thread calls it"
+        )
+
+    body = function_body(source, SCAN_METHOD)
+    if body is None:
+        failures.append(f"{SCANNER_FILE}: no {SCAN_METHOD}() to check")
+        return
+
+    if "worker.submit(" not in body:
+        failures.append(
+            f"{SCANNER_FILE}: {SCAN_METHOD}() does not submit its work to the "
+            "worker — the walk is back on the platform thread (#346)"
+        )
+
+    # The pre-fix shape: the whole walk evaluated as the argument to a reply,
+    # i.e. on the caller's thread. Whitespace-tolerant so reformatting the call
+    # does not hide it.
+    inline = re.compile(
+        rf"result\s*\.\s*success\s*\(\s*{re.escape(SCAN_WORK)}\s*\(",
+        re.DOTALL,
+    )
+    if inline.search(body):
+        failures.append(
+            f"{SCANNER_FILE}: {SCAN_METHOD}() answers with {SCAN_WORK}() inline, "
+            "which runs the whole library walk on the platform thread (#346)"
+        )
+
+
+def check(directory: Path) -> list[str]:
+    """Runs every claim against the Kotlin in [directory]. Empty list = passing."""
+    failures: list[str] = []
+    check_worker(directory, failures)
+    check_scanner(directory, failures)
+    return failures
+
+
+def main() -> int:
+    failures = check(KOTLIN)
+    if failures:
+        print("Android channel threading check FAILED:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+    print("Android channel threading check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_android_channel_threading.py
+++ b/scripts/check_android_channel_threading.py
@@ -1,38 +1,12 @@
 #!/usr/bin/env python3
-"""check_android_channel_threading.py — keep the SAF scan off the main thread.
+"""Guard the SAF method-channel threading boundary (#346).
 
-Flutter calls a `MethodChannel` handler on Android's platform (main) thread. It
-is therefore easy to write a handler that quietly blocks the UI: the code reads like ordinary
-straight-line Kotlin, it compiles, and on the developer's twelve-track test
-folder it returns instantly. It only hurts on a real library, on a slow
-provider, or on an SD card — where it becomes an ANR (#346).
-
-Nothing in the build catches that. Lint has no opinion about how long a channel
-handler runs, and a regression would look like a simplification: delete the
-worker, call `walk()` directly, tests still pass. So the boundary is asserted
-here instead.
-
-Three things have to hold, and each is checked against the sources rather than
-duplicated:
-
-    the worker exists          <- PlatformChannelWorker.kt runs the work and
-                                  callbacks inside an Executor task
-    the scan uses it           <- SafDocumentScanner.listAudioDocuments submits
-                                  the walk instead of running it inline
-    nothing answers inline     <- listAudioDocuments contains no direct
-                                  result.success(walk(...)) call
-
-The last one is the shape the bug had before the fix, so it is worth naming
-explicitly rather than inferring from the other two.
-
-This is deliberately a text check, not a parse: it has to run anywhere (no
-Android SDK, no Gradle, no network), the same way check_linux_runner.py does for
-the desktop runner. It is not a substitute for reading the code — it is a
-tripwire for the specific silent regression.
+This is a narrow, offline source tripwire, not a Kotlin compiler or a proof of
+thread safety. It checks that the expensive walk is evaluated inside the work
+lambda submitted to the real background worker, and that result encoding stays
+on that worker. A token appearing somewhere in the same method is not enough.
 
     python3 scripts/check_android_channel_threading.py
-
-Exits 0 when every claim holds, 1 with the failures listed otherwise.
 """
 
 from __future__ import annotations
@@ -43,29 +17,16 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 KOTLIN = (
-    ROOT
-    / "android"
-    / "app"
-    / "src"
-    / "main"
-    / "kotlin"
-    / "io"
-    / "github"
-    / "thezupzup"
-    / "linthra"
+    ROOT / "android" / "app" / "src" / "main" / "kotlin"
+    / "io" / "github" / "thezupzup" / "linthra"
 )
-
 WORKER_FILE = "PlatformChannelWorker.kt"
 SCANNER_FILE = "SafDocumentScanner.kt"
-
-# The channel method whose work is heavy enough to matter, and the private
-# function that does that work.
 SCAN_METHOD = "listAudioDocuments"
 SCAN_WORK = "walk"
 
 
 def read(directory: Path, name: str, failures: list[str]) -> str:
-    """Returns the text of ``directory/name``, or "" (recording why) if absent."""
     path = directory / name
     if not path.is_file():
         failures.append(f"{name}: missing (expected at {path})")
@@ -73,132 +34,191 @@ def read(directory: Path, name: str, failures: list[str]) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def strip_comments(source: str) -> str:
-    """Drops // and /* */ comments so a mention in prose is never a match.
+def code_only(source: str) -> str:
+    """Mask comments and Kotlin string/char literals, retaining offsets.
 
-    Every claim below is about code that runs. KDoc on these files talks about
-    `walk`, `result.success` and the main thread by name, so checking the raw
-    text would pass on a file whose comments still describe a fix its code no
-    longer has.
+    Braces, parentheses and fake calls inside prose must not affect nesting.
+    Kotlin block comments can nest, and triple-quoted strings can contain both
+    quotes and braces. This intentionally does not try to parse Kotlin syntax.
     """
-    source = re.sub(r"/\*.*?\*/", "", source, flags=re.DOTALL)
-    return re.sub(r"//[^\n]*", "", source)
+    result = list(source)
+    i = 0
+    n = len(source)
+
+    def mask(start: int, end: int) -> None:
+        for j in range(start, end):
+            if source[j] not in "\r\n":
+                result[j] = " "
+
+    while i < n:
+        start = i
+        if source.startswith("//", i):
+            end = source.find("\n", i)
+            i = n if end < 0 else end
+            mask(start, i)
+        elif source.startswith("/*", i):
+            depth = 1
+            i += 2
+            while i < n and depth:
+                if source.startswith("/*", i):
+                    depth += 1
+                    i += 2
+                elif source.startswith("*/", i):
+                    depth -= 1
+                    i += 2
+                else:
+                    i += 1
+            mask(start, i)
+        elif source.startswith('"""', i):
+            end = source.find('"""', i + 3)
+            i = n if end < 0 else end + 3
+            mask(start, i)
+        elif source[i] in ('"', "'"):
+            quote = source[i]
+            i += 1
+            while i < n:
+                if source[i] == "\\":
+                    i += 2
+                elif source[i] == quote:
+                    i += 1
+                    break
+                else:
+                    i += 1
+            i = min(i, n)
+            mask(start, i)
+        else:
+            i += 1
+    return "".join(result)
 
 
-def function_body(source: str, name: str) -> str | None:
-    """Returns the brace-balanced body of ``fun name(...)``, or None.
-
-    Tolerates a type-parameter list (``fun <T> submit(``), which the worker has.
-    """
-    match = re.search(rf"\bfun\s+(?:<[^>]*>\s*)?{re.escape(name)}\s*\(", source)
-    if match is None:
+def balanced_span(code: str, opening: int) -> tuple[int, int] | None:
+    """Return the inside of one balanced pair, using masked source offsets."""
+    pairs = {"{": "}", "(": ")"}
+    if opening >= len(code) or code[opening] not in pairs:
         return None
-    opening = source.find("{", match.end())
-    if opening == -1:
-        return None
-    depth = 0
-    for index in range(opening, len(source)):
-        char = source[index]
-        if char == "{":
-            depth += 1
-        elif char == "}":
-            depth -= 1
-            if depth == 0:
-                return source[opening + 1 : index]
+    stack = [pairs[code[opening]]]
+    for i in range(opening + 1, len(code)):
+        char = code[i]
+        if char in pairs:
+            stack.append(pairs[char])
+        elif stack and char == stack[-1]:
+            stack.pop()
+            if not stack:
+                return opening + 1, i
     return None
 
 
-def trailing_lambda_body(source: str, call: str) -> str | None:
-    """Returns the brace-balanced trailing lambda passed to ``call``."""
-    match = re.search(rf"\b{re.escape(call)}\s*\{{", source)
+def function_span(code: str, name: str) -> tuple[int, int] | None:
+    match = re.search(
+        rf"\bfun\s+(?:<[^>]*>\s*)?{re.escape(name)}\s*\(", code
+    )
     if match is None:
         return None
-    opening = source.find("{", match.start())
-    depth = 0
-    for index in range(opening, len(source)):
-        char = source[index]
-        if char == "{":
-            depth += 1
-        elif char == "}":
-            depth -= 1
-            if depth == 0:
-                return source[opening + 1 : index]
-    return None
+    parameters = balanced_span(code, match.end() - 1)
+    if parameters is None:
+        return None
+    opening = code.find("{", parameters[1] + 1)
+    return balanced_span(code, opening) if opening >= 0 else None
+
+
+def call_span(code: str, name: str) -> tuple[int, int] | None:
+    pattern = re.escape(name).replace(r"\.", r"\s*\.\s*")
+    match = re.search(rf"\b{pattern}\s*\(", code)
+    if match is None:
+        return None
+    return balanced_span(code, match.end() - 1)
+
+
+def lambda_span(code: str, name: str) -> tuple[int, int] | None:
+    match = re.search(rf"\b{re.escape(name)}\s*=\s*\{{", code)
+    if match is None:
+        return None
+    return balanced_span(code, match.end() - 1)
+
+
+def trailing_lambda_span(code: str, name: str) -> tuple[int, int] | None:
+    pattern = re.escape(name).replace(r"\.", r"\s*\.\s*")
+    match = re.search(rf"\b{pattern}\s*\{{", code)
+    if match is None:
+        return None
+    return balanced_span(code, match.end() - 1)
+
+
+def occurrences(code: str, pattern: str) -> list[int]:
+    return [match.start() for match in re.finditer(pattern, code)]
+
+
+def outside(positions: list[int], span: tuple[int, int]) -> bool:
+    return any(not (span[0] <= position < span[1]) for position in positions)
 
 
 def check_worker(directory: Path, failures: list[str]) -> None:
-    """The worker really evaluates work and callbacks off the caller thread."""
-    source = strip_comments(read(directory, WORKER_FILE, failures))
+    source = code_only(read(directory, WORKER_FILE, failures))
     if not source:
         return
-
     if "java.util.concurrent.Executor" not in source:
-        failures.append(
-            f"{WORKER_FILE}: no Executor import — work has to leave the caller's "
-            "thread on something"
-        )
-    body = function_body(source, "submit")
-    if body is None:
+        failures.append(f"{WORKER_FILE}: no Executor import")
+    if not re.search(r"background\s*:\s*Executor\s*=\s*SHARED_BACKGROUND", source):
+        failures.append(f"{WORKER_FILE}: production must use the background executor")
+    if not re.search(r"Executors\s*\.\s*newSingleThreadExecutor\s*\{", source):
+        failures.append(f"{WORKER_FILE}: no real background thread factory")
+    span = function_span(source, "submit")
+    if span is None:
         failures.append(f"{WORKER_FILE}: no submit() to hand work to")
         return
-    task = trailing_lambda_body(body, "background.execute")
+    body = source[span[0]:span[1]]
+    task = trailing_lambda_span(body, "background.execute")
     if task is None:
-        failures.append(
-            f"{WORKER_FILE}: submit() does not run its work on the background executor"
-        )
+        failures.append(f"{WORKER_FILE}: submit() does not run on the background executor")
         return
-    if not re.search(r"\bwork\s*\(\s*\)", task):
-        failures.append(
-            f"{WORKER_FILE}: work() is evaluated outside the background executor"
-        )
-    if not re.search(r"\bonSuccess\s*\(", task) or not re.search(
-        r"\bonFailure\s*\(", task
-    ):
-        failures.append(
-            f"{WORKER_FILE}: callbacks must stay inside the background executor "
-            "so MethodChannel encoding cannot stall the platform thread"
-        )
+    work_calls = occurrences(body, r"\bwork\s*\(\s*\)")
+    if not work_calls or outside(work_calls, task):
+        failures.append(f"{WORKER_FILE}: work() is evaluated outside the background executor")
+    for callback in ("onSuccess", "onFailure"):
+        calls = occurrences(body, rf"\b{callback}\s*\(")
+        if not calls or outside(calls, task):
+            failures.append(
+                f"{WORKER_FILE}: callbacks must stay inside the background executor "
+                "so MethodChannel encoding cannot stall the platform thread"
+            )
+            break
 
 
 def check_scanner(directory: Path, failures: list[str]) -> None:
-    """The scan is submitted to the worker, and never answered inline."""
-    source = strip_comments(read(directory, SCANNER_FILE, failures))
+    source = code_only(read(directory, SCANNER_FILE, failures))
     if not source:
         return
-
     if "PlatformChannelWorker" not in source:
-        failures.append(
-            f"{SCANNER_FILE}: does not use PlatformChannelWorker, so the walk "
-            "runs on whichever thread calls it"
-        )
-
-    body = function_body(source, SCAN_METHOD)
-    if body is None:
+        failures.append(f"{SCANNER_FILE}: does not use PlatformChannelWorker")
+    span = function_span(source, SCAN_METHOD)
+    if span is None:
         failures.append(f"{SCANNER_FILE}: no {SCAN_METHOD}() to check")
         return
-
-    if "worker.submit(" not in body:
+    body = source[span[0]:span[1]]
+    submit = call_span(body, "worker.submit")
+    if submit is None:
+        failures.append(f"{SCANNER_FILE}: {SCAN_METHOD}() does not submit its work to the worker")
+        return
+    arguments = body[submit[0]:submit[1]]
+    work = lambda_span(arguments, "work")
+    if work is None:
+        failures.append(f"{SCANNER_FILE}: submitted work must contain the scan invocation")
+        return
+    work_in_body = (submit[0] + work[0], submit[0] + work[1])
+    walk_calls = occurrences(body, rf"\b{re.escape(SCAN_WORK)}\s*\(")
+    if not walk_calls or outside(walk_calls, work_in_body):
         failures.append(
-            f"{SCANNER_FILE}: {SCAN_METHOD}() does not submit its work to the "
-            "worker — the walk is back on the platform thread (#346)"
+            f"{SCANNER_FILE}: {SCAN_WORK}() must be evaluated inside the submitted "
+            "work lambda, never eagerly on the platform thread (#346)"
         )
-
-    # The pre-fix shape: the whole walk evaluated as the argument to a reply,
-    # i.e. on the caller's thread. Whitespace-tolerant so reformatting the call
-    # does not hide it.
-    inline = re.compile(
-        rf"result\s*\.\s*success\s*\(\s*{re.escape(SCAN_WORK)}\s*\(",
-        re.DOTALL,
-    )
-    if inline.search(body):
-        failures.append(
-            f"{SCANNER_FILE}: {SCAN_METHOD}() answers with {SCAN_WORK}() inline, "
-            "which runs the whole library walk on the platform thread (#346)"
-        )
+    # A second reply or another submission cannot hide an eager walk.
+    if outside(occurrences(body, r"\bresult\s*\.\s*success\s*\("), submit):
+        failures.append(f"{SCANNER_FILE}: result.success() must not answer inline")
+    if len(occurrences(body, r"\bworker\s*\.\s*submit\s*\(")) != 1:
+        failures.append(f"{SCANNER_FILE}: expected exactly one worker submission")
 
 
 def check(directory: Path) -> list[str]:
-    """Runs every claim against the Kotlin in [directory]. Empty list = passing."""
     failures: list[str] = []
     check_worker(directory, failures)
     check_scanner(directory, failures)

--- a/scripts/verify_android.sh
+++ b/scripts/verify_android.sh
@@ -78,6 +78,14 @@ main() {
   # diagnostics fixture carrying real private data.
   run_step "secret & privacy scan" "$REPO_ROOT/scripts/check_secrets.sh"
 
+  # Also Flutter-independent, and the reason it is a check at all: a library
+  # walk that drifts back onto the platform thread still compiles and still
+  # passes every test — it only shows up as an ANR on a real library (#346).
+  run_step "Android channel threading" \
+    python3 scripts/check_android_channel_threading.py
+  run_step "Android channel threading tooling tests" \
+    python3 test/tooling/check_android_channel_threading_test.py
+
   if android_sdk_available; then
     run_step "flutter build apk --debug" "$FLUTTER" build apk --debug
   else

--- a/test/features/library/library_controller_test.dart
+++ b/test/features/library/library_controller_test.dart
@@ -175,7 +175,7 @@ void main() {
       expect(container.read(libraryControllerProvider).tracks, tracks);
     });
 
-    test('refresh invalidates a scan that is still in flight', () async {
+    test('explicit source invalidation discards an in-flight scan', () async {
       final repository = InMemoryMusicLibraryRepository();
       final scanner = _DeferredAudioFileScanner();
       final container = _scanContainer(
@@ -185,6 +185,7 @@ void main() {
       final controller = container.read(libraryControllerProvider.notifier);
 
       final Future<void> scan = controller.scanFolder('/forgotten');
+      controller.invalidatePendingScans();
       await controller.refresh();
       scanner.requests['/forgotten']!.complete(<String>[
         '/forgotten/ShouldNotReturn.mp3',
@@ -193,6 +194,27 @@ void main() {
 
       expect(await repository.getAllTracks(), isEmpty);
       expect(container.read(libraryControllerProvider).tracks, isEmpty);
+    });
+
+    test('an unrelated catalog refresh does not cancel a local scan', () async {
+      final repository = InMemoryMusicLibraryRepository();
+      final scanner = _DeferredAudioFileScanner();
+      final container = _scanContainer(
+        repository: repository,
+        scanner: scanner,
+      );
+      final controller = container.read(libraryControllerProvider.notifier);
+
+      final scan = controller.scanFolderWithReport('/music');
+      await controller.refresh();
+      scanner.requests['/music']!.complete(<String>['/music/One.mp3']);
+      final report = await scan;
+
+      expect(report, isNotNull);
+      expect(report!.hadError, isFalse);
+      expect(report.importedTracks, 1);
+      expect(await repository.getAllTracks(), hasLength(1));
+      expect(container.read(localScanReportProvider), same(report));
     });
 
     test(

--- a/test/features/library/library_controller_test.dart
+++ b/test/features/library/library_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/track.dart';
@@ -35,11 +37,19 @@ class _NeverReadable implements DirectoryReadability {
   Future<bool> canList(String path) async => false;
 }
 
+class _DeferredAudioFileScanner implements AudioFileScanner {
+  final Map<String, Completer<List<String>>> requests =
+      <String, Completer<List<String>>>{};
+
+  @override
+  Future<List<String>> listFiles(String folder) {
+    return (requests[folder] ??= Completer<List<String>>()).future;
+  }
+}
+
 ProviderContainer _containerWith(FakeMusicLibraryRepository repository) {
   final container = ProviderContainer(
-    overrides: [
-      musicLibraryRepositoryProvider.overrideWithValue(repository),
-    ],
+    overrides: [musicLibraryRepositoryProvider.overrideWithValue(repository)],
   );
   addTearDown(container.dispose);
   return container;
@@ -93,25 +103,30 @@ void main() {
       expect(state.isEmpty, isTrue);
     });
 
-    test('surfaces a friendly, leak-free error when the repository throws',
-        () async {
-      // A raw store failure (a corrupt-db or filesystem error on device) must
-      // not leak its text — the user sees one clean, actionable line instead.
-      final container = _containerWith(
-        FakeMusicLibraryRepository(
-          error: Exception('FileSystemException: /data/.../db errno = 13'),
-        ),
-      );
+    test(
+      'surfaces a friendly, leak-free error when the repository throws',
+      () async {
+        // A raw store failure (a corrupt-db or filesystem error on device) must
+        // not leak its text — the user sees one clean, actionable line instead.
+        final container = _containerWith(
+          FakeMusicLibraryRepository(
+            error: Exception('FileSystemException: /data/.../db errno = 13'),
+          ),
+        );
 
-      await container.read(libraryControllerProvider.notifier).refresh();
+        await container.read(libraryControllerProvider.notifier).refresh();
 
-      final state = container.read(libraryControllerProvider);
-      expect(state.status, LibraryStatus.error);
-      expect(state.errorMessage, contains("Couldn't open your music library"));
-      // The raw exception text never reaches the UI.
-      expect(state.errorMessage, isNot(contains('errno')));
-      expect(state.errorMessage, isNot(contains('Exception')));
-    });
+        final state = container.read(libraryControllerProvider);
+        expect(state.status, LibraryStatus.error);
+        expect(
+          state.errorMessage,
+          contains("Couldn't open your music library"),
+        );
+        // The raw exception text never reaches the UI.
+        expect(state.errorMessage, isNot(contains('errno')));
+        expect(state.errorMessage, isNot(contains('Exception')));
+      },
+    );
 
     test('scanFolder persists discovered tracks and reloads', () async {
       final repository = InMemoryMusicLibraryRepository();
@@ -139,28 +154,71 @@ void main() {
       expect(await repository.getAllTracks(), hasLength(2));
     });
 
-    test('scanFolder shows a friendly message for an unexpected scan failure',
-        () async {
-      // A raw scanner failure (a dart:io permission error on device, say) must
-      // not leak its text — the user sees one clean, actionable line instead.
+    test('an obsolete scan cannot overwrite a newer source scan', () async {
+      final repository = InMemoryMusicLibraryRepository();
+      final scanner = _DeferredAudioFileScanner();
       final container = _scanContainer(
-        repository: InMemoryMusicLibraryRepository(),
-        scanner: FakeAudioFileScanner(
-          error: Exception('FileSystemException: errno = 13'),
-        ),
+        repository: repository,
+        scanner: scanner,
       );
+      final controller = container.read(libraryControllerProvider.notifier);
 
-      await container
-          .read(libraryControllerProvider.notifier)
-          .scanFolder('/missing');
+      final Future<void> oldScan = controller.scanFolder('/old');
+      final Future<void> newScan = controller.scanFolder('/new');
+      scanner.requests['/new']!.complete(<String>['/new/New.mp3']);
+      await newScan;
+      scanner.requests['/old']!.complete(<String>['/old/Old.mp3']);
+      await oldScan;
 
-      final state = container.read(libraryControllerProvider);
-      expect(state.status, LibraryStatus.error);
-      expect(state.errorMessage, contains("Couldn't scan that folder"));
-      // The raw exception text never reaches the UI.
-      expect(state.errorMessage, isNot(contains('errno')));
-      expect(state.errorMessage, isNot(contains('Exception')));
+      final tracks = await repository.getAllTracks();
+      expect(tracks.map((track) => track.title), <String>['New']);
+      expect(container.read(libraryControllerProvider).tracks, tracks);
     });
+
+    test('refresh invalidates a scan that is still in flight', () async {
+      final repository = InMemoryMusicLibraryRepository();
+      final scanner = _DeferredAudioFileScanner();
+      final container = _scanContainer(
+        repository: repository,
+        scanner: scanner,
+      );
+      final controller = container.read(libraryControllerProvider.notifier);
+
+      final Future<void> scan = controller.scanFolder('/forgotten');
+      await controller.refresh();
+      scanner.requests['/forgotten']!.complete(<String>[
+        '/forgotten/ShouldNotReturn.mp3',
+      ]);
+      await scan;
+
+      expect(await repository.getAllTracks(), isEmpty);
+      expect(container.read(libraryControllerProvider).tracks, isEmpty);
+    });
+
+    test(
+      'scanFolder shows a friendly message for an unexpected scan failure',
+      () async {
+        // A raw scanner failure (a dart:io permission error on device, say) must
+        // not leak its text — the user sees one clean, actionable line instead.
+        final container = _scanContainer(
+          repository: InMemoryMusicLibraryRepository(),
+          scanner: FakeAudioFileScanner(
+            error: Exception('FileSystemException: errno = 13'),
+          ),
+        );
+
+        await container
+            .read(libraryControllerProvider.notifier)
+            .scanFolder('/missing');
+
+        final state = container.read(libraryControllerProvider);
+        expect(state.status, LibraryStatus.error);
+        expect(state.errorMessage, contains("Couldn't scan that folder"));
+        // The raw exception text never reaches the UI.
+        expect(state.errorMessage, isNot(contains('errno')));
+        expect(state.errorMessage, isNot(contains('Exception')));
+      },
+    );
 
     test('scanFolder surfaces a FolderScanException message verbatim',
         () async {
@@ -253,23 +311,25 @@ void main() {
       expect(state.tracks.map((t) => t.title), <String>['One']);
     });
 
-    test('scanFolder surfaces a clean error for an unscannable content URI',
-        () async {
-      final container = _scanContainer(
-        repository: InMemoryMusicLibraryRepository(),
-        scanner: const PlatformAudioFileScanner(),
-      );
+    test(
+      'scanFolder surfaces a clean error for an unscannable content URI',
+      () async {
+        final container = _scanContainer(
+          repository: InMemoryMusicLibraryRepository(),
+          scanner: const PlatformAudioFileScanner(),
+        );
 
-      const folderUri = 'content://com.android.providers.downloads.documents/'
-          'tree/raw%3A';
-      await container
-          .read(libraryControllerProvider.notifier)
-          .scanFolder(folderUri);
+        const folderUri = 'content://com.android.providers.downloads.documents/'
+            'tree/raw%3A';
+        await container
+            .read(libraryControllerProvider.notifier)
+            .scanFolder(folderUri);
 
-      final state = container.read(libraryControllerProvider);
-      expect(state.status, LibraryStatus.error);
-      expect(state.errorMessage, contains('Storage Access Framework'));
-    });
+        final state = container.read(libraryControllerProvider);
+        expect(state.status, LibraryStatus.error);
+        expect(state.errorMessage, contains('Storage Access Framework'));
+      },
+    );
 
     test(
         'scanFolder surfaces a clean error when a resolved content URI is '
@@ -299,43 +359,45 @@ void main() {
       expect(state.errorMessage, contains('not letting it read'));
     });
 
-    test('a folder Linthra can no longer reach keeps the catalog intact',
-        () async {
-      // The recoverable-source case (#438/#414): a selected folder that has
-      // gone away — an unplugged drive, a deleted folder, a revoked Flatpak
-      // portal document — must leave the already-indexed tracks alone. Wiping
-      // them would turn a "reselect the folder" problem into a lost library.
-      // The scan report recorder is a process-wide static; keep this test's
-      // report from leaking into the next one.
-      addTearDown(LocalScanDiagnostics.reset);
-      final repository = InMemoryMusicLibraryRepository();
-      await repository.upsertCatalog(
-        sourceId: 'local',
-        tracks: <Track>[_track('a'), _track('b')],
-        albums: const [],
-        artists: const [],
-      );
-      final container = _scanContainer(
-        repository: repository,
-        scanner: FakeAudioFileScanner(
-          error: const FolderScanException(
-            "Linthra couldn't find the selected folder.",
+    test(
+      'a folder Linthra can no longer reach keeps the catalog intact',
+      () async {
+        // The recoverable-source case (#438/#414): a selected folder that has
+        // gone away — an unplugged drive, a deleted folder, a revoked Flatpak
+        // portal document — must leave the already-indexed tracks alone. Wiping
+        // them would turn a "reselect the folder" problem into a lost library.
+        // The scan report recorder is a process-wide static; keep this test's
+        // report from leaking into the next one.
+        addTearDown(LocalScanDiagnostics.reset);
+        final repository = InMemoryMusicLibraryRepository();
+        await repository.upsertCatalog(
+          sourceId: 'local',
+          tracks: <Track>[_track('a'), _track('b')],
+          albums: const [],
+          artists: const [],
+        );
+        final container = _scanContainer(
+          repository: repository,
+          scanner: FakeAudioFileScanner(
+            error: const FolderScanException(
+              "Linthra couldn't find the selected folder.",
+            ),
           ),
-        ),
-      );
+        );
 
-      await container
-          .read(libraryControllerProvider.notifier)
-          .scanFolder('/home/me/Music');
+        await container
+            .read(libraryControllerProvider.notifier)
+            .scanFolder('/home/me/Music');
 
-      final state = container.read(libraryControllerProvider);
-      expect(state.status, LibraryStatus.error);
-      expect(await repository.getAllTracks(), hasLength(2));
-      // Recorded as a folder-availability failure, not as an Android SAF one,
-      // so a desktop diagnostics report says what actually happened.
-      final report = container.read(localScanReportProvider);
-      expect(report?.error, LocalScanError.folderUnavailable);
-      expect(report?.isContentUri, isFalse);
-    });
+        final state = container.read(libraryControllerProvider);
+        expect(state.status, LibraryStatus.error);
+        expect(await repository.getAllTracks(), hasLength(2));
+        // Recorded as a folder-availability failure, not as an Android SAF one,
+        // so a desktop diagnostics report says what actually happened.
+        final report = container.read(localScanReportProvider);
+        expect(report?.error, LocalScanError.folderUnavailable);
+        expect(report?.isContentUri, isFalse);
+      },
+    );
   });
 }

--- a/test/features/library/library_scan_concurrency_test.dart
+++ b/test/features/library/library_scan_concurrency_test.dart
@@ -1,0 +1,240 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/album.dart';
+import 'package:linthra/core/models/artist.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/core/sources/local/android_media_library.dart';
+import 'package:linthra/core/sources/local/audio_file_scanner.dart';
+import 'package:linthra/core/sources/local/local_scan_diagnostics.dart';
+import 'package:linthra/core/sources/local/saf_document_lister.dart';
+import 'package:linthra/data/repositories/host_platform_provider.dart';
+import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
+import 'package:linthra/data/repositories/in_memory_selected_music_folder_repository.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/data/repositories/selected_music_folder_repository_provider.dart';
+import 'package:linthra/features/library/library_controller.dart';
+import 'package:linthra/features/library/library_providers.dart';
+import 'package:linthra/features/library/local_scan_report_provider.dart';
+import 'package:linthra/features/library/selected_folder_controller.dart';
+import 'package:linthra/features/settings/source/local_music_controller.dart';
+
+import 'fake_audio_file_scanner.dart';
+
+class _DeferredScanner implements AudioFileScanner {
+  final requests = <String, Completer<List<String>>>{};
+
+  @override
+  Future<List<String>> listFiles(String folder) =>
+      (requests[folder] ??= Completer<List<String>>()).future;
+}
+
+/// Delays the first nonempty local write, then performs it only when released.
+/// This exposes the race between a started upsert and a later forget/switch.
+class _DeferredWriteRepository extends InMemoryMusicLibraryRepository {
+  final writeStarted = Completer<void>();
+  final releaseWrite = Completer<void>();
+  bool _delayed = false;
+
+  @override
+  Future<void> upsertCatalog({
+    required String sourceId,
+    required List<Track> tracks,
+    required List<Album> albums,
+    required List<Artist> artists,
+  }) async {
+    if (sourceId == 'local' && tracks.isNotEmpty && !_delayed) {
+      _delayed = true;
+      writeStarted.complete();
+      await releaseWrite.future;
+    }
+    await super.upsertCatalog(
+      sourceId: sourceId,
+      tracks: tracks,
+      albums: albums,
+      artists: artists,
+    );
+  }
+}
+
+class _DeferredMediaLibrary implements AndroidMediaLibrary {
+  final started = Completer<void>();
+  final result = Completer<SafScanResult>();
+
+  @override
+  Future<AndroidMusicPermissionStatus> permissionStatus() async =>
+      AndroidMusicPermissionStatus.allowed;
+
+  @override
+  Future<AndroidMusicPermissionStatus> requestPermission() async =>
+      AndroidMusicPermissionStatus.allowed;
+
+  @override
+  Future<void> openAppSettings() async {}
+
+  @override
+  Future<SafScanResult> listDeviceAudio() {
+    if (!started.isCompleted) started.complete();
+    return result.future;
+  }
+}
+
+ProviderContainer _container({
+  required InMemoryMusicLibraryRepository library,
+  required AudioFileScanner scanner,
+  InMemorySelectedMusicFolderRepository? selected,
+  List<Override> extra = const [],
+}) {
+  final container = ProviderContainer(overrides: [
+    musicLibraryRepositoryProvider.overrideWithValue(library),
+    audioFileScannerProvider.overrideWithValue(scanner),
+    selectedMusicFolderRepositoryProvider.overrideWithValue(
+      selected ?? InMemorySelectedMusicFolderRepository(),
+    ),
+    ...extra,
+  ]);
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  setUp(LocalScanDiagnostics.reset);
+  tearDown(LocalScanDiagnostics.reset);
+
+  test('a superseded scan returns null, not the previous successful report',
+      () async {
+    final library = InMemoryMusicLibraryRepository();
+    final scanner = _DeferredScanner();
+    final container = _container(library: library, scanner: scanner);
+    final controller = container.read(libraryControllerProvider.notifier);
+
+    final first = controller.scanFolderWithReport('/first');
+    scanner.requests['/first']!.complete(['/first/First.mp3']);
+    final previous = await first;
+    expect(previous?.importedTracks, 1);
+
+    final stale = controller.scanFolderWithReport('/stale');
+    controller.invalidatePendingScans();
+    scanner.requests['/stale']!.complete(['/stale/Stale.mp3']);
+    expect(await stale, isNull);
+    expect(container.read(localScanReportProvider), same(previous));
+    expect((await library.getAllTracks()).single.title, 'First');
+  });
+
+  test('forget invalidates a walk before it can enqueue a catalog write',
+      () async {
+    final library = InMemoryMusicLibraryRepository();
+    final scanner = _DeferredScanner();
+    final selected =
+        InMemorySelectedMusicFolderRepository(initialFolder: '/music');
+    final container = _container(
+      library: library,
+      scanner: scanner,
+      selected: selected,
+    );
+    await container.read(selectedFolderControllerProvider.future);
+    final controller = container.read(libraryControllerProvider.notifier);
+
+    final scan = controller.scanFolderWithReport('/music');
+    await container.read(localMusicControllerProvider.notifier).forget();
+    scanner.requests['/music']!.complete(['/music/ShouldNotReturn.mp3']);
+    expect(await scan, isNull);
+    expect(await library.getAllTracks(), isEmpty);
+    expect(container.read(localScanReportProvider), isNull);
+    expect(await selected.getSelectedFolder(), isNull);
+  });
+
+  test('forget waits for a started write and clears it without resurrection',
+      () async {
+    final library = _DeferredWriteRepository();
+    final scanner = FakeAudioFileScanner(files: ['/music/Old.mp3']);
+    final selected =
+        InMemorySelectedMusicFolderRepository(initialFolder: '/music');
+    final container = _container(
+      library: library,
+      scanner: scanner,
+      selected: selected,
+    );
+    await container.read(selectedFolderControllerProvider.future);
+    final controller = container.read(libraryControllerProvider.notifier);
+
+    final scan = controller.scanFolderWithReport('/music');
+    await library.writeStarted.future;
+    final forget =
+        container.read(localMusicControllerProvider.notifier).forget();
+    await Future<void>.delayed(Duration.zero);
+    expect(library.releaseWrite.isCompleted, isFalse);
+    library.releaseWrite.complete();
+    expect(await scan, isNull);
+    await forget;
+
+    expect(await library.getAllTracks(), isEmpty);
+    expect(container.read(localScanReportProvider), isNull);
+    expect(await selected.getSelectedFolder(), isNull);
+  });
+
+  test('a source change waits for an already-started local write', () async {
+    final library = _DeferredWriteRepository();
+    final selected =
+        InMemorySelectedMusicFolderRepository(initialFolder: '/old');
+    final container = _container(
+      library: library,
+      scanner: FakeAudioFileScanner(files: ['/old/Old.mp3']),
+      selected: selected,
+    );
+    await container.read(selectedFolderControllerProvider.future);
+    final controller = container.read(libraryControllerProvider.notifier);
+
+    final scan = controller.scanFolderWithReport('/old');
+    await library.writeStarted.future;
+    final change = container
+        .read(selectedFolderControllerProvider.notifier)
+        .setAndPersist('/new');
+    await Future<void>.delayed(Duration.zero);
+    expect(await selected.getSelectedFolder(), '/old');
+    library.releaseWrite.complete();
+    expect(await scan, isNull);
+    await change;
+    expect(await selected.getSelectedFolder(), '/new');
+  });
+
+  test('a canceled MediaStore switch cannot reuse an old report', () async {
+    final library = InMemoryMusicLibraryRepository();
+    final media = _DeferredMediaLibrary();
+    final selected =
+        InMemorySelectedMusicFolderRepository(initialFolder: '/old');
+    final container = _container(
+      library: library,
+      scanner: FakeAudioFileScanner(files: ['/old/Old.mp3']),
+      selected: selected,
+      extra: [
+        hostPlatformProvider.overrideWithValue(HostPlatform.android),
+        androidMediaLibraryProvider.overrideWithValue(media),
+      ],
+    );
+    await container.read(selectedFolderControllerProvider.future);
+    final controller = container.read(libraryControllerProvider.notifier);
+    final previous = await controller.scanFolderWithReport('/old');
+    expect(previous?.importedTracks, 1);
+
+    final local = container.read(localMusicControllerProvider.notifier);
+    final switching = local.useAllDeviceMusic();
+    await media.started.future;
+    await local.forget();
+    media.result.complete(const SafScanResult(
+      documents: [SafAudioDocument(
+        uri: 'content://media/external/audio/media/7',
+        name: 'New.mp3',
+        mimeType: 'audio/mpeg',
+      )],
+      filesVisited: 1,
+    ));
+    await switching;
+
+    expect(await selected.getSelectedFolder(), isNull);
+    expect(await library.getAllTracks(), isEmpty);
+    expect(container.read(localScanReportProvider), isNull);
+  });
+}

--- a/test/tooling/check_android_channel_threading_test.py
+++ b/test/tooling/check_android_channel_threading_test.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/check_android_channel_threading.py (#346).
+
+    python3 test/tooling/check_android_channel_threading_test.py
+
+The checker exists to notice one silent regression: the SAF library walk drifting
+back onto Android's platform thread, where it becomes an ANR on a real library.
+That regression compiles, passes every test in the repo, and reads like a
+simplification in review, so the tests here are "take a good checkout, break
+exactly one thing, expect it to be caught".
+
+They run against a synthetic Kotlin fixture rather than the real files, because a
+fixture is the only way to prove the checker *fails* when it should. One test
+does run against the real repository, since "the checker passes on the actual
+Kotlin" is what the CI step cares about.
+
+Everything is offline. No network, no Gradle, no Android SDK, no repository
+writes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+
+
+def _load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load("check_android_channel_threading", "check_android_channel_threading.py")
+
+
+GOOD_WORKER = """package io.github.thezupzup.linthra
+
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+
+/** Runs blocking channel work off the platform thread. */
+class PlatformChannelWorker(
+    private val background: Executor = SHARED_BACKGROUND,
+) {
+    fun <T> submit(
+        work: () -> T,
+        onSuccess: (T) -> Unit,
+        onFailure: (Exception) -> Unit,
+    ) {
+        background.execute {
+            val value =
+                try {
+                    work()
+                } catch (e: Exception) {
+                    onFailure(e)
+                    return@execute
+                }
+            onSuccess(value)
+        }
+    }
+
+    companion object {
+        private val SHARED_BACKGROUND: Executor =
+            Executors.newSingleThreadExecutor { runnable ->
+                Thread(runnable, "linthra-channel-work").apply { isDaemon = true }
+            }
+    }
+}
+"""
+
+SUBMITTING_SCAN = """        worker.submit(
+            work = { walk(Uri.parse(treeUri)) },
+            onSuccess = { documents -> result.success(documents) },
+            onFailure = { error ->
+                if (error is SecurityException) {
+                    result.error("saf_permission", "No access.", null)
+                } else {
+                    result.error("saf_failed", "Failed to read.", null)
+                }
+            },
+        )"""
+
+GOOD_SCANNER = (
+    """package io.github.thezupzup.linthra
+
+import android.content.Context
+import android.net.Uri
+import io.flutter.plugin.common.MethodChannel
+
+class SafDocumentScanner(
+    private val context: Context,
+    private val worker: PlatformChannelWorker = PlatformChannelWorker(),
+) {
+    /** Walks the tree off the platform thread. */
+    fun listAudioDocuments(treeUri: String, result: MethodChannel.Result) {
+"""
+    + SUBMITTING_SCAN
+    + """
+    }
+
+    fun hasPersistedPermission(treeUri: String): Boolean = true
+
+    private fun walk(treeUri: Uri): Map<String, Any?> = emptyMap()
+}
+"""
+)
+
+
+class CheckerTest(unittest.TestCase):
+    def check(self, *, worker: str = GOOD_WORKER, scanner: str = GOOD_SCANNER):
+        """Runs the checker over a throwaway Kotlin directory."""
+        with tempfile.TemporaryDirectory() as raw:
+            directory = Path(raw)
+            (directory / checker.WORKER_FILE).write_text(worker, encoding="utf-8")
+            (directory / checker.SCANNER_FILE).write_text(scanner, encoding="utf-8")
+            return checker.check(directory)
+
+    def assertCaught(self, failures: list[str], needle: str) -> None:
+        self.assertTrue(failures, "expected the checker to fail, it passed")
+        self.assertIn(needle, "\n".join(failures))
+
+    def test_a_good_pair_passes(self):
+        self.assertEqual(self.check(), [])
+
+    def test_the_real_kotlin_passes(self):
+        # The claim the CI step is actually making.
+        self.assertEqual(checker.check(checker.KOTLIN), [])
+
+    def test_a_missing_worker_file_is_caught(self):
+        with tempfile.TemporaryDirectory() as raw:
+            directory = Path(raw)
+            (directory / checker.SCANNER_FILE).write_text(
+                GOOD_SCANNER, encoding="utf-8"
+            )
+            self.assertCaught(checker.check(directory), "missing")
+
+    def test_the_pre_fix_shape_is_caught(self):
+        # Exactly how the scan looked before #346: the whole walk evaluated as
+        # the argument to the reply, on the caller's thread.
+        inline = """        try {
+            result.success(walk(Uri.parse(treeUri)))
+        } catch (e: Exception) {
+            result.error("saf_failed", "Failed to read.", null)
+        }"""
+        scanner = GOOD_SCANNER.replace(SUBMITTING_SCAN, inline)
+        self.assertCaught(self.check(scanner=scanner), "inline")
+
+    def test_a_reformatted_inline_reply_is_still_caught(self):
+        inline = """        result . success (
+            walk( Uri.parse(treeUri) )
+        )"""
+        scanner = GOOD_SCANNER.replace(SUBMITTING_SCAN, inline)
+        self.assertCaught(self.check(scanner=scanner), "inline")
+
+    def test_dropping_the_worker_from_the_scan_is_caught(self):
+        scanner = GOOD_SCANNER.replace("worker.submit(", "runNow(")
+        self.assertCaught(self.check(scanner=scanner), "does not submit")
+
+    def test_a_commented_out_submit_does_not_satisfy_the_checker(self):
+        # A file whose comments still describe the fix, whose code no longer
+        # has it. Checking raw text would pass this.
+        scanner = GOOD_SCANNER.replace(
+            "worker.submit(", "// worker.submit(\n        runNow("
+        )
+        self.assertCaught(self.check(scanner=scanner), "does not submit")
+
+    def test_a_worker_that_never_leaves_the_caller_thread_is_caught(self):
+        worker = GOOD_WORKER.replace("background.execute {", "run {")
+        self.assertCaught(self.check(worker=worker), "background executor")
+
+    def test_work_evaluated_before_the_executor_is_caught(self):
+        worker = GOOD_WORKER.replace(
+            "        background.execute {\n            val value =",
+            "        val eager = work()\n        background.execute {\n            val value =",
+        ).replace("                    work()", "                    eager")
+        self.assertCaught(self.check(worker=worker), "work() is evaluated outside")
+
+    def test_callbacks_outside_the_executor_are_caught(self):
+        worker = GOOD_WORKER.replace(
+            "                    onFailure(e)", "                    throw e"
+        ).replace(
+            "            onSuccess(value)",
+            "            value\n        }\n        onSuccess(work())",
+        )
+        self.assertCaught(self.check(worker=worker), "callbacks must stay inside")
+
+    def test_a_renamed_scan_method_is_caught(self):
+        scanner = GOOD_SCANNER.replace("fun listAudioDocuments", "fun listAudio")
+        self.assertCaught(self.check(scanner=scanner), "no listAudioDocuments()")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/tooling/check_android_channel_threading_test.py
+++ b/test/tooling/check_android_channel_threading_test.py
@@ -1,21 +1,9 @@
 #!/usr/bin/env python3
-"""Unit tests for scripts/check_android_channel_threading.py (#346).
+"""Mutation tests for the SAF threading tripwire (#346).
 
-    python3 test/tooling/check_android_channel_threading_test.py
-
-The checker exists to notice one silent regression: the SAF library walk drifting
-back onto Android's platform thread, where it becomes an ANR on a real library.
-That regression compiles, passes every test in the repo, and reads like a
-simplification in review, so the tests here are "take a good checkout, break
-exactly one thing, expect it to be caught".
-
-They run against a synthetic Kotlin fixture rather than the real files, because a
-fixture is the only way to prove the checker *fails* when it should. One test
-does run against the real repository, since "the checker passes on the actual
-Kotlin" is what the CI step cares about.
-
-Everything is offline. No network, no Gradle, no Android SDK, no repository
-writes.
+The synthetic fixtures deliberately move the walk outside the submitted work,
+including the regression that #570's previous checker failed to detect.
+Everything runs offline without an Android SDK or Gradle.
 """
 
 from __future__ import annotations
@@ -41,13 +29,9 @@ def _load(name: str, filename: str):
 
 checker = _load("check_android_channel_threading", "check_android_channel_threading.py")
 
-
 GOOD_WORKER = """package io.github.thezupzup.linthra
-
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
-
-/** Runs blocking channel work off the platform thread. */
 class PlatformChannelWorker(
     private val background: Executor = SHARED_BACKGROUND,
 ) {
@@ -67,7 +51,6 @@ class PlatformChannelWorker(
             onSuccess(value)
         }
     }
-
     companion object {
         private val SHARED_BACKGROUND: Executor =
             Executors.newSingleThreadExecutor { runnable ->
@@ -91,24 +74,18 @@ SUBMITTING_SCAN = """        worker.submit(
 
 GOOD_SCANNER = (
     """package io.github.thezupzup.linthra
-
 import android.content.Context
 import android.net.Uri
 import io.flutter.plugin.common.MethodChannel
-
 class SafDocumentScanner(
     private val context: Context,
     private val worker: PlatformChannelWorker = PlatformChannelWorker(),
 ) {
-    /** Walks the tree off the platform thread. */
     fun listAudioDocuments(treeUri: String, result: MethodChannel.Result) {
 """
     + SUBMITTING_SCAN
     + """
     }
-
-    fun hasPersistedPermission(treeUri: String): Boolean = true
-
     private fun walk(treeUri: Uri): Map<String, Any?> = emptyMap()
 }
 """
@@ -117,7 +94,6 @@ class SafDocumentScanner(
 
 class CheckerTest(unittest.TestCase):
     def check(self, *, worker: str = GOOD_WORKER, scanner: str = GOOD_SCANNER):
-        """Runs the checker over a throwaway Kotlin directory."""
         with tempfile.TemporaryDirectory() as raw:
             directory = Path(raw)
             (directory / checker.WORKER_FILE).write_text(worker, encoding="utf-8")
@@ -132,50 +108,43 @@ class CheckerTest(unittest.TestCase):
         self.assertEqual(self.check(), [])
 
     def test_the_real_kotlin_passes(self):
-        # The claim the CI step is actually making.
         self.assertEqual(checker.check(checker.KOTLIN), [])
 
     def test_a_missing_worker_file_is_caught(self):
         with tempfile.TemporaryDirectory() as raw:
             directory = Path(raw)
-            (directory / checker.SCANNER_FILE).write_text(
-                GOOD_SCANNER, encoding="utf-8"
-            )
+            (directory / checker.SCANNER_FILE).write_text(GOOD_SCANNER, encoding="utf-8")
             self.assertCaught(checker.check(directory), "missing")
 
     def test_the_pre_fix_shape_is_caught(self):
-        # Exactly how the scan looked before #346: the whole walk evaluated as
-        # the argument to the reply, on the caller's thread.
-        inline = """        try {
-            result.success(walk(Uri.parse(treeUri)))
-        } catch (e: Exception) {
-            result.error("saf_failed", "Failed to read.", null)
-        }"""
-        scanner = GOOD_SCANNER.replace(SUBMITTING_SCAN, inline)
-        self.assertCaught(self.check(scanner=scanner), "inline")
+        inline = '        result.success(walk(Uri.parse(treeUri)))'
+        self.assertCaught(
+            self.check(scanner=GOOD_SCANNER.replace(SUBMITTING_SCAN, inline)),
+            "does not submit",
+        )
 
-    def test_a_reformatted_inline_reply_is_still_caught(self):
-        inline = """        result . success (
-            walk( Uri.parse(treeUri) )
-        )"""
-        scanner = GOOD_SCANNER.replace(SUBMITTING_SCAN, inline)
-        self.assertCaught(self.check(scanner=scanner), "inline")
+    def test_a_reformatted_inline_reply_is_caught(self):
+        inline = '        result . success (\n walk(Uri.parse(treeUri))\n )'
+        self.assertCaught(
+            self.check(scanner=GOOD_SCANNER.replace(SUBMITTING_SCAN, inline)),
+            "does not submit",
+        )
 
     def test_dropping_the_worker_from_the_scan_is_caught(self):
-        scanner = GOOD_SCANNER.replace("worker.submit(", "runNow(")
-        self.assertCaught(self.check(scanner=scanner), "does not submit")
-
-    def test_a_commented_out_submit_does_not_satisfy_the_checker(self):
-        # A file whose comments still describe the fix, whose code no longer
-        # has it. Checking raw text would pass this.
-        scanner = GOOD_SCANNER.replace(
-            "worker.submit(", "// worker.submit(\n        runNow("
+        self.assertCaught(
+            self.check(scanner=GOOD_SCANNER.replace("worker.submit(", "runNow(")),
+            "does not submit",
         )
+
+    def test_a_commented_out_submit_is_not_a_submission(self):
+        scanner = GOOD_SCANNER.replace("worker.submit(", "// worker.submit(\n runNow(")
         self.assertCaught(self.check(scanner=scanner), "does not submit")
 
     def test_a_worker_that_never_leaves_the_caller_thread_is_caught(self):
-        worker = GOOD_WORKER.replace("background.execute {", "run {")
-        self.assertCaught(self.check(worker=worker), "background executor")
+        self.assertCaught(
+            self.check(worker=GOOD_WORKER.replace("background.execute {", "run {")),
+            "background executor",
+        )
 
     def test_work_evaluated_before_the_executor_is_caught(self):
         worker = GOOD_WORKER.replace(
@@ -185,17 +154,73 @@ class CheckerTest(unittest.TestCase):
         self.assertCaught(self.check(worker=worker), "work() is evaluated outside")
 
     def test_callbacks_outside_the_executor_are_caught(self):
-        worker = GOOD_WORKER.replace(
-            "                    onFailure(e)", "                    throw e"
-        ).replace(
-            "            onSuccess(value)",
-            "            value\n        }\n        onSuccess(work())",
+        worker = GOOD_WORKER.replace("                    onFailure(e)", "                    throw e").replace(
+            "            onSuccess(value)", "            value\n        }\n        onSuccess(work())"
         )
         self.assertCaught(self.check(worker=worker), "callbacks must stay inside")
 
     def test_a_renamed_scan_method_is_caught(self):
-        scanner = GOOD_SCANNER.replace("fun listAudioDocuments", "fun listAudio")
-        self.assertCaught(self.check(scanner=scanner), "no listAudioDocuments()")
+        self.assertCaught(
+            self.check(scanner=GOOD_SCANNER.replace("fun listAudioDocuments", "fun listAudio")),
+            "no listAudioDocuments()",
+        )
+
+    def test_eager_walk_then_submitted_value_is_caught(self):
+        scanner = GOOD_SCANNER.replace(
+            SUBMITTING_SCAN,
+            "        val documents = walk(Uri.parse(treeUri))\n"
+            + SUBMITTING_SCAN.replace("walk(Uri.parse(treeUri))", "documents"),
+        )
+        self.assertCaught(self.check(scanner=scanner), "inside the submitted work")
+
+    def test_eager_walk_with_another_valid_work_lambda_is_caught(self):
+        scanner = GOOD_SCANNER.replace(
+            SUBMITTING_SCAN,
+            "        val eager = walk(Uri.parse(treeUri))\n" + SUBMITTING_SCAN,
+        )
+        self.assertCaught(self.check(scanner=scanner), "inside the submitted work")
+
+    def test_walk_after_submission_is_caught(self):
+        scanner = GOOD_SCANNER.replace(
+            SUBMITTING_SCAN, SUBMITTING_SCAN + "\n        walk(Uri.parse(treeUri))"
+        )
+        self.assertCaught(self.check(scanner=scanner), "inside the submitted work")
+
+    def test_work_in_a_comment_cannot_hide_an_eager_walk(self):
+        scanner = GOOD_SCANNER.replace(
+            SUBMITTING_SCAN,
+            "        val documents = walk(Uri.parse(treeUri))\n"
+            "        // work = { walk(Uri.parse(treeUri)) }\n"
+            + SUBMITTING_SCAN.replace("walk(Uri.parse(treeUri))", "documents"),
+        )
+        self.assertCaught(self.check(scanner=scanner), "inside the submitted work")
+
+    def test_a_second_inline_success_is_caught(self):
+        scanner = GOOD_SCANNER.replace(
+            SUBMITTING_SCAN, SUBMITTING_SCAN + "\n        result.success(emptyMap())"
+        )
+        self.assertCaught(self.check(scanner=scanner), "must not answer inline")
+
+    def test_a_second_submission_is_caught(self):
+        scanner = GOOD_SCANNER.replace(SUBMITTING_SCAN, SUBMITTING_SCAN + "\n" + SUBMITTING_SCAN)
+        self.assertCaught(self.check(scanner=scanner), "exactly one")
+
+    def test_a_synchronous_production_executor_is_caught(self):
+        worker = GOOD_WORKER.replace("newSingleThreadExecutor", "newSingleThreadExecutorRemoved")
+        self.assertCaught(self.check(worker=worker), "background thread factory")
+
+    def test_comments_and_strings_cannot_fake_calls(self):
+        worker = GOOD_WORKER.replace("                    work()", '                    "work()"')
+        self.assertCaught(self.check(worker=worker), "work() is evaluated outside")
+
+    def test_nested_comments_and_raw_strings_do_not_break_nesting(self):
+        scanner = GOOD_SCANNER.replace(
+            SUBMITTING_SCAN,
+            '        /* outer { /* inner ) } */ still } */\n'
+            '        val prose = """{ ) worker.submit(work = { walk() })"""\n'
+            + SUBMITTING_SCAN,
+        )
+        self.assertEqual(self.check(scanner=scanner), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

- Prevent the ANR regression caused when a long SAF library walk or the method-channel result encoding runs on Android's platform (main) thread.
- Avoid races where a long-running SAF scan completes after the user changed/forgot the selected source and then overwrites a newer catalog.
- Strengthen the CI tripwire so the threading boundary is harder to regress silently.

### Description

- Introduce `PlatformChannelWorker` (`android/app/src/main/kotlin/.../PlatformChannelWorker.kt`) that runs `work()` and invokes `onSuccess`/`onFailure` inside the worker task so encoding the success envelope does not stall the platform thread.
- Wire `SafDocumentScanner` (`android/.../SafDocumentScanner.kt`) to submit the SAF `walk()` to `PlatformChannelWorker` and reply via `MethodChannel.Result` from the worker path instead of answering inline on the platform thread.
- Add generation-based invalidation to `LibraryController` (`lib/features/library/library_controller.dart`) so a completed scan will not persist or reload the catalog if a newer action (refresh/scan/forget) occurred while it was in flight.
- Strengthen the threading checker (`scripts/check_android_channel_threading.py`) to require `work()` and the callbacks to execute inside the background executor's trailing lambda rather than merely checking for token presence.
- Add tests and fixtures: `test/tooling/check_android_channel_threading_test.py` (unit tests for the checker) and extended `test/features/library/library_controller_test.dart` to cover stale-scan/invalidation and in-flight refresh scenarios.
- Update docs and verification: adjust `docs/local-music.md`, `android` method-channel comments, and call the new checker from `scripts/verify_android.sh` and CI steps so the guard runs early.

### Testing

- Ran the threading guard: `python3 scripts/check_android_channel_threading.py` — passed.
- Ran checker unit tests: `python3 test/tooling/check_android_channel_threading_test.py` — all tests passed.
- Ran focused Flutter tests: `.tool/flutter/bin/flutter test test/features/library/library_controller_test.dart` — tests passed (including new stale-scan/invalidation tests).
- Ran formatting and static checks: `.tool/flutter/bin/dart format --set-exit-if-changed .`, `ruff check` / `ruff format --check` — passed after formatting; `flutter analyze` reported no blocking issues in this environment.
- Note: full APK build was not executed in this environment because the Android SDK is not installed here; CI will still build the debug APK on the PR runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9e4251f0e0832d8f5d45b24a6ea216)