### PR TITLE
feat(library): reopen Library on the tab you were last using (#580)

### DIFF
--- a/lib/app/application_container.dart
+++ b/lib/app/application_container.dart
@@ -10,6 +10,7 @@ import '../data/repositories/jellyfin_auto_sync_store_provider.dart';
 import '../data/repositories/jellyfin_session_store_provider.dart';
 import '../data/repositories/launcher_icon_service_provider.dart';
 import '../data/repositories/library_added_store_provider.dart';
+import '../data/repositories/library_tab_store_provider.dart';
 import '../data/repositories/music_library_repository_provider.dart';
 import '../data/repositories/play_history_repository_provider.dart';
 import '../data/repositories/playback_preferences_provider.dart';
@@ -45,6 +46,7 @@ List<Override> productionApplicationOverrides({
   return <Override>[
     recordingDriftMusicLibraryRepositoryOverride,
     sharedPreferencesLibraryAddedStoreOverride,
+    sharedPreferencesLibraryTabStoreOverride,
     sharedPreferencesSelectedMusicFolderRepositoryOverride,
     sharedPreferencesPreferredSourceStoreOverride,
     sharedPreferencesDefaultProviderStoreOverride,

--- a/lib/core/repositories/library_tab_store.dart
+++ b/lib/core/repositories/library_tab_store.dart
@@ -1,0 +1,18 @@
+/// Persists which Library tab the user was last on, so the screen reopens where
+/// they left it instead of always on Songs.
+///
+/// The stored value is a single non-secret tab name (`songs`, `albums`,
+/// `artists`), never an index: an index silently points at the wrong tab the
+/// day one is added or reordered. An absent or unrecognised value reads as
+/// `null`, which the screen treats as "the first tab", so a storage hiccup or a
+/// renamed tab can never leave the user on a tab that no longer exists.
+///
+/// Carries no credential, URL, or library content, so a lightweight key/value
+/// store is the right weight.
+abstract interface class LibraryTabStore {
+  /// The persisted tab name, or `null` when there is no usable stored choice.
+  Future<String?> read();
+
+  /// Persists [tabName], or clears the choice when `null`.
+  Future<void> write(String? tabName);
+}

--- a/lib/data/repositories/in_memory_library_tab_store.dart
+++ b/lib/data/repositories/in_memory_library_tab_store.dart
@@ -1,0 +1,17 @@
+import '../../core/repositories/library_tab_store.dart';
+
+/// An in-memory [LibraryTabStore] for development and tests. Nothing is
+/// persisted; the choice lives only for the lifetime of the instance.
+class InMemoryLibraryTabStore implements LibraryTabStore {
+  InMemoryLibraryTabStore([this._tabName]);
+
+  String? _tabName;
+
+  @override
+  Future<String?> read() async => _tabName;
+
+  @override
+  Future<void> write(String? tabName) async {
+    _tabName = tabName;
+  }
+}

--- a/lib/data/repositories/library_tab_store_provider.dart
+++ b/lib/data/repositories/library_tab_store_provider.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/repositories/library_tab_store.dart';
+import 'in_memory_library_tab_store.dart';
+import 'shared_preferences_library_tab_store.dart';
+
+/// The single [LibraryTabStore] the Library screen remembers its tab through.
+///
+/// Defaults to the in-memory implementation so widget and unit tests stay free
+/// of platform plugins. The running app overrides this with
+/// [sharedPreferencesLibraryTabStoreOverride] so the choice survives a restart,
+/// which is when landing on the wrong tab is most annoying.
+final libraryTabStoreProvider = Provider<LibraryTabStore>((ref) {
+  return InMemoryLibraryTabStore();
+});
+
+/// Production binding: persists the last Library tab via `shared_preferences`.
+/// Applied in `main`.
+final sharedPreferencesLibraryTabStoreOverride =
+    libraryTabStoreProvider.overrideWithValue(
+  const SharedPreferencesLibraryTabStore(),
+);

--- a/lib/data/repositories/shared_preferences_library_tab_store.dart
+++ b/lib/data/repositories/shared_preferences_library_tab_store.dart
@@ -1,0 +1,32 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/repositories/library_tab_store.dart';
+
+/// A [LibraryTabStore] backed by `shared_preferences`.
+///
+/// One non-secret string under one key. An absent or empty value reads as
+/// `null` (the first tab) rather than throwing, so a storage problem degrades
+/// to today's behaviour instead of breaking the Library screen.
+class SharedPreferencesLibraryTabStore implements LibraryTabStore {
+  const SharedPreferencesLibraryTabStore();
+
+  static const String _key = 'library_tab_v1';
+
+  @override
+  Future<String?> read() async {
+    final prefs = await SharedPreferences.getInstance();
+    final String? value = prefs.getString(_key);
+    if (value == null || value.isEmpty) return null;
+    return value;
+  }
+
+  @override
+  Future<void> write(String? tabName) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (tabName == null || tabName.isEmpty) {
+      await prefs.remove(_key);
+      return;
+    }
+    await prefs.setString(_key, tabName);
+  }
+}

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -65,6 +65,15 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   String _query = '';
   int _lastTabIndex = 0;
 
+  /// Whether the user has picked a tab themselves. The current index cannot
+  /// answer that: Songs to Albums and back leaves it at zero again, and a
+  /// restore landing after that would move them somewhere they just left.
+  bool _userChangedTab = false;
+
+  /// Set only while [_restoreTab] drives the controller, so the one code path
+  /// that handles a tab change can tell a restore from a tap.
+  bool _restoringTab = false;
+
   /// Pending debounce timer. Cancelled and restarted on every keystroke so the
   /// filter re-runs only once the user pauses typing, not on every character.
   Timer? _debounce;
@@ -85,15 +94,41 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   /// guard matters anyway, because a user who switched tabs in the meantime has
   /// said something more recent than the stored value.
   Future<void> _restoreTab() async {
-    final String? stored = await ref.read(libraryTabStoreProvider).read();
-    if (!mounted || stored == null) return;
+    final String? stored;
+    try {
+      stored = await ref.read(libraryTabStoreProvider).read();
+    } catch (_) {
+      // A storage or plugin failure means no remembered tab, which is the
+      // behaviour before this existed. It must not reach the zone as an
+      // uncaught async error.
+      return;
+    }
+    if (!mounted || stored == null || _userChangedTab) return;
     final int index = _tabNames.indexOf(stored);
     if (index < 0) return; // A tab that no longer exists: stay on the first.
-    if (_tabController.index != 0 || _lastTabIndex != 0) return;
-    setState(() {
-      _lastTabIndex = index;
-      _tabController.index = index;
-    });
+    if (index == _tabController.index) return;
+
+    // Driven through the controller rather than around it, so a restore clears
+    // an in-progress search exactly as any other tab change does. Assigning
+    // _lastTabIndex first would make the shared handler return early and carry
+    // a query typed in Songs into Albums.
+    _restoringTab = true;
+    _tabController.index = index;
+    _restoringTab = false;
+  }
+
+  /// Persists the current tab, swallowing a storage failure.
+  ///
+  /// Losing this preference only means the next launch opens on Songs, which is
+  /// not worth surfacing to someone who was just browsing.
+  Future<void> _persistTab() async {
+    try {
+      await ref
+          .read(libraryTabStoreProvider)
+          .write(_tabNames[_tabController.index]);
+    } catch (_) {
+      // Nothing to recover: the next launch simply opens on the first tab.
+    }
   }
 
   @override
@@ -109,6 +144,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   /// when entering/leaving Folders, where the catalog search field is hidden.
   void _onTabChanged() {
     if (_tabController.index == _lastTabIndex) return;
+    if (!_restoringTab) _userChangedTab = true;
     _debounce?.cancel();
     setState(() {
       _lastTabIndex = _tabController.index;
@@ -117,11 +153,11 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
         _searchController.clear();
       }
     });
-    // Fire and forget: where the user was reading is not worth blocking a tab
-    // change on, and a failed write only means the next launch opens on Songs.
-    unawaited(
-      ref.read(libraryTabStoreProvider).write(_tabNames[_tabController.index]),
-    );
+    // A restore is replaying what is already stored, so there is nothing new to
+    // write back. Otherwise fire and forget: where the user is reading is not
+    // worth blocking a tab change on.
+    if (_restoringTab) return;
+    unawaited(_persistTab());
   }
 
   void _onQueryChanged(String value) {

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -107,7 +107,17 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
     // Selection is a modal state: it replaces the app bar, hides the tab bar
     // and blocks swiping. Moving the tab underneath it would leave the song
     // selection bar sitting over Albums with no visible way back.
-    if (!mounted || stored == null || _userChangedTab || _selecting) return;
+    // A swipe in progress has not moved the index yet, so _userChangedTab is
+    // still false while the user is very much choosing a tab. TabController
+    // reports the drag as a non-zero offset, which is the one signal available
+    // before the gesture settles.
+    if (!mounted ||
+        stored == null ||
+        _userChangedTab ||
+        _selecting ||
+        _tabController.offset != 0) {
+      return;
+    }
     final int index = _tabNames.indexOf(stored);
     if (index < 0) return; // A tab that no longer exists: stay on the first.
     if (index == _tabController.index) return;

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -103,7 +103,10 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
       // uncaught async error.
       return;
     }
-    if (!mounted || stored == null || _userChangedTab) return;
+    // Selection is a modal state: it replaces the app bar, hides the tab bar
+    // and blocks swiping. Moving the tab underneath it would leave the song
+    // selection bar sitting over Albums with no visible way back.
+    if (!mounted || stored == null || _userChangedTab || _selecting) return;
     final int index = _tabNames.indexOf(stored);
     if (index < 0) return; // A tab that no longer exists: stay on the first.
     if (index == _tabController.index) return;
@@ -148,7 +151,12 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
     _debounce?.cancel();
     setState(() {
       _lastTabIndex = _tabController.index;
-      if (_query.isNotEmpty) {
+      // The field is the source of truth, not [_query]: typing only reaches
+      // _query after the 300ms debounce, so between a keystroke and that timer
+      // the box holds text while _query is still empty. Testing _query alone
+      // left that text visible on the tab we just moved to, filtering nothing,
+      // and the next keystroke would then apply the whole thing there.
+      if (_query.isNotEmpty || _searchController.text.isNotEmpty) {
         _query = '';
         _searchController.clear();
       }

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -10,6 +10,7 @@ import '../../app/routes.dart';
 import '../../core/models/album.dart';
 import '../../core/models/artist.dart';
 import '../../core/models/track.dart';
+import '../../core/repositories/library_tab_store.dart';
 import '../../core/services/bulk_track_actions.dart';
 import '../../core/sources/local/folder_location.dart';
 import '../../data/repositories/library_tab_store_provider.dart';
@@ -135,22 +136,27 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   ///
   /// Switching Albums then Artists faster than the store can write would
   /// otherwise leave two writes racing, and a slow first one landing last would
-  /// store the tab the user had already left. Each queued write also reads the
-  /// index when it *runs* rather than when it was queued, so the latest tab
-  /// wins even if several pile up.
+  /// store the tab the user had already left. The queue is FIFO, so the value
+  /// queued last is the value written last.
   Future<void> _persistQueue = Future<void>.value();
 
   /// Persists the current tab, swallowing a storage failure.
   ///
   /// Losing this preference only means the next launch opens on Songs, which is
   /// not worth surfacing to someone who was just browsing.
+  ///
+  /// Both the store and the tab name are read here, synchronously, rather than
+  /// inside the queued write. Leaving the screen while a slow write is in
+  /// flight would otherwise strand every newer write behind a disposed
+  /// [State]: the queue would drop them and the older, already-superseded tab
+  /// would be what stayed stored. The write itself needs nothing from the
+  /// widget, so it does not have to outlive it to finish correctly.
   void _persistTab() {
+    final LibraryTabStore store = ref.read(libraryTabStoreProvider);
+    final String tabName = _tabNames[_tabController.index];
     _persistQueue = _persistQueue.then((_) async {
-      if (!mounted) return;
       try {
-        await ref
-            .read(libraryTabStoreProvider)
-            .write(_tabNames[_tabController.index]);
+        await store.write(tabName);
       } catch (_) {
         // Nothing to recover: the next launch simply opens on the first tab.
       }

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -12,6 +12,7 @@ import '../../core/models/artist.dart';
 import '../../core/models/track.dart';
 import '../../core/services/bulk_track_actions.dart';
 import '../../core/sources/local/folder_location.dart';
+import '../../data/repositories/library_tab_store_provider.dart';
 import '../../shared/layout/adaptive_layout.dart';
 import '../../shared/widgets/empty_state.dart';
 import '../playlists/widgets/add_to_playlist_sheet.dart';
@@ -52,6 +53,10 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   /// Widest the search box gets on a desktop window.
   static const double _searchFieldMaxWidth = 520;
 
+  /// Tab order, as stored names rather than indices, so the persisted choice
+  /// survives a tab being added or reordered later.
+  static const List<String> _tabNames = <String>['songs', 'albums', 'artists'];
+
   final Set<String> _selectedUris = <String>{};
   bool _selecting = false;
 
@@ -67,8 +72,28 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 3, vsync: this);
+    _tabController = TabController(length: _tabNames.length, vsync: this);
     _tabController.addListener(_onTabChanged);
+    unawaited(_restoreTab());
+  }
+
+  /// Reopens Library on the tab last used, instead of always on Songs.
+  ///
+  /// Reading is async, so the controller starts on the first tab and moves once
+  /// the value arrives. In practice that is not visible: the tabs only appear
+  /// once the catalog has loaded, which takes longer than a key/value read. The
+  /// guard matters anyway, because a user who switched tabs in the meantime has
+  /// said something more recent than the stored value.
+  Future<void> _restoreTab() async {
+    final String? stored = await ref.read(libraryTabStoreProvider).read();
+    if (!mounted || stored == null) return;
+    final int index = _tabNames.indexOf(stored);
+    if (index < 0) return; // A tab that no longer exists: stay on the first.
+    if (_tabController.index != 0 || _lastTabIndex != 0) return;
+    setState(() {
+      _lastTabIndex = index;
+      _tabController.index = index;
+    });
   }
 
   @override
@@ -92,6 +117,11 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
         _searchController.clear();
       }
     });
+    // Fire and forget: where the user was reading is not worth blocking a tab
+    // change on, and a failed write only means the next launch opens on Songs.
+    unawaited(
+      ref.read(libraryTabStoreProvider).write(_tabNames[_tabController.index]),
+    );
   }
 
   void _onQueryChanged(String value) {

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -70,9 +70,10 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   /// restore landing after that would move them somewhere they just left.
   bool _userChangedTab = false;
 
-  /// Set only while [_restoreTab] drives the controller, so the one code path
-  /// that handles a tab change can tell a restore from a tap.
-  bool _restoringTab = false;
+  /// Set while the app itself drives the controller, so the one handler for a
+  /// tab change can tell that from a tap: it is neither a choice to remember
+  /// nor a reason to stop a pending restore.
+  bool _programmaticTabChange = false;
 
   /// Pending debounce timer. Cancelled and restarted on every keystroke so the
   /// filter re-runs only once the user pauses typing, not on every character.
@@ -115,9 +116,9 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
     // an in-progress search exactly as any other tab change does. Assigning
     // _lastTabIndex first would make the shared handler return early and carry
     // a query typed in Songs into Albums.
-    _restoringTab = true;
+    _programmaticTabChange = true;
     _tabController.index = index;
-    _restoringTab = false;
+    _programmaticTabChange = false;
   }
 
   /// Persists the current tab, swallowing a storage failure.
@@ -147,7 +148,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   /// when entering/leaving Folders, where the catalog search field is hidden.
   void _onTabChanged() {
     if (_tabController.index == _lastTabIndex) return;
-    if (!_restoringTab) _userChangedTab = true;
+    if (!_programmaticTabChange) _userChangedTab = true;
     _debounce?.cancel();
     setState(() {
       _lastTabIndex = _tabController.index;
@@ -164,7 +165,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
     // A restore is replaying what is already stored, so there is nothing new to
     // write back. Otherwise fire and forget: where the user is reading is not
     // worth blocking a tab change on.
-    if (_restoringTab) return;
+    if (_programmaticTabChange) return;
     unawaited(_persistTab());
   }
 
@@ -460,6 +461,17 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
         ..clear()
         ..add(track.uri);
     });
+    // Selection is only reachable from the songs list, so that is the list it
+    // must show. Guarding the restore is not enough on its own: a long press
+    // holds the pointer for half a second before firing, and a restore landing
+    // inside that window sees no selection yet and moves the tab underneath the
+    // gesture. Coming back here closes it from the other end, whatever the
+    // timing was.
+    if (_tabController.index != 0) {
+      _programmaticTabChange = true;
+      _tabController.index = 0;
+      _programmaticTabChange = false;
+    }
   }
 
   void _toggle(Track track) {

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -277,10 +277,19 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
       key: const Key('library_tabs'),
       controller: _tabController,
       // Tapping the tab you are already on is still you choosing a tab, but it
-      // leaves the controller index untouched, so the listener never runs and
-      // _userChangedTab would stay false. A restore still in flight would then
-      // move you off the tab you just asked for.
-      onTap: (_) => _userChangedTab = true,
+      // leaves the controller index untouched, so the listener never runs: it
+      // would neither mark the choice nor store it. A restore still in flight
+      // would move you off the tab you just asked for, and the next cold launch
+      // would open on the tab you had just rejected.
+      //
+      // TabBar calls animateTo before onTap, so the index is already current
+      // here. A tap that did change tabs therefore queues the same value the
+      // listener just queued, which is a harmless second write of a value that
+      // is already stored.
+      onTap: (_) {
+        _userChangedTab = true;
+        _persistTab();
+      },
       indicatorColor: theme.colorScheme.secondary,
       indicatorSize: TabBarIndicatorSize.label,
       labelColor: theme.colorScheme.secondary,

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -121,18 +121,30 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
     _programmaticTabChange = false;
   }
 
+  /// Queues the tab writes so they cannot overtake each other.
+  ///
+  /// Switching Albums then Artists faster than the store can write would
+  /// otherwise leave two writes racing, and a slow first one landing last would
+  /// store the tab the user had already left. Each queued write also reads the
+  /// index when it *runs* rather than when it was queued, so the latest tab
+  /// wins even if several pile up.
+  Future<void> _persistQueue = Future<void>.value();
+
   /// Persists the current tab, swallowing a storage failure.
   ///
   /// Losing this preference only means the next launch opens on Songs, which is
   /// not worth surfacing to someone who was just browsing.
-  Future<void> _persistTab() async {
-    try {
-      await ref
-          .read(libraryTabStoreProvider)
-          .write(_tabNames[_tabController.index]);
-    } catch (_) {
-      // Nothing to recover: the next launch simply opens on the first tab.
-    }
+  void _persistTab() {
+    _persistQueue = _persistQueue.then((_) async {
+      if (!mounted) return;
+      try {
+        await ref
+            .read(libraryTabStoreProvider)
+            .write(_tabNames[_tabController.index]);
+      } catch (_) {
+        // Nothing to recover: the next launch simply opens on the first tab.
+      }
+    });
   }
 
   @override
@@ -166,7 +178,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
     // write back. Otherwise fire and forget: where the user is reading is not
     // worth blocking a tab change on.
     if (_programmaticTabChange) return;
-    unawaited(_persistTab());
+    _persistTab();
   }
 
   void _onQueryChanged(String value) {

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -276,6 +276,11 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
     return TabBar(
       key: const Key('library_tabs'),
       controller: _tabController,
+      // Tapping the tab you are already on is still you choosing a tab, but it
+      // leaves the controller index untouched, so the listener never runs and
+      // _userChangedTab would stay false. A restore still in flight would then
+      // move you off the tab you just asked for.
+      onTap: (_) => _userChangedTab = true,
       indicatorColor: theme.colorScheme.secondary,
       indicatorSize: TabBarIndicatorSize.label,
       labelColor: theme.colorScheme.secondary,

--- a/test/features/library/library_tab_memory_test.dart
+++ b/test/features/library/library_tab_memory_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -25,6 +27,21 @@ class _SlowLibraryTabStore implements LibraryTabStore {
     await Future<void>.delayed(delay);
     return _tabName;
   }
+
+  @override
+  Future<void> write(String? tabName) async {}
+}
+
+/// A store whose read resolves exactly when the test says so, for the windows
+/// that are too short to hit with a delay: between a keystroke and the 300ms
+/// search debounce, or while a long-press is being held.
+class _ManualLibraryTabStore implements LibraryTabStore {
+  final Completer<String?> _read = Completer<String?>();
+
+  void completeWith(String? tabName) => _read.complete(tabName);
+
+  @override
+  Future<String?> read() => _read.future;
 
   @override
   Future<void> write(String? tabName) async {}
@@ -128,6 +145,50 @@ void main() {
       expect(_currentTab(tester), 1);
       expect(tester.widget<TextField>(find.byType(TextField)).controller?.text,
           isEmpty);
+    });
+
+    testWidgets(
+        'a restore landing inside the search debounce still clears the '
+        'box', (tester) async {
+      final _ManualLibraryTabStore store = _ManualLibraryTabStore();
+      await _pump(tester, store);
+
+      await tester.enterText(find.byType(TextField), 'blue');
+      // Deliberately not waiting out the 300ms debounce: the field holds text
+      // while the query it feeds is still empty, which is the window a check on
+      // the query alone misses.
+      store.completeWith('albums');
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      expect(_currentTab(tester), 1);
+      expect(
+        tester.widget<TextField>(find.byType(TextField)).controller?.text,
+        isEmpty,
+      );
+    });
+
+    testWidgets('a restore does not move the tab out from under a selection',
+        (tester) async {
+      final _ManualLibraryTabStore store = _ManualLibraryTabStore();
+      await _pump(tester, store);
+
+      await tester.longPress(find.text('Song A'));
+      await tester.pumpAndSettle();
+      expect(find.text('1 selected'), findsOneWidget);
+
+      // Selection replaces the app bar, hides the tab bar and blocks swiping,
+      // so moving the tab underneath it would strand the user.
+      store.completeWith('albums');
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      expect(find.text('1 selected'), findsOneWidget);
+
+      await tester.tap(find.byTooltip('Cancel selection'));
+      await tester.pumpAndSettle();
+
+      expect(_currentTab(tester), 0);
     });
 
     testWidgets('a storage failure leaves the screen usable', (tester) async {

--- a/test/features/library/library_tab_memory_test.dart
+++ b/test/features/library/library_tab_memory_test.dart
@@ -38,13 +38,16 @@ class _SlowLibraryTabStore implements LibraryTabStore {
 class _ManualLibraryTabStore implements LibraryTabStore {
   final Completer<String?> _read = Completer<String?>();
 
+  /// The value left in the store, so a test can check what a tap wrote back.
+  String? stored;
+
   void completeWith(String? tabName) => _read.complete(tabName);
 
   @override
   Future<String?> read() => _read.future;
 
   @override
-  Future<void> write(String? tabName) async {}
+  Future<void> write(String? tabName) async => stored = tabName;
 }
 
 /// A store whose first write is slow and later ones instant, the shape that
@@ -292,6 +295,9 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(_currentTab(tester), 0);
+      // Keeping the screen on Songs is only half of it: leaving Artists stored
+      // would reopen there next launch, on a tab the user had just rejected.
+      expect(store.stored, 'songs');
     });
 
     testWidgets('a storage failure leaves the screen usable', (tester) async {

--- a/test/features/library/library_tab_memory_test.dart
+++ b/test/features/library/library_tab_memory_test.dart
@@ -254,6 +254,29 @@ void main() {
       expect(store.stored, 'artists');
     });
 
+    testWidgets('a restore does not hijack a swipe in progress',
+        (tester) async {
+      final _ManualLibraryTabStore store = _ManualLibraryTabStore();
+      await _pump(tester, store);
+
+      // Partway through a swipe that has not crossed the midpoint: the index
+      // has not moved yet, so nothing has marked this as a user tab change.
+      final TestGesture gesture =
+          await tester.startGesture(tester.getCenter(find.byType(TabBarView)));
+      await gesture.moveBy(const Offset(-60, 0));
+      await tester.pump();
+
+      store.completeWith('artists');
+      await tester.pump();
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      // The swipe fell short, so it belongs back on Songs. The stored tab must
+      // not have taken the wheel mid-gesture.
+      expect(_currentTab(tester), 0);
+    });
+
     testWidgets('a storage failure leaves the screen usable', (tester) async {
       await _pump(tester, _FailingLibraryTabStore());
 

--- a/test/features/library/library_tab_memory_test.dart
+++ b/test/features/library/library_tab_memory_test.dart
@@ -69,6 +69,22 @@ class _RacyWriteLibraryTabStore implements LibraryTabStore {
   }
 }
 
+/// A store whose writes all take a moment, so a test can unmount the screen
+/// while one is still in flight and see what the queue does with the rest.
+class _SlowWriteLibraryTabStore implements LibraryTabStore {
+  /// The value left in the store once everything has settled.
+  String? stored;
+
+  @override
+  Future<String?> read() async => null;
+
+  @override
+  Future<void> write(String? tabName) async {
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+    stored = tabName;
+  }
+}
+
 /// A store that fails the way a missing platform plugin or a full disk would.
 class _FailingLibraryTabStore implements LibraryTabStore {
   @override
@@ -298,6 +314,26 @@ void main() {
       // Keeping the screen on Songs is only half of it: leaving Artists stored
       // would reopen there next launch, on a tab the user had just rejected.
       expect(store.stored, 'songs');
+    });
+
+    testWidgets('leaving the screen does not strand a queued write',
+        (tester) async {
+      final _SlowWriteLibraryTabStore store = _SlowWriteLibraryTabStore();
+      await _pump(tester, store);
+
+      // Two tabs in quick succession, so the second write is queued behind the
+      // first and still waiting when the screen goes away.
+      await tester.tap(find.text('Albums'));
+      await tester.pump();
+      await tester.tap(find.text('Artists'));
+      await tester.pump();
+
+      await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+      await tester.pump(const Duration(seconds: 1));
+
+      // Artists is where the user actually left off. Dropping the queued write
+      // would leave Albums stored and reopen there.
+      expect(store.stored, 'artists');
     });
 
     testWidgets('a storage failure leaves the screen usable', (tester) async {

--- a/test/features/library/library_tab_memory_test.dart
+++ b/test/features/library/library_tab_memory_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/library_tab_store.dart';
+import 'package:linthra/data/repositories/download_repository_provider.dart';
+import 'package:linthra/data/repositories/in_memory_library_tab_store.dart';
+import 'package:linthra/data/repositories/library_tab_store_provider.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/library/library_screen.dart';
+
+import 'fake_music_library_repository.dart';
+import 'fake_remote_track_downloader.dart';
+
+const List<Track> _tracks = <Track>[
+  Track(id: 'a', title: 'Song A', uri: 'file:///a.mp3'),
+  Track(id: 'b', title: 'Song B', uri: 'file:///b.mp3'),
+];
+
+Future<void> _pump(WidgetTester tester, LibraryTabStore store) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        musicLibraryRepositoryProvider
+            .overrideWithValue(FakeMusicLibraryRepository(tracks: _tracks)),
+        remoteTrackDownloaderProvider
+            .overrideWithValue(FakeRemoteTrackDownloader()),
+        libraryTabStoreProvider.overrideWithValue(store),
+      ],
+      child: const MaterialApp(home: LibraryScreen()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// Which tab the TabBar is actually showing.
+int _currentTab(WidgetTester tester) {
+  return tester.widget<TabBar>(find.byType(TabBar)).controller!.index;
+}
+
+void main() {
+  group('Library remembers its tab (#580)', () {
+    testWidgets('a fresh install opens on the first tab', (tester) async {
+      await _pump(tester, InMemoryLibraryTabStore());
+
+      expect(_currentTab(tester), 0);
+    });
+
+    testWidgets('reopens on the tab last used', (tester) async {
+      // What a previous session left behind for someone who browses by album.
+      await _pump(tester, InMemoryLibraryTabStore('albums'));
+
+      expect(_currentTab(tester), 1);
+    });
+
+    testWidgets('switching tabs persists the choice', (tester) async {
+      final InMemoryLibraryTabStore store = InMemoryLibraryTabStore();
+      await _pump(tester, store);
+
+      await tester.tap(find.text('Artists'));
+      await tester.pumpAndSettle();
+
+      expect(await store.read(), 'artists');
+    });
+
+    testWidgets('a stored tab that no longer exists falls back to the first',
+        (tester) async {
+      // A rename or a removed tab must not leave the screen pointing at
+      // nothing, which is why the name is stored rather than the index.
+      await _pump(tester, InMemoryLibraryTabStore('genres'));
+
+      expect(_currentTab(tester), 0);
+    });
+  });
+}

--- a/test/features/library/library_tab_memory_test.dart
+++ b/test/features/library/library_tab_memory_test.dart
@@ -12,6 +12,34 @@ import 'package:linthra/features/library/library_screen.dart';
 import 'fake_music_library_repository.dart';
 import 'fake_remote_track_downloader.dart';
 
+/// A store whose read resolves only after [delay], so a test can act during the
+/// window the real shared_preferences read leaves open.
+class _SlowLibraryTabStore implements LibraryTabStore {
+  _SlowLibraryTabStore(this._tabName, this.delay);
+
+  final String? _tabName;
+  final Duration delay;
+
+  @override
+  Future<String?> read() async {
+    await Future<void>.delayed(delay);
+    return _tabName;
+  }
+
+  @override
+  Future<void> write(String? tabName) async {}
+}
+
+/// A store that fails the way a missing platform plugin or a full disk would.
+class _FailingLibraryTabStore implements LibraryTabStore {
+  @override
+  Future<String?> read() async => throw StateError('no preference storage');
+
+  @override
+  Future<void> write(String? tabName) async =>
+      throw StateError('no preference storage');
+}
+
 const List<Track> _tracks = <Track>[
   Track(id: 'a', title: 'Song A', uri: 'file:///a.mp3'),
   Track(id: 'b', title: 'Song B', uri: 'file:///b.mp3'),
@@ -61,6 +89,59 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(await store.read(), 'artists');
+    });
+
+    testWidgets('a tab the user picked wins over a late restore',
+        (tester) async {
+      // The read is still in flight while the user taps around. Going away from
+      // Songs and back leaves the index at zero again, so the index alone
+      // cannot tell "untouched" from "deliberately back on Songs".
+      await _pump(
+        tester,
+        _SlowLibraryTabStore('artists', const Duration(seconds: 2)),
+      );
+
+      await tester.tap(find.text('Albums'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Songs'));
+      await tester.pumpAndSettle();
+
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pumpAndSettle();
+
+      expect(_currentTab(tester), 0);
+    });
+
+    testWidgets('restoring clears a search typed before it landed',
+        (tester) async {
+      await _pump(
+        tester,
+        _SlowLibraryTabStore('albums', const Duration(seconds: 2)),
+      );
+
+      await tester.enterText(find.byType(TextField), 'blue');
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pumpAndSettle();
+
+      // The restore moved to Albums, so the query typed against Songs must be
+      // cleared, exactly as it is on any other tab change.
+      expect(_currentTab(tester), 1);
+      expect(tester.widget<TextField>(find.byType(TextField)).controller?.text,
+          isEmpty);
+    });
+
+    testWidgets('a storage failure leaves the screen usable', (tester) async {
+      await _pump(tester, _FailingLibraryTabStore());
+
+      expect(_currentTab(tester), 0);
+      expect(tester.takeException(), isNull);
+
+      // The write fails too, and must not surface either.
+      await tester.tap(find.text('Albums'));
+      await tester.pumpAndSettle();
+
+      expect(_currentTab(tester), 1);
+      expect(tester.takeException(), isNull);
     });
 
     testWidgets('a stored tab that no longer exists falls back to the first',

--- a/test/features/library/library_tab_memory_test.dart
+++ b/test/features/library/library_tab_memory_test.dart
@@ -277,6 +277,23 @@ void main() {
       expect(_currentTab(tester), 0);
     });
 
+    testWidgets('tapping the tab you are already on beats a late restore',
+        (tester) async {
+      final _ManualLibraryTabStore store = _ManualLibraryTabStore();
+      await _pump(tester, store);
+
+      // Songs is already selected, so this tap moves no index and the
+      // controller listener never runs. It is still the user choosing a tab.
+      await tester.tap(find.text('Songs'));
+      await tester.pumpAndSettle();
+
+      store.completeWith('artists');
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      expect(_currentTab(tester), 0);
+    });
+
     testWidgets('a storage failure leaves the screen usable', (tester) async {
       await _pump(tester, _FailingLibraryTabStore());
 

--- a/test/features/library/library_tab_memory_test.dart
+++ b/test/features/library/library_tab_memory_test.dart
@@ -47,6 +47,25 @@ class _ManualLibraryTabStore implements LibraryTabStore {
   Future<void> write(String? tabName) async {}
 }
 
+/// A store whose first write is slow and later ones instant, the shape that
+/// lets a stale write land last when writes are allowed to race.
+class _RacyWriteLibraryTabStore implements LibraryTabStore {
+  int _writes = 0;
+
+  /// The value left in the store once everything has settled.
+  String? stored;
+
+  @override
+  Future<String?> read() async => null;
+
+  @override
+  Future<void> write(String? tabName) async {
+    final bool first = _writes++ == 0;
+    if (first) await Future<void>.delayed(const Duration(milliseconds: 300));
+    stored = tabName;
+  }
+}
+
 /// A store that fails the way a missing platform plugin or a full disk would.
 class _FailingLibraryTabStore implements LibraryTabStore {
   @override
@@ -217,6 +236,22 @@ void main() {
       await tester.tap(find.byTooltip('Cancel selection'));
       await tester.pumpAndSettle();
       expect(_currentTab(tester), 0);
+    });
+
+    testWidgets('the last tab wins when writes overlap', (tester) async {
+      final _RacyWriteLibraryTabStore store = _RacyWriteLibraryTabStore();
+      await _pump(tester, store);
+
+      // Faster than the store can write: two writes in flight at once.
+      await tester.tap(find.text('Albums'));
+      await tester.pump();
+      await tester.tap(find.text('Artists'));
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      // Letting them race would land the slow first write last and store the
+      // tab the user had already left.
+      expect(_currentTab(tester), 2);
+      expect(store.stored, 'artists');
     });
 
     testWidgets('a storage failure leaves the screen usable', (tester) async {

--- a/test/features/library/library_tab_memory_test.dart
+++ b/test/features/library/library_tab_memory_test.dart
@@ -191,6 +191,34 @@ void main() {
       expect(_currentTab(tester), 0);
     });
 
+    testWidgets(
+        'a restore landing mid long-press does not strand the selection',
+        (tester) async {
+      final _ManualLibraryTabStore store = _ManualLibraryTabStore();
+      await _pump(tester, store);
+
+      // Pointer down, but the recognizer has not fired yet: at this instant
+      // neither the selection flag nor the user-interaction flag is set, so
+      // guarding the restore alone would let it move the tab under the gesture.
+      final TestGesture gesture =
+          await tester.startGesture(tester.getCenter(find.text('Song A')));
+      store.completeWith('albums');
+      await tester.pump();
+
+      // Hold past the long-press timeout, then let go.
+      await tester.pump(const Duration(milliseconds: 600));
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(find.text('1 selected'), findsOneWidget);
+
+      // Selection came from the songs list, so that is what it must be sitting
+      // on when it ends.
+      await tester.tap(find.byTooltip('Cancel selection'));
+      await tester.pumpAndSettle();
+      expect(_currentTab(tester), 0);
+    });
+
     testWidgets('a storage failure leaves the screen usable', (tester) async {
       await _pump(tester, _FailingLibraryTabStore());
 


### PR DESCRIPTION
Library always opened on Songs. For a large library browsed by album or artist that is the wrong place to land every time, and it costs most on a cold start, which is exactly when a session-only memory would not help. Reported in #580.

## What this is not

The issue proposed drag and drop for the tabs, or a tab-order setting. Both are heavier than the problem: drag and drop for three tabs is a lot of machinery, and an order setting is one more preference to discover and maintain.

Remembering the last tab gets the same result with nothing to configure, and it helps everyone rather than only those who go looking for a setting. If the reporter specifically wants the order itself to be theirs to set, that is a separate conversation on the issue.

Worth noting for context: the other half of #580, "I would love to see the Folders tab immediately", already shipped in 0.2.5. Folders left the Library tab strip and became its own top-level destination.

## How

A small `LibraryTabStore`, following the same shape as the other lightweight preference stores in the repo: an interface, an in-memory implementation so widget tests stay free of platform plugins, a `shared_preferences` implementation, and a production override applied in `main`.

The stored value is a tab **name**, not an index. An index silently points at the wrong tab the day one is added or reordered. An unrecognised name falls back to the first tab.

Reading is async, so the controller starts on Songs and moves once the value arrives. That is not visible in practice, because the tabs only appear once the catalog has loaded, which takes longer than a key/value read. The restore also stands down if the user already switched tabs, since that is a more recent instruction than the stored one.

## Tests

Four: a fresh install opens on the first tab, a stored tab is restored, switching tabs persists, and an unknown stored name falls back safely rather than pointing at a tab that no longer exists.

`dart format` clean, `flutter analyze` clean, full suite green at 4212 tests.

Refs #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwEthUnaMdNwUondxnB9jn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwEthUnaMdNwUondxnB9jn)_