### PR TITLE
docs(about): refresh the in-app What's New and AppStream list for 0.2.6

### DIFF
--- a/lib/features/settings/about/whats_new_section.dart
+++ b/lib/features/settings/about/whats_new_section.dart
@@ -20,12 +20,11 @@ class WhatsNewSection extends StatelessWidget {
   /// handful of concise bullets and updated when cutting a new build; exposed so
   /// the widget test can assert each line renders without duplicating the copy.
   static const List<String> releaseNotes = <String>[
-    'The Linux desktop app now keeps its navigation beside the content on wide windows, and each section remembers where you were.',
-    'Album and artist grids fit more on screen, and album, artist, Now Playing and lyrics views use the whole width instead of one stretched column.',
-    'Playback controls sit on the now-playing bar when there is room, and Folders is now a top-level destination of its own.',
-    'Resizing the window keeps your place, and the Linux app identifies itself properly to desktop launchers and task switchers.',
-    'On Android, using your whole device music library is now an explicit choice, and Android Auto no longer stalls on large Songs lists.',
-    'Jellyfin now reports as unavailable when the server cannot be reached, instead of looking connected while playback fails.',
+    'Casting is temporarily turned off while a security fix is finished. Local playback, downloads and your servers are unaffected, and your queue and settings are unchanged.',
+    'On Android, picking a large music folder no longer freezes the app while it scans.',
+    'On Linux, media keys and your desktop\'s media controls now drive Linthra, and it shows up in the lock screen and media applets.',
+    'Local files on Linux now show their real title, artist, album and duration instead of the file name.',
+    'Linux playback no longer leaves a stray cache file behind or logs errors when it cannot write one.',
   ];
 
   @override

--- a/linux/packaging/io.github.thezupzup.linthra.metainfo.xml
+++ b/linux/packaging/io.github.thezupzup.linthra.metainfo.xml
@@ -53,6 +53,7 @@
   </categories>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="0.2.6" date="2026-09-08"/>
     <release version="0.2.5" date="2026-09-06"/>
     <release version="0.2.4" date="2026-08-27"/>
   </releases>


### PR DESCRIPTION
Two version-facing surfaces that the 0.2.6 bump does not cover. Both were found by the automated review on #578.

**Merge this before #578.** See the ordering note at the bottom, it matters.

## What was wrong

- **The About screen.** `WhatsNewSection` reads its version label from `AppInfo`, but its bullets are a hand-maintained constant. A 0.2.6 build would have rendered "What's new — Version 0.2.6" above the 0.2.5 desktop bullets: persistent navigation, denser grids, adaptive layouts. All true of 0.2.5, none of it new in 0.2.6, and no mention of casting being turned off, which is the one thing a user needs to know about this build.
- **The AppStream metainfo.** `linux/packaging/io.github.thezupzup.linthra.metainfo.xml` still had 0.2.5 as its newest `<release>`, so a software centre reading the packaged Flatpak would keep advertising 0.2.5 while the app identifies as 0.2.6.

## What changed

The in-app bullets now describe 0.2.6: casting temporarily off (with the reassurance that local playback, downloads, servers, queue and settings are unaffected), the Android folder-scan freeze fix, the Linux media session, real tags for local Linux files, and the mpv cache file.

The metainfo gains `<release version="0.2.6" date="2026-09-08"/>`.

## Why this is a separate PR

`scripts/check_release_bump_files.sh` rejects both files on a `release/*` branch, and it is right to: they are content that happens to track the version, not the version itself, and keeping them out leaves #578 a clean version-only diff.

## Checks

- `flutter analyze` clean.
- Full suite: 4208 tests passing, including `whats_new_section_test.dart` and `about_screen_test.dart`, which assert every bullet renders.
- The metainfo parses as well-formed XML.

## Ordering

`publish-stable-release.yml` builds the release from the **merge commit of the release PR** it is invoked on. So this has to be on `main` before #578 merges, otherwise 0.2.6 ships from a commit that does not contain it:

1. Merge this PR.
2. Merge #578.
3. Comment `/publish-stable v0.2.6` on #578.

Refs #574.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwEthUnaMdNwUondxnB9jn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwEthUnaMdNwUondxnB9jn)_