### PR TITLE
Cast security follow-ups: verify the shipped containment, receiver trust, and what a handoff delegates (#574, #575, #576)

### DIFF
--- a/.github/workflows/android-release-build.yml
+++ b/.github/workflows/android-release-build.yml
@@ -162,6 +162,18 @@ jobs:
           # manual one.
           ref: ${{ inputs.release_tag }}
 
+      # The release tooling from the revision that is RUNNING, kept beside the
+      # build source rather than replacing it. A run rebuilding an older tag
+      # checks that tag's tree out above, which may predate the containment
+      # verifier; the check still has to happen, so the script comes from here
+      # and the expected message from the tag's own cast_containment.dart.
+      - name: Check out the release tooling from this workflow's revision
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          path: .release-tooling
+          sparse-checkout: scripts
+
       # Decide, in one place, how this run should sign, whether the tag is a
       # pre-release, and how to label/name the artifacts.
       #   trigger:    manual | tag
@@ -494,17 +506,22 @@ jobs:
         run: |
           set -euo pipefail
 
-          # A run rebuilding an OLD release tag checks out that tag's tree,
-          # which may predate this script (and the containment it looks for).
-          # That path is documented and must keep working, so say plainly that
-          # nothing was checked rather than failing the rebuild on a file the
-          # tag never had. Every current release builds a tree that has it.
-          if [ ! -f scripts/verify_release_containment.py ]; then
-            echo "::warning::This tag predates scripts/verify_release_containment.py, so the artifacts were not checked for the Cast containment. Verify the published assets by hand if the tag is expected to carry it (see docs/release-artifact-verification.md)."
+          source_file="lib/core/services/cast/cast_containment.dart"
+
+          # The one case with nothing to check: a tag from before the
+          # containment existed. Then there is no message to look for, and the
+          # documented rebuild path for such a tag must not fail on its absence.
+          # Anything else is checked — with the verifier from this workflow's
+          # revision, against the built tree's own message — because "the tag is
+          # old" must never become a way to replace public assets unverified.
+          if [ ! -f "$source_file" ] || ! grep -q 'static const String userMessage' "$source_file"; then
+            echo "::warning::This tag predates the Cast containment, so its artifacts carry nothing to check. See docs/release-artifact-verification.md."
             exit 0
           fi
 
-          python3 scripts/verify_release_containment.py dist/*.apk dist/*.aab
+          python3 .release-tooling/scripts/verify_release_containment.py \
+            --containment-source "$source_file" \
+            dist/*.apk dist/*.aab
 
       - name: Upload release APK
         uses: actions/upload-artifact@v7

--- a/.github/workflows/android-release-build.yml
+++ b/.github/workflows/android-release-build.yml
@@ -471,6 +471,19 @@ jobs:
 
           echo "Verified: all APK versions match the tag-derived version."
 
+      # Casting is withheld from shipped builds while a reported security issue
+      # is resolved (see lib/core/services/cast/cast_containment.dart). The
+      # source tripwire and the containment tests both run against the tree; this
+      # reads the compiled Dart inside the artifacts this job is about to upload,
+      # so a build that lost containment somewhere between the checkout and the
+      # APK never becomes a Release asset. It also prints each artifact's SHA-256
+      # for the release record. Fails closed — see the script's docstring for
+      # what it can and cannot see.
+      - name: Verify the built artifacts carry the Cast containment
+        run: |
+          set -euo pipefail
+          python3 scripts/verify_release_containment.py dist/*.apk dist/*.aab
+
       - name: Upload release APK
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/android-release-build.yml
+++ b/.github/workflows/android-release-build.yml
@@ -150,6 +150,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # A manual run targeting an existing release tag must build *that
+          # tag's* commit. The dispatch's own `--ref` only says which copy of
+          # this workflow file to run (publish-stable-release.yml dispatches
+          # with `--ref main`), so without this the artifacts would come from
+          # whatever `main` is at that moment — which is not necessarily the
+          # reviewed, tagged commit the Release claims to be built from.
+          # Empty for every other trigger, which is checkout's own default: the
+          # pushed tag for a tag build, the dispatched branch for a plain
+          # manual one.
+          ref: ${{ inputs.release_tag }}
 
       # Decide, in one place, how this run should sign, whether the tag is a
       # pre-release, and how to label/name the artifacts.

--- a/.github/workflows/android-release-build.yml
+++ b/.github/workflows/android-release-build.yml
@@ -493,6 +493,17 @@ jobs:
       - name: Verify the built artifacts carry the Cast containment
         run: |
           set -euo pipefail
+
+          # A run rebuilding an OLD release tag checks out that tag's tree,
+          # which may predate this script (and the containment it looks for).
+          # That path is documented and must keep working, so say plainly that
+          # nothing was checked rather than failing the rebuild on a file the
+          # tag never had. Every current release builds a tree that has it.
+          if [ ! -f scripts/verify_release_containment.py ]; then
+            echo "::warning::This tag predates scripts/verify_release_containment.py, so the artifacts were not checked for the Cast containment. Verify the published assets by hand if the tag is expected to carry it (see docs/release-artifact-verification.md)."
+            exit 0
+          fi
+
           python3 scripts/verify_release_containment.py dist/*.apk dist/*.aab
 
       - name: Upload release APK

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,16 @@ jobs:
       - name: Check cast containment markers
         run: python3 scripts/check_cast_containment.py
 
+      # The artifact-level twin of the tripwire above: scripts/
+      # verify_release_containment.py reads the compiled Dart inside a built
+      # APK/AAB/tarball and refuses an artifact that does not look contained.
+      # The release workflows run it on the real artifacts; this runs its unit
+      # tests on synthetic ones, so a change that makes the verifier stop
+      # catching an uncontained build is caught here rather than at release
+      # time. Local twin: `python3 test/tooling/verify_release_containment_test.py`.
+      - name: Test the release artifact verifier
+        run: python3 test/tooling/verify_release_containment_test.py
+
   release-bump-guard:
     name: Release bump touches only version files
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-desktop-build.yml
+++ b/.github/workflows/linux-desktop-build.yml
@@ -373,6 +373,18 @@ jobs:
           ARCHIVE_FILE: ${{ env.archive_file }}
         run: |
           set -euo pipefail
+
+          # A run rebuilding an OLD release tag checks out that tag's tree,
+          # which may predate this script (and the containment it looks for).
+          # That path is documented and must keep working, so say plainly that
+          # nothing was checked rather than failing the rebuild — after the
+          # whole build — on a file the tag never had. Same handling as the
+          # Android release build.
+          if [ ! -f scripts/verify_release_containment.py ]; then
+            echo "::warning::This tag predates scripts/verify_release_containment.py, so the archive was not checked for the Cast containment. Verify the published asset by hand if the tag is expected to carry it (see docs/release-artifact-verification.md)."
+            exit 0
+          fi
+
           python3 scripts/verify_release_containment.py "$ARCHIVE_FILE"
 
       - name: Attach archive to GitHub Release

--- a/.github/workflows/linux-desktop-build.yml
+++ b/.github/workflows/linux-desktop-build.yml
@@ -284,6 +284,15 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Checked out first, and at the exact tag being released, for the
+      # containment verification below: the script and the message it compares
+      # against both live in the repository, and checkout cleans the workspace,
+      # so it has to run before the bundle is downloaded into it.
+      - name: Checkout the released tag
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.build-linux.outputs.release_tag }}
+
       # The artifact upload above stores the *contents* of
       # build/linux/x64/release/bundle at its root (linthra, lib/, data/, ...),
       # so downloading it directly into the archive's staging directory already
@@ -351,6 +360,20 @@ jobs:
           head -5 "$archive_list"
 
           echo "archive_file=${archive_file}" >> "$GITHUB_ENV"
+
+      # Casting is withheld from shipped builds while a reported security issue
+      # is resolved (lib/core/services/cast/cast_containment.dart). The Android
+      # release build makes the same check on its APK/AAB before uploading them;
+      # this is the Linux half, and it runs *before* the upload on purpose —
+      # the Release is already public by this point, so an artifact that failed
+      # the check must never become downloadable from it. Fails closed; see the
+      # script's docstring for what it can and cannot see.
+      - name: Verify the archive carries the Cast containment
+        env:
+          ARCHIVE_FILE: ${{ env.archive_file }}
+        run: |
+          set -euo pipefail
+          python3 scripts/verify_release_containment.py "$ARCHIVE_FILE"
 
       - name: Attach archive to GitHub Release
         env:

--- a/.github/workflows/linux-desktop-build.yml
+++ b/.github/workflows/linux-desktop-build.yml
@@ -293,6 +293,16 @@ jobs:
         with:
           ref: ${{ needs.build-linux.outputs.release_tag }}
 
+      # Same split as the Android release build: the tag supplies the expected
+      # containment message, this workflow's own revision supplies the script
+      # that looks for it, so rebuilding an older tag is still verified.
+      - name: Check out the release tooling from this workflow's revision
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          path: .release-tooling
+          sparse-checkout: scripts
+
       # The artifact upload above stores the *contents* of
       # build/linux/x64/release/bundle at its root (linthra, lib/, data/, ...),
       # so downloading it directly into the archive's staging directory already
@@ -374,18 +384,20 @@ jobs:
         run: |
           set -euo pipefail
 
-          # A run rebuilding an OLD release tag checks out that tag's tree,
-          # which may predate this script (and the containment it looks for).
-          # That path is documented and must keep working, so say plainly that
-          # nothing was checked rather than failing the rebuild — after the
-          # whole build — on a file the tag never had. Same handling as the
-          # Android release build.
-          if [ ! -f scripts/verify_release_containment.py ]; then
-            echo "::warning::This tag predates scripts/verify_release_containment.py, so the archive was not checked for the Cast containment. Verify the published asset by hand if the tag is expected to carry it (see docs/release-artifact-verification.md)."
+          source_file="lib/core/services/cast/cast_containment.dart"
+
+          # Only a tag from before the containment existed has nothing to
+          # check; everything else is verified with the script from this
+          # workflow's revision against that tag's own message, so an old tag
+          # is never a way to attach an unverified asset.
+          if [ ! -f "$source_file" ] || ! grep -q 'static const String userMessage' "$source_file"; then
+            echo "::warning::This tag predates the Cast containment, so its archive carries nothing to check. See docs/release-artifact-verification.md."
             exit 0
           fi
 
-          python3 scripts/verify_release_containment.py "$ARCHIVE_FILE"
+          python3 .release-tooling/scripts/verify_release_containment.py \
+            --containment-source "$source_file" \
+            "$ARCHIVE_FILE"
 
       - name: Attach archive to GitHub Release
         env:

--- a/.github/workflows/publish-stable-release.yml
+++ b/.github/workflows/publish-stable-release.yml
@@ -293,6 +293,51 @@ jobs:
             done
           } >> "$GITHUB_STEP_SUMMARY"
 
+      # The assets exist — this asks what is inside them. Casting is withheld
+      # from shipped builds while a reported security issue is resolved
+      # (lib/core/services/cast/cast_containment.dart), and the check that
+      # matters for a release is not "the tree was contained when CI ran" but
+      # "the file a user downloads is". So this pulls the published assets back
+      # down and reads the compiled Dart inside each one, at the reviewed commit
+      # this job checked out.
+      #
+      # It also records every asset's SHA-256 in the job summary, so the release
+      # has an auditable list of exactly which bytes were verified. The script
+      # fails closed and its limits are in its docstring — it is evidence about
+      # the shipped artifact, not a proof that the binary cannot cast.
+      - name: Verify the published artifacts carry the Cast containment
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          TARGET_SHA: ${{ steps.release.outputs.target_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          assets="$RUNNER_TEMP/release-assets"
+          record="$RUNNER_TEMP/containment-record.json"
+          rm -rf "$assets"
+          mkdir -p "$assets"
+
+          gh release download "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir "$assets" \
+            --clobber
+
+          python3 scripts/verify_release_containment.py \
+            --json "$record" \
+            "$assets"/*.apk "$assets"/*.aab "$assets"/*.tar.gz
+
+          {
+            echo
+            echo "### Cast containment verified in the published artifacts"
+            echo
+            echo "Built from \`$TARGET_SHA\`."
+            echo
+            echo '| Asset | Bytes | SHA-256 |'
+            echo '| --- | --- | --- |'
+            jq -r '.[] | "| `\(.artifact)` | \(.bytes) | `\(.sha256)` |"' "$record"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Report publication failure
         if: ${{ failure() }}
         env:

--- a/.github/workflows/publish-stable-release.yml
+++ b/.github/workflows/publish-stable-release.yml
@@ -137,6 +137,10 @@ jobs:
             --json databaseId \
             --jq '.[].databaseId' > "$before"
 
+          # --ref selects which copy of the workflow file runs; what it builds
+          # is decided by release_tag, which that workflow checks out. That is
+          # what makes the digests recorded below attributable to the tagged
+          # commit rather than to main's tip at dispatch time.
           gh workflow run android-release-build.yml \
             --repo "$GITHUB_REPOSITORY" \
             --ref main \

--- a/.github/workflows/publish-stable-release.yml
+++ b/.github/workflows/publish-stable-release.yml
@@ -244,6 +244,7 @@ jobs:
         run: gh run watch "$RUN_ID" --repo "$GITHUB_REPOSITORY" --exit-status
 
       - name: Verify every public Release asset
+        id: assets
         env:
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
           RUN_URL: ${{ steps.dispatch.outputs.run_url }}
@@ -281,21 +282,13 @@ jobs:
             exit 1
           fi
 
-          release_url="$(jq -r '.url' "$release_json")"
-          {
-            echo "## ✅ $RELEASE_TAG published and verified"
-            echo
-            echo "Release PR: $PR_URL"
-            echo "Tagged commit: \`$TARGET_SHA\`"
-            echo "Signed Android build: $RUN_URL"
-            echo "Linux release build: $LINUX_RUN_URL"
-            echo "Release: $release_url"
-            echo
-            echo 'Verified assets:'
-            for asset in "${required[@]}"; do
-              echo "- \`$asset\`"
-            done
-          } >> "$GITHUB_STEP_SUMMARY"
+          # Deliberately no summary yet: "published and verified" is written by
+          # the containment step below, once the bytes have actually been
+          # checked. A banner here would survive a failed check and leave the
+          # security record claiming a verification that did not happen.
+          echo "release_url=$(jq -r '.url' "$release_json")" >> "$GITHUB_OUTPUT"
+          printf 'Present on the Release:\n'
+          printf '  %s\n' "${required[@]}"
 
       # The assets exist — this asks what is inside them. Casting is withheld
       # from shipped builds while a reported security issue is resolved
@@ -313,6 +306,10 @@ jobs:
         env:
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
           TARGET_SHA: ${{ steps.release.outputs.target_sha }}
+          RELEASE_URL: ${{ steps.assets.outputs.release_url }}
+          RUN_URL: ${{ steps.dispatch.outputs.run_url }}
+          LINUX_RUN_URL: ${{ steps.dispatch-linux.outputs.run_url }}
+          PR_URL: ${{ steps.release.outputs.pr_url }}
         shell: bash
         run: |
           set -euo pipefail
@@ -331,7 +328,16 @@ jobs:
             --json "$record" \
             "$assets"/*.apk "$assets"/*.aab "$assets"/*.tar.gz
 
+          # Only now, with the shipped bytes checked, does the run claim the
+          # release is verified.
           {
+            echo "## ✅ $RELEASE_TAG published and verified"
+            echo
+            echo "Release PR: $PR_URL"
+            echo "Tagged commit: \`$TARGET_SHA\`"
+            echo "Signed Android build: $RUN_URL"
+            echo "Linux release build: $LINUX_RUN_URL"
+            echo "Release: $RELEASE_URL"
             echo
             echo "### Cast containment verified in the published artifacts"
             echo

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ The full index of Linthra's docs. New to the project? Start with the
 | Streaming, buffering & recovery | [streaming.md](./streaming.md) |
 | Queue / Up Next | [queue.md](./queue.md) |
 | Offline cache & downloads | [offline-cache.md](./offline-cache.md) |
-| Cast / Chromecast | [cast.md](./cast.md) |
+| Cast / Chromecast | [cast.md](./cast.md) · [receiver trust](./cast-receiver-trust.md) · [what a handoff delegates](./cast-media-access.md) |
 | Remote control (drive Linthra from another app) | [remote-control.md](./remote-control.md) |
 | Android Auto | [android-auto.md](./android-auto.md) |
 | Playlists & safe removal | [playlists-and-delete.md](./playlists-and-delete.md) |
@@ -45,7 +45,7 @@ The full index of Linthra's docs. New to the project? Start with the
 | --- | --- |
 | Reporting a bug | [reporting-bugs.md](./reporting-bugs.md) |
 | Manual QA checklist | [manual-test-checklist.md](./manual-test-checklist.md) |
-| Release process & signing | [release-process.md](./release-process.md) · [signing](./release-signing.md) |
+| Release process & signing | [release-process.md](./release-process.md) · [signing](./release-signing.md) · [artifact verification](./release-artifact-verification.md) |
 | Dependency update bots | [dependency-updates.md](./dependency-updates.md) |
 | PR security surface guard | [pr-security-guard.md](./pr-security-guard.md) |
 | F-Droid readiness | [fdroid-readiness.md](./fdroid-readiness.md) |

--- a/docs/cast-media-access.md
+++ b/docs/cast-media-access.md
@@ -1,0 +1,115 @@
+# What a cast handoff delegates (least-privilege media access)
+
+When Linthra casts, it stops fetching the audio and tells a device on the
+network to fetch it instead. That device needs to be allowed to, so something is
+delegated. This page is what each supported server actually lets us delegate,
+what that costs, and what would have to change for a handoff to give a receiver
+no more than the one song it is playing. It tracks
+[#576](https://github.com/TheZupZup/Linthra/issues/576).
+
+This is defence in depth, not the fix. Narrowing what a receiver gets does not
+make an unauthenticated receiver safe to talk to — that is
+[#575](https://github.com/TheZupZup/Linthra/issues/575) and
+[cast-receiver-trust.md](cast-receiver-trust.md). Casting stays off in shipped
+builds until that lands.
+
+## The model in code
+
+`CastMediaAccess` (`lib/core/services/cast/cast_media_access.dart`) is how a
+source declares what casting one of its tracks hands over:
+
+- **`delegation`** — a `scopedCapability` (a signed or otherwise scoped URL good
+  for this item and nothing else), an `accountCredential` (the credential
+  itself, because that is all the server accepts), or `none`.
+- **`scope`** — how far it reaches if it is observed or kept: the single item, or
+  the whole account.
+- **`lifetime`** / **`revocableIndependently`** — whether the server bounds it,
+  and whether the user can revoke this access without invalidating their session
+  or changing their password.
+- **`summary`** — a short sentence safe to print anywhere. It describes a URL's
+  authority, never its contents.
+
+Each resolver declares its own (`JellyfinCastMediaResolver.access`,
+`SubsonicCastMediaResolver.access`), `CastMediaResolver.accessFor(track)` answers
+without resolving or touching the network, and resolved `CastMedia` carries the
+same answer. A source that declares nothing gets `CastMediaAccess.undeclared`,
+which reads as account-level exposure: an omission shows up as an overstatement,
+never as a quiet under-statement.
+
+`test/core/services/cast/cast_media_access_test.dart` holds the model to that,
+including the part that matters most — no source may claim a scoped capability
+its server does not issue.
+
+## What each server supports
+
+| Source | How a stream request is authenticated | Scoped alternative available? | What a receiver ends up holding |
+| --- | --- | --- | --- |
+| **Jellyfin** | The session access token, in the URL's `api_key`. A receiver cannot send headers, so the credential has to be in the URL. | Not in the stable API: no per-item signed URL, no scoped download token, no server-side expiry to request. | An account credential, good until the session ends. |
+| **Subsonic / Navidrome** | User name plus a salted token derived from the password, in the query, on every endpoint including streams. | Not through the Subsonic API. Navidrome has its own native API with shorter-lived tokens, but that is not the API Linthra speaks, and requiring it would break every other Subsonic server. | An account credential that does not expire on its own. |
+| **Plex** | The `X-Plex-Token` **header** — Linthra never puts it in a URL. Not wired for casting today. | Plex issues transient tokens, which bound the lifetime but are still account-scoped rather than per-item. | Would be a shorter-lived account credential, if casting ever routed through Plex. |
+| **Audiobookshelf** | Bearer token. Not wired for casting today. | Not evaluated; it would need its own review before a cast resolver exists. | n/a |
+| **On-device files** | Nothing: a receiver cannot reach a `file://` path, so these are not castable at all. | n/a | Nothing. |
+
+So today, for both servers Linthra can cast from, the honest answer is
+`accountCredential` / `account`. Saying otherwise — treating a token in a query
+string as a capability, or adding a client-side expiry the server does not
+enforce — would be inventing a restriction that only exists in our own code. A
+receiver does not check it, and an attacker does not either.
+
+Two things follow, and both are already true in the code:
+
+- **Nothing else in the handoff carries the credential.** It rides on the
+  `contentId` alone. Metadata does not carry it, `CastMedia.toString()` redacts
+  the URL to scheme/host/path, the diagnostics API has no field for a token or a
+  full URL, and error messages are generic by contract. Subsonic cover art is
+  omitted for exactly this reason: it would carry the same credential for no
+  playback benefit.
+- **No broader credential is ever introduced as a fallback.** If a source cannot
+  mint a castable URL, the track does not cast and the sheet says so. "Use the
+  account credential instead" is not an error path.
+
+## What would make this better
+
+**Per-provider, upstream.** The change that actually helps is server-side: a
+media endpoint that accepts a capability minted for one item, with an expiry and
+independent revocation. For Jellyfin and Subsonic that is a server feature
+request, not something a client can add. If either gains one, the work here is
+small: declare `scopedCapability` on that resolver, mint it in the resolver, and
+the model, tests and docs already have a place for it.
+
+**A media proxy on the device.** The app could stream from the server itself and
+re-serve to the receiver over the LAN, so the server credential never leaves the
+phone. It is a real option and it is not free:
+
+- the proxy is an HTTP server on the user's network, which needs its own
+  authentication — and the receiver has no way to authenticate to it, so
+  whatever guards it is per-session and unguessable at best;
+- it doubles the network traffic and keeps the phone awake for the whole track,
+  which is exactly the cost casting exists to avoid;
+- it needs a lifecycle: bound to the session, torn down on disconnect, on app
+  exit, and on a crash, with nothing left listening afterwards;
+- on Android it interacts with foreground-service and network-security policy.
+
+Per #576 this gets its own security and operational review **before** any
+implementation, not as part of a cast restoration. It is written down here so the
+option is not rediscovered as a shortcut later.
+
+**What is not on the table.** Client-side "restrictions" the server does not
+enforce; sending a credential to a receiver that has not been authenticated
+(regardless of scope); and weakening the model to keep a self-hosted deployment
+working. Where a server simply cannot do better, the answer is to document the
+limitation — as above — rather than pretend it away.
+
+## If a scoped capability is ever added
+
+Whatever mints it has to define, and test:
+
+- **expiry** — short, server-enforced, and long enough only for the track;
+- **revocation** — disconnecting or ending the session invalidates it, and the
+  user can revoke it without touching their password;
+- **cleanup** — nothing outlives the session: not in the catalog, not in a log,
+  not in app state, not on disk;
+- **redaction** — the same rule as today: the capability appears on exactly one
+  field, and never in metadata, diagnostics, errors, or `toString()`.
+
+And it still does not remove the receiver-authentication requirement.

--- a/docs/cast-media-access.md
+++ b/docs/cast-media-access.md
@@ -44,8 +44,8 @@ its server does not issue.
 
 | Source | How a stream request is authenticated | Scoped alternative available? | What a receiver ends up holding |
 | --- | --- | --- | --- |
-| **Jellyfin** | The session access token, in the URL's `api_key`. A receiver cannot send headers, so the credential has to be in the URL. | Not in the stable API: no per-item signed URL, no scoped download token, no server-side expiry to request. | An account credential, good until the session ends. |
-| **Subsonic / Navidrome** | User name plus a salted token derived from the password, in the query, on every endpoint including streams. | Not through the Subsonic API. Navidrome has its own native API with shorter-lived tokens, but that is not the API Linthra speaks, and requiring it would break every other Subsonic server. | An account credential that does not expire on its own. |
+| **Jellyfin** | The session access token, in the URL's `api_key`. A receiver cannot send headers, so the credential has to be in the URL. | Not in the stable API: no per-item signed URL, no scoped download token, no server-side expiry to request. | An account credential that keeps working until the server revokes it. Signing out of Jellyfin in Linthra forgets the token here; it does not ask the server to invalidate it, so a receiver that kept the URL is unaffected until the user revokes that device in Jellyfin. |
+| **Subsonic / Navidrome** | User name plus a salted token derived from the password, in the query, on every endpoint including streams. | Not through the Subsonic API. Navidrome has its own native API with shorter-lived tokens, but that is not the API Linthra speaks, and requiring it would break every other Subsonic server. | An account credential that does not expire on its own. It is derived from the password, so signing out here does not take it back either — only changing the password does. |
 | **Plex** | The `X-Plex-Token` **header** — Linthra never puts it in a URL. Not wired for casting today. | Plex issues transient tokens, which bound the lifetime but are still account-scoped rather than per-item. | Would be a shorter-lived account credential, if casting ever routed through Plex. |
 | **Audiobookshelf** | Bearer token. Not wired for casting today. | Not evaluated; it would need its own review before a cast resolver exists. | n/a |
 | **On-device files** | Nothing: a receiver cannot reach a `file://` path, so these are not castable at all. | n/a | Nothing. |
@@ -76,6 +76,16 @@ independent revocation. For Jellyfin and Subsonic that is a server feature
 request, not something a client can add. If either gains one, the work here is
 small: declare `scopedCapability` on that resolver, mint it in the resolver, and
 the model, tests and docs already have a place for it.
+
+**Revoking on sign-out.** Signing out of a server in Linthra is local: the
+credential is forgotten here, and the server is not asked to invalidate it. For
+a handoff that has already happened, that is the difference between "the
+receiver's copy stops working" and "it keeps working until the user goes and
+revokes the device themselves". Jellyfin can revoke a session server-side, so
+calling that on sign-out is a concrete, self-contained improvement — and a
+change to sign-out behaviour for every user, not only those who cast, so it
+belongs in its own change rather than riding along here. Subsonic has no
+equivalent: its credential is the password.
 
 **A media proxy on the device.** The app could stream from the server itself and
 re-serve to the receiver over the LAN, so the server credential never leaves the

--- a/docs/cast-receiver-trust.md
+++ b/docs/cast-receiver-trust.md
@@ -75,9 +75,11 @@ to reach a device.
 `test/core/services/cast/trust_gated_cast_transport_test.dart` covers the
 negative cases end to end: a refusal, a device that authenticates as a different
 device, a proof made over another connection, an authentication that never
-finishes, a session that drops or dies mid-handshake, a session that drops after
-a successful check, an authenticator that throws something unexpected, and a
-receiver that will not close cleanly or at all. Each one ends with the session
+finishes, a session that drops or dies mid-handshake, a session that drops in
+the gap between the check and the handoff, an authenticator that throws — before
+or after returning its future — and a receiver that will not close cleanly or at
+all. A readiness error becomes a clean "not ready" rather than an unhandled
+error escaping into the service. Each one ends with the session
 closed and nothing loaded, and no refusal message carries anything from the
 handshake.
 

--- a/docs/cast-receiver-trust.md
+++ b/docs/cast-receiver-trust.md
@@ -63,9 +63,12 @@ protocol rather than about the app's plumbing:
   refusal back); every outbound operation — the media handoff and the transport
   controls alike — refuses again on its own; and trust ends with the connection
   it was proved over, whether that is a close from here or the receiver
-  dropping. Only teardown stays ungated. `DefaultCastService` surfaces a refusal's own message
-  rather than a generic "couldn't connect", so a security refusal does not read
-  as a flaky network.
+  dropping. Only teardown stays ungated. The gate also owns the wording: a
+  refusal keeps its `CastTrustFailureKind` and nothing else, so nothing an
+  authenticator wrote into a message — possibly built from what the receiver
+  said — can reach the sheet. `DefaultCastService` surfaces that message rather
+  than a generic "couldn't connect", so a security refusal does not read as a
+  flaky network.
 
 Neither is wired into production, and neither restores casting. Containment
 still comes first in every path: the gate authenticates over a connection the

--- a/docs/cast-receiver-trust.md
+++ b/docs/cast-receiver-trust.md
@@ -80,13 +80,12 @@ to reach a device.
 negative cases end to end: a refusal, a device that authenticates as a different
 device, a proof made over another connection, an authentication that never
 finishes, a session that drops or dies mid-handshake, a session that drops in
-the gap between the check and the handoff, an authenticator that throws — before
-or after returning its future — and a receiver that will not close cleanly or at
-all — including one that throws before it returns a future at all. A readiness
-error becomes a clean "not ready" rather than an unhandled error escaping into
-the service. Each one ends with the session
-closed and nothing loaded, and no refusal message carries anything from the
-handshake.
+the gap between the check and the handoff, and a receiver that will not close
+cleanly, will not close at all, or throws on the way. An authenticator that
+throws counts either way — before or after it returns its future — and a
+readiness error becomes a clean "not ready" rather than an unhandled error
+escaping into the service. Each case ends with the session closed and nothing
+loaded, and no refusal message carries anything from the handshake.
 
 ## Choosing an implementation
 

--- a/docs/cast-receiver-trust.md
+++ b/docs/cast-receiver-trust.md
@@ -1,0 +1,140 @@
+# Receiver trust (what has to be true before casting comes back)
+
+Casting is switched off in shipped builds while a reported security issue is
+resolved ([cast.md](cast.md#temporary-containment)). This page is the public
+half of what restoring it requires: the trust model, the contract the code
+already enforces, the implementation choices on the table, and the tests that
+have to pass. It tracks
+[#575](https://github.com/TheZupZup/Linthra/issues/575).
+
+The report itself, the assessment of any specific implementation, and the
+protocol-level evidence stay in the private security advisory until coordinated
+disclosure. If you are picking this work up, ask for advisory access rather than
+reconstructing the details from the code or from this page.
+
+## The trust model
+
+Casting means telling a device on the network to fetch a stream and play it. Two
+separate questions decide whether that is safe, and answering one does not answer
+the other:
+
+1. **Who is the receiver?** A name and an address on a LAN are not an identity.
+   mDNS discovery is unauthenticated: anything on the network can answer to a
+   friendly name. Until the device proves cryptographically that it is the one
+   the user picked, the app is talking to "whatever answered".
+2. **What does the receiver get?** Whatever URL is handed over carries some
+   authority on the user's music server. Narrowing that is
+   [#576](https://github.com/TheZupZup/Linthra/issues/576) and
+   [cast-media-access.md](cast-media-access.md) — an additional layer, never a
+   substitute for this one. A scoped URL handed to an unauthenticated device is
+   still a handoff to an unknown device.
+
+So the rule the app enforces is: **no verified identity, no session, no media.**
+
+Google Cast has a device-authentication step for exactly question 1: receivers
+carry a manufacturer certificate chaining to a Cast root, and a sender
+challenges the device over the `deviceauth` namespace and verifies the response
+against that chain and the connection it arrived on. A sender that opens a
+connection and starts sending media without completing that step has not
+identified anything. Whether a given implementation does it, and what it does
+with the result, is what the advisory review covers.
+
+## What is already in the tree
+
+Two pieces of the restoration are built and tested now, deliberately ahead of
+the implementation choice, so that reviewing the eventual transport is about the
+protocol rather than about the app's plumbing:
+
+- **`CastReceiverAuthenticator`** (`lib/core/services/cast/cast_receiver_trust.dart`)
+  — the contract. It returns a `CastReceiverIdentity` bound to the device that
+  was checked, or throws. An inconclusive check (timeout, dropped connection,
+  an implementation that throws something unexpected) is a failure, never a
+  pass. The shipped implementation is `UnverifiedCastReceiverAuthenticator`,
+  which refuses every receiver, because nothing here can yet prove one.
+- **`TrustGatedCastTransport`** (`lib/core/services/cast/trust_gated_cast_transport.dart`)
+  — the readiness boundary. It wraps a `CastTransport`: a session is only handed
+  out after the receiver authenticated *and* the identity matches the device the
+  user picked; any failure closes the session; the media handoff refuses again
+  on its own; trust does not survive the session closing.
+
+Neither is wired into production, and neither restores casting. Containment
+still comes first in every path: the gate authenticates over a connection the
+delegate opened, so a contained transport refuses before trust is even asked
+about — there is a test for exactly that, so the gate cannot become a second way
+to reach a device.
+
+`test/core/services/cast/trust_gated_cast_transport_test.dart` covers the
+negative cases end to end: a refusal, a device that authenticates as a different
+device, an authentication that never finishes, a session that dies
+mid-handshake, an authenticator that throws something unexpected, and a receiver
+that will not close cleanly. Each one ends with the session closed and nothing
+loaded, and no refusal message carries anything from the handshake.
+
+## Choosing an implementation
+
+The restoration needs something that actually performs the handshake. The
+options, with the trade-offs that matter for Linthra:
+
+| Option | Why it might work | What it costs |
+| --- | --- | --- |
+| **Auditable fork of the pure-Dart Cast client** | Keeps the current architecture: no Google Play Services, no proprietary SDK, so F-Droid and sideloaded builds stay identical. The protocol code already exists. | We own the crypto review, the pinned Cast root certificates, and the maintenance. Fork provenance and update path have to be part of the review. |
+| **Upstream contribution to the existing package** | Same as above, and the fix helps every other app using it. | Depends on upstream's timeline, which the restoration cannot. Reasonable to pursue in parallel, not to wait on. |
+| **Narrowly scoped replacement** | Only the pieces Linthra uses (discover, connect, authenticate, load, status, volume), with authentication mandatory rather than optional, and a much smaller surface to review. | The most work up front, and the protocol details have to be right. |
+| **Google's Cast SDK via a platform plugin** | Google maintains the trust model. | Requires Play Services and proprietary components: it would break the F-Droid build and the "same app everywhere" property. Not acceptable for Linthra as it stands. |
+
+Whichever is chosen, the review has to cover: the trust anchors used to validate
+a receiver certificate and how they are updated; protocol compatibility with
+supported devices; the dependency's provenance (publisher, pinning in
+`pubspec.lock`, and — if vendored — placement under `third_party/` with the
+license audit in [dependency-license-audit.md](dependency-license-audit.md));
+and which platforms it actually supports.
+
+## Tests the restoration has to pass
+
+**Negative, in CI, with controlled fixtures.** Never with real credentials, real
+device certificates, or anything pulled from the private report:
+
+- a receiver presenting no certificate, an untrusted chain, an expired
+  certificate, or a chain for a different device;
+- a valid response replayed from another handshake or another challenge;
+- a receiver that completes the TLS connection and then never answers the
+  challenge;
+- a receiver that changes identity between selection and handoff, or a
+  connection that is swapped underneath a pending session;
+- cancellation: the user backing out, picking another device, or the app being
+  backgrounded mid-handshake.
+
+The boundary tests already in the tree are the app-side half of this list; the
+protocol-side half arrives with the implementation.
+
+**Positive, on real hardware.** A device is the only thing that proves
+interoperability: at least one Chromecast-class dongle, one Cast-enabled speaker,
+and one Cast-enabled TV, covering connect, handoff, transport controls, volume,
+disconnect, and the receiver dropping mid-playback. Results go in the advisory,
+not in a public PR description.
+
+## Restoration checklist
+
+Restoring casting is one reviewed change, not a revert. It has to:
+
+- [ ] land a real `CastReceiverAuthenticator` and the transport that performs the
+      handshake, reviewed in the advisory;
+- [ ] put the trust gate in front of the live transport in the production
+      wiring, with no path around it and no runtime flag that skips it;
+- [ ] flip `CastContainment.isActive` and update the production wiring, the
+      transport guards, `scripts/check_cast_containment.py` and
+      `scripts/verify_release_containment.py` together — the containment
+      markers describe a contained build, so after restoration they describe
+      nothing;
+- [ ] pass the negative tests above in CI and the device matrix by hand;
+- [ ] re-check the media handoff against
+      [cast-media-access.md](cast-media-access.md), so the restored path does not
+      quietly widen what a receiver is given;
+- [ ] offer the reporter a review through the advisory before production
+      availability returns;
+- [ ] ship as its own release, separate from the containment release recorded in
+      [release-artifact-verification.md](release-artifact-verification.md).
+
+Until every box is ticked, the safeguard stays. A partially reviewed
+restoration, a debug-only bypass, or a "temporarily re-enable to test on a
+device" flag are all the same thing as shipping it.

--- a/docs/cast-receiver-trust.md
+++ b/docs/cast-receiver-trust.md
@@ -60,9 +60,10 @@ protocol rather than about the app's plumbing:
   out after the receiver authenticated *and* the identity matches both the
   device the user picked and the session it will use; any failure closes the
   session (with a bounded cleanup, so an unresponsive receiver cannot hold the
-  refusal back); the media handoff refuses again on its own; and trust ends with
-  the connection it was proved over, whether that is a close from here or the
-  receiver dropping. `DefaultCastService` surfaces a refusal's own message
+  refusal back); every outbound operation — the media handoff and the transport
+  controls alike — refuses again on its own; and trust ends with the connection
+  it was proved over, whether that is a close from here or the receiver
+  dropping. Only teardown stays ungated. `DefaultCastService` surfaces a refusal's own message
   rather than a generic "couldn't connect", so a security refusal does not read
   as a flaky network.
 

--- a/docs/cast-receiver-trust.md
+++ b/docs/cast-receiver-trust.md
@@ -46,16 +46,25 @@ the implementation choice, so that reviewing the eventual transport is about the
 protocol rather than about the app's plumbing:
 
 - **`CastReceiverAuthenticator`** (`lib/core/services/cast/cast_receiver_trust.dart`)
-  — the contract. It returns a `CastReceiverIdentity` bound to the device that
-  was checked, or throws. An inconclusive check (timeout, dropped connection,
-  an implementation that throws something unexpected) is a failure, never a
-  pass. The shipped implementation is `UnverifiedCastReceiverAuthenticator`,
-  which refuses every receiver, because nothing here can yet prove one.
+  — the contract. It is handed the session to check, and returns a
+  `CastReceiverIdentity` naming both the device and that connection, or throws.
+  The connection half matters: Cast's device authentication is a challenge
+  answered on a connection, so a proof gathered anywhere else describes a
+  different conversation than the one the media would go to. An inconclusive
+  check (timeout, dropped connection, an implementation that throws something
+  unexpected) is a failure, never a pass. The shipped implementation is
+  `UnverifiedCastReceiverAuthenticator`, which refuses every receiver, because
+  nothing here can yet prove one.
 - **`TrustGatedCastTransport`** (`lib/core/services/cast/trust_gated_cast_transport.dart`)
   — the readiness boundary. It wraps a `CastTransport`: a session is only handed
-  out after the receiver authenticated *and* the identity matches the device the
-  user picked; any failure closes the session; the media handoff refuses again
-  on its own; trust does not survive the session closing.
+  out after the receiver authenticated *and* the identity matches both the
+  device the user picked and the session it will use; any failure closes the
+  session (with a bounded cleanup, so an unresponsive receiver cannot hold the
+  refusal back); the media handoff refuses again on its own; and trust ends with
+  the connection it was proved over, whether that is a close from here or the
+  receiver dropping. `DefaultCastService` surfaces a refusal's own message
+  rather than a generic "couldn't connect", so a security refusal does not read
+  as a flaky network.
 
 Neither is wired into production, and neither restores casting. Containment
 still comes first in every path: the gate authenticates over a connection the
@@ -65,10 +74,12 @@ to reach a device.
 
 `test/core/services/cast/trust_gated_cast_transport_test.dart` covers the
 negative cases end to end: a refusal, a device that authenticates as a different
-device, an authentication that never finishes, a session that dies
-mid-handshake, an authenticator that throws something unexpected, and a receiver
-that will not close cleanly. Each one ends with the session closed and nothing
-loaded, and no refusal message carries anything from the handshake.
+device, a proof made over another connection, an authentication that never
+finishes, a session that drops or dies mid-handshake, a session that drops after
+a successful check, an authenticator that throws something unexpected, and a
+receiver that will not close cleanly or at all. Each one ends with the session
+closed and nothing loaded, and no refusal message carries anything from the
+handshake.
 
 ## Choosing an implementation
 

--- a/docs/cast-receiver-trust.md
+++ b/docs/cast-receiver-trust.md
@@ -82,8 +82,9 @@ device, a proof made over another connection, an authentication that never
 finishes, a session that drops or dies mid-handshake, a session that drops in
 the gap between the check and the handoff, an authenticator that throws — before
 or after returning its future — and a receiver that will not close cleanly or at
-all. A readiness error becomes a clean "not ready" rather than an unhandled
-error escaping into the service. Each one ends with the session
+all — including one that throws before it returns a future at all. A readiness
+error becomes a clean "not ready" rather than an unhandled error escaping into
+the service. Each one ends with the session
 closed and nothing loaded, and no refusal message carries anything from the
 handshake.
 

--- a/docs/cast.md
+++ b/docs/cast.md
@@ -148,6 +148,14 @@ runs in CI, is a much weaker tripwire on top of that — it matches source patte
 and only catches the obvious removals it knows about. Its limitations are written
 down in the script itself; it is not evidence that casting cannot be reached.
 
+Both of those look at the source tree. A release also has to answer a different
+question — is the safeguard in the file people actually install? — so
+`scripts/verify_release_containment.py` reads the compiled Dart inside the built
+APK/AAB/tarball, and the release workflows run it before an artifact is uploaded
+and again on the published assets. The shipped `v0.2.6` artifacts and their
+SHA-256 digests are recorded in
+[release-artifact-verification.md](release-artifact-verification.md).
+
 In the app, the cast button stays visible but muted and the sheet says casting is
 temporarily unavailable — it does not claim the platform is unsupported, which
 would be untrue on the phones this affects.
@@ -159,6 +167,12 @@ tracked publicly in [#575](https://github.com/TheZupZup/Linthra/issues/575), and
 in detail in the private advisory, which is where that work is reviewed before
 anything is restored. [#576](https://github.com/TheZupZup/Linthra/issues/576) is
 an additional layer, not a substitute for it.
+
+The trust model, the contract already in the tree (`CastReceiverAuthenticator`
+and the fail-closed `TrustGatedCastTransport`), the implementation options and
+the test matrix are in
+[cast-receiver-trust.md](cast-receiver-trust.md). What a handoff delegates to a
+receiver, per server, is in [cast-media-access.md](cast-media-access.md).
 
 The reviewed restoration updates `CastContainment`, the production wiring, the
 transport guards, and `scripts/check_cast_containment.py` in one pull request.
@@ -191,6 +205,13 @@ freshly minted URL that never lands in `Track`, the catalog, a log, or app state
 - **Artwork follows the same rule**: a tokenised cover-art URL is never sent.
   Jellyfin's cover art is token-free (sent); Subsonic's needs the credential
   (omitted).
+
+How much authority that one field carries is a property of the server, not a
+choice: neither Jellyfin nor Subsonic issues a per-item capability, so the URL a
+receiver is given is backed by an account credential. Each source declares that
+in code (`CastMediaAccess`), so it can be stated rather than assumed — see
+[cast-media-access.md](cast-media-access.md) for the per-server matrix and what
+would have to change.
 
 ## Resilience while casting
 

--- a/docs/release-artifact-verification.md
+++ b/docs/release-artifact-verification.md
@@ -69,7 +69,7 @@ exit non-zero rather than reporting a pass.
 | When | Where | What it checks |
 | --- | --- | --- |
 | Every PR and push | `ci.yml` ▸ *Cast containment markers* | The verifier's own unit tests (`test/tooling/verify_release_containment_test.py`), on synthetic artifacts, so a change that stops it catching an uncontained build is caught here. |
-| Every release build | `android-release-build.yml` ▸ *Verify the built artifacts carry the Cast containment* | The APK/AAB in `dist/`, before they are uploaded anywhere. |
+| Every release build | `android-release-build.yml` ▸ *Verify the built artifacts carry the Cast containment* | The APK/AAB in `dist/`, before they are uploaded anywhere. A run rebuilding a tag from before this check existed says so with a warning instead of failing on a script that tag never had. |
 | Every Linux release build | `linux-desktop-build.yml` ▸ *Verify the archive carries the Cast containment* | The `.tar.gz`, before it is attached to the Release — the Release is already public by then, so an artifact that fails the check must never become downloadable from it. |
 | Stable publication | `publish-stable-release.yml` ▸ *Verify the published artifacts carry the Cast containment* | The assets downloaded back from the published GitHub Release, with every SHA-256 written into the job summary. |
 

--- a/docs/release-artifact-verification.md
+++ b/docs/release-artifact-verification.md
@@ -69,8 +69,17 @@ exit non-zero rather than reporting a pass.
 | When | Where | What it checks |
 | --- | --- | --- |
 | Every PR and push | `ci.yml` ▸ *Cast containment markers* | The verifier's own unit tests (`test/tooling/verify_release_containment_test.py`), on synthetic artifacts, so a change that stops it catching an uncontained build is caught here. |
-| Every release build | `android-release-build.yml` ▸ *Verify the built artifacts carry the Cast containment* | The APK/AAB in `dist/`, before they are uploaded anywhere. A run rebuilding a tag from before this check existed says so with a warning instead of failing on a script that tag never had. |
+| Every release build | `android-release-build.yml` ▸ *Verify the built artifacts carry the Cast containment* | The APK/AAB in `dist/`, before they are uploaded anywhere. |
 | Every Linux release build | `linux-desktop-build.yml` ▸ *Verify the archive carries the Cast containment* | The `.tar.gz`, before it is attached to the Release — the Release is already public by then, so an artifact that fails the check must never become downloadable from it. |
+
+Both release builds check out the tag they are building, so the script itself
+comes from a second, script-only checkout of the revision the workflow is
+running from, and `--containment-source` points it at the *built* tree's
+`cast_containment.dart`. That way rebuilding an existing release is still
+verified, against that release's own message, even though its tree predates the
+verifier. The one case with nothing to check is a tag from before the
+containment existed at all: there the step says so and continues, because those
+artifacts never carried a message to look for.
 | Stable publication | `publish-stable-release.yml` ▸ *Verify the published artifacts carry the Cast containment* | The assets downloaded back from the published GitHub Release, with every SHA-256 written into the job summary. |
 
 The source-level tripwire (`scripts/check_cast_containment.py`, also in `ci.yml`)

--- a/docs/release-artifact-verification.md
+++ b/docs/release-artifact-verification.md
@@ -1,0 +1,133 @@
+# Verifying a release's artifacts
+
+A green CI run says the *tree* was in the state we think it was. It does not say
+the file a user installs was built from that tree. For an ordinary release that
+gap is theoretical. For a security maintenance release it is the whole point: the
+release exists to put a safeguard on people's phones, so "the safeguard is in the
+distributed binary" has to be checked against the binary.
+
+This page is how that check is run, what it is worth, and the record of the
+releases it has been run on. The safeguard in question is the Cast security
+containment — casting is withheld from shipped builds while a reported security
+issue is resolved. See [cast.md](cast.md#temporary-containment); the report
+itself stays in the private advisory.
+
+## The check
+
+`scripts/verify_release_containment.py` reads an APK, an AAB, or the Linux
+tarball, pulls out every compiled Dart payload inside it (`libapp.so`, one per
+ABI on Android), and searches those bytes for:
+
+- **the containment message**, exactly as `CastContainment.userMessage` spells it
+  in the checkout the script runs from. It is a compile-time constant reached
+  only through the contained production wiring, so it is compiled into the
+  snapshot while containment holds and folded away when it does not;
+- **`UnavailableCastService`**, the service the contained wiring binds; and
+- **the absence** of `DefaultCastService`, `ChromecastCastTransport`, and the
+  Cast protocol namespaces the live transport talks. Nothing constructs them
+  while containment holds, so tree shaking drops them.
+
+It prints each artifact's SHA-256, and `--json` writes the same record to a file.
+
+Run it on a published release like this:
+
+```sh
+gh release download v0.2.6 --repo TheZupZup/Linthra --dir /tmp/linthra-v0.2.6
+python3 scripts/verify_release_containment.py \
+  --json /tmp/linthra-v0.2.6/containment.json \
+  /tmp/linthra-v0.2.6/*.apk /tmp/linthra-v0.2.6/*.aab /tmp/linthra-v0.2.6/*.tar.gz
+```
+
+Run it from a checkout of the commit the release was built from: the expected
+message is read from that checkout's `cast_containment.dart`, so checking an old
+release from today's `main` compares against today's copy.
+
+### What it proves, and what it does not
+
+It is a byte search over a compiled snapshot. What a green run really says is
+"this artifact was built from a tree whose containment constants were still
+reachable, and it carries none of the live-cast strings we know to look for". It
+cannot see a bypass that leaves every string in place, anything outside the Dart
+snapshot (platform channels, native libraries, a plugin's own Java/Kotlin), or
+whether an absent string is absent because the code is gone or because this build
+stored it differently.
+
+The behavioural evidence is still the test suite —
+`test/app/production_cast_containment_test.dart` drives the real production
+wiring per platform, and `test/core/services/cast/cast_containment_test.dart`
+calls the transport directly — at the commit the artifact is built from. What
+this script adds is the one thing those cannot give: it looks at the file that is
+actually distributed, so a release built from some other tree, or an artifact
+swapped after the fact, does not pass quietly.
+
+It fails closed. An artifact with no readable Dart payload, an unknown file type,
+an unreadable archive, or a message it cannot parse out of the Dart source all
+exit non-zero rather than reporting a pass.
+
+## Where it runs
+
+| When | Where | What it checks |
+| --- | --- | --- |
+| Every PR and push | `ci.yml` ▸ *Cast containment markers* | The verifier's own unit tests (`test/tooling/verify_release_containment_test.py`), on synthetic artifacts, so a change that stops it catching an uncontained build is caught here. |
+| Every release build | `android-release-build.yml` ▸ *Verify the built artifacts carry the Cast containment* | The APK/AAB in `dist/`, before they are uploaded anywhere. |
+| Stable publication | `publish-stable-release.yml` ▸ *Verify the published artifacts carry the Cast containment* | The assets downloaded back from the published GitHub Release, with every SHA-256 written into the job summary. |
+
+The source-level tripwire (`scripts/check_cast_containment.py`, also in `ci.yml`)
+is unchanged and still the first line: it greps the tree for the markers of the
+three containment layers. This is its artifact-level twin, not its replacement.
+
+## Record: `v0.2.6` (security maintenance release)
+
+The containment landed in `fix(cast): disable casting in production pending a
+security fix (#572, #573)` (PR #577) and shipped in `v0.2.6`, which also carried
+the Linux and Android work already on `main`. No feature work was added to the
+release for its own sake.
+
+| Field | Value |
+| --- | --- |
+| Tag | `v0.2.6` |
+| Commit | `f1d61f982b87665a95a447b47b49aa7fbf8aa046` |
+| Version | `0.2.6+206999` (`pubspec.yaml`, mirrored by `AppInfo._devVersionName`) |
+| Published | 2026-09-08 |
+| Release notes | [docs/release-notes/v0.2.6.md](release-notes/v0.2.6.md) |
+
+Every published asset was downloaded from the Release and verified with the
+script above. Digests are of the assets as published:
+
+| Asset | Bytes | SHA-256 |
+| --- | --- | --- |
+| `linthra-v0.2.6-release-signed.apk` | 69433151 | `3926bc77dc48a9ade7ed8d23c0f51c6072ae6c71e2a10baec3195a92667cfc6d` |
+| `linthra-v0.2.6-release-signed.aab` | 66113660 | `97616d6b49fd43b2a856773ce496f24c4c461f37c8dc6dcd4dc7a98fe9ea707d` |
+| `linthra-v0.2.6-arm64-v8a-release-signed.apk` | 24680721 | `a842079d61a4762c8cf02ea9f25005d11c562c3c7cfc074ebdf56e4fc4487c6a` |
+| `linthra-v0.2.6-armeabi-v7a-release-signed.apk` | 22549117 | `8b7646b879a802bbab40ce3effd044c149e8b1a973aff73da3ba707d25f325e5` |
+| `linthra-v0.2.6-x86_64-release-signed.apk` | 26244309 | `b8e80a7761952ea6d450e814c1940b187b288907ff6306ea4797ba799f3a6015` |
+| `Linthra-v0.2.6-linux-x64.tar.gz` | 13243680 | `bd27149460c17effb7cc94182a9fe7f4cbdcac7335231c1f20e891ee15571f50` |
+
+Payloads checked: `lib/{arm64-v8a,armeabi-v7a,x86_64}/libapp.so` in the universal
+APK, the matching single payload in each per-ABI APK, `base/lib/<abi>/libapp.so`
+in the AAB, and `Linthra-v0.2.6-linux-x64/lib/libapp.so` in the Linux bundle.
+Every one carries the containment message and `UnavailableCastService`, and none
+carries a live-cast marker.
+
+### Distribution channels
+
+| Channel | State |
+| --- | --- |
+| GitHub Release | Published, assets verified above. |
+| F-Droid | F-Droid builds `v0.2.6` from source on its own infrastructure and signs with its own key, picked up automatically (`UpdateCheckMode: Tags` + `AutoUpdateMode: Version`; `metadata/io.github.thezupzup.linthra.yml` names `0.2.6` / `2069993`). It is on F-Droid's build cycle, not ours, so confirm the published version on f-droid.org rather than assuming the tag is enough. An F-Droid APK is built from the same tagged source as the verified GitHub asset, but is a different binary — verify it there by version, not by the digests above. |
+| Google Play (closed testing) | Only ever receives the release-signed AAB from a tagged build, and only a non-production track (`google-play-publishing.md`). |
+
+The user-facing message, the disclosure timing, and any credential-rotation
+guidance are coordinated in the private advisory. Nothing in this repository
+claims that exploitation or credential theft occurred; there is no evidence of
+either, and saying otherwise without it would be its own harm.
+
+## When containment is lifted
+
+The reviewed restoration ([#575](https://github.com/TheZupZup/Linthra/issues/575))
+changes `CastContainment`, the production wiring, the transport guards and
+`scripts/check_cast_containment.py` in one pull request. It must update this
+verifier too — its markers describe a contained build, so after restoration they
+describe nothing. That edit is one of the signals a reviewer should look for, the
+same way the tripwire's is. Until then, an artifact that does not verify is not
+published.

--- a/docs/release-artifact-verification.md
+++ b/docs/release-artifact-verification.md
@@ -70,6 +70,7 @@ exit non-zero rather than reporting a pass.
 | --- | --- | --- |
 | Every PR and push | `ci.yml` ▸ *Cast containment markers* | The verifier's own unit tests (`test/tooling/verify_release_containment_test.py`), on synthetic artifacts, so a change that stops it catching an uncontained build is caught here. |
 | Every release build | `android-release-build.yml` ▸ *Verify the built artifacts carry the Cast containment* | The APK/AAB in `dist/`, before they are uploaded anywhere. |
+| Every Linux release build | `linux-desktop-build.yml` ▸ *Verify the archive carries the Cast containment* | The `.tar.gz`, before it is attached to the Release — the Release is already public by then, so an artifact that fails the check must never become downloadable from it. |
 | Stable publication | `publish-stable-release.yml` ▸ *Verify the published artifacts carry the Cast containment* | The assets downloaded back from the published GitHub Release, with every SHA-256 written into the job summary. |
 
 The source-level tripwire (`scripts/check_cast_containment.py`, also in `ci.yml`)

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -716,6 +716,7 @@ consume our signed artifacts:
 | Release APK/AAB build | **Manual** (`workflow_dispatch`) **and automatic on `v*` tags** (`android-release-build.yml`). |
 | Preparing the version-bump PR (pubspec, in-app mirror, Fastlane changelog, F-Droid `CurrentVersion`) | **Manual** (`workflow_dispatch`, `prepare-release-bump.yml`); opens a draft PR but never tags, builds, or publishes. The same edits are reproducible locally with `scripts/prepare_release_bump.py`. |
 | Verifying the tag matches `pubspec.yaml` (versionName/versionCode) | **Automatic** on a `v*` tag build (`scripts/release_preflight.sh`, encoding-checked against `tool/version_from_tag.dart`); fails fast on a mismatch and the workflow summary explicitly says "Version mismatch: release was not built." so it is not confused with an APK build failure. The same script is intended to be run locally before tagging (§3 step 9). Both manual and tag builds take the version from `pubspec.yaml`. |
+| Verifying the shipped artifacts carry the Cast containment | **Automatic**: on every release build (`android-release-build.yml`, before the artifacts are uploaded) and again on the published assets during a stable publication (`publish-stable-release.yml`, which records every SHA-256 in the job summary). Local twin: `python3 scripts/verify_release_containment.py dist/*.apk dist/*.aab`. See [release-artifact-verification.md](./release-artifact-verification.md). |
 | Attaching APK/AAB to a Release | **Automatic** on a `v*` tag build. Alpha/beta/rc tags attach (debug- or release-signed) to a **pre-release**; stable tags attach **release-signed** assets to an existing Release only. |
 | Linux `.tar.gz` build + attach to a Release | **Automatic**, via `workflow_dispatch` (`linux-desktop-build.yml` `release_tag` input, job `package-linux-release`) — see §4a. `publish-stable-release.yml` dispatches it for every stable release; `android-release-build.yml`'s `attach-release` job dispatches it for a directly-pushed alpha/beta/rc tag. Not wired to `push: tags` or `release: published` — a `GITHUB_TOKEN`-authored tag push/Release doesn't reliably start either. |
 | Creating a GitHub **pre-release** (alpha/beta/rc) | **Automatic** on the tag build if no Release exists yet (placeholder notes; edit afterwards). |
@@ -823,6 +824,9 @@ See [fdroid-readiness.md](./fdroid-readiness.md) for the broader F-Droid status.
 
 - [docs/release-signing.md](./release-signing.md) — signing keys, CI secrets,
   rotation.
+- [docs/release-artifact-verification.md](./release-artifact-verification.md) —
+  checking a published artifact actually carries the Cast security containment,
+  and the recorded digests per release.
 - [docs/fdroid-readiness.md](./fdroid-readiness.md) — F-Droid submission checklist.
 - [docs/fdroid-build-recipe.md](./fdroid-build-recipe.md) — F-Droid build recipe.
 - [docs/dependency-license-audit.md](./dependency-license-audit.md) — dependency

--- a/lib/core/models/cast_media.dart
+++ b/lib/core/models/cast_media.dart
@@ -1,14 +1,20 @@
+import '../services/cast/cast_media_access.dart';
+
 /// A track resolved into something a cast receiver (e.g. a Chromecast) can
 /// fetch and play. The receiver pulls the bytes itself over the network, so
 /// [url] must be a reachable `http`/`https` URL — never a `file://` path, which
 /// is why on-device files cannot be cast.
 ///
-/// Security: [url] may embed a short-lived access token in its query (a
-/// Jellyfin stream URL does). It is resolved on demand at cast time, handed
-/// straight to the cast session, and never persisted. [toString] redacts the
-/// query and any userinfo so the URL cannot leak into a log or error message —
-/// only the host and path survive, mirroring how [JellyfinSession] redacts its
-/// token.
+/// Security: [url] may embed an access token in its query (a Jellyfin stream URL
+/// does). It is resolved on demand at cast time, handed straight to the cast
+/// session, and never persisted. [toString] redacts the query and any userinfo
+/// so the URL cannot leak into a log or error message — only the host and path
+/// survive, mirroring how [JellyfinSession] redacts its token.
+///
+/// [access] says what that URL actually delegates: a capability for this one
+/// item, or an account credential the receiver could reuse. It is the source's
+/// own declaration, so the handoff can be described honestly rather than assumed
+/// harmless (see [CastMediaAccess] and docs/cast-media-access.md).
 class CastMedia {
   const CastMedia({
     required this.url,
@@ -18,6 +24,7 @@ class CastMedia {
     this.album,
     this.duration,
     this.artworkUrl,
+    this.access = CastMediaAccess.undeclared,
   });
 
   /// The reachable media URL the receiver fetches. May carry an access token in
@@ -36,6 +43,11 @@ class CastMedia {
   /// length immediately instead of waiting to probe the stream. Null (or zero)
   /// when unknown, in which case the receiver derives it from the stream.
   final Duration? duration;
+
+  /// What handing [url] to a receiver delegates, as declared by the source that
+  /// minted it. Defaults to [CastMediaAccess.undeclared] — the widest reading —
+  /// so a source that says nothing is never mistaken for a safe one.
+  final CastMediaAccess access;
 
   /// A token-free artwork URL for the receiver to show while playing, or null.
   /// Jellyfin's primary-image URL needs no auth, so it is safe to send as-is.

--- a/lib/core/services/cast/cast_media_access.dart
+++ b/lib/core/services/cast/cast_media_access.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/foundation.dart';
+
+/// What a source hands to a receiver so it can fetch the bytes.
+///
+/// A cast handoff is a delegation: the phone stops fetching the audio and tells
+/// a device on the network to fetch it instead, which means giving that device
+/// whatever it needs to be allowed to. How *much* it needs is not Linthra's
+/// choice alone — it is whatever the music server is willing to issue.
+enum CastMediaDelegation {
+  /// A capability minted for this one piece of media: a signed or otherwise
+  /// scoped URL that lets the bearer fetch this item and nothing else, and that
+  /// stops working on its own. This is the shape least privilege wants.
+  scopedCapability,
+
+  /// The account credential itself, carried in the URL because that is the only
+  /// authentication the server's stream endpoint accepts. Anyone holding the URL
+  /// holds an account credential, not a permission to play one song.
+  accountCredential,
+
+  /// Nothing is delegated, because nothing is handed over — an on-device file
+  /// has no URL a receiver could fetch at all.
+  none,
+}
+
+/// How much a delegated capability reaches.
+enum CastMediaScope {
+  /// The one item being cast.
+  singleItem,
+
+  /// Everything the signed-in account can reach on that server.
+  account,
+
+  /// Nothing.
+  nothing,
+}
+
+/// What casting one track actually hands over, per source.
+///
+/// This exists because "the URL has a token in it" is not a security model, and
+/// [#576](https://github.com/TheZupZup/Linthra/issues/576) is about being honest
+/// about the difference between the delegation a provider *supports* and the one
+/// Linthra is *forced* into. Declaring it in code — next to the resolver that
+/// mints the URL, checked by tests — means a new source cannot quietly widen the
+/// exposure, and the app can eventually tell a user what a handoff costs.
+///
+/// It carries no secret: it describes a URL's authority, never its contents.
+/// See docs/cast-media-access.md for the per-provider matrix and what each
+/// server would have to add for [CastMediaDelegation.scopedCapability] to become
+/// available.
+@immutable
+class CastMediaAccess {
+  const CastMediaAccess({
+    required this.delegation,
+    required this.scope,
+    required this.summary,
+    this.lifetime,
+    this.revocableIndependently = false,
+  });
+
+  /// The fail-safe default, used when nothing has declared otherwise: assume the
+  /// widest exposure a source could have. A resolver that forgets to describe
+  /// itself is treated as handing over an account credential rather than as
+  /// harmless, so the mistake shows up as an overstatement, never as a quiet
+  /// under-statement.
+  static const CastMediaAccess undeclared = CastMediaAccess(
+    delegation: CastMediaDelegation.accountCredential,
+    scope: CastMediaScope.account,
+    summary:
+        'No source declared what this handoff delegates, so it is treated as '
+        'handing the receiver account-level access.',
+  );
+
+  /// Nothing is handed over.
+  static const CastMediaAccess none = CastMediaAccess(
+    delegation: CastMediaDelegation.none,
+    scope: CastMediaScope.nothing,
+    summary: 'Nothing is delegated to a receiver.',
+  );
+
+  /// The mechanism the receiver is given.
+  final CastMediaDelegation delegation;
+
+  /// How far that mechanism reaches if it is observed or kept.
+  final CastMediaScope scope;
+
+  /// A short, non-secret sentence for docs, diagnostics and (eventually) the
+  /// cast sheet. Never contains a credential, a URL, or a fragment of either.
+  final String summary;
+
+  /// How long the delegated access stays usable, when the server bounds it.
+  /// Null means it lasts as long as the credential behind it does — which for
+  /// an account credential is "until the user signs out or changes it".
+  final Duration? lifetime;
+
+  /// Whether the user can revoke *this* access without invalidating their whole
+  /// session or changing their password.
+  final bool revocableIndependently;
+
+  /// Whether this handoff gives the receiver no more than the item being played.
+  bool get isLeastPrivilege =>
+      delegation != CastMediaDelegation.accountCredential &&
+      scope != CastMediaScope.account;
+
+  /// Whether the receiver ends up holding an account credential. The honest
+  /// answer for every server Linthra supports today; see the doc above.
+  bool get delegatesAccountCredential =>
+      delegation == CastMediaDelegation.accountCredential;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is CastMediaAccess &&
+          other.delegation == delegation &&
+          other.scope == scope &&
+          other.summary == summary &&
+          other.lifetime == lifetime &&
+          other.revocableIndependently == revocableIndependently);
+
+  @override
+  int get hashCode => Object.hash(
+        delegation,
+        scope,
+        summary,
+        lifetime,
+        revocableIndependently,
+      );
+
+  @override
+  String toString() =>
+      'CastMediaAccess(${delegation.name}, scope: ${scope.name}, '
+      'lifetime: ${lifetime ?? 'until the session ends'})';
+}

--- a/lib/core/services/cast/cast_media_resolver.dart
+++ b/lib/core/services/cast/cast_media_resolver.dart
@@ -1,5 +1,6 @@
 import '../../models/cast_media.dart';
 import '../../models/track.dart';
+import 'cast_media_access.dart';
 
 /// Why resolving a [Track] into castable media failed.
 enum CastMediaErrorKind {
@@ -47,4 +48,15 @@ abstract interface class CastMediaResolver {
   /// demand, or throws a [CastMediaException] with a friendly, secret-free
   /// message. Only call when [canCast] is true.
   Future<CastMedia> resolve(Track track);
+
+  /// What casting [track] would delegate to the receiver, without resolving
+  /// anything or touching the network.
+  ///
+  /// A resolver declares this from what its server actually supports — a
+  /// capability scoped to the item, or the account credential it has no
+  /// alternative to — so the exposure of a handoff is a property of the code
+  /// rather than a thing to work out from a URL at review time. Callers can ask
+  /// before casting; [CastMedia.access] carries the same answer afterwards. See
+  /// [CastMediaAccess] and docs/cast-media-access.md.
+  CastMediaAccess accessFor(Track track);
 }

--- a/lib/core/services/cast/cast_receiver_trust.dart
+++ b/lib/core/services/cast/cast_receiver_trust.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/foundation.dart';
+
+import '../../models/cast_state.dart';
+
+/// Why a receiver was not trusted. Every value means the same thing to the app —
+/// no session, no media — and they exist so the reason can be told apart in
+/// tests and in a calm, secret-free note to the user.
+enum CastTrustFailureKind {
+  /// Nothing here can vouch for this receiver: no verified transport is wired,
+  /// so authentication is not merely failing, it is not implemented. This is the
+  /// state Linthra ships in today, and it is deliberately a failure rather than
+  /// a skip.
+  unsupported,
+
+  /// The receiver answered and the answer was not good enough: an untrusted or
+  /// malformed certificate chain, a bad signature, a response for a different
+  /// challenge.
+  rejected,
+
+  /// The receiver proved *an* identity, but not the one the user picked. A
+  /// device that authenticates as some other device is exactly the case a
+  /// handoff must not survive.
+  identityMismatch,
+
+  /// Authentication never finished: the session ended underneath it, the user
+  /// moved on, or it ran out of time. An unfinished check is a failed check.
+  incomplete,
+}
+
+/// A typed, user-facing failure raised while establishing receiver trust.
+///
+/// Security invariant, identical to [CastMediaException]: [message] must NEVER
+/// carry a certificate, a challenge, a nonce, a token, or anything else from the
+/// handshake — only generic text the cast sheet can show. What actually went
+/// wrong belongs in the private advisory and in test expectations, not on a
+/// user's screen or in a log.
+class CastReceiverTrustException implements Exception {
+  const CastReceiverTrustException(this.message, {required this.kind});
+
+  final String message;
+  final CastTrustFailureKind kind;
+
+  @override
+  String toString() => message;
+}
+
+/// A receiver whose identity has been cryptographically verified.
+///
+/// Holding one of these is the *only* evidence the cast layers accept that the
+/// thing on the other end of a session is the device the user chose. It is
+/// deliberately small: an identity is a claim that was checked, not a channel,
+/// a credential, or a capability.
+///
+/// [deviceId] is the [CastDevice.id] the identity was established for, so the
+/// binding to the user's selection can be checked rather than assumed.
+/// [fingerprint] is a stable, non-secret digest of the verified receiver
+/// certificate — enough to notice that a device answering to the same name is
+/// not the same hardware, and useless to anyone who learns it.
+@immutable
+class CastReceiverIdentity {
+  const CastReceiverIdentity({
+    required this.deviceId,
+    required this.fingerprint,
+    this.model,
+  });
+
+  /// The id of the [CastDevice] this identity belongs to.
+  final String deviceId;
+
+  /// A stable, non-secret digest of the verified receiver certificate.
+  final String fingerprint;
+
+  /// What the receiver says it is (e.g. a model name), when the verified
+  /// material carries it. Informational only — never a trust input.
+  final String? model;
+
+  /// Whether this identity is the one the user's chosen [device] must present.
+  bool matches(CastDevice device) => device.id == deviceId;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is CastReceiverIdentity &&
+          other.deviceId == deviceId &&
+          other.fingerprint == fingerprint &&
+          other.model == model);
+
+  @override
+  int get hashCode => Object.hash(deviceId, fingerprint, model);
+
+  @override
+  String toString() =>
+      'CastReceiverIdentity(deviceId: $deviceId, fingerprint: $fingerprint)';
+}
+
+/// Proves that a receiver is the device the user picked, or refuses.
+///
+/// This is the contract [#575](https://github.com/TheZupZup/Linthra/issues/575)
+/// is about: casting stays withheld until a receiver's identity is
+/// cryptographically authenticated and the whole handoff path has been reviewed.
+/// Splitting the *contract* from the eventual implementation means the boundary
+/// the app enforces — no trusted identity, no session, no media — is written
+/// down, tested, and reviewable now, and the implementation choice (a maintained
+/// package, an auditable fork, or a narrowly scoped replacement) is reviewed on
+/// its own terms in the private advisory. See docs/cast-receiver-trust.md.
+///
+/// Implementations must:
+///  * complete only after the receiver has actually proved its identity, never
+///    on "the socket opened" or "the device replied";
+///  * return an identity bound to the requested device, so the caller can check
+///    the binding rather than trust the implementation to have checked it;
+///  * throw [CastReceiverTrustException] for every other outcome, including the
+///    ones that look like infrastructure (timeouts, dropped connections). An
+///    inconclusive check is a failure;
+///  * never return a partially verified identity, and never carry handshake
+///    material out of this call.
+abstract interface class CastReceiverAuthenticator {
+  /// Authenticates [device] and returns its verified identity, or throws a
+  /// [CastReceiverTrustException].
+  Future<CastReceiverIdentity> authenticate(CastDevice device);
+}
+
+/// The shipped authenticator: it trusts nothing, because nothing here can yet
+/// prove a receiver's identity.
+///
+/// It is not a placeholder that "will do for now" — it is the fail-closed half
+/// of the boundary. While casting is contained no transport is built at all, and
+/// when one is built again it must arrive with a real authenticator in the same
+/// reviewed change; until that lands, every receiver is refused here rather than
+/// waved through by a default that says yes.
+class UnverifiedCastReceiverAuthenticator implements CastReceiverAuthenticator {
+  const UnverifiedCastReceiverAuthenticator();
+
+  /// What the sheet would say. Free of any detail about the report, and honest
+  /// about the reason: the app cannot check the device, so it will not use it.
+  static const String message =
+      "Linthra can't verify this device yet, so it won't send your music to it.";
+
+  @override
+  Future<CastReceiverIdentity> authenticate(CastDevice device) async {
+    throw const CastReceiverTrustException(
+      message,
+      kind: CastTrustFailureKind.unsupported,
+    );
+  }
+}

--- a/lib/core/services/cast/cast_receiver_trust.dart
+++ b/lib/core/services/cast/cast_receiver_trust.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 
 import '../../models/cast_state.dart';
+import 'cast_transport.dart';
 
 /// Why a receiver was not trusted. Every value means the same thing to the app —
 /// no session, no media — and they exist so the reason can be told apart in
@@ -44,7 +45,8 @@ class CastReceiverTrustException implements Exception {
   String toString() => message;
 }
 
-/// A receiver whose identity has been cryptographically verified.
+/// A receiver whose identity has been cryptographically verified, on a
+/// particular connection.
 ///
 /// Holding one of these is the *only* evidence the cast layers accept that the
 /// thing on the other end of a session is the device the user chose. It is
@@ -53,6 +55,10 @@ class CastReceiverTrustException implements Exception {
 ///
 /// [deviceId] is the [CastDevice.id] the identity was established for, so the
 /// binding to the user's selection can be checked rather than assumed.
+/// [connection] is the session the proof was made over, so the binding to the
+/// socket that will carry the media can be checked too: a receiver proving
+/// itself on one connection says nothing about another, and Cast's own device
+/// authentication is a property of a connection, not of a name on the network.
 /// [fingerprint] is a stable, non-secret digest of the verified receiver
 /// certificate — enough to notice that a device answering to the same name is
 /// not the same hardware, and useless to anyone who learns it.
@@ -60,12 +66,17 @@ class CastReceiverTrustException implements Exception {
 class CastReceiverIdentity {
   const CastReceiverIdentity({
     required this.deviceId,
+    required this.connection,
     required this.fingerprint,
     this.model,
   });
 
   /// The id of the [CastDevice] this identity belongs to.
   final String deviceId;
+
+  /// The session the proof was made over. The media handoff happens on this
+  /// same session, which is what makes the proof worth anything.
+  final CastSessionHandle connection;
 
   /// A stable, non-secret digest of the verified receiver certificate.
   final String fingerprint;
@@ -74,19 +85,25 @@ class CastReceiverIdentity {
   /// material carries it. Informational only — never a trust input.
   final String? model;
 
-  /// Whether this identity is the one the user's chosen [device] must present.
-  bool matches(CastDevice device) => device.id == deviceId;
+  /// Whether this identity is what the user's chosen [device] must present, on
+  /// the very [session] that will carry the media. Both halves matter: the
+  /// right device on another connection is not the receiver we are about to
+  /// hand a stream to.
+  bool matches(CastDevice device, CastSessionHandle session) =>
+      device.id == deviceId && identical(session, connection);
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       (other is CastReceiverIdentity &&
           other.deviceId == deviceId &&
+          identical(other.connection, connection) &&
           other.fingerprint == fingerprint &&
           other.model == model);
 
   @override
-  int get hashCode => Object.hash(deviceId, fingerprint, model);
+  int get hashCode =>
+      Object.hash(deviceId, identityHashCode(connection), fingerprint, model);
 
   @override
   String toString() =>
@@ -105,19 +122,28 @@ class CastReceiverIdentity {
 /// its own terms in the private advisory. See docs/cast-receiver-trust.md.
 ///
 /// Implementations must:
+///  * perform the check over the session they are handed, because that is the
+///    connection the media will go to. Cast's device authentication is a
+///    challenge answered on a connection; a proof gathered anywhere else
+///    describes a different conversation;
 ///  * complete only after the receiver has actually proved its identity, never
 ///    on "the socket opened" or "the device replied";
-///  * return an identity bound to the requested device, so the caller can check
-///    the binding rather than trust the implementation to have checked it;
+///  * return an identity naming both the requested device and that session, so
+///    the caller can check the binding rather than trust the implementation to
+///    have checked it;
 ///  * throw [CastReceiverTrustException] for every other outcome, including the
 ///    ones that look like infrastructure (timeouts, dropped connections). An
 ///    inconclusive check is a failure;
 ///  * never return a partially verified identity, and never carry handshake
 ///    material out of this call.
 abstract interface class CastReceiverAuthenticator {
-  /// Authenticates [device] and returns its verified identity, or throws a
+  /// Authenticates the receiver reached over [session] — which the user picked
+  /// as [device] — and returns its verified identity, or throws a
   /// [CastReceiverTrustException].
-  Future<CastReceiverIdentity> authenticate(CastDevice device);
+  Future<CastReceiverIdentity> authenticate(
+    CastDevice device,
+    CastSessionHandle session,
+  );
 }
 
 /// The shipped authenticator: it trusts nothing, because nothing here can yet
@@ -137,7 +163,10 @@ class UnverifiedCastReceiverAuthenticator implements CastReceiverAuthenticator {
       "Linthra can't verify this device yet, so it won't send your music to it.";
 
   @override
-  Future<CastReceiverIdentity> authenticate(CastDevice device) async {
+  Future<CastReceiverIdentity> authenticate(
+    CastDevice device,
+    CastSessionHandle session,
+  ) async {
     throw const CastReceiverTrustException(
       message,
       kind: CastTrustFailureKind.unsupported,

--- a/lib/core/services/cast/default_cast_service.dart
+++ b/lib/core/services/cast/default_cast_service.dart
@@ -7,6 +7,7 @@ import '../../models/cast_volume.dart';
 import '../../models/playback_state.dart';
 import '../../models/track.dart';
 import 'cast_media_resolver.dart';
+import 'cast_receiver_trust.dart';
 import 'cast_service.dart';
 import 'cast_transport.dart';
 
@@ -198,6 +199,16 @@ class DefaultCastService implements CastService {
     final CastSessionHandle handle;
     try {
       handle = await _transport.connect(device);
+    } on CastReceiverTrustException catch (error) {
+      // A receiver that could not prove who it is failed for a reason worth
+      // saying: "couldn't connect" would read as a flaky network and invite the
+      // user to try again. The message is secret-free by contract.
+      _emit(CastState(
+        availability: CastAvailability.error,
+        devices: _state.devices,
+        message: error.message,
+      ));
+      return;
     } catch (_) {
       _emit(CastState(
         availability: CastAvailability.error,
@@ -294,6 +305,13 @@ class DefaultCastService implements CastService {
     if (_handle != handle) return;
     try {
       await handle.loadMedia(media);
+    } on CastReceiverTrustException catch (error) {
+      // The handoff refused because trust in this receiver ended. Same reason
+      // as above to say so plainly rather than blame playback.
+      _castingTrackUri = null;
+      _emitPlayback(CastPlaybackStatus.idle);
+      _emit(_connected(device, message: error.message));
+      return;
     } catch (_) {
       _castingTrackUri = null;
       _emitPlayback(CastPlaybackStatus.idle);

--- a/lib/core/services/cast/routing_cast_media_resolver.dart
+++ b/lib/core/services/cast/routing_cast_media_resolver.dart
@@ -1,5 +1,6 @@
 import '../../models/cast_media.dart';
 import '../../models/track.dart';
+import 'cast_media_access.dart';
 import 'cast_media_resolver.dart';
 
 /// A [CastMediaResolver] that delegates to the first member able to cast a
@@ -19,6 +20,17 @@ class RoutingCastMediaResolver implements CastMediaResolver {
   @override
   bool canCast(Track track) =>
       _resolvers.any((CastMediaResolver r) => r.canCast(track));
+
+  /// The delegation of the member that would actually cast [track], so routing
+  /// never averages two providers into one misleading answer. A track no member
+  /// can cast delegates nothing.
+  @override
+  CastMediaAccess accessFor(Track track) {
+    for (final CastMediaResolver resolver in _resolvers) {
+      if (resolver.canCast(track)) return resolver.accessFor(track);
+    }
+    return CastMediaAccess.none;
+  }
 
   @override
   Future<CastMedia> resolve(Track track) async {

--- a/lib/core/services/cast/trust_gated_cast_transport.dart
+++ b/lib/core/services/cast/trust_gated_cast_transport.dart
@@ -269,39 +269,70 @@ class _TrustedCastSession implements CastSessionHandle {
   @override
   Stream<CastVolume> get volumeStream => _session.volumeStream;
 
+  /// Refuses when the connection the receiver proved itself on is gone.
+  ///
+  /// Every outbound operation goes through this, not just the media handoff: a
+  /// command sent after trust ended is a command to a receiver nobody has
+  /// authenticated — the same connection may have been re-established
+  /// underneath, and this session's proof says nothing about that one. Inbound
+  /// streams are untouched; they carry no authority, and the app still needs to
+  /// see the session end.
+  void _requireTrust() {
+    if (_trusted) return;
+    throw const CastReceiverTrustException(
+      "Linthra stopped casting to that device because it couldn't keep "
+      'verifying it.',
+      kind: CastTrustFailureKind.incomplete,
+    );
+  }
+
   @override
   Future<void> loadMedia(CastMedia media) async {
     // The last refusal before a token-bearing URL leaves the device: the check
     // is repeated here, at the handoff, rather than trusted to have happened in
     // the right order somewhere above.
-    if (!_trusted) {
-      throw const CastReceiverTrustException(
-        "Linthra stopped casting to that device because it couldn't keep "
-        'verifying it.',
-        kind: CastTrustFailureKind.incomplete,
-      );
-    }
+    _requireTrust();
     await _session.loadMedia(media);
   }
 
   @override
-  Future<void> play() => _session.play();
+  Future<void> play() async {
+    _requireTrust();
+    await _session.play();
+  }
 
   @override
-  Future<void> pause() => _session.pause();
+  Future<void> pause() async {
+    _requireTrust();
+    await _session.pause();
+  }
 
   @override
-  Future<void> seek(Duration position) => _session.seek(position);
+  Future<void> seek(Duration position) async {
+    _requireTrust();
+    await _session.seek(position);
+  }
 
   @override
-  Future<void> setVolume(double level) => _session.setVolume(level);
+  Future<void> setVolume(double level) async {
+    _requireTrust();
+    await _session.setVolume(level);
+  }
 
   @override
-  Future<void> setMuted(bool muted) => _session.setMuted(muted);
+  Future<void> setMuted(bool muted) async {
+    _requireTrust();
+    await _session.setMuted(muted);
+  }
 
   @override
-  Future<void> requestStatus() => _session.requestStatus();
+  Future<void> requestStatus() async {
+    _requireTrust();
+    await _session.requestStatus();
+  }
 
+  /// Teardown is never gated: closing an untrusted session is exactly what the
+  /// caller should still be able to do.
   @override
   Future<void> close() async {
     _trusted = false;

--- a/lib/core/services/cast/trust_gated_cast_transport.dart
+++ b/lib/core/services/cast/trust_gated_cast_transport.dart
@@ -374,6 +374,12 @@ class _TrustedCastSession implements CastSessionHandle {
 
   /// Teardown is never gated: closing an untrusted session is exactly what the
   /// caller should still be able to do.
+  ///
+  /// Both halves are bounded. A receiver that stalls while closing — its socket
+  /// subscriptions winding down, say — would otherwise hold the service's own
+  /// teardown open, so a disconnect would never reach the idle state and the
+  /// next connection would never start. The delegate is free to finish closing
+  /// in its own time; nothing here waits on it.
   @override
   Future<void> close() async {
     _trusted = false;
@@ -382,7 +388,7 @@ class _TrustedCastSession implements CastSessionHandle {
     if (lifetime != null) {
       await settleWithin(lifetime.cancel(), _cleanupTimeout);
     }
-    await _session.close();
+    await settleWithin(_session.close(), _cleanupTimeout);
   }
 }
 

--- a/lib/core/services/cast/trust_gated_cast_transport.dart
+++ b/lib/core/services/cast/trust_gated_cast_transport.dart
@@ -72,9 +72,9 @@ class TrustGatedCastTransport implements CastTransport {
   Future<CastSessionHandle> connect(CastDevice device) async {
     final CastSessionHandle session = await _delegate.connect(device);
 
-    final CastReceiverIdentity identity;
+    final _Authentication proof;
     try {
-      identity = await _authenticate(device, session);
+      proof = await _authenticate(device, session);
     } catch (_) {
       // Every failure path closes the session it was handed. A connected but
       // unauthenticated receiver is exactly what must not survive this method,
@@ -83,7 +83,7 @@ class TrustGatedCastTransport implements CastTransport {
       rethrow;
     }
 
-    if (!identity.matches(device, session)) {
+    if (!proof.identity.matches(device, session)) {
       await _close(session);
       throw const CastReceiverTrustException(
         "Linthra couldn't confirm that this is the device you picked, so it "
@@ -92,12 +92,18 @@ class TrustGatedCastTransport implements CastTransport {
       );
     }
 
-    return _TrustedCastSession(session, identity);
+    // The readiness seen during the handshake is carried over deliberately: the
+    // wrapper subscribes a moment later, and if the session went ready and then
+    // dropped in between, all the wrapper is replayed is that latest `false`.
+    // Without knowing the session had been up, it would read that as "not ready
+    // yet" and keep trusting a connection that is already gone.
+    return _TrustedCastSession(session, proof.identity,
+        wasReady: proof.wasReady);
   }
 
   /// Races the receiver's proof against the session ending and the clock, so an
   /// authentication that cannot conclude fails instead of waiting forever.
-  Future<CastReceiverIdentity> _authenticate(
+  Future<_Authentication> _authenticate(
     CastDevice device,
     CastSessionHandle session,
   ) async {
@@ -140,31 +146,37 @@ class TrustGatedCastTransport implements CastTransport {
       () => fail(CastTrustFailureKind.incomplete, _incompleteMessage),
     );
 
-    unawaited(
-      _authenticator.authenticate(device, session).then(
-        (CastReceiverIdentity identity) {
-          if (!race.isCompleted) race.complete(identity);
-        },
-        onError: (Object error, StackTrace stack) {
-          if (race.isCompleted) return;
-          // A trust failure is passed through as itself; anything else — a
-          // socket error, a bug in an implementation — becomes a refusal too,
-          // because "the check threw" is never "the check passed".
-          race.completeError(
-            error is CastReceiverTrustException
-                ? error
-                : const CastReceiverTrustException(
-                    _rejectedMessage,
-                    kind: CastTrustFailureKind.rejected,
-                  ),
-            stack,
-          );
-        },
-      ),
-    );
-
     try {
-      return await race.future;
+      // Future.sync, inside the try: an implementation is free to throw before
+      // it ever returns a future, and that must land on the same refusal and
+      // the same cleanup as any other failed check — not escape past the timer
+      // and the subscription that are already running.
+      unawaited(
+        Future<CastReceiverIdentity>.sync(
+          () => _authenticator.authenticate(device, session),
+        ).then(
+          (CastReceiverIdentity identity) {
+            if (!race.isCompleted) race.complete(identity);
+          },
+          onError: (Object error, StackTrace stack) {
+            if (race.isCompleted) return;
+            // A trust failure is passed through as itself; anything else — a
+            // socket error, a bug in an implementation — becomes a refusal too,
+            // because "the check threw" is never "the check passed".
+            race.completeError(
+              error is CastReceiverTrustException
+                  ? error
+                  : const CastReceiverTrustException(
+                      _rejectedMessage,
+                      kind: CastTrustFailureKind.rejected,
+                    ),
+              stack,
+            );
+          },
+        ),
+      );
+
+      return _Authentication(await race.future, wasReady: wasReady);
     } finally {
       expiry.cancel();
       await ended.cancel();
@@ -194,7 +206,11 @@ class TrustGatedCastTransport implements CastTransport {
 /// apart from one that has not — and so the media handoff has its own refusal
 /// rather than relying on nobody ever holding on to a session that has ended.
 class _TrustedCastSession implements CastSessionHandle {
-  _TrustedCastSession(this._session, this.identity) {
+  _TrustedCastSession(
+    this._session,
+    this.identity, {
+    required bool wasReady,
+  }) : _wasReady = wasReady {
     // Trust belongs to the connection the proof was made over, so it ends when
     // that connection does — not when someone gets around to calling [close].
     // Without this, a track resolution that started before the receiver dropped
@@ -220,7 +236,11 @@ class _TrustedCastSession implements CastSessionHandle {
   final CastReceiverIdentity identity;
 
   StreamSubscription<bool>? _lifetime;
-  bool _wasReady = false;
+
+  /// Whether this session has been ready — seeded with what the handshake saw,
+  /// so a drop in the gap between the two subscriptions is not read as "not
+  /// ready yet".
+  bool _wasReady;
 
   /// Trust does not survive the session. Once the connection it was proved over
   /// has ended — dropped by the receiver, or closed from here — this handle
@@ -228,9 +248,20 @@ class _TrustedCastSession implements CastSessionHandle {
   /// a new receiver to prove.
   bool _trusted = true;
 
+  /// Readiness as the app should see it: false once trust is gone, and an error
+  /// on the delegate's stream turned into a clean "not ready" rather than passed
+  /// on. A readiness error escaping here would reach the service as an unhandled
+  /// async error instead of its ordinary session-lost teardown.
   @override
-  Stream<bool> get readyStream =>
-      _session.readyStream.map((bool ready) => ready && _trusted);
+  Stream<bool> get readyStream => _session.readyStream
+          .map((bool ready) => ready && _trusted)
+          .transform(StreamTransformer<bool, bool>.fromHandlers(
+        handleError: (Object error, StackTrace stack, EventSink<bool> sink) {
+          _trusted = false;
+          sink.add(false);
+          sink.close();
+        },
+      ));
 
   @override
   Stream<CastPlaybackStatus> get statusStream => _session.statusStream;
@@ -278,4 +309,13 @@ class _TrustedCastSession implements CastSessionHandle {
     _lifetime = null;
     await _session.close();
   }
+}
+
+/// What a completed check yields: the proof, plus whether the session had been
+/// ready while it ran. Both matter to the wrapper the caller gets.
+class _Authentication {
+  const _Authentication(this.identity, {required this.wasReady});
+
+  final CastReceiverIdentity identity;
+  final bool wasReady;
 }

--- a/lib/core/services/cast/trust_gated_cast_transport.dart
+++ b/lib/core/services/cast/trust_gated_cast_transport.dart
@@ -102,7 +102,7 @@ class TrustGatedCastTransport implements CastTransport {
     // Without knowing the session had been up, it would read that as "not ready
     // yet" and keep trusting a connection that is already gone.
     return _TrustedCastSession(session, proof.identity,
-        wasReady: proof.wasReady);
+        wasReady: proof.wasReady, cleanupTimeout: _cleanupTimeout);
   }
 
   /// Races the receiver's proof against the session ending and the clock, so an
@@ -188,7 +188,10 @@ class TrustGatedCastTransport implements CastTransport {
       return _Authentication(await race.future, wasReady: wasReady);
     } finally {
       expiry.cancel();
-      await ended.cancel();
+      // Bounded for the same reason closing is: cancelling a subscription can
+      // wait on the stream's own teardown, and a delegate that stalls there
+      // would hold the refusal — and the session's close with it — forever.
+      await settleWithin(ended.cancel(), _cleanupTimeout);
     }
   }
 
@@ -217,15 +220,21 @@ class TrustGatedCastTransport implements CastTransport {
   static const String _rejectedMessage =
       "Linthra couldn't verify that device, so it didn't send anything to it.";
 
-  Future<void> _close(CastSessionHandle session) async {
-    // Bounded and swallowed: the refusal above is what the caller needs, and a
-    // receiver that will not close — or will not answer at all — must not be
-    // able to turn a refusal into a hang or an unhandled error.
-    try {
-      await session.close().timeout(_cleanupTimeout);
-    } catch (_) {
-      // Intentionally ignored.
-    }
+  Future<void> _close(CastSessionHandle session) =>
+      // Bounded and swallowed: the refusal above is what the caller needs, and
+      // a receiver that will not close — or will not answer at all — must not
+      // be able to turn a refusal into a hang or an unhandled error.
+      settleWithin(session.close(), _cleanupTimeout);
+}
+
+/// Waits for best-effort cleanup, but never on it: [work] is given [limit] to
+/// finish, and whether it times out or throws, the caller carries on. Used for
+/// every teardown on a path whose real result is a refusal already in hand.
+Future<void> settleWithin(Future<void> work, Duration limit) async {
+  try {
+    await work.timeout(limit);
+  } catch (_) {
+    // Intentionally ignored: cleanup is not the outcome anyone is waiting for.
   }
 }
 
@@ -237,7 +246,9 @@ class _TrustedCastSession implements CastSessionHandle {
     this._session,
     this.identity, {
     required bool wasReady,
-  }) : _wasReady = wasReady {
+    required Duration cleanupTimeout,
+  })  : _wasReady = wasReady,
+        _cleanupTimeout = cleanupTimeout {
     // Trust belongs to the connection the proof was made over, so it ends when
     // that connection does — not when someone gets around to calling [close].
     // Without this, a track resolution that started before the receiver dropped
@@ -261,6 +272,9 @@ class _TrustedCastSession implements CastSessionHandle {
 
   /// The verified receiver this session is bound to.
   final CastReceiverIdentity identity;
+
+  /// How long teardown gets before it is left to finish on its own.
+  final Duration _cleanupTimeout;
 
   StreamSubscription<bool>? _lifetime;
 
@@ -363,8 +377,11 @@ class _TrustedCastSession implements CastSessionHandle {
   @override
   Future<void> close() async {
     _trusted = false;
-    await _lifetime?.cancel();
+    final StreamSubscription<bool>? lifetime = _lifetime;
     _lifetime = null;
+    if (lifetime != null) {
+      await settleWithin(lifetime.cancel(), _cleanupTimeout);
+    }
     await _session.close();
   }
 }

--- a/lib/core/services/cast/trust_gated_cast_transport.dart
+++ b/lib/core/services/cast/trust_gated_cast_transport.dart
@@ -1,0 +1,236 @@
+import 'dart:async';
+
+import '../../models/cast_media.dart';
+import '../../models/cast_playback_status.dart';
+import '../../models/cast_state.dart';
+import '../../models/cast_volume.dart';
+import 'cast_receiver_trust.dart';
+import 'cast_transport.dart';
+
+/// The readiness boundary casting has to cross before a receiver gets anything:
+/// a [CastTransport] that hands out a session only once the receiver on the
+/// other end has proved it is the device the user picked.
+///
+/// It is a decorator, not a transport: it opens no socket and speaks no
+/// protocol. That is deliberate. The rule — *no verified identity, no session,
+/// no media* — is policy, and policy that lives inside an I/O adapter can only
+/// be tested on a device. Here it is a few dozen lines of orchestration over a
+/// [CastTransport] and a [CastReceiverAuthenticator], so every failure the
+/// boundary must survive (a refusal, a device answering for another device, an
+/// authentication that never finishes, a session that dies mid-handshake) is a
+/// unit test rather than a code review.
+///
+/// **This does not restore casting.** Nothing in production builds a live
+/// transport while the security containment holds, and the shipped
+/// [UnverifiedCastReceiverAuthenticator] refuses every receiver anyway. This is
+/// the boundary the reviewed restoration
+/// ([#575](https://github.com/TheZupZup/Linthra/issues/575)) has to plug a real
+/// authenticator into, built and tested ahead of it rather than alongside it.
+///
+/// **Containment still comes first.** Trust is checked *after* the delegate
+/// opens the session, because a receiver can only prove itself over a
+/// connection. So a contained transport refuses before this class ever asks
+/// about identity, and this class never becomes a second way to reach a device
+/// that the transport itself would not reach.
+class TrustGatedCastTransport implements CastTransport {
+  TrustGatedCastTransport({
+    required CastTransport delegate,
+    CastReceiverAuthenticator authenticator =
+        const UnverifiedCastReceiverAuthenticator(),
+    Duration authenticationTimeout = const Duration(seconds: 10),
+  })  : _delegate = delegate,
+        _authenticator = authenticator,
+        _authenticationTimeout = authenticationTimeout;
+
+  final CastTransport _delegate;
+  final CastReceiverAuthenticator _authenticator;
+
+  /// How long a receiver has to prove itself. A handshake that hangs is not a
+  /// slow success: it expires as [CastTrustFailureKind.incomplete], the session
+  /// is closed, and nothing is handed over.
+  final Duration _authenticationTimeout;
+
+  /// Discovery is not a trust boundary — finding a name on the LAN says nothing
+  /// about who owns it — so it passes straight through, containment guards and
+  /// all. Trust is established per connection, on the connection.
+  @override
+  Future<List<CastDevice>> discover(Duration timeout) =>
+      _delegate.discover(timeout);
+
+  @override
+  Future<CastSessionHandle> connect(CastDevice device) async {
+    final CastSessionHandle session = await _delegate.connect(device);
+
+    final CastReceiverIdentity identity;
+    try {
+      identity = await _authenticate(device, session);
+    } catch (_) {
+      // Every failure path closes the session it was handed. A connected but
+      // unauthenticated receiver is exactly what must not survive this method,
+      // including when the failure is a timeout or a dropped connection.
+      await _close(session);
+      rethrow;
+    }
+
+    if (!identity.matches(device)) {
+      await _close(session);
+      throw const CastReceiverTrustException(
+        "That device didn't turn out to be the one you picked, so Linthra "
+        'stopped.',
+        kind: CastTrustFailureKind.identityMismatch,
+      );
+    }
+
+    return _TrustedCastSession(session, identity);
+  }
+
+  /// Races the receiver's proof against the session ending and the clock, so an
+  /// authentication that cannot conclude fails instead of waiting forever.
+  Future<CastReceiverIdentity> _authenticate(
+    CastDevice device,
+    CastSessionHandle session,
+  ) async {
+    final Completer<CastReceiverIdentity> race =
+        Completer<CastReceiverIdentity>();
+
+    void fail(CastTrustFailureKind kind, String message) {
+      if (!race.isCompleted) {
+        race.completeError(CastReceiverTrustException(message, kind: kind));
+      }
+    }
+
+    // The session dying underneath the handshake is an unfinished check, not a
+    // pass: whatever the receiver had said so far, it never finished saying it.
+    final StreamSubscription<bool> ended = session.readyStream.listen(
+      (_) {},
+      onError: (_) => fail(
+        CastTrustFailureKind.incomplete,
+        _incompleteMessage,
+      ),
+      onDone: () => fail(
+        CastTrustFailureKind.incomplete,
+        _incompleteMessage,
+      ),
+      cancelOnError: false,
+    );
+
+    final Timer expiry = Timer(
+      _authenticationTimeout,
+      () => fail(CastTrustFailureKind.incomplete, _incompleteMessage),
+    );
+
+    unawaited(
+      _authenticator.authenticate(device).then(
+        (CastReceiverIdentity identity) {
+          if (!race.isCompleted) race.complete(identity);
+        },
+        onError: (Object error, StackTrace stack) {
+          if (race.isCompleted) return;
+          // A trust failure is passed through as itself; anything else — a
+          // socket error, a bug in an implementation — becomes a refusal too,
+          // because "the check threw" is never "the check passed".
+          race.completeError(
+            error is CastReceiverTrustException
+                ? error
+                : const CastReceiverTrustException(
+                    _rejectedMessage,
+                    kind: CastTrustFailureKind.rejected,
+                  ),
+            stack,
+          );
+        },
+      ),
+    );
+
+    try {
+      return await race.future;
+    } finally {
+      expiry.cancel();
+      await ended.cancel();
+    }
+  }
+
+  static const String _incompleteMessage =
+      "Linthra couldn't finish checking that device, so it didn't send "
+      'anything to it.';
+
+  static const String _rejectedMessage =
+      "Linthra couldn't verify that device, so it didn't send anything to it.";
+
+  Future<void> _close(CastSessionHandle session) async {
+    // Closing is cleanup on a path that is already failing; a receiver that
+    // will not close cleanly must not turn a refusal into an unhandled error.
+    try {
+      await session.close();
+    } catch (_) {
+      // Intentionally ignored: the refusal above is what the caller needs.
+    }
+  }
+}
+
+/// A session whose receiver has been authenticated, wrapped so it can be told
+/// apart from one that has not — and so the media handoff has its own refusal
+/// rather than relying on nobody ever holding on to a closed session.
+class _TrustedCastSession implements CastSessionHandle {
+  _TrustedCastSession(this._session, this.identity);
+
+  final CastSessionHandle _session;
+
+  /// The verified receiver this session is bound to.
+  final CastReceiverIdentity identity;
+
+  /// Trust does not survive the session. Once closed, this handle refuses media
+  /// even though it authenticated a moment ago: the connection it was proved
+  /// over is gone, and a reconnection is a new receiver to prove.
+  bool _trusted = true;
+
+  @override
+  Stream<bool> get readyStream =>
+      _session.readyStream.map((bool ready) => ready && _trusted);
+
+  @override
+  Stream<CastPlaybackStatus> get statusStream => _session.statusStream;
+
+  @override
+  Stream<CastVolume> get volumeStream => _session.volumeStream;
+
+  @override
+  Future<void> loadMedia(CastMedia media) async {
+    // The last refusal before a token-bearing URL leaves the device. It is
+    // unreachable by construction — this class only exists after a successful
+    // check — which is exactly why it is here: the handoff should not depend on
+    // the caller having got the order right.
+    if (!_trusted) {
+      throw const CastReceiverTrustException(
+        "Linthra stopped casting to that device because it couldn't keep "
+        'verifying it.',
+        kind: CastTrustFailureKind.incomplete,
+      );
+    }
+    await _session.loadMedia(media);
+  }
+
+  @override
+  Future<void> play() => _session.play();
+
+  @override
+  Future<void> pause() => _session.pause();
+
+  @override
+  Future<void> seek(Duration position) => _session.seek(position);
+
+  @override
+  Future<void> setVolume(double level) => _session.setVolume(level);
+
+  @override
+  Future<void> setMuted(bool muted) => _session.setMuted(muted);
+
+  @override
+  Future<void> requestStatus() => _session.requestStatus();
+
+  @override
+  Future<void> close() async {
+    _trusted = false;
+    await _session.close();
+  }
+}

--- a/lib/core/services/cast/trust_gated_cast_transport.dart
+++ b/lib/core/services/cast/trust_gated_cast_transport.dart
@@ -9,16 +9,18 @@ import 'cast_transport.dart';
 
 /// The readiness boundary casting has to cross before a receiver gets anything:
 /// a [CastTransport] that hands out a session only once the receiver on the
-/// other end has proved it is the device the user picked.
+/// other end has proved, *on that session*, that it is the device the user
+/// picked.
 ///
 /// It is a decorator, not a transport: it opens no socket and speaks no
 /// protocol. That is deliberate. The rule — *no verified identity, no session,
 /// no media* — is policy, and policy that lives inside an I/O adapter can only
 /// be tested on a device. Here it is a few dozen lines of orchestration over a
 /// [CastTransport] and a [CastReceiverAuthenticator], so every failure the
-/// boundary must survive (a refusal, a device answering for another device, an
-/// authentication that never finishes, a session that dies mid-handshake) is a
-/// unit test rather than a code review.
+/// boundary must survive (a refusal, a device answering for another device, a
+/// proof made over some other connection, an authentication that never
+/// finishes, a session that dies mid-handshake or after it) is a unit test
+/// rather than a code review.
 ///
 /// **This does not restore casting.** Nothing in production builds a live
 /// transport while the security containment holds, and the shipped
@@ -38,9 +40,11 @@ class TrustGatedCastTransport implements CastTransport {
     CastReceiverAuthenticator authenticator =
         const UnverifiedCastReceiverAuthenticator(),
     Duration authenticationTimeout = const Duration(seconds: 10),
+    Duration cleanupTimeout = const Duration(seconds: 5),
   })  : _delegate = delegate,
         _authenticator = authenticator,
-        _authenticationTimeout = authenticationTimeout;
+        _authenticationTimeout = authenticationTimeout,
+        _cleanupTimeout = cleanupTimeout;
 
   final CastTransport _delegate;
   final CastReceiverAuthenticator _authenticator;
@@ -49,6 +53,13 @@ class TrustGatedCastTransport implements CastTransport {
   /// slow success: it expires as [CastTrustFailureKind.incomplete], the session
   /// is closed, and nothing is handed over.
   final Duration _authenticationTimeout;
+
+  /// How long the refused session gets to close before the refusal is returned
+  /// anyway. Closing is cleanup on a path that has already failed, so an
+  /// unresponsive receiver must not be able to hold the refusal back — the
+  /// caller would sit in "connecting" forever on the strength of a socket that
+  /// failed its check.
+  final Duration _cleanupTimeout;
 
   /// Discovery is not a trust boundary — finding a name on the LAN says nothing
   /// about who owns it — so it passes straight through, containment guards and
@@ -72,10 +83,10 @@ class TrustGatedCastTransport implements CastTransport {
       rethrow;
     }
 
-    if (!identity.matches(device)) {
+    if (!identity.matches(device, session)) {
       await _close(session);
       throw const CastReceiverTrustException(
-        "That device didn't turn out to be the one you picked, so Linthra "
+        "Linthra couldn't confirm that this is the device you picked, so it "
         'stopped.',
         kind: CastTrustFailureKind.identityMismatch,
       );
@@ -101,8 +112,18 @@ class TrustGatedCastTransport implements CastTransport {
 
     // The session dying underneath the handshake is an unfinished check, not a
     // pass: whatever the receiver had said so far, it never finished saying it.
+    // A `false` before the session has ever been ready is just "not yet" — the
+    // receiver's media app is still launching — but a `false` after a `true` is
+    // the session ending, exactly as DefaultCastService reads it.
+    bool wasReady = false;
     final StreamSubscription<bool> ended = session.readyStream.listen(
-      (_) {},
+      (bool ready) {
+        if (ready) {
+          wasReady = true;
+        } else if (wasReady) {
+          fail(CastTrustFailureKind.incomplete, _incompleteMessage);
+        }
+      },
       onError: (_) => fail(
         CastTrustFailureKind.incomplete,
         _incompleteMessage,
@@ -120,7 +141,7 @@ class TrustGatedCastTransport implements CastTransport {
     );
 
     unawaited(
-      _authenticator.authenticate(device).then(
+      _authenticator.authenticate(device, session).then(
         (CastReceiverIdentity identity) {
           if (!race.isCompleted) race.complete(identity);
         },
@@ -158,30 +179,53 @@ class TrustGatedCastTransport implements CastTransport {
       "Linthra couldn't verify that device, so it didn't send anything to it.";
 
   Future<void> _close(CastSessionHandle session) async {
-    // Closing is cleanup on a path that is already failing; a receiver that
-    // will not close cleanly must not turn a refusal into an unhandled error.
+    // Bounded and swallowed: the refusal above is what the caller needs, and a
+    // receiver that will not close — or will not answer at all — must not be
+    // able to turn a refusal into a hang or an unhandled error.
     try {
-      await session.close();
+      await session.close().timeout(_cleanupTimeout);
     } catch (_) {
-      // Intentionally ignored: the refusal above is what the caller needs.
+      // Intentionally ignored.
     }
   }
 }
 
 /// A session whose receiver has been authenticated, wrapped so it can be told
 /// apart from one that has not — and so the media handoff has its own refusal
-/// rather than relying on nobody ever holding on to a closed session.
+/// rather than relying on nobody ever holding on to a session that has ended.
 class _TrustedCastSession implements CastSessionHandle {
-  _TrustedCastSession(this._session, this.identity);
+  _TrustedCastSession(this._session, this.identity) {
+    // Trust belongs to the connection the proof was made over, so it ends when
+    // that connection does — not when someone gets around to calling [close].
+    // Without this, a track resolution that started before the receiver dropped
+    // could still hand a credential-bearing URL to a dead session while the
+    // service is still tearing it down.
+    _lifetime = _session.readyStream.listen(
+      (bool ready) {
+        if (ready) {
+          _wasReady = true;
+        } else if (_wasReady) {
+          _trusted = false;
+        }
+      },
+      onError: (_) => _trusted = false,
+      onDone: () => _trusted = false,
+      cancelOnError: false,
+    );
+  }
 
   final CastSessionHandle _session;
 
   /// The verified receiver this session is bound to.
   final CastReceiverIdentity identity;
 
-  /// Trust does not survive the session. Once closed, this handle refuses media
-  /// even though it authenticated a moment ago: the connection it was proved
-  /// over is gone, and a reconnection is a new receiver to prove.
+  StreamSubscription<bool>? _lifetime;
+  bool _wasReady = false;
+
+  /// Trust does not survive the session. Once the connection it was proved over
+  /// has ended — dropped by the receiver, or closed from here — this handle
+  /// refuses media even though it authenticated a moment ago: a reconnection is
+  /// a new receiver to prove.
   bool _trusted = true;
 
   @override
@@ -196,10 +240,9 @@ class _TrustedCastSession implements CastSessionHandle {
 
   @override
   Future<void> loadMedia(CastMedia media) async {
-    // The last refusal before a token-bearing URL leaves the device. It is
-    // unreachable by construction — this class only exists after a successful
-    // check — which is exactly why it is here: the handoff should not depend on
-    // the caller having got the order right.
+    // The last refusal before a token-bearing URL leaves the device: the check
+    // is repeated here, at the handoff, rather than trusted to have happened in
+    // the right order somewhere above.
     if (!_trusted) {
       throw const CastReceiverTrustException(
         "Linthra stopped casting to that device because it couldn't keep "
@@ -231,6 +274,8 @@ class _TrustedCastSession implements CastSessionHandle {
   @override
   Future<void> close() async {
     _trusted = false;
+    await _lifetime?.cancel();
+    _lifetime = null;
     await _session.close();
   }
 }

--- a/lib/core/services/cast/trust_gated_cast_transport.dart
+++ b/lib/core/services/cast/trust_gated_cast_transport.dart
@@ -191,7 +191,7 @@ class TrustGatedCastTransport implements CastTransport {
       // Bounded for the same reason closing is: cancelling a subscription can
       // wait on the stream's own teardown, and a delegate that stalls there
       // would hold the refusal — and the session's close with it — forever.
-      await settleWithin(ended.cancel(), _cleanupTimeout);
+      await settleWithin(ended.cancel, _cleanupTimeout);
     }
   }
 
@@ -224,15 +224,20 @@ class TrustGatedCastTransport implements CastTransport {
       // Bounded and swallowed: the refusal above is what the caller needs, and
       // a receiver that will not close — or will not answer at all — must not
       // be able to turn a refusal into a hang or an unhandled error.
-      settleWithin(session.close(), _cleanupTimeout);
+      settleWithin(session.close, _cleanupTimeout);
 }
 
 /// Waits for best-effort cleanup, but never on it: [work] is given [limit] to
 /// finish, and whether it times out or throws, the caller carries on. Used for
 /// every teardown on a path whose real result is a refusal already in hand.
-Future<void> settleWithin(Future<void> work, Duration limit) async {
+///
+/// [work] is a callback rather than a future on purpose: an implementation may
+/// throw before it ever returns one, and started outside this function that
+/// throw would replace the refusal the caller is carrying. Future.sync brings
+/// both kinds of failure inside.
+Future<void> settleWithin(Future<void> Function() work, Duration limit) async {
   try {
-    await work.timeout(limit);
+    await Future<void>.sync(work).timeout(limit);
   } catch (_) {
     // Intentionally ignored: cleanup is not the outcome anyone is waiting for.
   }
@@ -386,9 +391,9 @@ class _TrustedCastSession implements CastSessionHandle {
     final StreamSubscription<bool>? lifetime = _lifetime;
     _lifetime = null;
     if (lifetime != null) {
-      await settleWithin(lifetime.cancel(), _cleanupTimeout);
+      await settleWithin(lifetime.cancel, _cleanupTimeout);
     }
-    await settleWithin(_session.close(), _cleanupTimeout);
+    await settleWithin(_session.close, _cleanupTimeout);
   }
 }
 

--- a/lib/core/services/cast/trust_gated_cast_transport.dart
+++ b/lib/core/services/cast/trust_gated_cast_transport.dart
@@ -22,6 +22,11 @@ import 'cast_transport.dart';
 /// finishes, a session that dies mid-handshake or after it) is a unit test
 /// rather than a code review.
 ///
+/// It also owns what the user is told. A refusal keeps its
+/// [CastTrustFailureKind] and nothing else: the message the sheet shows is
+/// written here, so no message an authenticator produces — which may have been
+/// built from something the receiver said — can reach the UI.
+///
 /// **This does not restore casting.** Nothing in production builds a live
 /// transport while the security containment holds, and the shipped
 /// [UnverifiedCastReceiverAuthenticator] refuses every receiver anyway. This is
@@ -85,9 +90,8 @@ class TrustGatedCastTransport implements CastTransport {
 
     if (!proof.identity.matches(device, session)) {
       await _close(session);
-      throw const CastReceiverTrustException(
-        "Linthra couldn't confirm that this is the device you picked, so it "
-        'stopped.',
+      throw CastReceiverTrustException(
+        _messageFor(CastTrustFailureKind.identityMismatch),
         kind: CastTrustFailureKind.identityMismatch,
       );
     }
@@ -160,16 +164,21 @@ class TrustGatedCastTransport implements CastTransport {
           },
           onError: (Object error, StackTrace stack) {
             if (race.isCompleted) return;
-            // A trust failure is passed through as itself; anything else — a
-            // socket error, a bug in an implementation — becomes a refusal too,
-            // because "the check threw" is never "the check passed".
+            // Every failure becomes a refusal — "the check threw" is never
+            // "the check passed" — and every refusal gets *this class's* copy.
+            // A typed failure keeps only its kind: an implementation that wrote
+            // a fingerprint or a challenge into its message would otherwise
+            // have it published in CastState.message, and one natural
+            // error-wrapping mistake should not be able to do that.
             race.completeError(
-              error is CastReceiverTrustException
-                  ? error
-                  : const CastReceiverTrustException(
-                      _rejectedMessage,
-                      kind: CastTrustFailureKind.rejected,
-                    ),
+              CastReceiverTrustException(
+                _messageFor(error is CastReceiverTrustException
+                    ? error.kind
+                    : CastTrustFailureKind.rejected),
+                kind: error is CastReceiverTrustException
+                    ? error.kind
+                    : CastTrustFailureKind.rejected,
+              ),
               stack,
             );
           },
@@ -180,6 +189,24 @@ class TrustGatedCastTransport implements CastTransport {
     } finally {
       expiry.cancel();
       await ended.cancel();
+    }
+  }
+
+  /// The only wording a refusal ever reaches the user with. Owned here, chosen
+  /// by [CastTrustFailureKind] alone, so nothing an implementation writes into
+  /// an exception can travel to the cast sheet.
+  static String _messageFor(CastTrustFailureKind kind) {
+    switch (kind) {
+      case CastTrustFailureKind.unsupported:
+        return "Linthra can't verify this device yet, so it won't send your "
+            'music to it.';
+      case CastTrustFailureKind.rejected:
+        return _rejectedMessage;
+      case CastTrustFailureKind.identityMismatch:
+        return "Linthra couldn't confirm that this is the device you picked, "
+            'so it stopped.';
+      case CastTrustFailureKind.incomplete:
+        return _incompleteMessage;
     }
   }
 

--- a/lib/core/sources/jellyfin/jellyfin_cast_media_resolver.dart
+++ b/lib/core/sources/jellyfin/jellyfin_cast_media_resolver.dart
@@ -42,7 +42,14 @@ class JellyfinCastMediaResolver implements CastMediaResolver {
   /// accepts for a client that is not sending headers. There is no per-item
   /// signed URL, no scoped download token, and no server-side expiry to ask for
   /// in the stable API, so a receiver handed this URL is handed account-level
-  /// access for as long as the session lives.
+  /// access.
+  ///
+  /// How long that access lasts is not the app's to say. Signing out of
+  /// Jellyfin in Linthra forgets the token on this device; it does not ask the
+  /// server to invalidate it, so a receiver that kept the URL keeps working
+  /// until the user revokes that device in Jellyfin, or the server expires it
+  /// on its own terms. Recording the lifetime as "until the user signs out"
+  /// would be the comfortable answer and the wrong one.
   ///
   /// Declaring that plainly is the point: pretending a token in a query string
   /// is a capability would be inventing a restriction the server does not
@@ -52,7 +59,8 @@ class JellyfinCastMediaResolver implements CastMediaResolver {
     delegation: CastMediaDelegation.accountCredential,
     scope: CastMediaScope.account,
     summary: 'The receiver is given a Jellyfin stream URL carrying the session '
-        'access token, which reaches the whole account until the session ends.',
+        'access token, which reaches the whole account and keeps working until '
+        'the server revokes it.',
   );
 
   @override

--- a/lib/core/sources/jellyfin/jellyfin_cast_media_resolver.dart
+++ b/lib/core/sources/jellyfin/jellyfin_cast_media_resolver.dart
@@ -1,5 +1,6 @@
 import '../../models/cast_media.dart';
 import '../../models/track.dart';
+import '../../services/cast/cast_media_access.dart';
 import '../../services/cast/cast_media_resolver.dart';
 import '../../services/playback_diagnostics.dart';
 import 'jellyfin_exception.dart';
@@ -33,9 +34,34 @@ class JellyfinCastMediaResolver implements CastMediaResolver {
   /// transcoded cast profile for exotic codecs is a documented follow-up.
   static const String _defaultContentType = 'audio/mpeg';
 
+  /// What casting a Jellyfin track hands over.
+  ///
+  /// Jellyfin authenticates a stream request with the session's access token —
+  /// the same token the app uses for everything else — carried in the URL's
+  /// `api_key`, because that is the only authentication its stream endpoint
+  /// accepts for a client that is not sending headers. There is no per-item
+  /// signed URL, no scoped download token, and no server-side expiry to ask for
+  /// in the stable API, so a receiver handed this URL is handed account-level
+  /// access for as long as the session lives.
+  ///
+  /// Declaring that plainly is the point: pretending a token in a query string
+  /// is a capability would be inventing a restriction the server does not
+  /// enforce. What Jellyfin would need for [CastMediaDelegation.scopedCapability]
+  /// is in docs/cast-media-access.md.
+  static const CastMediaAccess access = CastMediaAccess(
+    delegation: CastMediaDelegation.accountCredential,
+    scope: CastMediaScope.account,
+    summary: 'The receiver is given a Jellyfin stream URL carrying the session '
+        'access token, which reaches the whole account until the session ends.',
+  );
+
   @override
   bool canCast(Track track) =>
       track.uri.startsWith(JellyfinTrackMapper.uriScheme);
+
+  @override
+  CastMediaAccess accessFor(Track track) =>
+      canCast(track) ? access : CastMediaAccess.none;
 
   @override
   Future<CastMedia> resolve(Track track) async {
@@ -77,6 +103,7 @@ class JellyfinCastMediaResolver implements CastMediaResolver {
       duration: track.duration > Duration.zero ? track.duration : null,
       // Token-free per JellyfinEndpoints.primaryImage, so safe to send as-is.
       artworkUrl: track.artworkUri,
+      access: access,
     );
   }
 

--- a/lib/core/sources/subsonic/subsonic_cast_media_resolver.dart
+++ b/lib/core/sources/subsonic/subsonic_cast_media_resolver.dart
@@ -1,5 +1,6 @@
 import '../../models/cast_media.dart';
 import '../../models/track.dart';
+import '../../services/cast/cast_media_access.dart';
 import '../../services/cast/cast_media_resolver.dart';
 import '../../services/playback_diagnostics.dart';
 import 'subsonic_exception.dart';
@@ -30,9 +31,32 @@ class SubsonicCastMediaResolver implements CastMediaResolver {
   /// compatible audio format; an exact per-track content type is a follow-up.
   static const String _defaultContentType = 'audio/mpeg';
 
+  /// What casting a Subsonic/Navidrome track hands over.
+  ///
+  /// The Subsonic API authenticates every request, streaming included, with the
+  /// user name plus a salted token derived from the password. It is a
+  /// credential, not a capability: it is accepted on every endpoint, it does not
+  /// expire, and it cannot be narrowed to one song. A receiver handed this URL
+  /// can reach the whole account with it, which is also why the cover-art URL is
+  /// never sent (it would carry the same credential for no playback benefit).
+  ///
+  /// Navidrome and some other servers can issue their own shorter-lived tokens
+  /// for their own clients, but not through the Subsonic API Linthra speaks; see
+  /// docs/cast-media-access.md.
+  static const CastMediaAccess access = CastMediaAccess(
+    delegation: CastMediaDelegation.accountCredential,
+    scope: CastMediaScope.account,
+    summary: 'The receiver is given a Subsonic stream URL carrying the salted '
+        'credential, which reaches the whole account and does not expire.',
+  );
+
   @override
   bool canCast(Track track) =>
       track.uri.startsWith(SubsonicTrackMapper.uriScheme);
+
+  @override
+  CastMediaAccess accessFor(Track track) =>
+      canCast(track) ? access : CastMediaAccess.none;
 
   @override
   Future<CastMedia> resolve(Track track) async {
@@ -72,6 +96,7 @@ class SubsonicCastMediaResolver implements CastMediaResolver {
       artist: track.artistName,
       album: track.albumName,
       duration: track.duration > Duration.zero ? track.duration : null,
+      access: access,
       // Artwork is intentionally omitted: Subsonic's getCoverArt URL embeds the
       // salt+token, so sending it would leak the credential to the receiver.
     );

--- a/lib/core/sources/subsonic/subsonic_cast_media_resolver.dart
+++ b/lib/core/sources/subsonic/subsonic_cast_media_resolver.dart
@@ -40,6 +40,10 @@ class SubsonicCastMediaResolver implements CastMediaResolver {
   /// can reach the whole account with it, which is also why the cover-art URL is
   /// never sent (it would carry the same credential for no playback benefit).
   ///
+  /// Signing out in Linthra does not take it back either: the token is derived
+  /// from the password, so only changing that password invalidates a copy
+  /// somebody else kept.
+  ///
   /// Navidrome and some other servers can issue their own shorter-lived tokens
   /// for their own clients, but not through the Subsonic API Linthra speaks; see
   /// docs/cast-media-access.md.
@@ -47,7 +51,8 @@ class SubsonicCastMediaResolver implements CastMediaResolver {
     delegation: CastMediaDelegation.accountCredential,
     scope: CastMediaScope.account,
     summary: 'The receiver is given a Subsonic stream URL carrying the salted '
-        'credential, which reaches the whole account and does not expire.',
+        'credential, which reaches the whole account and stays valid until the '
+        'password changes.',
   );
 
   @override

--- a/scripts/verify_release_containment.py
+++ b/scripts/verify_release_containment.py
@@ -54,6 +54,8 @@ Usage:
 
     python3 scripts/verify_release_containment.py dist/*.apk dist/*.aab
     python3 scripts/verify_release_containment.py --json report.json build/*.tar.gz
+    python3 .../verify_release_containment.py \
+        --containment-source lib/core/services/cast/cast_containment.dart *.apk
 
 Every artifact's SHA-256 is printed (and written to `--json`) so a release can
 record exactly which bytes were checked.
@@ -72,6 +74,11 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CONTAINMENT_SOURCE = REPO_ROOT / "lib/core/services/cast/cast_containment.dart"
+
+# The expected message must come from the tree the artifact was BUILT from, which
+# is not always the tree this script lives in: a release build checks out the tag
+# it is building, while the workflow (and this script with it) comes from the
+# revision that runs. `--containment-source` is how that caller says so.
 
 # The compiled Dart snapshot inside every Flutter release artifact. Android puts
 # one per ABI under lib/<abi>/ (an AAB nests that under base/), the Linux bundle
@@ -242,6 +249,15 @@ def main(argv: list[str]) -> int:
     )
     parser.add_argument("artifacts", nargs="+", type=Path)
     parser.add_argument(
+        "--containment-source",
+        type=Path,
+        default=CONTAINMENT_SOURCE,
+        help=(
+            "cast_containment.dart of the tree the artifacts were built from "
+            "(default: this checkout's). The expected message is read from it."
+        ),
+    )
+    parser.add_argument(
         "--json",
         type=Path,
         help="Write the per-artifact record (name, size, SHA-256) here.",
@@ -249,7 +265,7 @@ def main(argv: list[str]) -> int:
     args = parser.parse_args(argv)
 
     try:
-        message = containment_message(CONTAINMENT_SOURCE)
+        message = containment_message(args.containment_source)
     except VerificationError as error:
         print(f"ERROR: {error}", file=sys.stderr)
         return 1

--- a/scripts/verify_release_containment.py
+++ b/scripts/verify_release_containment.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Checks a built artifact for the Cast security containment.
+
+Casting is withheld from shipped builds while a reported security issue is
+resolved (see lib/core/services/cast/cast_containment.dart and docs/cast.md).
+`scripts/check_cast_containment.py` looks at the *source tree*; this script looks
+at the *artifact a user installs* — an APK, an AAB, or the Linux tarball — and
+asks whether the compiled Dart in it looks like a contained build.
+
+It reads every Dart AOT payload in the artifact (`libapp.so`) and looks for
+three things:
+
+  * the containment message, exactly as `CastContainment.userMessage` spells it
+    in this checkout. The message is a compile-time constant reached only
+    through the contained production wiring, so it is compiled into the snapshot
+    when containment holds and folded away when it does not;
+  * `UnavailableCastService`, the service the contained wiring binds; and
+  * the absence of `DefaultCastService`, `ChromecastCastTransport`, and the Cast
+    protocol namespaces the live transport talks — none of which survive tree
+    shaking when nothing constructs them.
+
+WHAT THIS IS NOT
+----------------
+This is NOT a proof that the binary cannot cast, and it must not be described as
+one. It is a byte search over a compiled snapshot, so what it really reports is
+"this artifact was built from a tree whose containment constants were still
+reachable, and carries none of the live-cast strings we know to look for". It
+cannot see:
+
+  * a bypass that keeps every string in place — a second cast implementation
+    under a different name, a live path reached through code this script has no
+    string for, or a receiver socket opened from platform code rather than Dart;
+  * anything outside the Dart snapshot: platform channels, native libraries,
+    the Android manifest, or a plugin's own Java/Kotlin;
+  * whether the absent strings are absent because the code is gone or because
+    the compiler happened to store them differently in this build.
+
+WHAT IS THE EVIDENCE
+--------------------
+The same evidence as ever: `test/app/production_cast_containment_test.dart` and
+`test/core/services/cast/cast_containment_test.dart` drive the real production
+wiring and the transport at runtime, at the commit the artifact is built from.
+This script adds one thing those cannot — it is run against the file that is
+actually distributed, so a release whose artifacts were built from some other
+tree does not pass quietly. Treat a green run as "the markers we know to look
+for are as expected in the shipped bytes", and a red one as a question to answer
+before publishing.
+
+Ambiguity fails closed. An artifact with no readable Dart payload, a message
+this script cannot parse out of the Dart source, an unknown file type, or an
+unreadable archive all exit non-zero rather than reporting success.
+
+Usage:
+
+    python3 scripts/verify_release_containment.py dist/*.apk dist/*.aab
+    python3 scripts/verify_release_containment.py --json report.json build/*.tar.gz
+
+Every artifact's SHA-256 is printed (and written to `--json`) so a release can
+record exactly which bytes were checked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONTAINMENT_SOURCE = REPO_ROOT / "lib/core/services/cast/cast_containment.dart"
+
+# The compiled Dart snapshot inside every Flutter release artifact. Android puts
+# one per ABI under lib/<abi>/ (an AAB nests that under base/), the Linux bundle
+# ships a single one next to the other bundled libraries.
+AOT_PAYLOAD = "libapp.so"
+
+# Strings that must be in a contained build's snapshot.
+REQUIRED_MARKERS = ("UnavailableCastService",)
+
+# Strings a contained build must NOT have. Each one exists only in the live cast
+# path, which nothing constructs while containment holds, so tree shaking drops
+# them along with the code.
+FORBIDDEN_MARKERS = (
+    "DefaultCastService",
+    "ChromecastCastTransport",
+    "urn:x-cast:com.google.cast.media",
+    "urn:x-cast:com.google.cast.receiver",
+)
+
+
+class VerificationError(Exception):
+    """A reason this script cannot report success. Always fatal."""
+
+
+def containment_message(source: Path) -> str:
+    """Reads `CastContainment.userMessage` out of the Dart source.
+
+    Taking the expected string from the checkout rather than hard-coding it here
+    means editing the user-facing copy cannot silently turn this check into a
+    search for a string nothing says any more. A message this cannot parse is an
+    error, not a fallback.
+    """
+    try:
+        text = source.read_text(encoding="utf-8")
+    except OSError as error:
+        raise VerificationError(f"cannot read {source}: {error}") from error
+
+    match = re.search(r"static const String userMessage\s*=\s*(.*?);", text, re.DOTALL)
+    if match is None:
+        raise VerificationError(
+            f"no `static const String userMessage` in {source}; this script "
+            "cannot tell what a contained build should say."
+        )
+
+    # The literal is written as adjacent single-quoted parts across several
+    # lines; Dart concatenates them, so join them in the same order.
+    parts = re.findall(r"'([^']*)'", match.group(1))
+    if not parts:
+        raise VerificationError(f"could not parse the userMessage literal in {source}.")
+    return "".join(parts)
+
+
+def encodings_of(marker: str) -> list[bytes]:
+    """Both ways Dart stores a string literal in an AOT snapshot.
+
+    Latin-1-representable literals are stored one byte per code unit; anything
+    with a wider character (the containment message has an em dash) is stored as
+    UTF-16. Searching for both keeps the check working whichever way the copy is
+    written.
+    """
+    candidates = [marker.encode("utf-16-le")]
+    try:
+        candidates.append(marker.encode("latin-1"))
+    except UnicodeEncodeError:
+        pass
+    return candidates
+
+
+def contains(blob: bytes, marker: str) -> bool:
+    return any(encoded in blob for encoded in encodings_of(marker))
+
+
+def sha256_of(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def aot_payloads(path: Path) -> dict[str, bytes]:
+    """Every Dart AOT payload in the artifact, keyed by its path inside it."""
+    suffixes = "".join(path.suffixes[-2:])
+    if path.suffix in {".apk", ".aab", ".zip"}:
+        return _zip_payloads(path)
+    if suffixes in {".tar.gz", ".tar.xz"} or path.suffix == ".tgz":
+        return _tar_payloads(path)
+    raise VerificationError(
+        f"{path.name}: unknown artifact type; this script reads .apk, .aab and "
+        "the Linux .tar.gz."
+    )
+
+
+def _zip_payloads(path: Path) -> dict[str, bytes]:
+    try:
+        with zipfile.ZipFile(path) as archive:
+            names = [
+                name
+                for name in archive.namelist()
+                if name.rsplit("/", 1)[-1] == AOT_PAYLOAD
+            ]
+            return {name: archive.read(name) for name in names}
+    except (OSError, zipfile.BadZipFile) as error:
+        raise VerificationError(f"cannot read {path.name}: {error}") from error
+
+
+def _tar_payloads(path: Path) -> dict[str, bytes]:
+    payloads: dict[str, bytes] = {}
+    try:
+        with tarfile.open(path, "r:*") as archive:
+            for member in archive.getmembers():
+                if not member.isfile():
+                    continue
+                if member.name.rsplit("/", 1)[-1] != AOT_PAYLOAD:
+                    continue
+                handle = archive.extractfile(member)
+                if handle is None:
+                    raise VerificationError(f"{path.name}: cannot read {member.name}.")
+                payloads[member.name] = handle.read()
+    except (OSError, tarfile.TarError) as error:
+        raise VerificationError(f"cannot read {path.name}: {error}") from error
+    return payloads
+
+
+def verify_artifact(path: Path, message: str) -> dict[str, object]:
+    """Checks one artifact and returns what was found. Raises on any failure."""
+    if not path.is_file():
+        raise VerificationError(f"{path}: not a file.")
+
+    payloads = aot_payloads(path)
+    if not payloads:
+        raise VerificationError(
+            f"{path.name}: no {AOT_PAYLOAD} inside, so there is no compiled "
+            "Dart to check. Failing closed rather than reporting a pass."
+        )
+
+    problems: list[str] = []
+    for name, blob in sorted(payloads.items()):
+        if not contains(blob, message):
+            problems.append(
+                f"{name}: the containment message is missing, so this payload "
+                "was not built from a contained tree."
+            )
+        for marker in REQUIRED_MARKERS:
+            if not contains(blob, marker):
+                problems.append(f"{name}: expected marker {marker!r} is missing.")
+        for marker in FORBIDDEN_MARKERS:
+            if contains(blob, marker):
+                problems.append(
+                    f"{name}: live-cast marker {marker!r} is present; this "
+                    "artifact carries the cast path containment removes."
+                )
+
+    if problems:
+        raise VerificationError(f"{path.name}:\n  - " + "\n  - ".join(problems))
+
+    return {
+        "artifact": path.name,
+        "bytes": path.stat().st_size,
+        "sha256": sha256_of(path),
+        "payloads": sorted(payloads),
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify the Cast containment in built release artifacts."
+    )
+    parser.add_argument("artifacts", nargs="+", type=Path)
+    parser.add_argument(
+        "--json",
+        type=Path,
+        help="Write the per-artifact record (name, size, SHA-256) here.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        message = containment_message(CONTAINMENT_SOURCE)
+    except VerificationError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    records: list[dict[str, object]] = []
+    failures = 0
+    for artifact in args.artifacts:
+        try:
+            record = verify_artifact(artifact, message)
+        except VerificationError as error:
+            print(f"FAIL {error}", file=sys.stderr)
+            failures += 1
+            continue
+        records.append(record)
+        print(f"OK   {record['artifact']}  sha256={record['sha256']}")
+        for payload in record["payloads"]:
+            print(f"       contained: {payload}")
+
+    if args.json and records:
+        args.json.write_text(
+            json.dumps(records, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+
+    if failures:
+        print(
+            f"\n{failures} artifact(s) did not verify. Do not publish them.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"\nVerified {len(records)} artifact(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/test/core/services/cast/cast_media_access_test.dart
+++ b/test/core/services/cast/cast_media_access_test.dart
@@ -1,0 +1,152 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/cast_media.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/cast/cast_media_access.dart';
+import 'package:linthra/core/services/cast/cast_media_resolver.dart';
+import 'package:linthra/core/services/cast/routing_cast_media_resolver.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_cast_media_resolver.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_cast_media_resolver.dart';
+
+/// What a cast handoff actually delegates, per source
+/// ([#576](https://github.com/TheZupZup/Linthra/issues/576)).
+///
+/// The point of the model is honesty, so these tests mostly guard against a
+/// pleasant lie: a source that claims to hand over a scoped capability when its
+/// server issues nothing of the sort, or a default that treats an undeclared
+/// source as harmless. Neither Jellyfin nor Subsonic supports a per-item
+/// capability today, and the tests say so on purpose — when one of them gains
+/// one, this file is where the change shows up.
+void main() {
+  const Track jellyfinTrack =
+      Track(id: 'j1', title: 'Streamed', uri: 'jellyfin:j1');
+  const Track subsonicTrack =
+      Track(id: 's1', title: 'Streamed', uri: 'subsonic:s1');
+  const Track localTrack =
+      Track(id: 'l1', title: 'On device', uri: '/music/x.mp3');
+
+  group('the model', () {
+    test('an undeclared handoff is read as the widest one', () {
+      // A source that says nothing must never be mistaken for a safe one.
+      expect(CastMediaAccess.undeclared.delegatesAccountCredential, isTrue);
+      expect(CastMediaAccess.undeclared.isLeastPrivilege, isFalse);
+      expect(CastMediaAccess.undeclared.scope, CastMediaScope.account);
+    });
+
+    test('media that nobody described defaults to that reading', () {
+      final CastMedia media = CastMedia(
+        url: Uri.parse('https://music.example.test/stream?api_key=TOKEN'),
+        contentType: 'audio/mpeg',
+      );
+
+      expect(media.access, CastMediaAccess.undeclared);
+    });
+
+    test('nothing is delegated when nothing is handed over', () {
+      expect(CastMediaAccess.none.delegation, CastMediaDelegation.none);
+      expect(CastMediaAccess.none.scope, CastMediaScope.nothing);
+      expect(CastMediaAccess.none.isLeastPrivilege, isTrue);
+      expect(CastMediaAccess.none.delegatesAccountCredential, isFalse);
+    });
+
+    test('a per-item capability is what least privilege means here', () {
+      const CastMediaAccess signedUrl = CastMediaAccess(
+        delegation: CastMediaDelegation.scopedCapability,
+        scope: CastMediaScope.singleItem,
+        summary: 'A signed URL for this item only.',
+        lifetime: Duration(minutes: 15),
+        revocableIndependently: true,
+      );
+
+      expect(signedUrl.isLeastPrivilege, isTrue);
+      expect(signedUrl.delegatesAccountCredential, isFalse);
+      expect(signedUrl.lifetime, const Duration(minutes: 15));
+    });
+
+    test('describing a handoff never quotes one', () {
+      // The summary is written for docs and diagnostics, so it must stay the
+      // kind of sentence that is safe to print anywhere.
+      for (final CastMediaAccess access in <CastMediaAccess>[
+        CastMediaAccess.undeclared,
+        CastMediaAccess.none,
+        JellyfinCastMediaResolver.access,
+        SubsonicCastMediaResolver.access,
+      ]) {
+        expect(access.summary, isNotEmpty);
+        expect(access.summary, isNot(contains('://')));
+        expect(access.summary, isNot(contains('=')));
+        expect(access.toString(), isNot(contains('://')));
+      }
+    });
+  });
+
+  group('what each server actually supports', () {
+    test('Jellyfin delegates the session token, account-wide', () {
+      // Jellyfin's stream endpoint authenticates with the session access token
+      // in api_key. There is no per-item signed URL to ask for, so claiming a
+      // narrower delegation would be inventing a restriction the server does
+      // not enforce.
+      const CastMediaAccess access = JellyfinCastMediaResolver.access;
+
+      expect(access.delegation, CastMediaDelegation.accountCredential);
+      expect(access.scope, CastMediaScope.account);
+      expect(access.isLeastPrivilege, isFalse);
+      expect(access.lifetime, isNull);
+      expect(access.revocableIndependently, isFalse);
+    });
+
+    test('Subsonic delegates the salted credential, account-wide', () {
+      const CastMediaAccess access = SubsonicCastMediaResolver.access;
+
+      expect(access.delegation, CastMediaDelegation.accountCredential);
+      expect(access.scope, CastMediaScope.account);
+      expect(access.lifetime, isNull);
+      expect(access.revocableIndependently, isFalse);
+    });
+
+    test('each resolver answers for its own tracks and nothing else', () {
+      final JellyfinCastMediaResolver jellyfin =
+          JellyfinCastMediaResolver(() => null);
+      final SubsonicCastMediaResolver subsonic =
+          SubsonicCastMediaResolver(() => null);
+
+      expect(
+          jellyfin.accessFor(jellyfinTrack), JellyfinCastMediaResolver.access);
+      expect(jellyfin.accessFor(localTrack), CastMediaAccess.none);
+      expect(
+          subsonic.accessFor(subsonicTrack), SubsonicCastMediaResolver.access);
+      expect(subsonic.accessFor(localTrack), CastMediaAccess.none);
+    });
+  });
+
+  group('routing', () {
+    final CastMediaResolver resolver = RoutingCastMediaResolver(
+      <CastMediaResolver>[
+        JellyfinCastMediaResolver(() => null),
+        SubsonicCastMediaResolver(() => null),
+      ],
+    );
+
+    test('reports the delegation of the source that would cast the track', () {
+      expect(
+        resolver.accessFor(jellyfinTrack),
+        JellyfinCastMediaResolver.access,
+      );
+      expect(
+        resolver.accessFor(subsonicTrack),
+        SubsonicCastMediaResolver.access,
+      );
+    });
+
+    test('a track nothing can cast delegates nothing', () {
+      expect(resolver.accessFor(localTrack), CastMediaAccess.none);
+    });
+
+    test('asking costs nothing: no session, no network, no resolution', () {
+      // Both resolvers are signed out (their source supplier returns null), so
+      // resolving would throw. Describing the delegation must not.
+      expect(() => resolver.accessFor(jellyfinTrack), returnsNormally);
+      expect(
+          resolver.resolve(jellyfinTrack), throwsA(isA<CastMediaException>()));
+    });
+  });
+}

--- a/test/core/services/cast/cast_media_access_test.dart
+++ b/test/core/services/cast/cast_media_access_test.dart
@@ -94,6 +94,22 @@ void main() {
       expect(access.revocableIndependently, isFalse);
     });
 
+    test('neither source claims that signing out takes the access back', () {
+      // Signing out of Jellyfin here forgets the token locally; it does not ask
+      // the server to invalidate it. Subsonic's credential is derived from the
+      // password, so only changing that password invalidates a kept copy.
+      // Saying "until you sign out" would be the comfortable answer and the
+      // wrong one — this model exists to avoid exactly that.
+      for (final CastMediaAccess access in <CastMediaAccess>[
+        JellyfinCastMediaResolver.access,
+        SubsonicCastMediaResolver.access,
+      ]) {
+        expect(access.lifetime, isNull);
+        expect(access.summary.toLowerCase(), isNot(contains('sign out')));
+        expect(access.summary.toLowerCase(), isNot(contains('session ends')));
+      }
+    });
+
     test('Subsonic delegates the salted credential, account-wide', () {
       const CastMediaAccess access = SubsonicCastMediaResolver.access;
 

--- a/test/core/services/cast/default_cast_service_test.dart
+++ b/test/core/services/cast/default_cast_service_test.dart
@@ -9,6 +9,7 @@ import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/services/cast/cast_media_access.dart';
 import 'package:linthra/core/services/cast/cast_media_resolver.dart';
+import 'package:linthra/core/services/cast/cast_receiver_trust.dart';
 import 'package:linthra/core/services/cast/cast_transport.dart';
 import 'package:linthra/core/services/cast/default_cast_service.dart';
 
@@ -38,6 +39,10 @@ class _FakeHandle implements CastSessionHandle {
   /// When set, [setVolume]/[setMuted] throw it, so a test can drive a failed
   /// volume command.
   Object? volumeError;
+
+  /// When set, [loadMedia] throws it instead of recording the media, so a test
+  /// can drive a refused handoff.
+  Object? loadError;
   bool closed = false;
 
   void becomeReady() {
@@ -71,7 +76,10 @@ class _FakeHandle implements CastSessionHandle {
   Stream<CastVolume> get volumeStream => _volume.stream;
 
   @override
-  Future<void> loadMedia(CastMedia media) async => loaded.add(media);
+  Future<void> loadMedia(CastMedia media) async {
+    if (loadError != null) throw loadError!;
+    loaded.add(media);
+  }
 
   @override
   Future<void> play() async => playCount++;
@@ -302,6 +310,43 @@ void main() {
 
       expect(service.state.hasError, isTrue);
       expect(service.state.message, isNot(contains('Exception')));
+    });
+
+    test('a refused receiver says why, not "couldn\'t connect"', () async {
+      // The trust gate (#575) refuses a receiver that cannot prove who it is.
+      // That is not a flaky network, and telling the user to try again would be
+      // wrong — its own secret-free message has to survive to the sheet.
+      transport.connectError = const CastReceiverTrustException(
+        "Linthra can't verify this device yet, so it won't send your music to "
+        'it.',
+        kind: CastTrustFailureKind.unsupported,
+      );
+      final service = build();
+      addTearDown(service.dispose);
+
+      await service.connect(_d1);
+
+      expect(service.state.hasError, isTrue);
+      expect(service.state.message, contains("can't verify this device"));
+      expect(service.state.isCasting, isFalse);
+    });
+
+    test('a handoff refused by the trust gate says why too', () async {
+      current = _jellyfinTrack;
+      final handle = _FakeHandle()
+        ..loadError = const CastReceiverTrustException(
+          "Linthra stopped casting to that device because it couldn't keep "
+          'verifying it.',
+          kind: CastTrustFailureKind.incomplete,
+        );
+      transport.handle = handle;
+      final service = build();
+      addTearDown(service.dispose);
+
+      await service.connect(_d1);
+
+      expect(service.state.isCasting, isFalse);
+      expect(service.state.message, contains('stopped casting'));
     });
 
     test('re-casts when the playing track changes mid-session', () async {

--- a/test/core/services/cast/default_cast_service_test.dart
+++ b/test/core/services/cast/default_cast_service_test.dart
@@ -7,6 +7,7 @@ import 'package:linthra/core/models/cast_state.dart';
 import 'package:linthra/core/models/cast_volume.dart';
 import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/cast/cast_media_access.dart';
 import 'package:linthra/core/services/cast/cast_media_resolver.dart';
 import 'package:linthra/core/services/cast/cast_transport.dart';
 import 'package:linthra/core/services/cast/default_cast_service.dart';
@@ -140,6 +141,10 @@ class _FakeResolver implements CastMediaResolver {
 
   @override
   bool canCast(Track track) => castable;
+
+  @override
+  CastMediaAccess accessFor(Track track) =>
+      castable ? CastMediaAccess.undeclared : CastMediaAccess.none;
 
   @override
   Future<CastMedia> resolve(Track track) async {

--- a/test/core/services/cast/trust_gated_cast_transport_test.dart
+++ b/test/core/services/cast/trust_gated_cast_transport_test.dart
@@ -228,6 +228,22 @@ void main() {
       expect(transport.session.loaded, isEmpty);
     });
 
+    test('a typed failure keeps its kind but not its words', () async {
+      // An authenticator could build its message from something the receiver
+      // said. The gate owns the wording, so only the kind survives.
+      final _FakeTransport transport = _FakeTransport();
+
+      final CastReceiverTrustException error = await refusal(
+        transport,
+        authenticator: const _LeakyAuthenticator(),
+      );
+
+      expect(error.kind, CastTrustFailureKind.rejected);
+      expect(error.message, isNot(contains('sha256:de:ad:be:ef')));
+      expect(error.message, isNot(contains('CN=Some Receiver')));
+      expect(transport.session.closed, isTrue);
+    });
+
     test('an authenticator that throws something else is still a refusal',
         () async {
       final _FakeTransport transport = _FakeTransport();
@@ -433,6 +449,7 @@ void main() {
         const UnverifiedCastReceiverAuthenticator(),
         const _RefusingAuthenticator(),
         const _ExplodingAuthenticator(),
+        const _LeakyAuthenticator(),
         _AcceptingAuthenticator(as: other),
         _HangingAuthenticator(),
       ]) {
@@ -696,6 +713,23 @@ class _ExplodingAuthenticator implements CastReceiverAuthenticator {
     CastSessionHandle session,
   ) async {
     throw StateError('challenge nonce-4711 rejected by peer certificate');
+  }
+}
+
+/// Refuses with handshake material in its message — the mistake the gate has to
+/// make harmless.
+class _LeakyAuthenticator implements CastReceiverAuthenticator {
+  const _LeakyAuthenticator();
+
+  @override
+  Future<CastReceiverIdentity> authenticate(
+    CastDevice device,
+    CastSessionHandle session,
+  ) async {
+    throw const CastReceiverTrustException(
+      'Chain rejected: CN=Some Receiver, fingerprint sha256:de:ad:be:ef',
+      kind: CastTrustFailureKind.rejected,
+    );
   }
 }
 

--- a/test/core/services/cast/trust_gated_cast_transport_test.dart
+++ b/test/core/services/cast/trust_gated_cast_transport_test.dart
@@ -1,0 +1,459 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/cast_media.dart';
+import 'package:linthra/core/models/cast_playback_status.dart';
+import 'package:linthra/core/models/cast_state.dart';
+import 'package:linthra/core/models/cast_volume.dart';
+import 'package:linthra/core/services/cast/cast_containment.dart';
+import 'package:linthra/core/services/cast/cast_receiver_trust.dart';
+import 'package:linthra/core/services/cast/cast_transport.dart';
+import 'package:linthra/core/services/cast/trust_gated_cast_transport.dart';
+
+/// The receiver-trust boundary: no verified identity, no session, no media
+/// ([#575](https://github.com/TheZupZup/Linthra/issues/575)).
+///
+/// Casting is still withheld from production — nothing here restores it, and the
+/// shipped authenticator refuses every receiver. What these tests are for is the
+/// half of the restoration that can be proved without a device: that the failure
+/// cases a real handshake will hit (a refusal, a device answering for another
+/// device, a check that never finishes, a session that dies mid-handshake) all
+/// end the same way, with the session closed and nothing handed over.
+///
+/// Interoperability with real receivers is the other half, and it cannot be
+/// faked here: it needs supported hardware and the reviewed implementation. The
+/// scenarios for it are in docs/cast-receiver-trust.md and, in detail, the
+/// private advisory.
+void main() {
+  const CastDevice speaker = CastDevice(id: 'speaker-1', name: 'Kitchen');
+  const CastDevice other = CastDevice(id: 'speaker-2', name: 'Bedroom');
+
+  const CastReceiverIdentity speakerIdentity = CastReceiverIdentity(
+    deviceId: 'speaker-1',
+    fingerprint: 'sha256:aa:bb',
+    model: 'Test Receiver',
+  );
+
+  final CastMedia media = CastMedia(
+    url: Uri.parse('https://example.test/stream?api_key=secret-token'),
+    contentType: 'audio/mpeg',
+    title: 'Track',
+  );
+
+  TrustGatedCastTransport gate(
+    _FakeTransport transport, {
+    CastReceiverAuthenticator? authenticator,
+    Duration timeout = const Duration(milliseconds: 50),
+  }) {
+    return TrustGatedCastTransport(
+      delegate: transport,
+      authenticator: authenticator ?? _AcceptingAuthenticator(),
+      authenticationTimeout: timeout,
+    );
+  }
+
+  group('a receiver that proves itself', () {
+    test('gets a session, and media reaches it', () async {
+      final _FakeTransport transport = _FakeTransport();
+
+      final CastSessionHandle session = await gate(transport).connect(speaker);
+      await session.loadMedia(media);
+
+      expect(transport.session.loaded, <CastMedia>[media]);
+      expect(transport.session.closed, isFalse);
+      expect(await session.readyStream.first, isTrue);
+    });
+
+    test('every other command still reaches the receiver', () async {
+      final _FakeTransport transport = _FakeTransport();
+
+      final CastSessionHandle session = await gate(transport).connect(speaker);
+      await session.play();
+      await session.pause();
+      await session.seek(const Duration(seconds: 12));
+      await session.setVolume(0.4);
+      await session.setMuted(true);
+      await session.requestStatus();
+
+      expect(transport.session.playCount, 1);
+      expect(transport.session.pauseCount, 1);
+      expect(transport.session.seeks, <Duration>[const Duration(seconds: 12)]);
+      expect(transport.session.volumes, <double>[0.4]);
+      expect(transport.session.mutes, <bool>[true]);
+      expect(transport.session.statusRequests, 1);
+    });
+  });
+
+  group('a receiver that does not prove itself', () {
+    Future<CastReceiverTrustException> refusal(
+      _FakeTransport transport, {
+      required CastReceiverAuthenticator authenticator,
+    }) async {
+      try {
+        await gate(transport, authenticator: authenticator).connect(speaker);
+      } on CastReceiverTrustException catch (error) {
+        return error;
+      }
+      fail('connect() returned a session for an unverified receiver.');
+    }
+
+    test('the shipped authenticator refuses every device', () async {
+      final _FakeTransport transport = _FakeTransport();
+
+      final CastReceiverTrustException error = await refusal(
+        transport,
+        authenticator: const UnverifiedCastReceiverAuthenticator(),
+      );
+
+      expect(error.kind, CastTrustFailureKind.unsupported);
+      expect(transport.session.closed, isTrue);
+      expect(transport.session.loaded, isEmpty);
+    });
+
+    test('a rejected handshake closes the session and loads nothing', () async {
+      final _FakeTransport transport = _FakeTransport();
+
+      final CastReceiverTrustException error = await refusal(
+        transport,
+        authenticator: const _RefusingAuthenticator(),
+      );
+
+      expect(error.kind, CastTrustFailureKind.rejected);
+      expect(transport.session.closed, isTrue);
+      expect(transport.session.loaded, isEmpty);
+    });
+
+    test('a device that authenticates as another device is refused', () async {
+      final _FakeTransport transport = _FakeTransport();
+
+      // The receiver proves an identity — just not the one the user picked.
+      final CastReceiverTrustException error = await refusal(
+        transport,
+        authenticator: _AcceptingAuthenticator(as: other),
+      );
+
+      expect(error.kind, CastTrustFailureKind.identityMismatch);
+      expect(transport.session.closed, isTrue);
+      expect(transport.session.loaded, isEmpty);
+    });
+
+    test('an authentication that never finishes expires', () async {
+      final _FakeTransport transport = _FakeTransport();
+
+      final CastReceiverTrustException error = await refusal(
+        transport,
+        authenticator: _HangingAuthenticator(),
+      );
+
+      expect(error.kind, CastTrustFailureKind.incomplete);
+      expect(transport.session.closed, isTrue);
+      expect(transport.session.loaded, isEmpty);
+    });
+
+    test('a session that dies mid-handshake is an unfinished check', () async {
+      final _FakeTransport transport = _FakeTransport();
+      final _HangingAuthenticator hanging = _HangingAuthenticator();
+
+      // Long timeout: the refusal must come from the session ending, not from
+      // the clock running out.
+      final Future<CastSessionHandle> connecting = gate(
+        transport,
+        authenticator: hanging,
+        timeout: const Duration(seconds: 30),
+      ).connect(speaker);
+      await pumpEventQueue();
+      transport.session.end();
+
+      await expectLater(
+        connecting,
+        throwsA(isA<CastReceiverTrustException>().having(
+          (CastReceiverTrustException e) => e.kind,
+          'kind',
+          CastTrustFailureKind.incomplete,
+        )),
+      );
+      expect(transport.session.loaded, isEmpty);
+    });
+
+    test('an authenticator that throws something else is still a refusal',
+        () async {
+      final _FakeTransport transport = _FakeTransport();
+
+      final CastReceiverTrustException error = await refusal(
+        transport,
+        authenticator: const _ExplodingAuthenticator(),
+      );
+
+      expect(error.kind, CastTrustFailureKind.rejected);
+      // The thrown detail does not become user-facing copy: a handshake error
+      // can carry anything, including material from the receiver.
+      expect(error.message, isNot(contains('challenge')));
+      expect(error.message, isNot(contains('nonce-')));
+    });
+
+    test('a receiver that will not close cleanly still gets refused', () async {
+      final _FakeTransport transport = _FakeTransport()
+        ..session.closeError = StateError('socket already gone');
+
+      final CastReceiverTrustException error = await refusal(
+        transport,
+        authenticator: const _RefusingAuthenticator(),
+      );
+
+      expect(error.kind, CastTrustFailureKind.rejected);
+      expect(transport.session.loaded, isEmpty);
+    });
+  });
+
+  group('the boundary itself', () {
+    test('containment refuses before trust is even asked about', () async {
+      // The gate is not a second route to a receiver: a contained transport
+      // fails first, and no handshake is attempted.
+      final _FakeTransport transport = _FakeTransport()
+        ..connectError = CastContainmentError('connecting');
+      final _AcceptingAuthenticator authenticator = _AcceptingAuthenticator();
+
+      await expectLater(
+        gate(transport, authenticator: authenticator).connect(speaker),
+        throwsA(isA<CastContainmentError>()),
+      );
+      expect(authenticator.calls, isEmpty);
+    });
+
+    test('discovery passes through, refusals and all', () async {
+      final _FakeTransport transport = _FakeTransport();
+
+      expect(
+        await gate(transport).discover(const Duration(seconds: 1)),
+        <CastDevice>[speaker],
+      );
+
+      transport.discoverError = CastContainmentError('discovery');
+      await expectLater(
+        gate(transport).discover(const Duration(seconds: 1)),
+        throwsA(isA<CastContainmentError>()),
+      );
+    });
+
+    test('trust does not survive the session being closed', () async {
+      final _FakeTransport transport = _FakeTransport();
+
+      final CastSessionHandle session = await gate(transport).connect(speaker);
+      await session.close();
+
+      await expectLater(
+        session.loadMedia(media),
+        throwsA(isA<CastReceiverTrustException>().having(
+          (CastReceiverTrustException e) => e.kind,
+          'kind',
+          CastTrustFailureKind.incomplete,
+        )),
+      );
+      expect(transport.session.loaded, isEmpty);
+      expect(await session.readyStream.first, isFalse);
+    });
+
+    test('no refusal carries anything from the handshake', () async {
+      for (final CastReceiverAuthenticator authenticator
+          in <CastReceiverAuthenticator>[
+        const UnverifiedCastReceiverAuthenticator(),
+        const _RefusingAuthenticator(),
+        const _ExplodingAuthenticator(),
+        _AcceptingAuthenticator(as: other),
+        _HangingAuthenticator(),
+      ]) {
+        final _FakeTransport transport = _FakeTransport();
+        String message = '';
+        try {
+          await gate(transport, authenticator: authenticator).connect(speaker);
+        } on CastReceiverTrustException catch (error) {
+          message = error.message.toLowerCase();
+        }
+
+        expect(message, isNotEmpty);
+        for (final String leak in <String>[
+          'certificate',
+          'challenge',
+          'signature',
+          'nonce',
+          'token',
+          'key',
+          'fingerprint',
+          'sha256',
+        ]) {
+          expect(message, isNot(contains(leak)),
+              reason: '${authenticator.runtimeType} leaks "$leak"');
+        }
+      }
+    });
+  });
+
+  group('CastReceiverIdentity', () {
+    test('is bound to the device it was proved for', () {
+      expect(speakerIdentity.matches(speaker), isTrue);
+      expect(speakerIdentity.matches(other), isFalse);
+    });
+
+    test('two proofs of the same device are only equal if they agree', () {
+      expect(
+        speakerIdentity,
+        const CastReceiverIdentity(
+          deviceId: 'speaker-1',
+          fingerprint: 'sha256:aa:bb',
+          model: 'Test Receiver',
+        ),
+      );
+      expect(
+        speakerIdentity,
+        isNot(const CastReceiverIdentity(
+          deviceId: 'speaker-1',
+          fingerprint: 'sha256:cc:dd',
+        )),
+      );
+    });
+  });
+}
+
+/// A transport whose session, and whose failures, the test drives.
+class _FakeTransport implements CastTransport {
+  final _FakeHandle session = _FakeHandle();
+
+  /// When set, [connect] throws it — how a contained transport behaves.
+  Object? connectError;
+
+  /// When set, [discover] throws it.
+  Object? discoverError;
+
+  @override
+  Future<List<CastDevice>> discover(Duration timeout) async {
+    if (discoverError != null) throw discoverError!;
+    return const <CastDevice>[CastDevice(id: 'speaker-1', name: 'Kitchen')];
+  }
+
+  @override
+  Future<CastSessionHandle> connect(CastDevice device) async {
+    if (connectError != null) throw connectError!;
+    return session;
+  }
+}
+
+/// The same shape as the real handle: readiness replays to a late listener, and
+/// every command is recorded so a test can assert nothing reached the receiver.
+class _FakeHandle implements CastSessionHandle {
+  final StreamController<bool> _ready = StreamController<bool>.broadcast();
+  bool? _last = true;
+
+  final List<CastMedia> loaded = <CastMedia>[];
+  final List<Duration> seeks = <Duration>[];
+  final List<double> volumes = <double>[];
+  final List<bool> mutes = <bool>[];
+  int playCount = 0;
+  int pauseCount = 0;
+  int statusRequests = 0;
+  bool closed = false;
+
+  /// When set, [close] throws it, so a failing teardown can be exercised.
+  Object? closeError;
+
+  /// Ends the session the way a dropped receiver does.
+  void end() {
+    _last = false;
+    if (!_ready.isClosed) {
+      _ready.add(false);
+      _ready.close();
+    }
+  }
+
+  @override
+  Stream<bool> get readyStream async* {
+    if (_last != null) yield _last!;
+    yield* _ready.stream;
+  }
+
+  @override
+  Stream<CastPlaybackStatus> get statusStream =>
+      const Stream<CastPlaybackStatus>.empty();
+
+  @override
+  Stream<CastVolume> get volumeStream => const Stream<CastVolume>.empty();
+
+  @override
+  Future<void> loadMedia(CastMedia media) async => loaded.add(media);
+
+  @override
+  Future<void> play() async => playCount++;
+
+  @override
+  Future<void> pause() async => pauseCount++;
+
+  @override
+  Future<void> seek(Duration position) async => seeks.add(position);
+
+  @override
+  Future<void> setVolume(double level) async => volumes.add(level);
+
+  @override
+  Future<void> setMuted(bool muted) async => mutes.add(muted);
+
+  @override
+  Future<void> requestStatus() async => statusRequests++;
+
+  @override
+  Future<void> close() async {
+    closed = true;
+    if (closeError != null) throw closeError!;
+    if (!_ready.isClosed) await _ready.close();
+  }
+}
+
+/// Vouches for a receiver — as itself by default, or as [as] to model a device
+/// answering for another one.
+class _AcceptingAuthenticator implements CastReceiverAuthenticator {
+  _AcceptingAuthenticator({this.as});
+
+  final CastDevice? as;
+
+  /// Every device this was asked about, so a test can show it was never asked.
+  final List<String> calls = <String>[];
+
+  @override
+  Future<CastReceiverIdentity> authenticate(CastDevice device) async {
+    calls.add(device.id);
+    return CastReceiverIdentity(
+      deviceId: (as ?? device).id,
+      fingerprint: 'sha256:aa:bb',
+    );
+  }
+}
+
+/// Answers, and fails the check.
+class _RefusingAuthenticator implements CastReceiverAuthenticator {
+  const _RefusingAuthenticator();
+
+  @override
+  Future<CastReceiverIdentity> authenticate(CastDevice device) async {
+    throw const CastReceiverTrustException(
+      "Linthra couldn't verify that device.",
+      kind: CastTrustFailureKind.rejected,
+    );
+  }
+}
+
+/// Throws something that is not a trust failure, carrying detail that must not
+/// reach the user.
+class _ExplodingAuthenticator implements CastReceiverAuthenticator {
+  const _ExplodingAuthenticator();
+
+  @override
+  Future<CastReceiverIdentity> authenticate(CastDevice device) async {
+    throw StateError('challenge nonce-4711 rejected by peer certificate');
+  }
+}
+
+/// Never answers, the way a receiver that accepts a socket and then goes quiet
+/// does not.
+class _HangingAuthenticator implements CastReceiverAuthenticator {
+  @override
+  Future<CastReceiverIdentity> authenticate(CastDevice device) =>
+      Completer<CastReceiverIdentity>().future;
+}

--- a/test/core/services/cast/trust_gated_cast_transport_test.dart
+++ b/test/core/services/cast/trust_gated_cast_transport_test.dart
@@ -260,6 +260,23 @@ void main() {
       expect(error.message, isNot(contains('nonce-')));
     });
 
+    test('a subscription that will not cancel still lets the refusal out',
+        () async {
+      // Cancelling a subscription can wait on the stream's own teardown. If the
+      // delegate stalls there, the refusal must still come back rather than
+      // leaving the caller connecting forever.
+      final _FakeTransport transport = _FakeTransport()
+        ..session.cancelHangs = true;
+
+      final CastReceiverTrustException error = await refusal(
+        transport,
+        authenticator: const _RefusingAuthenticator(),
+      );
+
+      expect(error.kind, CastTrustFailureKind.rejected);
+      expect(transport.session.loaded, isEmpty);
+    });
+
     test('a receiver that will not close at all still gets refused', () async {
       // Cleanup is best-effort on a path that has already failed: a receiver
       // that accepts the close and then goes quiet must not leave the caller
@@ -578,6 +595,10 @@ class _FakeHandle implements CastSessionHandle {
   /// and then says nothing.
   bool closeHangs = false;
 
+  /// When true, cancelling a [readyStream] subscription never completes — a
+  /// stream whose own teardown stalls.
+  bool cancelHangs = false;
+
   /// Reports the receiver's media app as up.
   void becomeReady() {
     _last = true;
@@ -610,7 +631,17 @@ class _FakeHandle implements CastSessionHandle {
   }
 
   @override
-  Stream<bool> get readyStream async* {
+  Stream<bool> get readyStream {
+    if (!cancelHangs) return _replayed();
+    final StreamController<bool> stalling = StreamController<bool>();
+    stalling.onListen = () {
+      if (_last != null) stalling.add(_last!);
+    };
+    stalling.onCancel = () => Completer<void>().future;
+    return stalling.stream;
+  }
+
+  Stream<bool> _replayed() async* {
     if (_last != null) yield _last!;
     yield* _ready.stream;
   }

--- a/test/core/services/cast/trust_gated_cast_transport_test.dart
+++ b/test/core/services/cast/trust_gated_cast_transport_test.dart
@@ -442,6 +442,23 @@ void main() {
       expect(transport.session.closed, isTrue);
     });
 
+    test('closing returns even when the receiver stalls', () async {
+      // Teardown that never finishes would keep DefaultCastService from
+      // reaching its idle state, so the next connection could never start.
+      final _FakeTransport transport = _FakeTransport();
+
+      final CastSessionHandle session = await gate(transport).connect(speaker);
+      transport.session.closeHangs = true;
+
+      await session.close();
+
+      expect(transport.session.closed, isTrue);
+      await expectLater(
+        session.loadMedia(media),
+        throwsA(isA<CastReceiverTrustException>()),
+      );
+    });
+
     test('trust does not survive the session being closed', () async {
       final _FakeTransport transport = _FakeTransport();
 

--- a/test/core/services/cast/trust_gated_cast_transport_test.dart
+++ b/test/core/services/cast/trust_gated_cast_transport_test.dart
@@ -293,6 +293,22 @@ void main() {
       expect(transport.session.loaded, isEmpty);
     });
 
+    test('a close that throws before returning still gets refused', () async {
+      // An implementation may throw before it ever returns a future. Cleanup
+      // started outside the guarded region would replace the refusal the caller
+      // is already carrying.
+      final _FakeTransport transport = _FakeTransport()
+        ..session.closeThrowsSynchronously = true;
+
+      final CastReceiverTrustException error = await refusal(
+        transport,
+        authenticator: const _RefusingAuthenticator(),
+      );
+
+      expect(error.kind, CastTrustFailureKind.rejected);
+      expect(transport.session.loaded, isEmpty);
+    });
+
     test('a receiver that will not close cleanly still gets refused', () async {
       final _FakeTransport transport = _FakeTransport()
         ..session.closeError = StateError('socket already gone');
@@ -612,6 +628,9 @@ class _FakeHandle implements CastSessionHandle {
   /// and then says nothing.
   bool closeHangs = false;
 
+  /// When true, [close] throws before it returns a future at all.
+  bool closeThrowsSynchronously = false;
+
   /// When true, cancelling a [readyStream] subscription never completes — a
   /// stream whose own teardown stalls.
   bool cancelHangs = false;
@@ -692,8 +711,14 @@ class _FakeHandle implements CastSessionHandle {
   Future<void> requestStatus() async => statusRequests++;
 
   @override
-  Future<void> close() async {
+  Future<void> close() {
     closed = true;
+    // Deliberately not `async`: this throw happens before any future exists.
+    if (closeThrowsSynchronously) throw StateError('socket already disposed');
+    return _close();
+  }
+
+  Future<void> _close() async {
     if (closeHangs) return Completer<void>().future;
     if (closeError != null) throw closeError!;
     if (!_ready.isClosed) await _ready.close();

--- a/test/core/services/cast/trust_gated_cast_transport_test.dart
+++ b/test/core/services/cast/trust_gated_cast_transport_test.dart
@@ -212,6 +212,22 @@ void main() {
       expect(transport.session.loaded, isEmpty);
     });
 
+    test('an authenticator that throws before returning a future is refused',
+        () async {
+      // A method satisfying the interface may throw synchronously. That has to
+      // land on the same refusal, and the same cleanup, as any other failure.
+      final _FakeTransport transport = _FakeTransport();
+
+      final CastReceiverTrustException error = await refusal(
+        transport,
+        authenticator: const _SynchronouslyThrowingAuthenticator(),
+      );
+
+      expect(error.kind, CastTrustFailureKind.rejected);
+      expect(transport.session.closed, isTrue);
+      expect(transport.session.loaded, isEmpty);
+    });
+
     test('an authenticator that throws something else is still a refusal',
         () async {
       final _FakeTransport transport = _FakeTransport();
@@ -310,6 +326,47 @@ void main() {
         )),
       );
       expect(transport.session.loaded, isEmpty);
+    });
+
+    test('a drop between the check and the handoff still revokes trust',
+        () async {
+      // The handshake sees the session go ready; it drops in the gap before the
+      // wrapper subscribes, so all the wrapper is replayed is that latest
+      // `false`. Read naively that looks like "not ready yet" — it is not.
+      final _FakeTransport transport = _FakeTransport();
+
+      final CastSessionHandle session = await gate(
+        transport,
+        authenticator: _AcceptingAuthenticator(
+          after: const Duration(milliseconds: 5),
+        ),
+      ).connect(speaker);
+      transport.session.dropSilently();
+      await pumpEventQueue();
+
+      await expectLater(
+        session.loadMedia(media),
+        throwsA(isA<CastReceiverTrustException>()),
+      );
+      expect(transport.session.loaded, isEmpty);
+    });
+
+    test('a readiness error ends the session instead of escaping', () async {
+      // An error on the delegate's readiness stream must not reach the service
+      // as an unhandled async error: it becomes a clean "not ready" so the
+      // ordinary session-lost teardown runs.
+      final _FakeTransport transport = _FakeTransport();
+
+      final CastSessionHandle session = await gate(transport).connect(speaker);
+      final Future<List<bool>> readiness = session.readyStream.toList();
+      await pumpEventQueue();
+      transport.session.failReadiness(StateError('socket blew up'));
+
+      expect(await readiness, <bool>[true, false]);
+      await expectLater(
+        session.loadMedia(media),
+        throwsA(isA<CastReceiverTrustException>()),
+      );
     });
 
     test('trust does not survive the session being closed', () async {
@@ -477,6 +534,15 @@ class _FakeHandle implements CastSessionHandle {
     if (!_ready.isClosed) _ready.add(false);
   }
 
+  /// Drops without emitting, so only a later listener's replay carries it —
+  /// the receiver going away between two subscriptions.
+  void dropSilently() => _last = false;
+
+  /// Fails the readiness stream, the way a broken socket does.
+  void failReadiness(Object error) {
+    if (!_ready.isClosed) _ready.addError(error);
+  }
+
   /// Ends the session the way a receiver that went away entirely does.
   void end() {
     _last = false;
@@ -533,9 +599,13 @@ class _FakeHandle implements CastSessionHandle {
 /// [as] / over [over] to model a device answering for another one, or a proof
 /// made on a different connection.
 class _AcceptingAuthenticator implements CastReceiverAuthenticator {
-  _AcceptingAuthenticator({this.as, this.over});
+  _AcceptingAuthenticator({this.as, this.over, this.after});
 
   final CastDevice? as;
+
+  /// When set, the check takes this long, so a test can be sure the handshake
+  /// observed the session's readiness before it completes.
+  final Duration? after;
 
   /// When set, the proof names this session instead of the one being
   /// authenticated — a receiver proved over some other connection.
@@ -550,6 +620,7 @@ class _AcceptingAuthenticator implements CastReceiverAuthenticator {
     CastSessionHandle session,
   ) async {
     calls.add(device.id);
+    if (after != null) await Future<void>.delayed(after!);
     return CastReceiverIdentity(
       deviceId: (as ?? device).id,
       connection: over ?? session,
@@ -586,6 +657,18 @@ class _ExplodingAuthenticator implements CastReceiverAuthenticator {
   ) async {
     throw StateError('challenge nonce-4711 rejected by peer certificate');
   }
+}
+
+/// Throws before it ever returns a future.
+class _SynchronouslyThrowingAuthenticator implements CastReceiverAuthenticator {
+  const _SynchronouslyThrowingAuthenticator();
+
+  @override
+  Future<CastReceiverIdentity> authenticate(
+    CastDevice device,
+    CastSessionHandle session,
+  ) =>
+      throw StateError('no trust anchors configured');
 }
 
 /// Never answers, the way a receiver that accepts a socket and then goes quiet

--- a/test/core/services/cast/trust_gated_cast_transport_test.dart
+++ b/test/core/services/cast/trust_gated_cast_transport_test.dart
@@ -28,12 +28,6 @@ void main() {
   const CastDevice speaker = CastDevice(id: 'speaker-1', name: 'Kitchen');
   const CastDevice other = CastDevice(id: 'speaker-2', name: 'Bedroom');
 
-  const CastReceiverIdentity speakerIdentity = CastReceiverIdentity(
-    deviceId: 'speaker-1',
-    fingerprint: 'sha256:aa:bb',
-    model: 'Test Receiver',
-  );
-
   final CastMedia media = CastMedia(
     url: Uri.parse('https://example.test/stream?api_key=secret-token'),
     contentType: 'audio/mpeg',
@@ -44,11 +38,13 @@ void main() {
     _FakeTransport transport, {
     CastReceiverAuthenticator? authenticator,
     Duration timeout = const Duration(milliseconds: 50),
+    Duration cleanupTimeout = const Duration(milliseconds: 50),
   }) {
     return TrustGatedCastTransport(
       delegate: transport,
       authenticator: authenticator ?? _AcceptingAuthenticator(),
       authenticationTimeout: timeout,
+      cleanupTimeout: cleanupTimeout,
     );
   }
 
@@ -137,6 +133,47 @@ void main() {
       expect(transport.session.loaded, isEmpty);
     });
 
+    test('a proof made over another connection is refused', () async {
+      final _FakeTransport transport = _FakeTransport();
+
+      // The right device, authenticated somewhere else. Cast's device
+      // authentication is a property of a connection, so a proof from another
+      // one says nothing about the socket the stream would go to.
+      final CastReceiverTrustException error = await refusal(
+        transport,
+        authenticator: _AcceptingAuthenticator(over: _FakeHandle()),
+      );
+
+      expect(error.kind, CastTrustFailureKind.identityMismatch);
+      expect(transport.session.closed, isTrue);
+      expect(transport.session.loaded, isEmpty);
+    });
+
+    test('a session that drops mid-handshake is an unfinished check', () async {
+      final _FakeTransport transport = _FakeTransport();
+
+      // Ready, then not: the receiver went away while it was being checked.
+      // (A `false` before the first `true` is only "not ready yet" — the
+      // receiver's media app is still launching — and must not fail the check.)
+      final Future<CastSessionHandle> connecting = gate(
+        transport,
+        authenticator: _HangingAuthenticator(),
+        timeout: const Duration(seconds: 30),
+      ).connect(speaker);
+      await pumpEventQueue();
+      transport.session.drop();
+
+      await expectLater(
+        connecting,
+        throwsA(isA<CastReceiverTrustException>().having(
+          (CastReceiverTrustException e) => e.kind,
+          'kind',
+          CastTrustFailureKind.incomplete,
+        )),
+      );
+      expect(transport.session.loaded, isEmpty);
+    });
+
     test('an authentication that never finishes expires', () async {
       final _FakeTransport transport = _FakeTransport();
 
@@ -191,6 +228,22 @@ void main() {
       expect(error.message, isNot(contains('nonce-')));
     });
 
+    test('a receiver that will not close at all still gets refused', () async {
+      // Cleanup is best-effort on a path that has already failed: a receiver
+      // that accepts the close and then goes quiet must not leave the caller
+      // stuck in "connecting" on a session that failed its check.
+      final _FakeTransport transport = _FakeTransport()
+        ..session.closeHangs = true;
+
+      final CastReceiverTrustException error = await refusal(
+        transport,
+        authenticator: const _RefusingAuthenticator(),
+      );
+
+      expect(error.kind, CastTrustFailureKind.rejected);
+      expect(transport.session.loaded, isEmpty);
+    });
+
     test('a receiver that will not close cleanly still gets refused', () async {
       final _FakeTransport transport = _FakeTransport()
         ..session.closeError = StateError('socket already gone');
@@ -233,6 +286,30 @@ void main() {
         gate(transport).discover(const Duration(seconds: 1)),
         throwsA(isA<CastContainmentError>()),
       );
+    });
+
+    test('trust does not survive the receiver dropping the session', () async {
+      final _FakeTransport transport = _FakeTransport();
+
+      final CastSessionHandle session = await gate(transport).connect(speaker);
+      // Let the wrapper's lifetime listener attach (the handle replays its
+      // readiness to it) before the receiver goes away.
+      await pumpEventQueue();
+      transport.session.drop();
+      await pumpEventQueue();
+
+      // The connection the proof was made over is gone, so the handoff refuses
+      // even though nobody has called close() yet — a track resolution that
+      // started before the drop must not still reach a dead receiver.
+      await expectLater(
+        session.loadMedia(media),
+        throwsA(isA<CastReceiverTrustException>().having(
+          (CastReceiverTrustException e) => e.kind,
+          'kind',
+          CastTrustFailureKind.incomplete,
+        )),
+      );
+      expect(transport.session.loaded, isEmpty);
     });
 
     test('trust does not survive the session being closed', () async {
@@ -289,24 +366,52 @@ void main() {
   });
 
   group('CastReceiverIdentity', () {
-    test('is bound to the device it was proved for', () {
-      expect(speakerIdentity.matches(speaker), isTrue);
-      expect(speakerIdentity.matches(other), isFalse);
+    test('is bound to the device *and* the connection it was proved on', () {
+      final _FakeHandle session = _FakeHandle();
+      final _FakeHandle elsewhere = _FakeHandle();
+      final CastReceiverIdentity identity = CastReceiverIdentity(
+        deviceId: 'speaker-1',
+        connection: session,
+        fingerprint: 'sha256:aa:bb',
+        model: 'Test Receiver',
+      );
+
+      expect(identity.matches(speaker, session), isTrue);
+      // Right device, wrong connection: a proof made somewhere else says
+      // nothing about the socket the media would go to.
+      expect(identity.matches(speaker, elsewhere), isFalse);
+      expect(identity.matches(other, session), isFalse);
     });
 
-    test('two proofs of the same device are only equal if they agree', () {
+    test('two proofs are only equal if they agree on all of it', () {
+      final _FakeHandle session = _FakeHandle();
+      final CastReceiverIdentity identity = CastReceiverIdentity(
+        deviceId: 'speaker-1',
+        connection: session,
+        fingerprint: 'sha256:aa:bb',
+      );
+
       expect(
-        speakerIdentity,
-        const CastReceiverIdentity(
+        identity,
+        CastReceiverIdentity(
           deviceId: 'speaker-1',
+          connection: session,
           fingerprint: 'sha256:aa:bb',
-          model: 'Test Receiver',
         ),
       );
       expect(
-        speakerIdentity,
-        isNot(const CastReceiverIdentity(
+        identity,
+        isNot(CastReceiverIdentity(
           deviceId: 'speaker-1',
+          connection: _FakeHandle(),
+          fingerprint: 'sha256:aa:bb',
+        )),
+      );
+      expect(
+        identity,
+        isNot(CastReceiverIdentity(
+          deviceId: 'speaker-1',
+          connection: session,
           fingerprint: 'sha256:cc:dd',
         )),
       );
@@ -355,7 +460,24 @@ class _FakeHandle implements CastSessionHandle {
   /// When set, [close] throws it, so a failing teardown can be exercised.
   Object? closeError;
 
-  /// Ends the session the way a dropped receiver does.
+  /// When true, [close] never completes — a receiver that accepts the request
+  /// and then says nothing.
+  bool closeHangs = false;
+
+  /// Reports the receiver's media app as up.
+  void becomeReady() {
+    _last = true;
+    if (!_ready.isClosed) _ready.add(true);
+  }
+
+  /// Reports the session as no longer ready, the way a dropped receiver does,
+  /// without closing the stream.
+  void drop() {
+    _last = false;
+    if (!_ready.isClosed) _ready.add(false);
+  }
+
+  /// Ends the session the way a receiver that went away entirely does.
   void end() {
     _last = false;
     if (!_ready.isClosed) {
@@ -401,26 +523,36 @@ class _FakeHandle implements CastSessionHandle {
   @override
   Future<void> close() async {
     closed = true;
+    if (closeHangs) return Completer<void>().future;
     if (closeError != null) throw closeError!;
     if (!_ready.isClosed) await _ready.close();
   }
 }
 
-/// Vouches for a receiver — as itself by default, or as [as] to model a device
-/// answering for another one.
+/// Vouches for a receiver — as itself over its own session by default, or as
+/// [as] / over [over] to model a device answering for another one, or a proof
+/// made on a different connection.
 class _AcceptingAuthenticator implements CastReceiverAuthenticator {
-  _AcceptingAuthenticator({this.as});
+  _AcceptingAuthenticator({this.as, this.over});
 
   final CastDevice? as;
+
+  /// When set, the proof names this session instead of the one being
+  /// authenticated — a receiver proved over some other connection.
+  final CastSessionHandle? over;
 
   /// Every device this was asked about, so a test can show it was never asked.
   final List<String> calls = <String>[];
 
   @override
-  Future<CastReceiverIdentity> authenticate(CastDevice device) async {
+  Future<CastReceiverIdentity> authenticate(
+    CastDevice device,
+    CastSessionHandle session,
+  ) async {
     calls.add(device.id);
     return CastReceiverIdentity(
       deviceId: (as ?? device).id,
+      connection: over ?? session,
       fingerprint: 'sha256:aa:bb',
     );
   }
@@ -431,7 +563,10 @@ class _RefusingAuthenticator implements CastReceiverAuthenticator {
   const _RefusingAuthenticator();
 
   @override
-  Future<CastReceiverIdentity> authenticate(CastDevice device) async {
+  Future<CastReceiverIdentity> authenticate(
+    CastDevice device,
+    CastSessionHandle session,
+  ) async {
     throw const CastReceiverTrustException(
       "Linthra couldn't verify that device.",
       kind: CastTrustFailureKind.rejected,
@@ -445,7 +580,10 @@ class _ExplodingAuthenticator implements CastReceiverAuthenticator {
   const _ExplodingAuthenticator();
 
   @override
-  Future<CastReceiverIdentity> authenticate(CastDevice device) async {
+  Future<CastReceiverIdentity> authenticate(
+    CastDevice device,
+    CastSessionHandle session,
+  ) async {
     throw StateError('challenge nonce-4711 rejected by peer certificate');
   }
 }
@@ -454,6 +592,9 @@ class _ExplodingAuthenticator implements CastReceiverAuthenticator {
 /// does not.
 class _HangingAuthenticator implements CastReceiverAuthenticator {
   @override
-  Future<CastReceiverIdentity> authenticate(CastDevice device) =>
+  Future<CastReceiverIdentity> authenticate(
+    CastDevice device,
+    CastSessionHandle session,
+  ) =>
       Completer<CastReceiverIdentity>().future;
 }

--- a/test/core/services/cast/trust_gated_cast_transport_test.dart
+++ b/test/core/services/cast/trust_gated_cast_transport_test.dart
@@ -369,6 +369,46 @@ void main() {
       );
     });
 
+    test('every receiver command refuses once trust is gone', () async {
+      // Not just the media handoff: after the proved connection ends, the
+      // delegate may have reconnected underneath, and this session's proof says
+      // nothing about that one.
+      final _FakeTransport transport = _FakeTransport();
+
+      final CastSessionHandle session = await gate(transport).connect(speaker);
+      await pumpEventQueue();
+      transport.session.drop();
+      await pumpEventQueue();
+
+      for (final Future<void> Function() command in <Future<void> Function()>[
+        () => session.loadMedia(media),
+        session.play,
+        session.pause,
+        () => session.seek(const Duration(seconds: 3)),
+        () => session.setVolume(0.5),
+        () => session.setMuted(true),
+        session.requestStatus,
+      ]) {
+        await expectLater(
+          command(),
+          throwsA(isA<CastReceiverTrustException>()),
+        );
+      }
+
+      expect(transport.session.loaded, isEmpty);
+      expect(transport.session.playCount, 0);
+      expect(transport.session.pauseCount, 0);
+      expect(transport.session.seeks, isEmpty);
+      expect(transport.session.volumes, isEmpty);
+      expect(transport.session.mutes, isEmpty);
+      expect(transport.session.statusRequests, 0);
+
+      // Teardown still works: closing an untrusted session is exactly what the
+      // caller should still be able to do.
+      await session.close();
+      expect(transport.session.closed, isTrue);
+    });
+
     test('trust does not survive the session being closed', () async {
       final _FakeTransport transport = _FakeTransport();
 

--- a/test/tooling/verify_release_containment_test.py
+++ b/test/tooling/verify_release_containment_test.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/verify_release_containment.py (#574).
+
+    python3 test/tooling/verify_release_containment_test.py
+
+The script decides whether a *shipped* artifact looks like a contained build, so
+the thing worth testing is that it says no when it should. Real APKs are 25-70 MB
+and cannot be built here, so every case is a synthetic archive: a zip or a
+tarball holding a `libapp.so` that is a few hundred bytes of made-up snapshot
+with (or without) the markers the script looks for. That is exactly the surface
+the script reads — it searches bytes for strings — so a fixture is a faithful
+stand-in, and it keeps the tests independent of Linthra's current version, the
+Flutter SDK, and the network.
+
+The one case that does use the real repository is the message parser: "the
+expected message is the one the app actually shows" is the property that keeps
+this check honest, and only reading the real `cast_containment.dart` proves it.
+
+Everything is offline. No network, no builds, no repository writes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import tarfile
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+
+sys.path.insert(0, str(SCRIPTS))
+
+
+def _load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+verifier = _load("verify_release_containment", "verify_release_containment.py")
+
+MESSAGE = "Casting is off — everything else works."
+
+# Filler around the markers, so a fixture payload looks like what the script
+# really reads: a blob where the strings sit among unrelated bytes.
+NOISE = b"\x00\x01flutter\x00snapshot\x00" * 8
+
+
+def contained_payload(
+    *,
+    message: str = MESSAGE,
+    required: tuple[str, ...] = verifier.REQUIRED_MARKERS,
+    extra: tuple[str, ...] = (),
+) -> bytes:
+    """A fake `libapp.so` carrying the strings a contained build would have."""
+    blob = bytearray(NOISE)
+    blob += message.encode("utf-16-le")
+    for marker in required + extra:
+        blob += NOISE
+        blob += marker.encode("utf-16-le")
+    blob += NOISE
+    return bytes(blob)
+
+
+class ContainmentMessageTest(unittest.TestCase):
+    """The expected string comes from the app's own source, or not at all."""
+
+    def test_reads_the_real_message_from_the_app_source(self):
+        message = verifier.containment_message(verifier.CONTAINMENT_SOURCE)
+
+        # Not an equality check against a copy of the copy: what matters is that
+        # the parser returns the real sentence, including the parts that live on
+        # later lines of the adjacent-literal expression.
+        self.assertIn("Casting is temporarily turned off", message)
+        self.assertIn("your servers", message)
+        self.assertNotIn("'", message)
+
+    def test_joins_adjacent_literals_in_order(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "cast_containment.dart"
+            source.write_text(
+                "abstract final class CastContainment {\n"
+                "  static const String userMessage =\n"
+                "      'one '\n"
+                "      'two '\n"
+                "      'three';\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                verifier.containment_message(source), "one two three"
+            )
+
+    def test_missing_message_is_an_error_not_a_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "cast_containment.dart"
+            source.write_text("class CastContainment {}\n", encoding="utf-8")
+
+            with self.assertRaises(verifier.VerificationError):
+                verifier.containment_message(source)
+
+    def test_unreadable_source_is_an_error(self):
+        with self.assertRaises(verifier.VerificationError):
+            verifier.containment_message(Path("does/not/exist.dart"))
+
+
+class ArtifactVerificationTest(unittest.TestCase):
+    """Take a good artifact, break exactly one thing, expect it to be caught."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp = Path(self._tmp.name)
+
+    def write_zip(self, name: str, entries: dict[str, bytes]) -> Path:
+        path = self.tmp / name
+        with zipfile.ZipFile(path, "w") as archive:
+            for entry, blob in entries.items():
+                archive.writestr(entry, blob)
+        return path
+
+    def write_tar(self, name: str, entries: dict[str, bytes]) -> Path:
+        path = self.tmp / name
+        with tarfile.open(path, "w:gz") as archive:
+            for entry, blob in entries.items():
+                info = tarfile.TarInfo(entry)
+                info.size = len(blob)
+                archive.addfile(info, io.BytesIO(blob))
+        return path
+
+    def verify(self, path: Path):
+        return verifier.verify_artifact(path, MESSAGE)
+
+    def test_contained_apk_passes_and_reports_its_digest(self):
+        apk = self.write_zip(
+            "linthra-release-signed.apk",
+            {
+                "lib/arm64-v8a/libapp.so": contained_payload(),
+                "lib/armeabi-v7a/libapp.so": contained_payload(),
+                "AndroidManifest.xml": b"<manifest/>",
+            },
+        )
+
+        record = self.verify(apk)
+
+        self.assertEqual(record["artifact"], "linthra-release-signed.apk")
+        self.assertEqual(len(record["sha256"]), 64)
+        self.assertEqual(
+            record["payloads"],
+            ["lib/arm64-v8a/libapp.so", "lib/armeabi-v7a/libapp.so"],
+        )
+
+    def test_latin1_message_is_found_too(self):
+        # A message with no wide character is stored one byte per code unit, so
+        # rewording the copy must not quietly stop the check from finding it.
+        plain = "Casting is off for now."
+        apk = self.write_zip(
+            "plain.apk",
+            {
+                "lib/arm64-v8a/libapp.so": bytes(NOISE)
+                + plain.encode("latin-1")
+                + b"".join(
+                    NOISE + m.encode("latin-1")
+                    for m in verifier.REQUIRED_MARKERS
+                )
+            },
+        )
+
+        self.assertEqual(
+            verifier.verify_artifact(apk, plain)["artifact"], "plain.apk"
+        )
+
+    def test_aab_payloads_under_base_are_checked(self):
+        aab = self.write_zip(
+            "linthra-release-signed.aab",
+            {"base/lib/x86_64/libapp.so": contained_payload()},
+        )
+
+        self.assertEqual(
+            self.verify(aab)["payloads"], ["base/lib/x86_64/libapp.so"]
+        )
+
+    def test_linux_tarball_is_checked(self):
+        archive = self.write_tar(
+            "Linthra-linux-x64.tar.gz",
+            {
+                "Linthra-linux-x64/linthra": b"ELF",
+                "Linthra-linux-x64/lib/libapp.so": contained_payload(),
+            },
+        )
+
+        self.assertEqual(
+            self.verify(archive)["payloads"], ["Linthra-linux-x64/lib/libapp.so"]
+        )
+
+    def test_missing_containment_message_fails(self):
+        apk = self.write_zip(
+            "uncontained.apk",
+            {"lib/arm64-v8a/libapp.so": contained_payload(message="something else")},
+        )
+
+        with self.assertRaises(verifier.VerificationError) as caught:
+            self.verify(apk)
+        self.assertIn("containment message is missing", str(caught.exception))
+
+    def test_missing_required_marker_fails(self):
+        apk = self.write_zip(
+            "no-unavailable-service.apk",
+            {"lib/arm64-v8a/libapp.so": contained_payload(required=())},
+        )
+
+        with self.assertRaises(verifier.VerificationError) as caught:
+            self.verify(apk)
+        self.assertIn("expected marker", str(caught.exception))
+
+    def test_each_live_cast_marker_fails_on_its_own(self):
+        for marker in verifier.FORBIDDEN_MARKERS:
+            with self.subTest(marker=marker):
+                apk = self.write_zip(
+                    "live.apk",
+                    {
+                        "lib/arm64-v8a/libapp.so": contained_payload(
+                            extra=(marker,)
+                        )
+                    },
+                )
+
+                with self.assertRaises(verifier.VerificationError) as caught:
+                    self.verify(apk)
+                self.assertIn("live-cast marker", str(caught.exception))
+
+    def test_one_bad_payload_among_good_ones_fails(self):
+        # The universal APK carries one payload per ABI, and a build that lost
+        # containment for a single architecture is still a build that must not
+        # ship.
+        apk = self.write_zip(
+            "universal.apk",
+            {
+                "lib/arm64-v8a/libapp.so": contained_payload(),
+                "lib/x86_64/libapp.so": contained_payload(message="nope"),
+            },
+        )
+
+        with self.assertRaises(verifier.VerificationError) as caught:
+            self.verify(apk)
+        self.assertIn("lib/x86_64/libapp.so", str(caught.exception))
+
+    def test_artifact_without_dart_payload_fails_closed(self):
+        apk = self.write_zip("empty.apk", {"AndroidManifest.xml": b"<manifest/>"})
+
+        with self.assertRaises(verifier.VerificationError) as caught:
+            self.verify(apk)
+        self.assertIn("no libapp.so", str(caught.exception))
+
+    def test_unknown_artifact_type_fails_closed(self):
+        stray = self.tmp / "release-notes.txt"
+        stray.write_text("not an artifact", encoding="utf-8")
+
+        with self.assertRaises(verifier.VerificationError) as caught:
+            self.verify(stray)
+        self.assertIn("unknown artifact type", str(caught.exception))
+
+    def test_unreadable_archive_fails_closed(self):
+        broken = self.tmp / "truncated.apk"
+        broken.write_bytes(b"PK\x03\x04 not really a zip")
+
+        with self.assertRaises(verifier.VerificationError):
+            self.verify(broken)
+
+    def test_missing_file_fails_closed(self):
+        with self.assertRaises(verifier.VerificationError):
+            self.verify(self.tmp / "never-built.apk")
+
+
+class CommandLineTest(unittest.TestCase):
+    """The exit code is what CI reads, so it gets its own coverage."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp = Path(self._tmp.name)
+        # main() checks against the real app message, not this file's fixture.
+        self.message = verifier.containment_message(verifier.CONTAINMENT_SOURCE)
+
+    def apk(self, name: str, *, message: str) -> Path:
+        path = self.tmp / name
+        with zipfile.ZipFile(path, "w") as archive:
+            archive.writestr(
+                "lib/arm64-v8a/libapp.so", contained_payload(message=message)
+            )
+        return path
+
+    def test_passing_run_writes_the_json_record(self):
+        good = self.apk("good.apk", message=self.message)
+        record = self.tmp / "record.json"
+
+        self.assertEqual(
+            verifier.main([str(good), "--json", str(record)]),
+            0,
+        )
+        self.assertIn('"sha256"', record.read_text(encoding="utf-8"))
+
+    def test_one_bad_artifact_fails_the_whole_run(self):
+        good = self.apk("good.apk", message=self.message)
+        bad = self.apk("bad.apk", message="not the containment message")
+
+        self.assertEqual(verifier.main([str(good), str(bad)]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/tooling/verify_release_containment_test.py
+++ b/test/tooling/verify_release_containment_test.py
@@ -309,6 +309,31 @@ class CommandLineTest(unittest.TestCase):
         )
         self.assertIn('"sha256"', record.read_text(encoding="utf-8"))
 
+    def test_the_expected_message_can_come_from_another_tree(self):
+        # A release build checks out the tag it builds; the verifier comes from
+        # the workflow's own revision. --containment-source is how the caller
+        # says which tree's message the artifact should carry.
+        source = self.tmp / "cast_containment.dart"
+        source.write_text(
+            "abstract final class CastContainment {\n"
+            "  static const String userMessage = 'An older wording.';\n"
+            "}\n",
+            encoding="utf-8",
+        )
+        matching = self.apk("old.apk", message="An older wording.")
+        mismatched = self.apk("new.apk", message=self.message)
+
+        self.assertEqual(
+            verifier.main([str(matching), "--containment-source", str(source)]),
+            0,
+        )
+        self.assertEqual(
+            verifier.main(
+                [str(mismatched), "--containment-source", str(source)]
+            ),
+            1,
+        )
+
     def test_one_bad_artifact_fails_the_whole_run(self):
         good = self.apk("good.apk", message=self.message)
         bad = self.apk("bad.apk", message="not the containment message")


### PR DESCRIPTION
Three issues, one commit each, plus a follow-up commit for the review findings. Casting stays off in shipped builds: nothing here restores it, and nothing new is wired into production.

## #574 — verify and record the maintenance release

The containment shipped in v0.2.6, but everything checking it looked at the source tree. For a security release the question is whether the safeguard is in the file people install.

- `scripts/verify_release_containment.py` reads the compiled Dart inside an APK, an AAB or the Linux tarball and checks for the containment message and `UnavailableCastService`, plus the absence of the live-cast strings tree shaking drops while nothing constructs them. Prints each artifact's SHA-256, fails closed, and says plainly in its docstring that it is a byte search rather than a proof.
- It runs before an artifact is uploaded anywhere (the Android release build and the Linux packaging job), and again on the published assets during a stable publication, with the digests recorded in the job summary. Its own unit tests run in CI on synthetic artifacts.
- `docs/release-artifact-verification.md` records the v0.2.6 run: commit `f1d61f9`, version `0.2.6+206999`, and every published asset with its SHA-256, plus where each distribution channel stands.

I ran it against the six published v0.2.6 assets while writing this: all of them carry the containment, none carries a live-cast marker. Those are the digests in the doc.

## #575 — receiver trust contract and fail-closed gate

The app's half of the restoration, built ahead of the implementation choice so reviewing the eventual transport is about the protocol rather than our plumbing.

- `CastReceiverAuthenticator` is handed the session to check and returns an identity naming both the device and that connection, or throws. The connection half matters: Cast's device authentication is a challenge answered on a connection, so a proof gathered elsewhere describes a different conversation than the one the media would go to. An inconclusive check is a failure. The shipped `UnverifiedCastReceiverAuthenticator` refuses every receiver.
- `TrustGatedCastTransport` hands out a session only after the receiver authenticated and the identity matches both the device the user picked and the session it will use. Any failure closes the session (bounded, so an unresponsive receiver cannot hold the refusal back), the media handoff refuses again on its own, and trust ends with the connection it was proved over — a close from here or the receiver dropping.
- `DefaultCastService` surfaces a refusal's own secret-free message instead of a generic "couldn't connect", so a security refusal does not read as a flaky network.
- Containment still comes first: the gate authenticates over a connection the delegate opened, so a contained transport refuses before trust is even asked about. There is a test for that, so this cannot become a second route to a receiver.
- Negative tests cover a refusal, a device authenticating as another device, a proof made over another connection, a handshake that never finishes, a session dropping or dying mid-handshake, a drop after a successful check, an authenticator throwing something unexpected, and a receiver that will not close cleanly or at all. No refusal message carries anything from the handshake.
- `docs/cast-receiver-trust.md` has the trust model, implementation options and trade-offs, the negative/device test matrix, and the restoration checklist.

## #576 — what a cast handoff delegates

- `CastMediaAccess` makes each source declare what casting one of its tracks hands over: a capability scoped to the item, or the account credential, with scope, lifetime and revocation.
- Jellyfin and Subsonic both declare `accountCredential` / `account`, because neither issues a per-item signed URL. No client-side restriction the server does not enforce, and no broader credential as a fallback.
- A source that declares nothing reads as account-level exposure, so an omission overstates rather than understates.
- `CastMediaResolver.accessFor` answers without resolving or touching the network; routing reports the source that would actually cast the track.
- `docs/cast-media-access.md` has the per-server matrix, what each server would need for a scoped capability, and the on-device media proxy option with its real costs, deferred to its own security and operational review.

## Checks

- `flutter analyze` clean, full `flutter test` green (4249 tests), `dart format` clean.
- `ruff check` / `ruff format --check` clean over `scripts tool tools`.
- `scripts/check_cast_containment.py` still passes, and `test/tooling/verify_release_containment_test.py` passes.

Security-sensitive details stay in the private advisory; nothing about the report is in the code, the docs, or these commits.
