### PR TITLE
chore(release): bump to 0.2.6+206999

### DIFF
--- a/docs/release-notes/v0.2.6.md
+++ b/docs/release-notes/v0.2.6.md
@@ -21,8 +21,9 @@ recommended for anyone who has used or might use casting.
   folder used to walk the whole tree on Android's main thread, one query per
   folder plus metadata and artwork extraction per file. On a real library that
   froze the UI and could end in an ANR. The scan now runs on a background thread
-  and replies once when it is done, so the app stays responsive. Two scans of the
-  same tree queue instead of competing. No change to the permission model: the
+  and replies once when it is done, so the app stays responsive. Picking a second
+  folder supersedes the first: the older scan stops rather than making you wait
+  out a folder you already moved on from. No change to the permission model: the
   same folder grant, no MediaStore, no broad storage access.
 
 ### Linux

--- a/docs/release-notes/v0.2.6.md
+++ b/docs/release-notes/v0.2.6.md
@@ -1,0 +1,133 @@
+# Linthra v0.2.6
+
+Linthra 0.2.6 is a security maintenance release. Casting is temporarily turned
+off while a security fix is finished, and the release also carries the Linux
+desktop and Android library work that landed since 0.2.5. Updating is
+recommended for anyone who has used or might use casting.
+
+## What's new
+
+### Casting
+
+- **Casting is temporarily unavailable.** Linthra will not hand a track to a Cast
+  receiver in this build. The cast control is still there, but it is muted and the
+  device sheet explains that casting is off for now rather than offering devices.
+  This is a deliberate, temporary safeguard while a reported security issue is
+  resolved, not a removal of the feature. See below.
+
+### Android
+
+- **A large music folder no longer freezes the app while it scans.** Picking a
+  folder used to walk the whole tree on Android's main thread, one query per
+  folder plus metadata and artwork extraction per file. On a real library that
+  froze the UI and could end in an ANR. The scan now runs on a background thread
+  and replies once when it is done, so the app stays responsive. Two scans of the
+  same tree queue instead of competing. No change to the permission model: the
+  same folder grant, no MediaStore, no broad storage access.
+
+### Linux
+
+- **Media keys and desktop media controls work.** Linthra now exports an MPRIS
+  media session, so it shows up in GNOME's lock screen and top bar, KDE's media
+  applet, and `playerctl`, and hardware media keys drive it. Play, pause, stop,
+  next, previous, seek and absolute position are all wired, along with shuffle,
+  repeat and the track's title, artist, album and duration.
+  - Two things are deliberately not published on the session bus: the track's URL
+    (for a streamed track that is an authenticated URL, for a local one it is your
+    file path) and any cover reference that is not a plain loadable image. The
+    track identifier is a counter, not your library's own id.
+- **Local files show their real tags.** A local Linux library used to show
+  filenames. Linthra now reads title, artist, album, album artist and duration
+  from the files themselves, parsing tags rather than loading whole files, and
+  without pulling cover images out of every file during a scan. A file with
+  missing, unsupported or broken tags still appears under its filename instead of
+  vanishing. Embedded artwork is still to come.
+- **No more stray mpv cache file.** The audio backend was letting mpv keep an
+  on-disk packet cache, which is the right default for a video player and the
+  wrong one here, and which logged "Failed to create cache temporary file" on
+  every stream where it could not write. That cache is now off. Memory and network
+  buffering are unchanged, and Linthra's own offline downloads are a separate
+  mechanism this does not touch.
+
+### Project
+
+- **A security policy and a private reporting route.** The repository now has a
+  `SECURITY.md` and GitHub private vulnerability reporting is enabled, so a
+  security issue has somewhere to go that is not a public issue.
+
+Everything else behaves as it did in 0.2.5. Your queue, playback settings, saved
+servers, downloads and library are untouched by the update.
+
+## Why casting is off
+
+A security researcher reported an issue in Linthra's Cast path through
+[private vulnerability reporting](https://github.com/TheZupZup/Linthra/security/advisories).
+The report is being handled in a private advisory, and the technical details stay
+there until a fix is ready and disclosure is coordinated with the reporter. There
+is no evidence that anyone was affected, and this release makes no such claim.
+
+The honest position until receiver identity can be verified properly is to not
+cast at all, so this release disables the path rather than papering over it. That
+containment is enforced in three independent places in the code, so a UI change
+or a single reverted line cannot quietly re-enable it.
+
+Public tracking issues:
+[#572](https://github.com/TheZupZup/Linthra/issues/572) (this containment),
+[#575](https://github.com/TheZupZup/Linthra/issues/575) (restoring casting
+properly) and [#576](https://github.com/TheZupZup/Linthra/issues/576) (reducing
+what any external playback device is given in the first place).
+
+Casting will come back in a later release, in a separate reviewed change. It is
+not restored by this one.
+
+## Android and F-Droid
+
+The canonical Android version for this release is:
+
+- versionName: `0.2.6`
+- base versionCode: `206999`
+
+F-Droid's split-ABI scheme:
+
+- armeabi-v7a: `2069991`
+- arm64-v8a: `2069992`
+- x86_64: `2069993`
+
+F-Droid builds from source at this tag on its own infrastructure, so its build
+will follow once it picks the tag up.
+
+GitHub APKs and F-Droid packages are signed by different keys, so keep updating
+from the same install source you originally chose. They cannot update each other.
+
+Linthra is **not** publicly available on Google Play.
+
+## Linux
+
+The native Linux x64 archive is published as usual:
+
+`Linthra-v0.2.6-linux-x64.tar.gz`
+
+Casting was never wired up on Linux, so that part of this release changes nothing
+there. Linthra is not on Flathub yet.
+
+## Upgrade notes
+
+No manual migration is required. Update normally from the source you installed
+from. Your library, queue, downloads and saved servers stay exactly where they
+are.
+
+If you were using casting, it will stop being offered after this update. That is
+expected, and it is temporary.
+
+## Reporting security issues
+
+If you have found something, please use
+[private vulnerability reporting](https://github.com/TheZupZup/Linthra/security/advisories/new)
+rather than a public issue. See [SECURITY.md](https://github.com/TheZupZup/Linthra/blob/main/SECURITY.md).
+
+## Community
+
+Thank you to the reporter for a careful, responsibly disclosed report, and for
+coordinating privately while this was prepared. Thanks as always to everyone
+testing Linthra, filing issues, and contributing the desktop and library work in
+this release.

--- a/fastlane/metadata/android/en-US/changelogs/206999.txt
+++ b/fastlane/metadata/android/en-US/changelogs/206999.txt
@@ -1,4 +1,7 @@
 Linthra 0.2.6
 
-- Casting is temporarily turned off while a security fix is finished. Local playback, downloads, and your servers are unaffected, and your queue and settings are unchanged.
-- The cast controls now say casting is temporarily unavailable instead of offering devices.
+- Casting is temporarily turned off while a security fix is finished. Local playback, downloads, and your servers are unaffected.
+- Android: picking a large music folder no longer freezes the app while it scans.
+- Linux: media keys and desktop media controls now work.
+- Linux: local files show their real title, artist, album and duration instead of the filename.
+- Linux: no more stray mpv cache file and its error logs.

--- a/fastlane/metadata/android/en-US/changelogs/206999.txt
+++ b/fastlane/metadata/android/en-US/changelogs/206999.txt
@@ -1,0 +1,4 @@
+Linthra 0.2.6
+
+- Casting is temporarily turned off while a security fix is finished. Local playback, downloads, and your servers are unaffected, and your queue and settings are unchanged.
+- The cast controls now say casting is temporarily unavailable instead of offering devices.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.2.5';
+  static const String _devVersionName = '0.2.6';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/metadata/io.github.thezupzup.linthra.yml
+++ b/metadata/io.github.thezupzup.linthra.yml
@@ -653,5 +653,5 @@ VercodeOperation:
   - "%c*10 + 3"
 UpdateCheckData: pubspec.yaml|version:\s*[^+]+\+(\d+)|.|version:\s*([^\+]+)\+
 
-CurrentVersion: 0.2.5
-CurrentVersionCode: 2059993
+CurrentVersion: 0.2.6
+CurrentVersionCode: 2069993

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none"
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.2.5+205999
+version: 0.2.6+206999
 
 environment:
   sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
Version bump plus release notes for the security maintenance release that carries the Cast containment merged in #577.

| File | Change |
| --- | --- |
| `pubspec.yaml` | `0.2.5+205999` → `0.2.6+206999` |
| `lib/core/app_info.dart` | in-app version mirror → `0.2.6` |
| `fastlane/metadata/android/en-US/changelogs/206999.txt` | new changelog |
| `metadata/io.github.thezupzup.linthra.yml` | `CurrentVersion` `0.2.6`, `CurrentVersionCode` `2069993` |
| `docs/release-notes/v0.2.6.md` | GitHub Release body |

Nothing else. The bump itself was produced with `scripts/prepare_release_bump.py 0.2.6`, so it is reproducible locally.

## What 0.2.6 actually contains

Eight commits since `v0.2.5`, so the changelog and the release notes cover all of it, not just the containment:

- Cast containment (#577)
- Android: the SAF library scan moved off the platform thread (#567)
- Linux: an MPRIS media session (#569)
- Linux: local audio tags read off the filesystem (#568)
- Linux: mpv's on-disk packet cache turned off (#566)
- `SECURITY.md` and a private reporting route (#565)
- two CI fixes, not user-visible (#564, #571)

## Store changelog

```
Linthra 0.2.6

- Casting is temporarily turned off while a security fix is finished. Local playback, downloads, and your servers are unaffected.
- Android: picking a large music folder no longer freezes the app while it scans.
- Linux: media keys and desktop media controls now work.
- Linux: local files show their real title, artist, album and duration instead of the filename.
- Linux: no more stray mpv cache file and its error logs.
```

438 bytes, inside the 500-character store limit.

## Checks run before pushing

- `scripts/release_preflight.sh v0.2.6` → `OK: v0.2.6 matches pubspec.yaml version 0.2.6+206999.`
- `scripts/check_release_bump_files.sh` → only allowed version files.
- `flutter test test/core/app_info_version_test.dart test/tooling/` → 406 passing, including the version-drift and changelog-exists guards.

## Publishing

**#579 has to merge before this PR.** It refreshes the in-app What's New and the AppStream release list, which are not in the release-bump allowlist and so cannot ride along here. `publish-stable-release.yml` builds from the merge commit of the release PR it is invoked on, so if #579 lands afterwards, 0.2.6 ships from a commit that does not contain it, and the About screen shows 0.2.5's bullets under "Version 0.2.6".

1. Merge #579.
2. Merge this PR.
3. Comment `/publish-stable v0.2.6` here.

That workflow verifies the tag against `pubspec.yaml`, checks `AppInfo` agrees, requires `docs/release-notes/v0.2.6.md` (added in this PR), refuses an existing tag, then creates the annotated tag and the Release from those notes. It is restricted to the repository owner.

Afterwards: confirm the five F-Droid-referenced assets are attached, record the commit, artifact names and SHA-256 digests for #574, and run the contained-build device pass in `docs/manual-test-checklist.md` §4.

F-Droid needs no manual edit: the recipe uses `UpdateCheckMode: Tags` with `AutoUpdateMode: Version` and reads the version straight from `pubspec.yaml` at each tag, so `206999` is picked up once `v0.2.6` exists.

Refs #574.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwEthUnaMdNwUondxnB9jn