### PR TITLE
feat(folders): keep visited folder levels briefly, and add pull to refresh (#581)

### DIFF
--- a/lib/features/library/folder_browser_providers.dart
+++ b/lib/features/library/folder_browser_providers.dart
@@ -62,15 +62,32 @@ final folderBrowsableSourcesProvider =
 /// on the server shows up again quickly.
 const Duration folderListingCacheDuration = Duration(minutes: 5);
 
-/// Holds this provider's value past its last listener for
-/// [folderListingCacheDuration], then lets it dispose as usual.
+/// Holds this provider's value for [folderListingCacheDuration] *after its last
+/// listener leaves*, then lets it dispose as usual.
+///
+/// The window deliberately starts on [Ref.onCancel] rather than at fetch time.
+/// Measuring from the fetch would expire the cache while the user is still
+/// looking at the folder, so opening a child after reading a long track list and
+/// coming straight back would re-fetch the level they never left — exactly the
+/// walk this exists to make instant. Returning within the window cancels the
+/// timer through [Ref.onResume], so the level is kept for as long as it stays in
+/// use.
 ///
 /// Applied only after a successful fetch: caching a failure would keep an error
 /// on screen for minutes, and the retry path invalidates anyway.
 void _cacheBriefly(Ref ref) {
   final KeepAliveLink link = ref.keepAlive();
-  final Timer timer = Timer(folderListingCacheDuration, link.close);
-  ref.onDispose(timer.cancel);
+  Timer? expiry;
+
+  ref.onCancel(() {
+    expiry?.cancel();
+    expiry = Timer(folderListingCacheDuration, link.close);
+  });
+  ref.onResume(() {
+    expiry?.cancel();
+    expiry = null;
+  });
+  ref.onDispose(() => expiry?.cancel());
 }
 
 /// Loads the top-level folders for one connected provider.

--- a/lib/features/library/folder_browser_providers.dart
+++ b/lib/features/library/folder_browser_providers.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/models/music_folder.dart';
@@ -50,10 +52,34 @@ final folderBrowsableSourcesProvider =
   ];
 });
 
+/// How long a fetched directory level stays cached once nothing is watching it.
+///
+/// Browsing is a walk: you open a folder, look, and come back up. Without this
+/// every step back re-asked the server for a level that was on screen seconds
+/// earlier, which is slow on a remote library and rude to a self-hosted one
+/// (#581). Bounded rather than kept for the whole session so a long browse does
+/// not hold every level it ever visited, and short enough that a folder changed
+/// on the server shows up again quickly.
+const Duration folderListingCacheDuration = Duration(minutes: 5);
+
+/// Holds this provider's value past its last listener for
+/// [folderListingCacheDuration], then lets it dispose as usual.
+///
+/// Applied only after a successful fetch: caching a failure would keep an error
+/// on screen for minutes, and the retry path invalidates anyway.
+void _cacheBriefly(Ref ref) {
+  final KeepAliveLink link = ref.keepAlive();
+  final Timer timer = Timer(folderListingCacheDuration, link.close);
+  ref.onDispose(timer.cancel);
+}
+
 /// Loads the top-level folders for one connected provider.
 final folderRootFoldersProvider = FutureProvider.autoDispose
     .family<List<MusicFolder>, String>((ref, sourceId) async {
-  return _source(ref, sourceId).fetchRootFolders();
+  final List<MusicFolder> roots =
+      await _source(ref, sourceId).fetchRootFolders();
+  _cacheBriefly(ref);
+  return roots;
 });
 
 /// Identifies one directory request without exposing provider credentials.
@@ -78,9 +104,16 @@ class FolderBrowseRequest {
 }
 
 /// Loads exactly one level of a provider's directory hierarchy.
+///
+/// Cached briefly (see [_cacheBriefly]) so walking back up a tree is instant
+/// instead of re-fetching a level the user just left. A sign-out still clears
+/// it: the source this watches disappears, which invalidates the value.
 final folderListingProvider = FutureProvider.autoDispose
     .family<MusicFolderListing, FolderBrowseRequest>((ref, request) async {
-  return _source(ref, request.sourceId).fetchFolder(request.folderId);
+  final MusicFolderListing listing =
+      await _source(ref, request.sourceId).fetchFolder(request.folderId);
+  _cacheBriefly(ref);
+  return listing;
 });
 
 FolderBrowsableMusicSource _source(Ref ref, String sourceId) {

--- a/lib/features/library/folders_screen.dart
+++ b/lib/features/library/folders_screen.dart
@@ -292,33 +292,42 @@ class _FolderContents extends ConsumerWidget {
                   message: 'No child folders or playable songs were found.',
                 );
               }
-              return ListView.builder(
-                key: const Key('folder_browser_contents'),
-                itemCount: data.folders.length + data.tracks.length,
-                itemBuilder: (BuildContext context, int index) {
-                  if (index < data.folders.length) {
-                    final MusicFolder folder = data.folders[index];
-                    return ListTile(
-                      key: ValueKey<String>('folder_child_${folder.id}'),
-                      leading: const Icon(Icons.folder_outlined),
-                      title: Text(
-                        folder.name,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                      trailing: const Icon(Icons.chevron_right),
-                      onTap: () => onOpen(folder),
-                    );
-                  }
-                  final int trackIndex = index - data.folders.length;
-                  return TrackTile(
-                    key: ValueKey<String>(
-                      'folder_track_${data.tracks[trackIndex].uri}',
-                    ),
-                    tracks: data.tracks,
-                    index: trackIndex,
-                  );
+              // Pull to refresh is the way out of the cache above: the level
+              // is held for a few minutes, so a folder you just changed on the
+              // server needs a deliberate way to be re-read (#581).
+              return RefreshIndicator(
+                onRefresh: () async {
+                  ref.invalidate(folderListingProvider(request));
+                  await ref.read(folderListingProvider(request).future);
                 },
+                child: ListView.builder(
+                  key: const Key('folder_browser_contents'),
+                  itemCount: data.folders.length + data.tracks.length,
+                  itemBuilder: (BuildContext context, int index) {
+                    if (index < data.folders.length) {
+                      final MusicFolder folder = data.folders[index];
+                      return ListTile(
+                        key: ValueKey<String>('folder_child_${folder.id}'),
+                        leading: const Icon(Icons.folder_outlined),
+                        title: Text(
+                          folder.name,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        trailing: const Icon(Icons.chevron_right),
+                        onTap: () => onOpen(folder),
+                      );
+                    }
+                    final int trackIndex = index - data.folders.length;
+                    return TrackTile(
+                      key: ValueKey<String>(
+                        'folder_track_${data.tracks[trackIndex].uri}',
+                      ),
+                      tracks: data.tracks,
+                      index: trackIndex,
+                    );
+                  },
+                ),
               );
             },
           ),

--- a/lib/features/library/folders_screen.dart
+++ b/lib/features/library/folders_screen.dart
@@ -233,6 +233,22 @@ class _SourceRootsSection extends ConsumerWidget {
   }
 }
 
+/// Re-reads [request] for a pull-to-refresh gesture.
+///
+/// The failure is swallowed on purpose. RefreshIndicator drives this from a
+/// gesture and does not handle a rejected future, so letting a dropped server
+/// connection through would surface it as an unhandled async error on top of
+/// the error state the provider already renders. The watched AsyncValue is what
+/// tells the user; this future only has to end so the spinner retracts.
+Future<void> _refresh(WidgetRef ref, FolderBrowseRequest request) async {
+  ref.invalidate(folderListingProvider(request));
+  try {
+    await ref.read(folderListingProvider(request).future);
+  } catch (_) {
+    // Rendered by the provider's error state, not by the indicator.
+  }
+}
+
 class _FolderContents extends ConsumerWidget {
   const _FolderContents({
     required this.location,
@@ -285,49 +301,66 @@ class _FolderContents extends ConsumerWidget {
               onRetry: () => ref.invalidate(folderListingProvider(request)),
             ),
             data: (MusicFolderListing data) {
-              if (data.isEmpty) {
-                return const EmptyState(
-                  icon: Icons.folder_open_outlined,
-                  title: 'This folder is empty',
-                  message: 'No child folders or playable songs were found.',
-                );
-              }
-              // Pull to refresh is the way out of the cache above: the level
-              // is held for a few minutes, so a folder you just changed on the
+              // Pull to refresh is the way out of the cache above: the level is
+              // held for a few minutes, so a folder you just changed on the
               // server needs a deliberate way to be re-read (#581).
+              //
+              // The empty state lives *inside* the refreshable scrollable, and
+              // the physics are always-scrollable, because those are exactly
+              // the folders that need it most: a folder that is empty or has
+              // three entries cannot overscroll on clamping physics, so an
+              // indicator wrapped around content alone would be unreachable in
+              // the one case where the user knows the server has changed.
               return RefreshIndicator(
-                onRefresh: () async {
-                  ref.invalidate(folderListingProvider(request));
-                  await ref.read(folderListingProvider(request).future);
-                },
-                child: ListView.builder(
-                  key: const Key('folder_browser_contents'),
-                  itemCount: data.folders.length + data.tracks.length,
-                  itemBuilder: (BuildContext context, int index) {
-                    if (index < data.folders.length) {
-                      final MusicFolder folder = data.folders[index];
-                      return ListTile(
-                        key: ValueKey<String>('folder_child_${folder.id}'),
-                        leading: const Icon(Icons.folder_outlined),
-                        title: Text(
-                          folder.name,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                        trailing: const Icon(Icons.chevron_right),
-                        onTap: () => onOpen(folder),
-                      );
-                    }
-                    final int trackIndex = index - data.folders.length;
-                    return TrackTile(
-                      key: ValueKey<String>(
-                        'folder_track_${data.tracks[trackIndex].uri}',
+                onRefresh: () => _refresh(ref, request),
+                child: data.isEmpty
+                    ? ListView(
+                        key: const Key('folder_browser_contents'),
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        children: <Widget>[
+                          SizedBox(
+                            height: MediaQuery.sizeOf(context).height * 0.5,
+                            child: const EmptyState(
+                              icon: Icons.folder_open_outlined,
+                              title: 'This folder is empty',
+                              message:
+                                  'No child folders or playable songs were '
+                                  'found.',
+                            ),
+                          ),
+                        ],
+                      )
+                    : ListView.builder(
+                        key: const Key('folder_browser_contents'),
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        itemCount: data.folders.length + data.tracks.length,
+                        itemBuilder: (BuildContext context, int index) {
+                          if (index < data.folders.length) {
+                            final MusicFolder folder = data.folders[index];
+                            return ListTile(
+                              key: ValueKey<String>(
+                                'folder_child_${folder.id}',
+                              ),
+                              leading: const Icon(Icons.folder_outlined),
+                              title: Text(
+                                folder.name,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                              trailing: const Icon(Icons.chevron_right),
+                              onTap: () => onOpen(folder),
+                            );
+                          }
+                          final int trackIndex = index - data.folders.length;
+                          return TrackTile(
+                            key: ValueKey<String>(
+                              'folder_track_${data.tracks[trackIndex].uri}',
+                            ),
+                            tracks: data.tracks,
+                            index: trackIndex,
+                          );
+                        },
                       ),
-                      tracks: data.tracks,
-                      index: trackIndex,
-                    );
-                  },
-                ),
               );
             },
           ),

--- a/lib/features/library/folders_screen.dart
+++ b/lib/features/library/folders_screen.dart
@@ -123,7 +123,7 @@ class _FoldersScreenState extends ConsumerState<FoldersScreen> {
   }
 }
 
-class _FolderRoots extends StatelessWidget {
+class _FolderRoots extends ConsumerWidget {
   const _FolderRoots({required this.sources, required this.onOpen});
 
   final List<FolderBrowsableMusicSource> sources;
@@ -131,7 +131,7 @@ class _FolderRoots extends StatelessWidget {
       onOpen;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     if (sources.isEmpty) {
       return const EmptyState(
         icon: Icons.folder_off_outlined,
@@ -141,19 +141,51 @@ class _FolderRoots extends StatelessWidget {
       );
     }
 
-    return ListView(
-      key: const Key('folder_browser_roots'),
-      padding: const EdgeInsets.only(bottom: AppSpacing.xl),
-      children: <Widget>[
-        for (final FolderBrowsableMusicSource source in sources)
-          _SourceRootsSection(
-            key: ValueKey<String>('folder_source_${source.id}'),
-            source: source,
-            onOpen: (folder) => onOpen(source, folder),
-          ),
-      ],
+    // Roots are cached like any other level, so they need the same deliberate
+    // way past it: a top-level folder added or renamed on the server would
+    // otherwise stay hidden behind the cached list. Always-scrollable for the
+    // usual reason, a couple of servers do not fill a screen.
+    return RefreshIndicator(
+      onRefresh: () => _refreshRoots(ref, sources),
+      child: ListView(
+        key: const Key('folder_browser_roots'),
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.only(bottom: AppSpacing.xl),
+        children: <Widget>[
+          for (final FolderBrowsableMusicSource source in sources)
+            _SourceRootsSection(
+              key: ValueKey<String>('folder_source_${source.id}'),
+              source: source,
+              onOpen: (folder) => onOpen(source, folder),
+            ),
+        ],
+      ),
     );
   }
+}
+
+/// Re-reads every connected source's root list for one pull-to-refresh.
+///
+/// Failures are swallowed for the same reason as [_refresh]: each section shows
+/// its own error state, and a gesture-driven future that rejects would surface
+/// the same failure a second time as an unhandled async error. One slow or
+/// broken server must not stop the others from refreshing, so these are awaited
+/// together rather than in sequence.
+Future<void> _refreshRoots(
+  WidgetRef ref,
+  List<FolderBrowsableMusicSource> sources,
+) async {
+  await Future.wait<void>(<Future<void>>[
+    for (final FolderBrowsableMusicSource source in sources)
+      () async {
+        ref.invalidate(folderRootFoldersProvider(source.id));
+        try {
+          await ref.read(folderRootFoldersProvider(source.id).future);
+        } catch (_) {
+          // Rendered by the section's own error state.
+        }
+      }(),
+  ]);
 }
 
 class _SourceRootsSection extends ConsumerWidget {

--- a/test/features/library/folders_screen_test.dart
+++ b/test/features/library/folders_screen_test.dart
@@ -39,9 +39,17 @@ class _FakeFolderSource implements FolderBrowsableMusicSource {
   @override
   Future<List<MusicFolder>> fetchRootFolders() async => roots;
 
+  /// When true, the next fetchFolder throws, standing in for a server that
+  /// dropped mid-refresh.
+  bool failNextFolderFetch = false;
+
   @override
   Future<MusicFolderListing> fetchFolder(String folderId) async {
     folderFetches[folderId] = (folderFetches[folderId] ?? 0) + 1;
+    if (failNextFolderFetch) {
+      failNextFolderFetch = false;
+      throw StateError('server unavailable');
+    }
     return children[folderId] ?? MusicFolderListing.empty;
   }
 }
@@ -199,6 +207,101 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(source.folderFetches['r1'], 2);
+    });
+
+    testWidgets(
+        'the cache window starts when the level is left, not when it '
+        'was fetched (#581)', (tester) async {
+      final _FakeFolderSource source = _FakeFolderSource(
+        id: 'subsonic',
+        displayName: 'Navidrome',
+        roots: const <MusicFolder>[MusicFolder(id: 'r1', name: 'Music')],
+        children: const <String, MusicFolderListing>{
+          'r1': MusicFolderListing(
+            folders: <MusicFolder>[MusicFolder(id: 'c1', name: 'Live Sets')],
+          ),
+          'c1': MusicFolderListing(
+            tracks: <Track>[Track(id: 't1', title: 'Opener', uri: 'sub:t1')],
+          ),
+        },
+      );
+      await _pump(tester, sources: <FolderBrowsableMusicSource>[source]);
+
+      await tester.tap(find.text('Music'));
+      await tester.pumpAndSettle();
+      expect(source.folderFetches['r1'], 1);
+
+      // Reading a long track list for longer than the cache window. Measuring
+      // the window from the fetch would expire it right here, while the folder
+      // is still on screen.
+      await tester.pump(folderListingCacheDuration * 2);
+
+      await tester.tap(find.text('Live Sets'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byTooltip('Back to previous folder'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Live Sets'), findsOneWidget);
+      expect(source.folderFetches['r1'], 1);
+    });
+
+    testWidgets('an empty folder can still be pulled to refresh (#581)',
+        (tester) async {
+      final _FakeFolderSource source = _FakeFolderSource(
+        id: 'subsonic',
+        displayName: 'Navidrome',
+        roots: const <MusicFolder>[MusicFolder(id: 'r1', name: 'Music')],
+        // No children and no tracks: nothing to overscroll against, which is
+        // exactly the folder someone refreshes after filling it server-side.
+        children: const <String, MusicFolderListing>{},
+      );
+      await _pump(tester, sources: <FolderBrowsableMusicSource>[source]);
+
+      await tester.tap(find.text('Music'));
+      await tester.pumpAndSettle();
+      expect(find.text('This folder is empty'), findsOneWidget);
+      expect(source.folderFetches['r1'], 1);
+
+      await tester.fling(
+        find.byKey(const Key('folder_browser_contents')),
+        const Offset(0, 300),
+        1000,
+      );
+      await tester.pumpAndSettle();
+
+      expect(source.folderFetches['r1'], 2);
+    });
+
+    testWidgets('a refresh that fails shows the error, not a crash (#581)',
+        (tester) async {
+      final _FakeFolderSource source = _FakeFolderSource(
+        id: 'subsonic',
+        displayName: 'Navidrome',
+        roots: const <MusicFolder>[MusicFolder(id: 'r1', name: 'Music')],
+        children: const <String, MusicFolderListing>{
+          'r1': MusicFolderListing(
+            folders: <MusicFolder>[MusicFolder(id: 'c1', name: 'Live Sets')],
+          ),
+        },
+      );
+      await _pump(tester, sources: <FolderBrowsableMusicSource>[source]);
+
+      await tester.tap(find.text('Music'));
+      await tester.pumpAndSettle();
+
+      source.failNextFolderFetch = true;
+      await tester.fling(
+        find.byKey(const Key('folder_browser_contents')),
+        const Offset(0, 300),
+        1000,
+      );
+      await tester.pumpAndSettle();
+
+      // The provider's error state is what the user sees. The gesture's future
+      // must not also surface the same failure as an unhandled async error,
+      // which the test binding would report as a failure.
+      expect(find.text('Could not open this folder.'), findsOneWidget);
+      expect(tester.takeException(), isNull);
     });
 
     testWidgets('signing the source out returns to the roots', (tester) async {

--- a/test/features/library/folders_screen_test.dart
+++ b/test/features/library/folders_screen_test.dart
@@ -32,12 +32,18 @@ class _FakeFolderSource implements FolderBrowsableMusicSource {
   final List<MusicFolder> roots;
   final Map<String, MusicFolderListing> children;
 
+  /// How many times each folder id was actually asked of the "server", so a
+  /// test can tell a cache hit from a round trip.
+  final Map<String, int> folderFetches = <String, int>{};
+
   @override
   Future<List<MusicFolder>> fetchRootFolders() async => roots;
 
   @override
-  Future<MusicFolderListing> fetchFolder(String folderId) async =>
-      children[folderId] ?? MusicFolderListing.empty;
+  Future<MusicFolderListing> fetchFolder(String folderId) async {
+    folderFetches[folderId] = (folderFetches[folderId] ?? 0) + 1;
+    return children[folderId] ?? MusicFolderListing.empty;
+  }
 }
 
 /// The screen registers a [BackButtonListener] while it is inside a folder, so
@@ -135,6 +141,64 @@ void main() {
 
       expect(find.text('Music'), findsOneWidget);
       expect(find.byKey(const Key('folder_browser_header')), findsNothing);
+    });
+
+    testWidgets('walking back up does not re-ask the server (#581)',
+        (tester) async {
+      final _FakeFolderSource source = _FakeFolderSource(
+        id: 'subsonic',
+        displayName: 'Navidrome',
+        roots: const <MusicFolder>[MusicFolder(id: 'r1', name: 'Music')],
+        children: const <String, MusicFolderListing>{
+          'r1': MusicFolderListing(
+            folders: <MusicFolder>[MusicFolder(id: 'c1', name: 'Live Sets')],
+          ),
+        },
+      );
+      await _pump(tester, sources: <FolderBrowsableMusicSource>[source]);
+
+      await tester.tap(find.text('Music'));
+      await tester.pumpAndSettle();
+      expect(source.folderFetches['r1'], 1);
+
+      await tester.tap(find.byTooltip('Back to previous folder'));
+      await tester.pumpAndSettle();
+
+      // Coming back to a level that was on screen a moment ago used to re-fetch
+      // it, which is what made going up feel slow on a remote library.
+      await tester.tap(find.text('Music'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Live Sets'), findsOneWidget);
+      expect(source.folderFetches['r1'], 1);
+    });
+
+    testWidgets('pull to refresh re-reads the folder (#581)', (tester) async {
+      final _FakeFolderSource source = _FakeFolderSource(
+        id: 'subsonic',
+        displayName: 'Navidrome',
+        roots: const <MusicFolder>[MusicFolder(id: 'r1', name: 'Music')],
+        children: const <String, MusicFolderListing>{
+          'r1': MusicFolderListing(
+            folders: <MusicFolder>[MusicFolder(id: 'c1', name: 'Live Sets')],
+          ),
+        },
+      );
+      await _pump(tester, sources: <FolderBrowsableMusicSource>[source]);
+
+      await tester.tap(find.text('Music'));
+      await tester.pumpAndSettle();
+      expect(source.folderFetches['r1'], 1);
+
+      // The deliberate way past the cache, for a folder changed on the server.
+      await tester.fling(
+        find.byKey(const Key('folder_browser_contents')),
+        const Offset(0, 300),
+        1000,
+      );
+      await tester.pumpAndSettle();
+
+      expect(source.folderFetches['r1'], 2);
     });
 
     testWidgets('signing the source out returns to the roots', (tester) async {

--- a/test/features/library/folders_screen_test.dart
+++ b/test/features/library/folders_screen_test.dart
@@ -36,8 +36,14 @@ class _FakeFolderSource implements FolderBrowsableMusicSource {
   /// test can tell a cache hit from a round trip.
   final Map<String, int> folderFetches = <String, int>{};
 
+  /// How many times the root list was asked of the "server".
+  int rootFetches = 0;
+
   @override
-  Future<List<MusicFolder>> fetchRootFolders() async => roots;
+  Future<List<MusicFolder>> fetchRootFolders() async {
+    rootFetches++;
+    return roots;
+  }
 
   /// When true, the next fetchFolder throws, standing in for a server that
   /// dropped mid-refresh.
@@ -301,6 +307,29 @@ void main() {
       // must not also surface the same failure as an unhandled async error,
       // which the test binding would report as a failure.
       expect(find.text('Could not open this folder.'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('the root list can be pulled to refresh too (#581)',
+        (tester) async {
+      final _FakeFolderSource source = _FakeFolderSource(
+        id: 'subsonic',
+        displayName: 'Navidrome',
+        roots: const <MusicFolder>[MusicFolder(id: 'r1', name: 'Music')],
+      );
+      await _pump(tester, sources: <FolderBrowsableMusicSource>[source]);
+      expect(source.rootFetches, 1);
+
+      // Roots are cached like any other level, so a top-level folder added on
+      // the server needs the same deliberate way past it.
+      await tester.fling(
+        find.byKey(const Key('folder_browser_roots')),
+        const Offset(0, 300),
+        1000,
+      );
+      await tester.pumpAndSettle();
+
+      expect(source.rootFetches, 2);
       expect(tester.takeException(), isNull);
     });
 


### PR DESCRIPTION
Walking back up a folder tree re-asked the server for a level that was on screen seconds earlier. Reported in #581.

## Cause

Both browse providers were `autoDispose`:

```dart
final folderListingProvider = FutureProvider.autoDispose
    .family<MusicFolderListing, FolderBrowseRequest>(...)
```

Leaving a folder dropped its listing, so returning re-fetched it. On a remote library that is a visible pause every time you go up, and a needless round trip for a self-hosted server.

## Change

A successful fetch now holds its value for five minutes past its last listener.

- **Bounded, not session-long**, so a long browse does not retain every level it ever visited.
- **Short enough** that a folder changed server-side reappears without ceremony.
- **Successes only.** Caching a failure would leave an error on screen for minutes, and the retry path invalidates anyway.
- **A sign-out still clears it**, since the source these providers watch disappears with the session. That path already has a test and it still passes.

Pull to refresh on a folder's contents is the deliberate way past that window, for when you did just change something on the server. It is the part of the reporter's proposal I am taking as-is, and it matches how the rest of the app behaves.

## What I am not doing, and why

Both are argued on the issue rather than silently dropped:

- A multi-day on-disk cache trades staleness (a folder renamed on the server keeps showing the old contents until it expires) against a delay that this change already removes.
- Prefetching visible subfolders spends requests on someone else's server for folders that may never be opened. With a large library that can be a dozen speculative requests per screen.

If slowness survives this change, the persistent cache goes back on the table. The reporter browses a 35k track library over the wire, which is a more representative test bench than mine.

## Tests

Two, and I checked each fails without the change rather than assuming it:

- walking back up does not re-ask the server (the fake source counts calls per folder id)
- pull to refresh does re-ask

`dart format` clean, `flutter analyze` clean, full suite green at 4210 tests.

Refs #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwEthUnaMdNwUondxnB9jn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwEthUnaMdNwUondxnB9jn)_