### PR TITLE
fix(cast): disable casting in production pending a security fix (#572, #573)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ name: CI
 # main. Four independent jobs run in parallel:
 #   * flutter             — format, analyze, test, lockfile-enforced pub get.
 #   * secret-scan         — offline scan for committed secrets / private data.
+#   * cast-containment    — tripwire on the Cast containment's source markers.
 #   * release-bump-guard  — release/* PRs only: the bump must be version-only.
 #   * dependency-guard    — deps/* PRs only: the update must be lockfile-only.
 #   * toolchain-guard     — toolchain/flutter-sdk only: the bump must be
@@ -76,6 +77,28 @@ jobs:
       # `./scripts/check_secrets.sh` (also wired into scripts/verify_android.sh).
       - name: Scan for secrets and private data
         run: ./scripts/check_secrets.sh
+
+  cast-containment:
+    name: Cast containment markers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # Pure python, no toolchain: greps for the markers of the three layers
+      # that keep casting out of production builds (the constant, the production
+      # wiring, the transport's own refusals), because the change that quietly
+      # restores casting is exactly the one nobody labels as such.
+      #
+      # It is a tripwire, not proof — it matches source patterns in four known
+      # files and cannot see a bypass that leaves those patterns intact. The
+      # runtime evidence is in the Flutter checks job above
+      # (test/app/production_cast_containment_test.dart and
+      # test/core/services/cast/cast_containment_test.dart); the script's own
+      # limitations are documented in its docstring. Local twin:
+      # `python3 scripts/check_cast_containment.py`.
+      - name: Check cast containment markers
+        run: python3 scripts/check_cast_containment.py
 
   release-bump-guard:
     name: Release bump touches only version files

--- a/docs/cast.md
+++ b/docs/cast.md
@@ -1,5 +1,13 @@
 # Cast / Chromecast
 
+> **Casting is temporarily unavailable.** It is switched off in shipped builds
+> while a reported security issue is resolved. Local playback, downloads, and
+> every server integration are unaffected, and your queue and settings are
+> untouched. See [Temporary containment](#temporary-containment) below, and
+> issues [#572](https://github.com/TheZupZup/Linthra/issues/572) and
+> [#575](https://github.com/TheZupZup/Linthra/issues/575). The rest of this page
+> describes how casting works and will work again once it is restored.
+
 Linthra can hand a Jellyfin or Navidrome/Subsonic stream off to a **Chromecast**
 device (a Cast-enabled speaker, TV, or display) on your network. It uses a
 pure-Dart implementation of the Google Cast v2 protocol — **no Google Play
@@ -92,13 +100,12 @@ The UI renders a `CastState` and drives discovery/connection through the
 `CastService` interface, never a cast SDK directly — mirroring how the audio
 engine is hidden behind `PlaybackController`.
 
-- Android and iOS get the real `DefaultCastService`, which owns cast state and
-  the playback handoff: it resolves the current track's stream URL **at cast
-  time**, loads it on the receiver, pauses local audio, and resumes on
-  disconnect. It delegates the wire protocol to a thin `ChromecastCastTransport`
-  over the pure-Dart `cast` package (Cast v2 over a TLS socket; `bonsoir` for
-  discovery). Other platforms keep `UnavailableCastService`, so the button stays
-  honest.
+- `DefaultCastService` owns cast state and the playback handoff: it resolves the
+  current track's stream URL **at cast time**, loads it on the receiver, pauses
+  local audio, and resumes on disconnect. It delegates the wire protocol to a
+  thin `ChromecastCastTransport` over the pure-Dart `cast` package (Cast v2 over
+  a TLS socket; `bonsoir` for discovery). **While containment is in place no
+  build binds it**: every platform gets `UnavailableCastService`.
 - The network-touching transport is isolated, so all of casting's decision-making
   is unit-tested behind a fake `CastTransport`; the only code that opens a socket
   is verified by analysis and on-device testing.
@@ -107,6 +114,54 @@ engine is hidden behind `PlaybackController`.
   position/play-state, while the queue stays owned locally and track changes are
   mirrored onto the receiver. This is what fixes Cast desync. See
   [architecture.md](architecture.md#the-single-playback-seam-local--cast).
+
+## Temporary containment
+
+Casting is withheld from production builds by `CastContainment` while a reported
+security issue is resolved. The report, its assessment, and the requirements a
+restoration has to meet are held in the repository's private security advisory
+and are not reproduced here, in the code, or in pull requests, until coordinated
+disclosure. If you are picking this work up, ask a maintainer for advisory
+access rather than inferring the details from the code.
+
+It is enforced at three independent layers, because a containment one edit can
+undo is not a containment:
+
+1. **Production wiring** — `containedCastServiceOverride` binds
+   `UnavailableCastService` on every platform. No live backend is constructed,
+   so there is nothing to discover or connect with.
+2. **Transport** — `ChromecastCastTransport` refuses discovery and connection
+   outright. Re-wiring the service on its own, or injecting the transport from
+   somewhere else, still cannot open a receiver socket.
+3. **Media handoff** — the session handle refuses to hand media to a receiver,
+   so a session obtained some other way is still given nothing.
+
+`CastContainment.isActive` is a compile-time constant. There is deliberately no
+setting, environment variable, or debug affordance that flips it: an unreviewed
+runtime switch would be a second production path with none of the review the
+restoration requires.
+
+What demonstrates the containment is the test suite: the production-wiring tests
+build the real override list per platform and drive the service, and the
+transport tests call it directly. `scripts/check_cast_containment.py`, which also
+runs in CI, is a much weaker tripwire on top of that — it matches source patterns
+and only catches the obvious removals it knows about. Its limitations are written
+down in the script itself; it is not evidence that casting cannot be reached.
+
+In the app, the cast button stays visible but muted and the sheet says casting is
+temporarily unavailable — it does not claim the platform is unsupported, which
+would be untrue on the phones this affects.
+
+### Restoring casting
+
+Restoration is a separate, reviewed change, not a revert. Its requirements are
+tracked publicly in [#575](https://github.com/TheZupZup/Linthra/issues/575), and
+in detail in the private advisory, which is where that work is reviewed before
+anything is restored. [#576](https://github.com/TheZupZup/Linthra/issues/576) is
+an additional layer, not a substitute for it.
+
+The reviewed restoration updates `CastContainment`, the production wiring, the
+transport guards, and `scripts/check_cast_containment.py` in one pull request.
 
 ## Cast volume
 
@@ -117,6 +172,9 @@ following the receiver's reported level live. It is all behind `CastService`
 `volume` / `muted` / `supportsVolumeControl`.
 
 ## Security / token notes
+
+These describe the handoff as designed; while casting is contained, none of it
+runs, because no handoff happens at all.
 
 The handoff resolves the current track's stream URL **only at cast time**
 (Jellyfin's or Subsonic's authenticated URL, the credential woven in on demand)
@@ -144,6 +202,8 @@ freshly minted URL that never lands in `Track`, the catalog, a log, or app state
 
 ## Known limitations
 
+- **Casting is off in shipped builds** pending the security fix above. Everything
+  below describes the feature as built, for when it returns.
 - **No Linthra app name/logo on the receiver** with the default media receiver —
   it shows "Default Media Receiver". True branding needs a custom receiver app
   (see [above](#receiver-app-name--logo-branding)). Tracked as a follow-up.

--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -171,8 +171,31 @@ playback.
 
 ## 4. Cast / Chromecast
 
-Run the end-to-end pass in this order (a streamed track is required — local
-files can't cast):
+**Casting is currently contained** (see [cast.md](cast.md#temporary-containment)),
+so a shipped build has one pass, and it is the one that matters for the security
+maintenance release. Run it on a **real Android device and a real iPhone**, with a
+Chromecast powered on and on the same Wi-Fi:
+
+1. ☐ Start a **Jellyfin** (or Subsonic) track playing.
+2. ☐ Open the cast sheet: it says casting is **temporarily unavailable**, and does
+   *not* claim the platform is unsupported.
+3. ☐ **No device ever appears**, however long the sheet stays open, with a
+   powered-on Chromecast on the same network.
+4. ☐ Nothing can be tapped to connect; there is no retry or "search again".
+5. ☐ Local playback **keeps going untouched** the whole time: no pause, no
+   restart, no jump in position.
+6. ☐ Close and reopen the sheet a few times, background and foreground the app —
+   still no devices, still no interruption.
+7. ☐ The **queue, playback settings, and server sessions are unchanged** after
+   all of the above.
+8. ☐ Local files, downloads, Jellyfin, Navidrome/Subsonic and Plex playback all
+   behave normally.
+
+The end-to-end pass below applies **only once casting is restored** by the
+reviewed change that authenticates receivers. Keep it here; do not run it against
+a contained build (it will fail at step 2 by design).
+
+Run it in this order (a streamed track is required — local files can't cast):
 
 1. ☐ Start a **Jellyfin** (or Subsonic) track playing on the phone.
 2. ☐ Open the cast sheet, discover, and **connect** to a real Chromecast.

--- a/lib/app/application_container.dart
+++ b/lib/app/application_container.dart
@@ -78,6 +78,8 @@ List<Override> productionApplicationOverrides({
     platformLauncherIconServiceOverride,
     platformShareServiceOverride,
     lyricsServiceOverride,
-    chromecastCastServiceOverride,
+    // Casting is withheld from production builds by the security
+    // containment; see [CastContainment].
+    containedCastServiceOverride,
   ];
 }

--- a/lib/core/services/cast/cast_containment.dart
+++ b/lib/core/services/cast/cast_containment.dart
@@ -1,0 +1,72 @@
+import '../../models/cast_state.dart';
+
+/// The emergency security containment that keeps casting off in shipped builds.
+///
+/// Casting is withheld from production while a reported security issue is being
+/// resolved. The report itself, its assessment, and the requirements any
+/// restoration has to meet are held in the repository's private security
+/// advisory; [#575](https://github.com/TheZupZup/Linthra/issues/575) tracks the
+/// public side of that work. Details of the report do not belong in this file,
+/// in the app, in a commit message, or in a pull request.
+///
+/// Containment is not a UI decision. It is enforced at three independent layers,
+/// so that no single edit re-enables the path by accident:
+///
+///  1. **Production wiring** — the production override binds
+///     [UnavailableCastService]; the real service is not constructed at all, on
+///     any platform, so there is nothing to discover or connect with.
+///  2. **Transport** — [ChromecastCastTransport] refuses to discover or connect
+///     while [isActive], so re-wiring the service in isolation (a test-only
+///     injection reaching production, a revert of the provider) still cannot
+///     open a receiver socket.
+///  3. **Media handoff** — the session handle refuses to hand media to a
+///     receiver, so a session obtained some other way is still given nothing.
+///
+/// [isActive] is a compile-time constant on purpose. There is deliberately no
+/// setting, environment variable, or debug affordance that flips it: an
+/// unreviewed runtime switch would be a second production path with none of the
+/// review the restoration itself requires. Restoring casting means changing this
+/// constant *and* the wiring in one reviewed change.
+///
+/// What actually demonstrates the containment is the test suite —
+/// `test/app/production_cast_containment_test.dart` and
+/// `test/core/services/cast/cast_containment_test.dart` exercise the real
+/// production wiring and the transport at runtime.
+/// `scripts/check_cast_containment.py` is a much weaker source-pattern tripwire
+/// on top of that, and its own limitations are written down in it.
+///
+/// Local playback, downloads, and every server integration are untouched by
+/// containment; only casting is withheld.
+abstract final class CastContainment {
+  /// Whether casting is withheld from production. Flipping this to `false` is a
+  /// security decision, not a cleanup: see `docs/cast.md` and the private
+  /// advisory.
+  static const bool isActive = true;
+
+  /// What the cast UI tells the user. Deliberately specific about what is off
+  /// and what is unaffected, and deliberately free of any detail about the
+  /// report — that stays in the private advisory until coordinated disclosure.
+  static const String userMessage =
+      'Casting is temporarily turned off in this version while a security fix '
+      'is finished. Everything else — local playback, downloads, and your '
+      'servers — works as usual, and your queue and settings are untouched.';
+
+  /// The state the cast UI renders while contained: unavailable, with the
+  /// explanation above.
+  static const CastState state = CastState(message: userMessage);
+}
+
+/// Thrown by the fail-closed cast layers when something asks them to reach a
+/// receiver while [CastContainment.isActive].
+///
+/// Reaching this is a bug rather than a user-facing condition — the production
+/// wiring never builds a live transport — so it is an [Error]: it should crash a
+/// debug build and be fixed, not be caught and retried. It carries no detail
+/// about the report.
+class CastContainmentError extends StateError {
+  CastContainmentError(String operation)
+      : super(
+          'Cast is contained for security: $operation was refused. See '
+          'CastContainment.',
+        );
+}

--- a/lib/core/services/cast/chromecast_cast_transport.dart
+++ b/lib/core/services/cast/chromecast_cast_transport.dart
@@ -7,6 +7,7 @@ import '../../models/cast_playback_status.dart';
 import '../../models/cast_state.dart';
 import '../../models/cast_volume.dart';
 import '../../models/playback_state.dart';
+import 'cast_containment.dart';
 import 'cast_load_message.dart';
 import 'cast_transport.dart';
 
@@ -21,6 +22,14 @@ import 'cast_transport.dart';
 /// [DefaultCastService] (and is unit-tested there); this adapter only does I/O,
 /// so it is verified by static analysis and on-device testing rather than unit
 /// tests, which can't open real sockets.
+///
+/// **Contained.** While [CastContainment.isActive] every entry point here fails
+/// closed. The check is deliberately here, in the layer that opens the socket,
+/// rather than only in the provider wiring: restoring the provider by itself, or
+/// injecting this transport from anywhere else, still cannot reach a receiver.
+/// These throws are unreachable in shipped builds (production binds
+/// [UnavailableCastService]); reaching one means the wiring regressed, which is
+/// why it is an [Error] and not a state the UI renders. See [CastContainment].
 class ChromecastCastTransport implements CastTransport {
   /// The published "Default Media Receiver" app id — a generic player that
   /// streams a media URL with no custom receiver app to host.
@@ -32,6 +41,7 @@ class ChromecastCastTransport implements CastTransport {
 
   @override
   Future<List<CastDevice>> discover(Duration timeout) async {
+    if (CastContainment.isActive) throw CastContainmentError('discovery');
     final List<cast.CastDevice> found =
         await cast.CastDiscoveryService().search(timeout: timeout);
     _devices
@@ -44,6 +54,7 @@ class ChromecastCastTransport implements CastTransport {
 
   @override
   Future<CastSessionHandle> connect(CastDevice device) async {
+    if (CastContainment.isActive) throw CastContainmentError('connecting');
     final cast.CastDevice? target = _devices[device.id];
     if (target == null) {
       throw StateError('Unknown cast device ${device.id}; re-run discovery.');
@@ -126,6 +137,10 @@ class _ChromecastSessionHandle implements CastSessionHandle {
 
   @override
   Future<void> loadMedia(CastMedia media) async {
+    // The last of the three containment layers, checked before anything is
+    // built or sent: a session that reached this point while contained is given
+    // nothing at all.
+    if (CastContainment.isActive) throw CastContainmentError('a media handoff');
     // A LOAD starts a brand-new media session on the receiver, which mints a
     // fresh mediaSessionId and reports the new track's own duration. Forget the
     // previous track's session id and duration so a poll between this LOAD and

--- a/lib/core/services/cast/unavailable_cast_service.dart
+++ b/lib/core/services/cast/unavailable_cast_service.dart
@@ -4,19 +4,32 @@ import '../../models/cast_playback_status.dart';
 import '../../models/cast_state.dart';
 import 'cast_service.dart';
 
-/// The shipped [CastService]: casting is **not implemented** in this build, so
-/// it honestly reports [CastAvailability.unavailable] and no-ops every command.
+/// The shipped [CastService]: casting is not reachable in this build, so it
+/// honestly reports [CastAvailability.unavailable] and no-ops every command.
 ///
 /// It exists so the now-playing screen can show a real cast button backed by a
-/// real (if inert) service today, and so swapping in a Chromecast/Cast SDK
-/// implementation later is a one-line provider change with no UI edits. It never
-/// invents devices or pretends to connect.
+/// real (if inert) service, and so swapping in a live backend later is a
+/// provider change with no UI edits. It never invents devices or pretends to
+/// connect.
+///
+/// Two situations produce it, told apart by [message]:
+///  - the platform has no cast backend (Linux and every non-mobile target),
+///    which needs no explanation beyond the UI's own platform copy; and
+///  - the security containment ([CastContainment]), which passes
+///    [CastContainment.userMessage] so the sheet can say casting is *temporarily*
+///    off rather than unsupported here.
 class UnavailableCastService implements CastService {
+  UnavailableCastService({this.message});
+
+  /// A calm, secret-free explanation for the cast sheet, or null to let the UI
+  /// use its own platform wording. Never carries security detail.
+  final String? message;
+
   final StreamController<CastState> _states =
       StreamController<CastState>.broadcast();
 
   @override
-  CastState get state => CastState.unavailable;
+  CastState get state => CastState(message: message);
 
   @override
   Stream<CastState> get stateStream =>

--- a/lib/features/player/cast/cast_button.dart
+++ b/lib/features/player/cast/cast_button.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/models/cast_state.dart';
 import 'cast_devices_sheet.dart';
 import 'cast_providers.dart';
 
@@ -8,9 +9,10 @@ import 'cast_providers.dart';
 /// the [CastDevicesSheet]; it never talks to a cast SDK directly.
 ///
 /// Honest by design: with the shipped [UnavailableCastService] the button is
-/// visible but muted, signalling casting is a foundation rather than live. When
-/// connected it switches to the filled cast-connected glyph. Tapping always
-/// opens the sheet, which states the real status for the current backend.
+/// visible but muted, so it never implies casting works today. When connected it
+/// switches to the filled cast-connected glyph. Tapping always opens the sheet,
+/// which states the real status — including that casting is temporarily
+/// withheld while the security containment is in place.
 class CastButton extends ConsumerWidget {
   const CastButton({super.key});
 
@@ -36,8 +38,18 @@ class CastButton extends ConsumerWidget {
       icon: Icon(state.isConnected ? Icons.cast_connected : Icons.cast),
       color: color,
       isSelected: state.isConnected,
-      tooltip: state.isAvailable ? 'Cast' : 'Cast (coming soon)',
+      tooltip: _tooltip(state),
     );
+  }
+
+  /// A carried message on an unavailable state means casting is off for its own
+  /// reason (the security containment), not merely unsupported here — the sheet
+  /// spells it out, and the tooltip shouldn't promise it is coming.
+  String _tooltip(CastState state) {
+    if (state.isAvailable) return 'Cast';
+    return state.message != null
+        ? 'Cast (temporarily unavailable)'
+        : 'Cast (coming soon)';
   }
 
   void _openSheet(BuildContext context) {

--- a/lib/features/player/cast/cast_devices_sheet.dart
+++ b/lib/features/player/cast/cast_devices_sheet.dart
@@ -11,9 +11,10 @@ import 'cast_providers.dart';
 
 /// The cast target picker, opened from the now-playing [CastButton].
 ///
-/// It renders honestly from [castStateProvider]: when casting is unavailable
-/// (the shipped default — no cast backend wired yet) it shows a calm
-/// foundation/"coming soon" state rather than an empty or fake device list.
+/// It renders honestly from [castStateProvider]: when casting is unavailable it
+/// shows a calm explanation rather than an empty or fake device list — the
+/// platform has no backend, or (with a [CastState.message]) casting is
+/// temporarily withheld by the security containment.
 /// When a real backend lands, the same sheet lists discovered devices and lets
 /// the user connect/disconnect — no UI changes needed. Discovery is started
 /// while the sheet is open and stopped when it closes.
@@ -100,13 +101,21 @@ class _Body extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     if (!state.isAvailable) {
-      return const Padding(
+      // A carried message means casting is off for a reason of its own (the
+      // security containment) rather than unsupported by the platform, so it
+      // replaces the platform copy: telling an Android user to "try a supported
+      // platform" would be untrue and unhelpful.
+      final String? reason = state.message;
+      return Padding(
         padding: _pad,
         child: EmptyState(
           icon: Icons.cast,
-          title: 'Casting isn\'t available here',
-          message: 'Streaming to Chromecast needs Android or iOS. The control '
-              'is here; pick a device on a supported platform to cast.',
+          title: reason != null
+              ? 'Casting is temporarily unavailable'
+              : 'Casting isn\'t available here',
+          message: reason ??
+              'Streaming to Chromecast needs Android or iOS. The control '
+                  'is here; pick a device on a supported platform to cast.',
         ),
       );
     }

--- a/lib/features/player/cast/cast_providers.dart
+++ b/lib/features/player/cast/cast_providers.dart
@@ -1,26 +1,23 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/lifecycle/async_disposal_registry.dart';
 import '../../../core/models/cast_state.dart';
+import '../../../core/services/cast/cast_containment.dart';
 import '../../../core/services/cast/cast_media_resolver.dart';
 import '../../../core/services/cast/cast_service.dart';
-import '../../../core/services/cast/chromecast_cast_transport.dart';
-import '../../../core/services/cast/default_cast_service.dart';
 import '../../../core/services/cast/routing_cast_media_resolver.dart';
 import '../../../core/services/cast/unavailable_cast_service.dart';
 import '../../../core/sources/jellyfin/jellyfin_cast_media_resolver.dart';
 import '../../../core/sources/subsonic/subsonic_cast_media_resolver.dart';
 import '../../settings/jellyfin/jellyfin_settings_controller.dart';
 import '../../settings/subsonic/subsonic_settings_controller.dart';
-import '../player_providers.dart';
 
 /// The single [CastService] the app drives casting through.
 ///
 /// Defaults to [UnavailableCastService] so tests (and any platform without a
-/// Chromecast stack) keep an honest, inert cast button. Production swaps in the
-/// real backend via [chromecastCastServiceOverride]; the cast button and device
-/// sheet are unchanged either way.
+/// cast backend) keep an honest, inert cast button. A service test that needs
+/// live behaviour overrides this provider with its own fake; production applies
+/// [containedCastServiceOverride].
 final castServiceProvider = Provider<CastService>((ref) {
   final service = UnavailableCastService();
   ref.onDisposeAsync(service.dispose);
@@ -39,6 +36,11 @@ final castStateProvider = StreamProvider<CastState>((ref) {
 /// [CastMediaResolver.canCast] false so the service can show a clear limitation
 /// instead of failing. Composed so multiple remote sources cast through one
 /// resolver.
+///
+/// Unused by production while [CastContainment.isActive] — nothing resolves a
+/// stream URL for a receiver when no session can be opened. It stays wired and
+/// tested because [#576](https://github.com/TheZupZup/Linthra/issues/576) builds
+/// on it, rather than rebuilding it afterwards.
 final castMediaResolverProvider = Provider<CastMediaResolver>((ref) {
   return RoutingCastMediaResolver(<CastMediaResolver>[
     JellyfinCastMediaResolver(() => ref.read(jellyfinMusicSourceProvider)),
@@ -46,38 +48,22 @@ final castMediaResolverProvider = Provider<CastMediaResolver>((ref) {
   ]);
 });
 
-/// Production binding: the real Chromecast backend, applied in `main`.
+/// Production binding: the security containment ([CastContainment]).
 ///
-/// It wires [DefaultCastService] to the live [ChromecastCastTransport] and to
-/// the local engine — reading the current track and mirroring track changes
-/// onto the receiver. It does *not* pause or resume local playback itself: the
-/// `ActivePlaybackController` owns that, suspending the engine on handoff and
-/// resuming it paused when a session ends, so casting never surprise-starts the
-/// phone. Reading [localPlaybackControllerProvider] (the queue owner) rather
-/// than the routing controller keeps the dependency graph acyclic. Only Android
-/// and iOS get this; every other platform keeps the unavailable default so the
-/// app never claims a cast ability the platform lacks. Tests don't apply this,
-/// so they keep the inert default unless they override the service themselves.
-final chromecastCastServiceOverride = castServiceProvider.overrideWith((ref) {
-  final bool castable = defaultTargetPlatform == TargetPlatform.android ||
-      defaultTargetPlatform == TargetPlatform.iOS;
-  if (!castable) {
-    final UnavailableCastService fallback = UnavailableCastService();
-    ref.onDisposeAsync(fallback.dispose);
-    return fallback;
-  }
-
-  final local = ref.read(localPlaybackControllerProvider);
-  final service = DefaultCastService(
-    transport: ChromecastCastTransport(),
-    mediaResolver: ref.read(castMediaResolverProvider),
-    currentTrack: () => local.state.currentTrack,
-    // Distinct by uri, not Track == (which is bare-id), so a same-bare-id cast
-    // skip/fallback (jellyfin:101 -> subsonic:101) still reaches the receiver
-    // instead of being filtered out before _handOff sees it.
-    trackChanges: local.stateStream
-        .map((s) => s.currentTrack)
-        .distinct((a, b) => a?.uri == b?.uri),
+/// Every platform gets [UnavailableCastService], so shipped builds construct no
+/// cast transport and open no receiver socket. This *is* the production path:
+/// there is no branch here that builds a live backend, and no flag that selects
+/// one, because a second production path is exactly what containment cannot
+/// have. The cast button and device sheet are unchanged; they read the message
+/// and say casting is temporarily off.
+///
+/// Restoring casting is a separate reviewed change, tracked in
+/// [#575](https://github.com/TheZupZup/Linthra/issues/575). Until then the
+/// transport and the media handoff refuse independently of this provider, so
+/// reverting this alone still cannot reach a receiver.
+final containedCastServiceOverride = castServiceProvider.overrideWith((ref) {
+  final service = UnavailableCastService(
+    message: CastContainment.isActive ? CastContainment.userMessage : null,
   );
   ref.onDisposeAsync(service.dispose);
   return service;

--- a/scripts/check_cast_containment.py
+++ b/scripts/check_cast_containment.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""A source-pattern tripwire for the Cast security containment.
+
+Casting is withheld from production builds while a reported security issue is
+resolved (see lib/core/services/cast/cast_containment.dart and docs/cast.md).
+This script greps four files for the markers of the three layers that hold that
+in place: the `isActive` constant, the production override binding, the absence
+of a live backend in the cast provider wiring, and the transport's own guards.
+
+WHAT THIS IS NOT
+----------------
+This is NOT proof that casting cannot be reached, and it must not be described
+as one. It is a set of regexes over four known files, so it catches the obvious
+regression — someone flips the constant, drops the override, reverts the
+provider, deletes a guard — and nothing subtler. It cannot see:
+
+  * a bypass that keeps every marker in place, such as a new CastService
+    implementation, a second override applied after this one, a live transport
+    constructed somewhere other than cast_providers.dart, or a guard left intact
+    while the code path around it moves;
+  * anything in a file this script does not read, including new files;
+  * a guard that is present but no longer reachable, or a constant read through
+    an indirection this script does not resolve;
+  * the actual runtime behaviour of any of it, since nothing here executes the
+    app.
+
+WHAT IS THE EVIDENCE
+--------------------
+The tests are. test/app/production_cast_containment_test.dart builds the real
+production override list per platform and drives the resulting service;
+test/core/services/cast/cast_containment_test.dart calls the transport directly.
+Those exercise behaviour rather than text. Treat a green run of this script as
+"the markers we know to look for are still there", and treat a red one as a
+question that needs answering before merge.
+
+Ambiguity fails closed: a missing file, an unreadable file, or a pattern this
+script no longer recognises exits non-zero rather than reporting success. That
+is a property of this script's own inputs, not a guarantee about the app.
+
+When the reviewed restoration lands, this script is updated in the same pull
+request — that edit is one of the signals a reviewer looks for.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+CONTAINMENT = Path("lib/core/services/cast/cast_containment.dart")
+CONTAINER = Path("lib/app/application_container.dart")
+PROVIDERS = Path("lib/features/player/cast/cast_providers.dart")
+TRANSPORT = Path("lib/core/services/cast/chromecast_cast_transport.dart")
+
+# Constructing either of these is what puts a live cast backend into the app, so
+# neither may appear in the production wiring while containment holds.
+LIVE_BACKEND = (
+    ("DefaultCastService", re.compile(r"\bDefaultCastService\s*\(")),
+    ("ChromecastCastTransport", re.compile(r"\bChromecastCastTransport\s*\(")),
+)
+
+# The transport's own fail-closed guards, one per entry point that can reach a
+# receiver. Matched loosely enough to survive reformatting, strictly enough that
+# deleting a guard is caught.
+TRANSPORT_GUARDS = (
+    ("discovery", re.compile(r"CastContainment\.isActive.*discovery", re.S)),
+    ("connecting", re.compile(r"CastContainment\.isActive.*connecting", re.S)),
+    ("media handoff", re.compile(r"CastContainment\.isActive.*media handoff", re.S)),
+)
+
+
+def read(path: Path) -> str:
+    full = REPO_ROOT / path
+    try:
+        return full.read_text(encoding="utf-8")
+    except OSError as error:
+        sys.exit(f"ERROR: cannot read {path}: {error}")
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    containment = read(CONTAINMENT)
+    if not re.search(r"static\s+const\s+bool\s+isActive\s*=\s*true\s*;", containment):
+        failures.append(
+            f"{CONTAINMENT}: CastContainment.isActive is not `true`. Casting may "
+            "only be restored by a reviewed change that also authenticates the "
+            "receiver before any media handoff."
+        )
+
+    container = read(CONTAINER)
+    if "containedCastServiceOverride" not in container:
+        failures.append(
+            f"{CONTAINER}: the production override list no longer applies "
+            "containedCastServiceOverride, so production would fall back to an "
+            "unreviewed cast binding."
+        )
+
+    providers = read(PROVIDERS)
+    for name, pattern in LIVE_BACKEND:
+        if pattern.search(providers):
+            failures.append(
+                f"{PROVIDERS}: constructs {name} — production must build no live "
+                "cast backend while contained."
+            )
+
+    transport = read(TRANSPORT)
+    for name, pattern in TRANSPORT_GUARDS:
+        if not pattern.search(transport):
+            failures.append(
+                f"{TRANSPORT}: the fail-closed guard for {name} is missing. The "
+                "transport must refuse independently of the provider wiring."
+            )
+
+    if failures:
+        print("Cast containment marker check FAILED:\n", file=sys.stderr)
+        for failure in failures:
+            print(f"  * {failure}\n", file=sys.stderr)
+        print(
+            "If this is the reviewed restoration of casting, update this script "
+            "in the same pull request and say so in the description.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        "Cast containment markers present (constant, production wiring, "
+        "transport guards). This is a pattern check, not proof: the runtime "
+        "evidence is test/app/production_cast_containment_test.dart and "
+        "test/core/services/cast/cast_containment_test.dart."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/app/production_cast_containment_test.dart
+++ b/test/app/production_cast_containment_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/app/application_container.dart';
+import 'package:linthra/core/models/cast_state.dart';
+import 'package:linthra/core/models/theme_mode_preference.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/core/services/cast/cast_containment.dart';
+import 'package:linthra/core/services/cast/cast_service.dart';
+import 'package:linthra/core/services/cast/default_cast_service.dart';
+import 'package:linthra/core/services/cast/unavailable_cast_service.dart';
+import 'package:linthra/features/player/cast/cast_providers.dart';
+
+/// What a *shipped* build gets for casting, walked through the real production
+/// override list rather than a test's own wiring.
+///
+/// Casting is withheld from production while a reported security issue is
+/// resolved (see [CastContainment]). The regression this guards against is the
+/// quiet one: a provider revert, a platform branch reintroduced "just for
+/// Android", a test-only injection reaching production. Each platform is checked
+/// individually because a branch is precisely what containment must not have.
+///
+/// This walks the real production override list and drives the service it
+/// returns, so it is behavioural evidence rather than a source-pattern check.
+void main() {
+  ProviderContainer productionContainer(HostPlatform host) {
+    final container = ProviderContainer(
+      overrides: productionApplicationOverrides(
+        storedThemeMode: ThemeModePreference.system,
+        host: host,
+      ),
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  for (final HostPlatform host in <HostPlatform>[
+    HostPlatform.android,
+    HostPlatform.ios,
+    HostPlatform.linux,
+    HostPlatform.macOS,
+    HostPlatform.windows,
+    HostPlatform.other,
+  ]) {
+    group('production build on ${host.name}', () {
+      test('binds the unavailable cast service, never a live backend', () {
+        final CastService service =
+            productionContainer(host).read(castServiceProvider);
+
+        expect(service, isA<UnavailableCastService>());
+        expect(service, isNot(isA<DefaultCastService>()));
+        expect(service.state.isAvailable, isFalse);
+      });
+
+      test('tells the user casting is temporarily off', () {
+        final CastService service =
+            productionContainer(host).read(castServiceProvider);
+
+        expect(service.state.message, CastContainment.userMessage);
+      });
+
+      test('the state stream reports the same containment', () async {
+        final CastService service =
+            productionContainer(host).read(castServiceProvider);
+
+        await expectLater(
+          service.stateStream,
+          emits(
+            predicate<CastState>(
+              (CastState s) =>
+                  !s.isAvailable && s.message == CastContainment.userMessage,
+              'an unavailable state carrying the containment message',
+            ),
+          ),
+        );
+      });
+
+      test('direct service calls cannot discover, connect, or hand off',
+          () async {
+        final CastService service =
+            productionContainer(host).read(castServiceProvider);
+
+        // Straight at the service, the way application code would if the UI
+        // were bypassed entirely — the containment is not a UI decision.
+        await service.startDiscovery();
+        await service.connect(const CastDevice(id: 'r1', name: 'Living room'));
+        await service.play();
+        await service.seek(const Duration(minutes: 1));
+        await service.setVolume(1.0);
+        await service.refresh();
+        await service.disconnect();
+        await service.stopDiscovery();
+
+        expect(service.state.isAvailable, isFalse);
+        expect(service.state.isCasting, isFalse);
+        expect(service.state.connectedDevice, isNull);
+        expect(service.state.devices, isEmpty);
+        expect(service.playbackStatus.status.name, 'idle');
+      });
+
+      test('repeated startup and disposal stay contained', () async {
+        for (int run = 0; run < 3; run++) {
+          final ProviderContainer container = ProviderContainer(
+            overrides: productionApplicationOverrides(
+              storedThemeMode: ThemeModePreference.system,
+              host: host,
+            ),
+          );
+          final CastService service = container.read(castServiceProvider);
+          await service.startDiscovery();
+          expect(service.state.isAvailable, isFalse);
+          container.dispose();
+        }
+      });
+    });
+  }
+
+  test('the production override list applies the containment binding', () {
+    // Belt and braces with the CI guard: if the override is dropped from the
+    // list, production silently falls back to the default provider.
+    final List<Override> overrides = productionApplicationOverrides(
+      storedThemeMode: ThemeModePreference.system,
+      host: HostPlatform.android,
+    );
+
+    expect(overrides, contains(containedCastServiceOverride));
+  });
+
+  test('an unavailable service without a message keeps the platform wording',
+      () {
+    // The Linux/desktop fallback predates containment and must survive it: no
+    // message means the sheet uses its own "not on this platform" copy.
+    final service = UnavailableCastService();
+    addTearDown(service.dispose);
+
+    expect(service.state.message, isNull);
+    expect(service.state.isAvailable, isFalse);
+  });
+}

--- a/test/core/services/cast/cast_containment_test.dart
+++ b/test/core/services/cast/cast_containment_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/cast_state.dart';
+import 'package:linthra/core/services/cast/cast_containment.dart';
+import 'package:linthra/core/services/cast/chromecast_cast_transport.dart';
+
+/// The fail-closed half of the Cast security containment.
+///
+/// Production binds an inert service, so these paths are unreachable in a
+/// shipped build — which is the point of testing them. They are the safety net
+/// under the wiring: if the provider is ever reverted, injected around, or
+/// restored early, the transport itself must still refuse to reach a device.
+///
+/// **A known gap.** The third layer — the session handle's own refusal — has no
+/// test here: the handle is private and only [ChromecastCastTransport.connect]
+/// hands one out, so a test cannot obtain one while contained. That layer is
+/// therefore covered only by reading the code and by the marker check in
+/// `scripts/check_cast_containment.py`, which is a source-pattern tripwire
+/// rather than proof. It is a backstop behind two layers that *are* exercised
+/// here and in test/app/production_cast_containment_test.dart, not the thing
+/// containment rests on.
+void main() {
+  group('CastContainment', () {
+    test('is active, and is a compile-time constant with no runtime switch',
+        () {
+      // A settable flag would be a second production path with none of the
+      // review restoring casting requires. If this fails, casting was restored
+      // — which must happen in a reviewed change that also authenticates the
+      // receiver (see docs/cast.md), together with scripts/check_cast_containment.py.
+      expect(CastContainment.isActive, isTrue);
+    });
+
+    test('the user-facing message explains the situation without leaking it',
+        () {
+      final String message = CastContainment.userMessage.toLowerCase();
+
+      // Says casting is temporarily off, and reassures about the rest.
+      expect(message, contains('casting'));
+      expect(message, contains('temporarily'));
+
+      // Carries nothing about the weakness itself: that stays private until
+      // coordinated disclosure.
+      for (final String leak in <String>[
+        'token',
+        'credential',
+        'vulnerab',
+        'exploit',
+        'attack',
+        'cve',
+        'ghsa',
+        'advisory',
+      ]) {
+        expect(message, isNot(contains(leak)), reason: 'leaks "$leak"');
+      }
+    });
+
+    test('the contained state is unavailable and carries the message', () {
+      expect(CastContainment.state.isAvailable, isFalse);
+      expect(CastContainment.state.message, CastContainment.userMessage);
+      expect(CastContainment.state.devices, isEmpty);
+      expect(CastContainment.state.connectedDevice, isNull);
+      expect(CastContainment.state.isCasting, isFalse);
+    });
+  });
+
+  group('ChromecastCastTransport (contained)', () {
+    test('refuses to discover receivers', () async {
+      await expectLater(
+        ChromecastCastTransport().discover(const Duration(seconds: 1)),
+        throwsA(isA<CastContainmentError>()),
+      );
+    });
+
+    test('refuses to connect, even to a device it was handed directly',
+        () async {
+      // Bypasses discovery entirely, the way a reverted provider or a stray
+      // injection would: the refusal must not depend on discovery running.
+      await expectLater(
+        ChromecastCastTransport().connect(
+          const CastDevice(id: 'receiver-1', name: 'Living room'),
+        ),
+        throwsA(isA<CastContainmentError>()),
+      );
+    });
+
+    test('repeated attempts keep failing (no first-call-only guard)', () async {
+      final ChromecastCastTransport transport = ChromecastCastTransport();
+      for (int attempt = 0; attempt < 3; attempt++) {
+        await expectLater(
+          transport.discover(const Duration(milliseconds: 1)),
+          throwsA(isA<CastContainmentError>()),
+        );
+        await expectLater(
+          transport.connect(const CastDevice(id: 'r', name: 'Receiver')),
+          throwsA(isA<CastContainmentError>()),
+        );
+      }
+    });
+
+    test('the refusal names no security detail', () {
+      final Object error = CastContainmentError('a media handoff');
+      final String text = error.toString().toLowerCase();
+
+      expect(text, contains('contained'));
+      for (final String leak in <String>[
+        'token',
+        'credential',
+        'vulnerab',
+        'ghsa',
+        'advisory',
+      ]) {
+        expect(text, isNot(contains(leak)), reason: 'leaks "$leak"');
+      }
+    });
+  });
+}

--- a/test/features/player/cast/cast_button_test.dart
+++ b/test/features/player/cast/cast_button_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/cast_state.dart';
+import 'package:linthra/core/services/cast/cast_containment.dart';
 import 'package:linthra/features/player/cast/cast_button.dart';
 import 'package:linthra/features/player/cast/cast_providers.dart';
 
@@ -28,6 +29,16 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byIcon(Icons.cast), findsOneWidget);
+    });
+
+    testWidgets('reads as temporarily unavailable while contained',
+        (tester) async {
+      await _pump(tester, FakeCastService(initial: CastContainment.state));
+      await tester.pumpAndSettle();
+
+      // "Coming soon" would misdescribe a feature that shipped and was pulled.
+      expect(find.byTooltip('Cast (temporarily unavailable)'), findsOneWidget);
+      expect(_button(tester).isSelected, isFalse);
     });
 
     testWidgets('is shown but marked "coming soon" when unavailable', (

--- a/test/features/player/cast/cast_devices_sheet_test.dart
+++ b/test/features/player/cast/cast_devices_sheet_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/cast_state.dart';
+import 'package:linthra/core/services/cast/cast_containment.dart';
 import 'package:linthra/features/player/cast/cast_devices_sheet.dart';
 import 'package:linthra/features/player/cast/cast_providers.dart';
 
@@ -23,6 +24,40 @@ Future<void> _pumpSheet(WidgetTester tester, FakeCastService service) async {
 const _device = CastDevice(id: 'd1', name: 'Living Room');
 
 void main() {
+  group('CastDevicesSheet security containment', () {
+    testWidgets('says casting is temporarily off, not unsupported here',
+        (tester) async {
+      await _pumpSheet(
+        tester,
+        FakeCastService(initial: CastContainment.state),
+      );
+
+      expect(find.text('Casting is temporarily unavailable'), findsOneWidget);
+      expect(find.text(CastContainment.userMessage), findsOneWidget);
+      // The platform copy would be wrong on the phones this actually affects.
+      expect(find.textContaining('needs Android or iOS'), findsNothing);
+    });
+
+    testWidgets('starts no discovery while contained', (tester) async {
+      final service = FakeCastService(initial: CastContainment.state);
+      await _pumpSheet(tester, service);
+      await tester.pump(const Duration(seconds: 1));
+
+      // Opening the picker is the UI's one chance to kick off a scan; an
+      // unavailable service must never get that call.
+      expect(service.discoveryStarts, 0);
+      expect(service.connectRequests, isEmpty);
+    });
+
+    testWidgets('offers no device to connect to', (tester) async {
+      final service = FakeCastService(initial: CastContainment.state);
+      await _pumpSheet(tester, service);
+
+      expect(find.byType(ListTile), findsNothing);
+      expect(find.text('Search again'), findsNothing);
+    });
+  });
+
   group('CastDevicesSheet states', () {
     testWidgets('searching: shows a spinner and a friendly message',
         (tester) async {


### PR DESCRIPTION
Emergency containment for #572, with the regression coverage from #573.

Casting is withheld from shipped builds while a reported security issue is resolved. The report, its assessment, and the requirements a restoration has to meet stay in the private security advisory, and are not reproduced here or in the code. Please keep security-sensitive discussion there rather than in this thread.

This is containment, not removal: the feature, its service, and its tests stay in the tree for the reviewed restoration tracked in #575.

## Three independent layers

A containment that one edit can undo is not a containment, so nothing here depends on the UI or on a single provider:

1. **Production wiring** binds `UnavailableCastService` on every platform, so no cast backend is constructed at all.
2. **`ChromecastCastTransport`** refuses discovery and connection on its own. Re-wiring the provider, or injecting the transport from somewhere else, still cannot reach a receiver.
3. **The session handle** refuses to hand media to a receiver, so a session obtained some other way is still given nothing.

`CastContainment.isActive` is a compile-time constant. There is deliberately no setting, environment variable, or debug affordance behind it: an unreviewed runtime switch would be a second production path with none of the review that restoring casting requires.

## What users see

The cast button stays visible but muted, and the sheet says casting is temporarily unavailable while a security fix is finished. It does not claim the platform is unsupported, which would be untrue on the phones this affects, and it carries no detail about the report.

Local playback, downloads, Jellyfin, Navidrome/Subsonic, Plex, and Linux are untouched, and the queue and saved settings are unchanged.

## Evidence, and its limits

The runtime tests are the evidence:

- `test/app/production_cast_containment_test.dart` builds the **real production override list** per platform (Android, iOS, the Linux/desktop fallback, and the rest) and drives the service it returns: unavailable service, no live backend, and direct calls that cannot discover, connect, or hand off. Startup, repeat calls, and disposal included.
- `test/core/services/cast/cast_containment_test.dart` calls the transport directly: discovery and connection refuse, repeatedly, including a device handed in without discovery.
- UI tests: the sheet shows the temporary wording, starts no discovery, and offers no device.

Two limitations, stated rather than papered over:

- **Layer 3 has a test gap.** The session handle is private and only obtainable through `connect`, which refuses, so a test cannot reach it while contained. That layer rests on code review, and is a backstop behind two layers that are exercised. It is documented in the test file.
- **`scripts/check_cast_containment.py` is a tripwire, not proof.** It matches source patterns in four known files, so it catches an obvious removal (the constant flipped, the override dropped, a guard deleted) and nothing subtler: it cannot see a bypass that leaves those markers intact, anything in a file it does not read, or the actual runtime behaviour. Its limitations are written into the script and the CI job comment. Treat a green run as "the markers are still there".

Full suite green locally: `dart format`, `flutter analyze`, 4208 tests, the secret scan, and the marker check.

## Not in this PR

- **#574** (the maintenance release, v0.2.6) needs a version bump PR, signed builds, publication, and real-device smoke tests. The device pass for a contained build is written up in `docs/manual-test-checklist.md` so it is ready to run.
- **#575** and **#576** are the remediation itself and stay separate.

Closes #572
Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwEthUnaMdNwUondxnB9jn