### PR TITLE
fix: the two things that turned main red at 3e59033

### DIFF
--- a/.github/workflows/flatpak-build.yml
+++ b/.github/workflows/flatpak-build.yml
@@ -130,15 +130,50 @@ jobs:
             flatpak-builder-ci \
             io.github.thezupzup.linthra.yml
 
+      # Fetch the manifest's declared sources before the build, with retries,
+      # because one bad response from a source host fails the whole run.
+      #
+      # That is not hypothetical: run 34173146020 on main died on libplacebo
+      # with "Wrong sha256 checksum ... was 150e307c..." after
+      # code.videolan.org answered with 3857 bytes — an error page, not the
+      # 10 MB tarball. The manifest was fine; it had built on the previous 40+
+      # runs and on the feature branch 14 minutes earlier.
+      #
+      # flatpak-builder only moves a download into its cache once the checksum
+      # verifies, so a bad response is never cached and a retry really does
+      # re-fetch. This never fails the job: an attempt that keeps failing is a
+      # warning and the build step below downloads what is missing and reports
+      # the real error, exactly as it does today. It is a retry, not a new gate.
+      - name: Prefetch manifest sources
+        working-directory: flatpak
+        run: |
+          set -uo pipefail
+          for attempt in 1 2 3; do
+            if flatpak-builder \
+                 --user \
+                 --download-only \
+                 --force-clean \
+                 flatpak-builder-prefetch \
+                 io.github.thezupzup.linthra.yml; then
+              echo "Sources downloaded on attempt $attempt."
+              exit 0
+            fi
+            echo "::warning::Source download attempt $attempt failed."
+            sleep "$((attempt * 15))"
+          done
+          echo "::warning::Prefetch did not complete; the build step downloads the rest."
+
       # Do not restore a module cache here. The CI contract is that the checked
       # in manifest and its declared sources are sufficient on a clean runner.
+      # The prefetch above only retries downloads within this same run on this
+      # same clean runner, so it changes nothing about that contract.
       # --disable-rofiles-fuse avoids depending on FUSE support in the hosted
       # runner while preserving flatpak-builder's normal sandbox/build model.
       - name: Build Flatpak
         working-directory: flatpak
         run: |
           set -euo pipefail
-          rm -rf -- flatpak-builder-ci repo-ci
+          rm -rf -- flatpak-builder-ci flatpak-builder-prefetch repo-ci
           flatpak-builder \
             --user \
             --force-clean \

--- a/lib/app/application_lifecycle.dart
+++ b/lib/app/application_lifecycle.dart
@@ -178,6 +178,7 @@ Future<ApplicationHandle> bootstrapApplication(
   ProviderContainer container, {
   bool installPersistentArtworkCache = true,
   Directory? artworkCacheDirectory,
+  MediaSessionBinding mediaSessionBinding = const PlatformMediaSessionBinding(),
 }) async {
   final ApplicationHandle handle = ApplicationHandle(container: container);
   try {
@@ -185,8 +186,14 @@ Future<ApplicationHandle> bootstrapApplication(
     // the real `audio_service` session, Linux gets MPRIS, and every other
     // platform gets the inert binding so `audio_service` is never initialised
     // where it has no implementation.
-    final MediaSession? session =
-        await const PlatformMediaSessionBinding().attach(
+    //
+    // Injectable for the same reason `MprisMediaSessionBinding` takes a D-Bus
+    // client factory: the default reads the real host, so a bootstrap test run
+    // on a Linux machine reaches the real session bus. That is not this
+    // suite's business, and it is not deterministic either — how long the
+    // connection attempt takes decides how far bootstrap has got by the time
+    // the test looks, which is what made the failure-cleanup test flaky.
+    final MediaSession? session = await mediaSessionBinding.attach(
       container.read(playbackControllerProvider),
       container.read(musicLibraryRepositoryProvider),
       playlists: container.read(playlistRepositoryProvider),

--- a/test/app/application_bootstrap_failure_test.dart
+++ b/test/app/application_bootstrap_failure_test.dart
@@ -20,6 +20,7 @@ import 'package:path/path.dart' as p;
 
 import '../support/counting_audio_player.dart';
 import '../support/lifecycle_test_graph.dart';
+import '../support/recording_media_session.dart';
 import '../support/recording_remote_control_receiver.dart';
 
 /// The failure injected into a real `bootstrapApplication()` run. A distinct
@@ -49,6 +50,16 @@ Override _failLate(_BootstrapFailure failure) =>
       (Ref<PlaybackSessionPersistence?> ref) => throw failure,
     );
 
+/// A media session that attaches immediately and owns nothing.
+///
+/// Bootstrap's default binding reads the real host, so on a Linux machine
+/// these tests would reach the real MPRIS session bus — a connection attempt
+/// whose duration is the machine's business, not the test's, and long enough
+/// on a loaded runner to leave bootstrap still in attach when a test that
+/// times cleanup looks at it.
+RecordingMediaSessionBinding _attachedSession() =>
+    RecordingMediaSessionBinding(session: RecordingMediaSession());
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -69,14 +80,22 @@ void main() {
       );
       final LinthraDatabase database = container.read(linthraDatabaseProvider);
       await openDatabase(database);
+      final RecordingMediaSession session = RecordingMediaSession();
 
       await expectLater(
-        bootstrapApplication(container, installPersistentArtworkCache: false),
+        bootstrapApplication(
+          container,
+          installPersistentArtworkCache: false,
+          mediaSessionBinding: RecordingMediaSessionBinding(session: session),
+        ),
         throwsA(same(failure)),
       );
 
       expect(player.disposeCount, 1);
       expect(player.disposeFinished, isTrue);
+      expect(session.detachCount, 1,
+          reason: 'a failed startup gives the media session back too — on '
+              'Linux that is the MPRIS bus name');
       // The failure lands before the remote-control providers are read, so the
       // receiver was never built — and cleanup does not conjure it up in order
       // to dispose it.
@@ -114,6 +133,7 @@ void main() {
         bootstrapApplication(
           container,
           artworkCacheDirectory: cacheDirectory,
+          mediaSessionBinding: _attachedSession(),
         ),
         throwsA(same(failure)),
       );
@@ -152,6 +172,7 @@ void main() {
       final Future<void> attempt = bootstrapApplication(
         container,
         installPersistentArtworkCache: false,
+        mediaSessionBinding: _attachedSession(),
       )
           .then<void>(
             (ApplicationHandle _) {},
@@ -188,8 +209,11 @@ void main() {
       await openDatabase(firstDatabase);
 
       await expectLater(
-        bootstrapApplication(firstContainer,
-            installPersistentArtworkCache: false),
+        bootstrapApplication(
+          firstContainer,
+          installPersistentArtworkCache: false,
+          mediaSessionBinding: _attachedSession(),
+        ),
         throwsA(same(failure)),
       );
 
@@ -201,6 +225,7 @@ void main() {
       final ApplicationHandle handle = await bootstrapApplication(
         secondContainer,
         installPersistentArtworkCache: false,
+        mediaSessionBinding: _attachedSession(),
       );
 
       expect(await isDatabaseOpen(firstDatabase), isFalse);

--- a/test/app/linux_shutdown_lifecycle_test.dart
+++ b/test/app/linux_shutdown_lifecycle_test.dart
@@ -24,19 +24,29 @@ import 'package:path/path.dart' as p;
 
 import '../support/counting_audio_player.dart';
 import '../support/lifecycle_test_graph.dart';
+import '../support/recording_media_session.dart';
 import '../support/recording_remote_control_receiver.dart';
 
 /// Builds the Linux provider graph the way `main()` wires it, without
 /// `runApp`, so shutdown cycles can be exercised deterministically.
+///
+/// The media session is a test double for the same reason the audio player is:
+/// bootstrap's default binding reads the real host, so on a Linux machine this
+/// would attach over the real MPRIS session bus. A shutdown suite has no
+/// business opening one, and how long that takes is the machine's answer, not
+/// a deterministic one.
 Future<ApplicationHandle> _bootstrap(
   ProviderContainer container, {
   bool installPersistentArtworkCache = false,
   Directory? artworkCacheDirectory,
+  RecordingMediaSessionBinding? mediaSessionBinding,
 }) {
   return bootstrapApplication(
     container,
     installPersistentArtworkCache: installPersistentArtworkCache,
     artworkCacheDirectory: artworkCacheDirectory,
+    mediaSessionBinding: mediaSessionBinding ??
+        RecordingMediaSessionBinding(session: RecordingMediaSession()),
   );
 }
 
@@ -114,6 +124,43 @@ void main() {
 
       expect(player.disposeCount, 1);
       expect(player.playCount, 0);
+    });
+
+    test('shutdown gives the media session back', () async {
+      final RecordingMediaSession session = RecordingMediaSession();
+      final ProviderContainer container = ProviderContainer(
+        overrides: linuxLifecycleOverrides(audioPlayer: CountingAudioPlayer()),
+      );
+
+      final ApplicationHandle handle = await _bootstrap(
+        container,
+        mediaSessionBinding: RecordingMediaSessionBinding(session: session),
+      );
+      expect(session.detachCount, 0,
+          reason: 'the session is live for as long as the app is');
+
+      await handle.shutdown();
+
+      // On Linux that detach is what releases org.mpris.MediaPlayer2.linthra:
+      // a player that exits still holding it leaves a ghost in every shell
+      // that was listening.
+      expect(session.detachCount, 1);
+    });
+
+    test('a host with no media session still shuts down cleanly', () async {
+      final CountingAudioPlayer player = CountingAudioPlayer();
+      final ProviderContainer container = ProviderContainer(
+        overrides: linuxLifecycleOverrides(audioPlayer: player),
+      );
+      final RecordingMediaSessionBinding binding =
+          RecordingMediaSessionBinding();
+
+      final ApplicationHandle handle =
+          await _bootstrap(container, mediaSessionBinding: binding);
+      await handle.shutdown();
+
+      expect(binding.attachCount, 1);
+      expect(player.disposeCount, 1);
     });
 
     test('shutdown stops playback that is still running', () async {

--- a/test/support/recording_media_session.dart
+++ b/test/support/recording_media_session.dart
@@ -1,0 +1,54 @@
+import 'package:linthra/core/repositories/download_repository.dart';
+import 'package:linthra/core/repositories/favorites_repository.dart';
+import 'package:linthra/core/repositories/music_library_repository.dart';
+import 'package:linthra/core/repositories/playlist_repository.dart';
+import 'package:linthra/core/services/media_artwork_source.dart';
+import 'package:linthra/core/services/media_session_binding.dart';
+import 'package:linthra/core/services/playback_controller.dart';
+
+/// A [MediaSessionBinding] test double that attaches without a platform.
+///
+/// `bootstrapApplication`'s default binding reads the real host, so on a Linux
+/// machine — every CI runner included — a bootstrap test would open a real
+/// session-bus connection through MPRIS. Nothing in these suites is about the
+/// bus, and the connection attempt is as fast or as slow as the machine it runs
+/// on, which is enough to change what a test sees mid-bootstrap. Pass one of
+/// these instead and the attach is a single completed future.
+///
+/// It also records the detach, so the shutdown path that gives the session back
+/// is asserted rather than assumed.
+class RecordingMediaSessionBinding implements MediaSessionBinding {
+  RecordingMediaSessionBinding({this.session});
+
+  /// The session [attach] hands back, or null for a host that has none.
+  final RecordingMediaSession? session;
+
+  /// How many times startup asked for a session.
+  int attachCount = 0;
+
+  @override
+  bool get isSupported => session != null;
+
+  @override
+  Future<MediaSession?> attach(
+    PlaybackController controller,
+    MusicLibraryRepository library, {
+    PlaylistRepository? playlists,
+    FavoritesRepository? favorites,
+    DownloadRepository? downloads,
+    MediaArtworkSource? artwork,
+  }) async {
+    attachCount++;
+    return session;
+  }
+}
+
+/// A [MediaSession] that owns nothing and counts its releases.
+class RecordingMediaSession implements MediaSession {
+  int detachCount = 0;
+
+  @override
+  Future<void> detach() async {
+    detachCount++;
+  }
+}

--- a/test/tooling/flatpak_ci_guardrails_test.dart
+++ b/test/tooling/flatpak_ci_guardrails_test.dart
@@ -23,6 +23,24 @@ void main() {
     expect(workflow, contains('--force-clean'));
   });
 
+  // A single bad response from a source host used to fail the whole run: main
+  // died on libplacebo when code.videolan.org answered the archive request
+  // with an error page and the sha256 did not match. The prefetch retries the
+  // downloads without becoming a gate of its own — it must never fail the job,
+  // so the build step stays the one place a real source problem is reported.
+  test('Flatpak CI retries source downloads without gating on them', () {
+    expect(workflow, contains('--download-only'));
+    expect(workflow, contains('for attempt in 1 2 3; do'));
+    expect(
+      workflow,
+      contains(
+        'echo "::warning::Prefetch did not complete; '
+        'the build step downloads the rest."',
+      ),
+      reason: 'a failed prefetch must warn and carry on, not fail the job',
+    );
+  });
+
   test(
     'Flatpak CI installs manifest dependencies and builds the real package',
     () {


### PR DESCRIPTION
Two unrelated failures on main at 3e59033, one commit each.

## 1. Linux desktop build: a race, not a broken assertion

```
bootstrapApplication failure waits for asynchronous cleanup before surfacing the failure
Expected: true
  Actual: <false>
test/app/application_bootstrap_failure_test.dart 163:7
```

That line is `expect(receiver.disposeStarted, isTrue)` right after a `pumpEventQueue()`. The `CI` workflow ran the same suite on the same sha and passed, so the test is timing out on something, not asserting something false.

MPRIS (#569) is what changed underneath it. `bootstrapApplication` attached through a hardcoded `const PlatformMediaSessionBinding()`, and that reads the real host. A `flutter test` run on a Linux runner *is* a Linux host, so attach routed to `MprisMediaSessionBinding` and opened a real `DBusClient.session()`.

How long that connect takes is the runner's answer, not the test's. Long enough, and `pumpEventQueue()` returns with bootstrap still sitting inside attach: the injected failure has not been reached, nothing has started cleaning up, and `disposeStarted` is still false. On a machine with no session bus the connect fails immediately and everything passes, which is why the feature branch never showed it.

`bootstrapApplication` takes the binding as a named parameter now, defaulting to the same `PlatformMediaSessionBinding` — production behaviour is unchanged. It is the same seam `MprisMediaSessionBinding` already has for its `DBusClientFactory`, one level up. The bootstrap and shutdown suites pass a recording double, so attach is a single completed future and no unit test reaches the bus.

Reproduced against the fixed code with a binding that takes 50ms: same assertion, same line, same `Expected: true / Actual: <false>`.

Two tests added while the seam is there, since nothing covered the detach `handle.own(session.detach)` registers: shutdown gives the session back, and a failed bootstrap gives it back too. On Linux that detach is what releases `org.mpris.MediaPlayer2.linthra`, and a player that exits still holding it leaves a ghost in every shell that was listening.

## 2. Flatpak build: one bad response from a source host

```
Wrong sha256 checksum for libplacebo-v7.360.1.tar.gz,
expected "14c0a99f...", was "150e307c..."
```

The manifest is fine. code.videolan.org answered the archive request with 3857 bytes, an error page rather than the 10 MB tarball, and flatpak-builder did the right thing with it. The same manifest built on the feature branch 14 minutes earlier and on the 40+ runs before that.

Normally this is just a re-run. The workflow is path-filtered and I have neither `rerun-failed-jobs` nor `workflow_dispatch` (both 403), so there was nothing to re-run it with, and editing the source list is the wrong answer to a host that returned one bad response.

So: a prefetch step that downloads the declared sources first, retrying three times with a backoff. flatpak-builder only moves a download into its cache once the checksum verifies, so a bad response is never cached and a retry genuinely re-fetches. The step never fails the job — three failed attempts leave a warning and the build step then downloads what is missing and reports the real error exactly as it does today. A retry, not a new gate.

Nothing is restored across runs, so the workflow's "sufficient on a clean runner" contract is unchanged. A guardrail test covers both halves: the retry exists, and it stays non-blocking.

Touching the workflow also puts it back inside its own path filter, so this PR actually runs the Flatpak build. That is the evidence about the download that I could not get any other way.

## Checks

`flutter analyze` clean, `dart format` clean, `flutter test` 4165 passing (4162 on main, plus three new tests), run locally against the pinned 3.44.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRqSWra9iPPbMg5VeYq4cn