### PR TITLE
feat(audio): hold the foreground service only across a transient-focus pause (#499)

### DIFF
--- a/docs/audio-bluetooth-cpu-audit.md
+++ b/docs/audio-bluetooth-cpu-audit.md
@@ -74,10 +74,9 @@ routes them to `LinthraAudioHandler`, which forwards to the single
   only when a previous track exists, `skipToNext` only when one is queued, so no
   dead button is shown. This invariant is now locked by a test (see §5).
 - **Lock screen / notification.** Driven by the same `playbackState`/`mediaItem`
-  the handler publishes; the notification is configured ongoing while playing
-  (`androidNotificationOngoing: true`, `androidStopForegroundOnPause: true` at
-  `:482`). `MediaButtonReceiver` in the manifest (`:95`) handles hardware/Bluetooth
-  `MEDIA_BUTTON` intents.
+  the handler publishes (`androidNotificationOngoing: false`,
+  `androidStopForegroundOnPause: true`). `MediaButtonReceiver` in the manifest
+  (`:95`) handles hardware/Bluetooth `MEDIA_BUTTON` intents.
 
 ### Metadata sent to Bluetooth / lock screen / car
 
@@ -231,6 +230,7 @@ now-playing screen. Those rebuilds happen only while that screen is foregrounded
 | Local playback | CPU is busy decoding regardless; the ~4 Hz flush + ≤1 Hz session push are negligible on top. |
 | Streaming playback | As local, plus network buffering tuned for resilience (`_streamBuffering`); preload warms only the immediate next track, sequentially. |
 | Paused playback | Engine idle; flush timer stopped; foreground service demoted (`androidStopForegroundOnPause`); wake locks released. |
+| Paused by another app's focus | As above, except the service is kept foreground until focus returns (bounded by `focusHoldTimeout`), so the isolate can process the focus regain and resume by itself (#499). |
 | Bluetooth playback | Same as local/streaming; routing is OS-level, no extra app work. |
 | Cast playback | Local engine suspended (silent); ~1 Hz receiver poll + 250 ms position ticker, both gated to *playing* (#142). |
 

--- a/docs/battery.md
+++ b/docs/battery.md
@@ -20,9 +20,19 @@ cache/pre-cache behaviour in [docs/offline-cache.md](./offline-cache.md).
 - **The foreground service runs only while audio is actually working.**
   `audio_service`'s media service (and the CPU/Wi-Fi wake locks it holds) is
   promoted to the foreground while the session reports `playing` and demoted on a
-  real pause (`androidStopForegroundOnPause: true`). A paused track holds no wake
-  lock. See `connectMediaSession` in
+  real pause (`androidStopForegroundOnPause: true`). A track you paused yourself
+  holds no wake lock. See `connectMediaSession` in
   `lib/core/services/linthra_audio_handler.dart`.
+- **One exception: a pause caused by another app.** When a call, a navigation
+  prompt, or a voice assistant takes audio focus, Linthra keeps the service
+  foreground for that pause only, and drops it again the moment focus comes back
+  (or after a bounded window if the other app never hands focus back). This is
+  what makes playback resume on its own when the interruption ends: the audio
+  focus handling runs in the Flutter isolate, and a demoted service lets the OS
+  freeze that isolate, so the "focus regained" signal would never be seen and
+  music would only come back when you reopened the app. See
+  `PlaybackState.interruptedByTransientFocus` and
+  `JustAudioPlaybackController.focusHoldTimeout`.
 - **A mid-stream re-buffer or a track transition never drops the service.**
   The session is reported as `playing` while the engine is actively working
   toward sound — steadily playing, re-buffering, or loading the next track — so

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,8 +46,9 @@ changes.
   reopening Linthra).
 
 The one intentional follow-up it left behind — a *battery-optimal* audio-focus
-mode that keeps the service alive **only during a transient-focus pause** — rolls
-into Phase 1.
+mode that keeps the service alive **only during a transient-focus pause** — landed
+in Phase 1 ([#499](https://github.com/thezupzup/linthra/issues/499)), so a track
+you pause yourself no longer holds a wake lock.
 
 ## Phase 1 — v0.1.7 stabilization pass
 
@@ -59,10 +60,11 @@ Focus areas, with the existing issues they map to:
 
 - **Background playback reliability** — keep the gains from #244 solid across
   Doze, screen-off, and long pauses.
-- **Audio-focus regressions** — guard the #244 behaviour with the deterministic
-  focus tests already in place, and land the **battery-optimal follow-up** (keep
-  `stopForegroundOnPause: true`, hold the service only across a transient-focus
-  pause). See [docs/battery.md](./battery.md) → *Possible future work*.
+- **Audio-focus regressions** — ✅ the #244 behaviour is guarded by the
+  deterministic focus tests, and the **battery-optimal follow-up** has landed
+  (`stopForegroundOnPause: true`, with the service held only across a
+  transient-focus pause). See [docs/battery.md](./battery.md) → *Playback service
+  & wake locks*.
 - **Screen-lock playback** — no pause/mute on a brief screen-off focus blip.
 - **Android Auto sanity** — real head-unit and Desktop-Head-Unit passes
   ([#82](https://github.com/thezupzup/linthra/issues/82)).

--- a/lib/core/models/playback_state.dart
+++ b/lib/core/models/playback_state.dart
@@ -40,6 +40,7 @@ class PlaybackState {
     this.source,
     this.shuffleEnabled = false,
     this.repeatMode = RepeatMode.off,
+    this.interruptedByTransientFocus = false,
     this.errorMessage,
   });
 
@@ -82,6 +83,23 @@ class PlaybackState {
   /// button from; the controller consults it when a track finishes.
   final RepeatMode repeatMode;
 
+  /// Whether playback is paused *only* because another app is holding a
+  /// transient audio focus (a call, a navigation prompt, a voice interaction)
+  /// and Linthra intends to resume the moment focus comes back.
+  ///
+  /// This is the signal the Android media session uses to keep its foreground
+  /// service (and the CPU wake lock that comes with it) alive across such a
+  /// pause: the on-device focus handling runs in the Flutter isolate, so a
+  /// demoted service can be frozen by the OS and never see the `AUDIOFOCUS_GAIN`
+  /// that ends the interruption. It is set only while a transient loss that
+  /// interrupted *active* playback is outstanding, and cleared on the regain, on
+  /// a permanent loss, on any explicit user transport, and once the controller's
+  /// bounded hold window expires — so an ordinary user pause still demotes the
+  /// service and holds no wake lock. See
+  /// `JustAudioPlaybackController._armTransientResume` and
+  /// `LinthraAudioHandler._isSessionPlaying`.
+  final bool interruptedByTransientFocus;
+
   /// A friendly, secret-free explanation shown when [status] is
   /// [PlaybackStatus.error]. Deliberately *not* carried by [copyWith]: it is set
   /// only on a freshly built error state and clears on the next state change, so
@@ -120,6 +138,7 @@ class PlaybackState {
     PlaybackSource? source,
     bool? shuffleEnabled,
     RepeatMode? repeatMode,
+    bool? interruptedByTransientFocus,
   }) {
     return PlaybackState(
       status: status ?? this.status,
@@ -132,6 +151,32 @@ class PlaybackState {
       source: source ?? this.source,
       shuffleEnabled: shuffleEnabled ?? this.shuffleEnabled,
       repeatMode: repeatMode ?? this.repeatMode,
+      interruptedByTransientFocus:
+          interruptedByTransientFocus ?? this.interruptedByTransientFocus,
+    );
+  }
+
+  /// Returns this state with [interruptedByTransientFocus] set to [value].
+  ///
+  /// Unlike [copyWith] this preserves [errorMessage], because it re-stamps a
+  /// state the controller has *already* built rather than deriving a new one:
+  /// the focus hold is orthogonal to why playback stopped, so an error state
+  /// must keep its message when the flag is stamped onto it.
+  PlaybackState withTransientFocusInterruption(bool value) {
+    if (value == interruptedByTransientFocus) return this;
+    return PlaybackState(
+      status: status,
+      currentTrack: currentTrack,
+      upNext: upNext,
+      previous: previous,
+      hasPrevious: hasPrevious,
+      position: position,
+      duration: duration,
+      source: source,
+      shuffleEnabled: shuffleEnabled,
+      repeatMode: repeatMode,
+      interruptedByTransientFocus: value,
+      errorMessage: errorMessage,
     );
   }
 
@@ -149,6 +194,7 @@ class PlaybackState {
           other.source == source &&
           other.shuffleEnabled == shuffleEnabled &&
           other.repeatMode == repeatMode &&
+          other.interruptedByTransientFocus == interruptedByTransientFocus &&
           other.errorMessage == errorMessage);
 
   @override
@@ -164,6 +210,7 @@ class PlaybackState {
       source,
       shuffleEnabled,
       repeatMode,
+      interruptedByTransientFocus,
       errorMessage,
     );
   }

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -195,7 +195,35 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   /// becoming-noisy pause, and once consumed. So another media app taking focus,
   /// a plain screen-on, or a track the user had paused never auto-resumes, while
   /// a brief transient interruption to background playback recovers.
+  ///
+  /// Always write it through [_armTransientResume]: arming is also what holds
+  /// the Android foreground media service across the pause.
   bool _resumeAfterTransientLoss = false;
+
+  /// Whether the media session is currently asked to keep its foreground service
+  /// alive across a pause, mirrored onto every emitted state as
+  /// [PlaybackState.interruptedByTransientFocus].
+  ///
+  /// Tracks [_resumeAfterTransientLoss], except that it also drops on its own
+  /// once [focusHoldTimeout] elapses, so a focus loss whose `AUDIOFOCUS_GAIN`
+  /// never arrives (the app holding focus died) cannot hold a wake lock forever.
+  bool _foregroundHeldForFocus = false;
+
+  /// Releases [_foregroundHeldForFocus] when the hold outlives [focusHoldTimeout].
+  /// Null when no hold is active.
+  Timer? _focusHoldExpiry;
+
+  /// How long the foreground service may be held across a transient-focus pause
+  /// before it is demoted anyway.
+  ///
+  /// Long enough to cover what a transient loss actually is in the field — a
+  /// navigation prompt, an assistant, a notification read-out, a short call — so
+  /// those still recover in the background without reopening the app. Bounded so
+  /// the "held while paused" wake lock the pre-#499 configuration kept
+  /// indefinitely now has a worst case, including when the interrupting app dies
+  /// without ever handing focus back. Settable in tests; never in production.
+  @visibleForTesting
+  Duration focusHoldTimeout = const Duration(minutes: 5);
 
   /// Whether another app currently holds a *duckable* transient focus
   /// (`AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK`), so the engine volume is attenuated
@@ -428,8 +456,8 @@ class JustAudioPlaybackController implements LocalPlaybackController {
         // pauses). Re-reading `isPlaying` on the 2nd event would see the
         // already-paused state and wrongly disarm, so the eventual regain would
         // never resume (the "voice ends and Linthra stays silent" bug).
-        _resumeAfterTransientLoss =
-            _state.isPlaying || _state.isBusy || _resumeAfterTransientLoss;
+        _armTransientResume(
+            _state.isPlaying || _state.isBusy || _resumeAfterTransientLoss);
         // A real transient loss supersedes a duck: clear it so the resume (or a
         // later manual play) is at full volume, never stuck at the duck level.
         _restoreDuckedVolume();
@@ -441,7 +469,7 @@ class JustAudioPlaybackController implements LocalPlaybackController {
         StabilityDiagnostics.audioFocus(
             'loss-transient:scheduled armed=$_resumeAfterTransientLoss');
       case AudioFocusAction.pausePermanent:
-        _resumeAfterTransientLoss = false;
+        _armTransientResume(false);
         _cancelPendingFocusPause();
         StabilityDiagnostics.audioFocus('loss-permanent:paused');
         _restoreDuckedVolume();
@@ -472,10 +500,10 @@ class JustAudioPlaybackController implements LocalPlaybackController {
           // screen-off / Doze focus blip. We never paused, so just keep playing
           // and disarm the now-moot resume. Pausing+resuming here would demote
           // the foreground service and risk an OS freeze with the screen off.
-          _resumeAfterTransientLoss = false;
+          _armTransientResume(false);
           StabilityDiagnostics.audioFocus('regain:churn-absorbed');
         } else if (_resumeAfterTransientLoss) {
-          _resumeAfterTransientLoss = false;
+          _armTransientResume(false);
           StabilityDiagnostics.audioFocus('regain:resumed');
           _enqueueFocusResume();
         } else {
@@ -581,6 +609,40 @@ class JustAudioPlaybackController implements LocalPlaybackController {
         // A volume failure must never break playback; leave the prior volume.
       }
     }).catchError((Object _) {});
+  }
+
+  /// Arms (or disarms) the resume-on-regain intent, and with it the foreground
+  /// hold that keeps the media service — and the isolate that processes focus
+  /// events — alive across the pause.
+  ///
+  /// The two are the same fact: "a transient loss interrupted playback we mean
+  /// to resume". Every write goes through here so the emitted state can never
+  /// disagree with the intent, and so an ordinary user pause (which disarms) is
+  /// free to demote the service and drop the wake lock.
+  void _armTransientResume(bool armed) {
+    _resumeAfterTransientLoss = armed;
+    _setForegroundHeldForFocus(armed);
+  }
+
+  /// Applies [held] to the foreground hold, (re)starting or cancelling the
+  /// [focusHoldTimeout] bound, and re-stamps the current state so the media
+  /// session sees the change immediately.
+  void _setForegroundHeldForFocus(bool held) {
+    if (_foregroundHeldForFocus == held) return;
+    _foregroundHeldForFocus = held;
+    _focusHoldExpiry?.cancel();
+    _focusHoldExpiry = null;
+    if (held) {
+      _focusHoldExpiry = Timer(focusHoldTimeout, () {
+        _focusHoldExpiry = null;
+        // The resume arming deliberately survives: if the isolate is still
+        // alive when focus finally returns, playback still recovers. Only the
+        // battery cost of the hold is given up.
+        StabilityDiagnostics.audioFocus('hold:expired');
+        _setForegroundHeldForFocus(false);
+      });
+    }
+    _emit(_state);
   }
 
   /// Clears an active duck and pushes the normal (un-attenuated) volume back to
@@ -720,7 +782,7 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   /// never auto-resumes when they're plugged back in.
   void _onBecomingNoisy() {
     if (_suspended) return;
-    _resumeAfterTransientLoss = false;
+    _armTransientResume(false);
     // Headphones really were pulled: cancel a pending debounce pause and pause
     // now (the enqueued pause bumps the epoch, superseding any queued resume).
     _cancelPendingFocusPause();
@@ -1005,15 +1067,19 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   }
 
   void _emit(PlaybackState next, {bool force = false}) {
+    // Stamp the foreground focus hold on from one place, so no emit path can
+    // publish a state that disagrees with the current hold.
+    final PlaybackState stamped =
+        next.withTransientFocusInterruption(_foregroundHeldForFocus);
     // [force] bypasses the equality guard for a state that differs only in a way
     // PlaybackState == can't see — namely a same-bare-id provider swap, where
     // Track == compares only the bare id (jellyfin:101 == subsonic:101), so the
     // new state compares equal even though a different provider's copy is now
     // playing. Without it the update would be dropped and UI/reporting would keep
     // showing the failed provider.
-    if (!force && next == _state) return;
-    _state = next;
-    if (!_states.isClosed) _states.add(next);
+    if (!force && stamped == _state) return;
+    _state = stamped;
+    if (!_states.isClosed) _states.add(stamped);
   }
 
   /// Emits the latest coalesced position. When nothing new has arrived since the
@@ -1518,6 +1584,9 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   Future<void> suspend() async {
     if (_suspended) return;
     _suspended = true;
+    // A cast receiver owns the audio now, so a local focus loss is nothing to
+    // recover from: drop any hold rather than keeping the service foreground.
+    _armTransientResume(false);
     // A cast receiver now owns position; stop flushing local ticks underneath it.
     _resetPositionFlush();
     // Silence the engine but keep the loaded source and queue intact, so a
@@ -1574,7 +1643,7 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     // the resume arming and supersede any pending or already-queued focus pause
     // so a stale focus action can't undo the user's play, then restore full
     // volume in case a duck was active.
-    _resumeAfterTransientLoss = false;
+    _armTransientResume(false);
     _supersedeFocusTransport();
     _restoreDuckedVolume();
     // After a server outage the engine may be in error with no loaded source.
@@ -1594,7 +1663,7 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     // An explicit user / media-session pause overrides focus: clear the resume
     // arming and supersede any pending or queued focus pause/resume so the
     // regain after an interruption never auto-resumes a track the user paused.
-    _resumeAfterTransientLoss = false;
+    _armTransientResume(false);
     _supersedeFocusTransport();
     return _player.pause();
   }
@@ -1604,7 +1673,7 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     _resetPositionFlush();
     // A stop is definitive: drop any focus resume intent and supersede any
     // pending/queued focus action so it can't resurrect playback after stop.
-    _resumeAfterTransientLoss = false;
+    _armTransientResume(false);
     _supersedeFocusTransport();
     // A stop is a playback action, so supersede any still-resolving load the
     // same way seek() does below. Stopping the engine says nothing to a
@@ -1649,6 +1718,8 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     _resetPositionFlush();
     _cancelBufferingWatchdog();
     _cancelPendingFocusPause();
+    _focusHoldExpiry?.cancel();
+    _focusHoldExpiry = null;
     await _interruptionSub?.cancel();
     await _becomingNoisySub?.cancel();
     for (final subscription in _subscriptions) {

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -575,7 +575,7 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
         audio.MediaAction.setRepeatMode,
       },
       processingState: _processingStateFor(state.status),
-      playing: _isSessionPlaying(state.status),
+      playing: _isSessionPlaying(state),
       updatePosition: state.position,
       shuffleMode: state.shuffleEnabled
           ? audio.AudioServiceShuffleMode.all
@@ -589,7 +589,7 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   /// This is the value that keeps the foreground media service (and the CPU +
   /// Wi-Fi wake locks `audio_service` holds with it) alive: `audio_service`
   /// promotes the service to the foreground while `playing` is `true` and, with
-  /// the default `androidStopForegroundOnPause`, demotes it the moment it goes
+  /// `androidStopForegroundOnPause: true`, demotes it the moment it goes
   /// `false`. If a mid-stream re-buffer or a track transition reported
   /// `playing: false`, the OS could freeze the backgrounded process with the
   /// screen off — so streaming would go silent and only resume when the app is
@@ -597,18 +597,33 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   ///
   /// So the session is "playing" whenever the engine is actively working toward
   /// sound — steadily playing, re-buffering mid-stream, or loading the next
-  /// track — and only reports `false` on a real user pause, stop, idle, normal
-  /// completion, or error. The distinct buffering/loading `processingState`
-  /// still drives the notification's spinner; the foreground service stays up.
-  static bool _isSessionPlaying(PlaybackStatus status) {
-    switch (status) {
+  /// track. The distinct buffering/loading `processingState` still drives the
+  /// notification's spinner; the foreground service stays up.
+  ///
+  /// A pause is the one state that depends on *why* it happened, which is what
+  /// makes this the battery-optimal mode (#499):
+  ///  - paused because another app holds a transient focus and Linthra will
+  ///    resume when it hands focus back (the controller's
+  ///    [PlaybackState.interruptedByTransientFocus]) → still `playing`, so the
+  ///    service stays foreground and the isolate that processes
+  ///    `AUDIOFOCUS_GAIN` stays alive. Without it, recovery from a call or a
+  ///    navigation prompt would again need the app reopened (#244).
+  ///  - paused by the user → `false`, so the service is demoted and the wake
+  ///    lock released straight away, exactly like stop / idle / completion /
+  ///    error. That is the battery win over holding it across *every* pause.
+  ///
+  /// The controller bounds the transient hold, so a pause can never keep the
+  /// service foreground indefinitely.
+  static bool _isSessionPlaying(PlaybackState state) {
+    switch (state.status) {
       case PlaybackStatus.playing:
       case PlaybackStatus.buffering:
       case PlaybackStatus.reconnecting:
       case PlaybackStatus.loading:
         return true;
-      case PlaybackStatus.idle:
       case PlaybackStatus.paused:
+        return state.interruptedByTransientFocus;
+      case PlaybackStatus.idle:
       case PlaybackStatus.completed:
       case PlaybackStatus.error:
         return false;
@@ -645,7 +660,7 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
     // icon during a mid-stream re-buffer.
     return <audio.MediaControl>[
       if (state.hasPrevious) audio.MediaControl.skipToPrevious,
-      _isSessionPlaying(state.status)
+      _isSessionPlaying(state)
           ? audio.MediaControl.pause
           : audio.MediaControl.play,
       audio.MediaControl.stop,
@@ -725,28 +740,35 @@ Future<LinthraAudioHandler?> connectMediaSession(
       config: const audio.AudioServiceConfig(
         androidNotificationChannelId: 'com.linthra.audio',
         androidNotificationChannelName: 'Linthra playback',
-        // Keep the foreground media service alive *across a pause*, not just
-        // while playing. With `androidStopForegroundOnPause: true`,
+        // Demote the foreground media service on a pause — but only on a pause
+        // that is really the user's (#499).
+        //
         // `audio_service` releases the foreground service AND the CPU wake lock
-        // the moment the session reports `playing: false` — which lets the OS
+        // the moment the session reports `playing: false`, which lets the OS
         // freeze the Flutter isolate while backgrounded. The on-device audio
         // focus handling runs in that isolate (just_audio disables ExoPlayer's
         // native focus and routes interruptions through audio_session/Dart), so
         // a frozen isolate can't process the `AUDIOFOCUS_GAIN` that another app
-        // emits when it ends a voice/transient interruption — and playback only
-        // recovers when reopening the app unfreezes the isolate. Keeping the
-        // service foreground on pause keeps the isolate alive, so recovery
-        // happens in the background from the controller, never depending on the
-        // UI being reopened. The notification can no longer be ongoing-only
-        // (audio_service asserts `!ongoing || stopForegroundOnPause`); with the
-        // service kept foreground the notification persists regardless. Tradeoff:
-        // the wake lock is held while paused too (audio_service couples the two),
-        // i.e. slightly more battery if left paused — not stopped — for a long
-        // time; this is the standard "keep the session resumable while paused"
-        // behaviour. Foreground-while-playing (the screen-off-cutout fix in
-        // [_isSessionPlaying]) is unchanged.
+        // emits when it ends a voice/transient interruption — and playback would
+        // only recover when reopening the app (#244).
+        //
+        // #244 solved that with `androidStopForegroundOnPause: false`, which
+        // held the service — and the wake lock — across *every* pause, including
+        // one left paused-not-stopped for hours. The recovery guarantee is now
+        // carried by the `playing` flag instead: [_isSessionPlaying] keeps
+        // reporting `playing` across a transient-focus pause (bounded by the
+        // controller), so the isolate survives exactly the interruption it has
+        // to recover from, and an ordinary user pause demotes the service and
+        // drops the wake lock right away. Foreground-while-playing (the
+        // screen-off cutout fix, also in [_isSessionPlaying]) is unchanged.
+        //
+        // The notification stays non-ongoing. `stopForegroundOnPause: true`
+        // would now let it be ongoing again (audio_service asserts
+        // `!ongoing || stopForegroundOnPause`), but with the service demoted on
+        // a real pause there is nothing to gain from making it undismissable, so
+        // this is left exactly as #244 set it.
         androidNotificationOngoing: false,
-        androidStopForegroundOnPause: false,
+        androidStopForegroundOnPause: true,
         // Downscale the album-art bitmap `audio_service` embeds in the session
         // metadata. The metadata (with the bitmap) is delivered to the platform
         // session and to Android Auto across a process boundary; a full-size

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -419,6 +419,10 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   ) {
     if (last == null) return true;
     if (next.playing != last.playing ||
+        // A transient-focus hold keeps `playing` and the controls steady but
+        // drops the speed to 0, and that is exactly the push that stops the
+        // displayed position running away during the interruption.
+        next.speed != last.speed ||
         next.processingState != last.processingState ||
         next.shuffleMode != last.shuffleMode ||
         next.repeatMode != last.repeatMode ||
@@ -577,6 +581,7 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
       processingState: _processingStateFor(state.status),
       playing: _isSessionPlaying(state),
       updatePosition: state.position,
+      speed: _sessionSpeed(state),
       shuffleMode: state.shuffleEnabled
           ? audio.AudioServiceShuffleMode.all
           : audio.AudioServiceShuffleMode.none,
@@ -629,6 +634,25 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
         return false;
     }
   }
+
+  /// The rate the reported position is actually advancing at.
+  ///
+  /// `audio_service` — and, through it, `PlaybackStateCompat` — extrapolates the
+  /// position every consumer *displays* (notification, lock screen, Android
+  /// Auto, Bluetooth head unit) from `updatePosition` + wall clock × speed while
+  /// the session says it is playing. A transient-focus hold is the one state
+  /// where the session says `playing` while the engine is stopped for an
+  /// open-ended stretch — up to the controller's hold timeout — so leaving the
+  /// speed at 1.0 would run the progress bar (and a car's) minutes ahead of the
+  /// audio during a call, then snap it back on the resume.
+  ///
+  /// Reporting 0.0 freezes the displayed position exactly where the audio
+  /// stopped, with no extra pushes or timers, and does not touch the foreground
+  /// service: `audio_service` promotes and demotes it on the `playing` flag
+  /// alone. Buffering and loading keep 1.0 — they are bounded by the engine's
+  /// own watchdog and behave as before.
+  static double _sessionSpeed(PlaybackState state) =>
+      state.status == PlaybackStatus.paused ? 0.0 : 1.0;
 
   static RepeatMode _repeatModeFrom(audio.AudioServiceRepeatMode mode) {
     switch (mode) {

--- a/test/core/services/just_audio_playback_controller_focus_test.dart
+++ b/test/core/services/just_audio_playback_controller_focus_test.dart
@@ -500,4 +500,194 @@ void main() {
       expect(p.volumes.last, 1.0);
     });
   });
+
+  // #499 — battery-optimal audio-focus mode. The foreground media service (and
+  // the CPU wake lock audio_service holds with it) is kept alive *only* while a
+  // transient-focus pause is outstanding, instead of across every pause as #244
+  // left it. The controller publishes that as
+  // `PlaybackState.interruptedByTransientFocus`, which the media session turns
+  // into the `playing` flag audio_service promotes the service on.
+  group('the foreground hold covers a transient-focus pause only (#499)', () {
+    test('a sustained transient loss holds it, and the regain releases it',
+        () async {
+      final p = _RecordingPlayer();
+      final controller = JustAudioPlaybackController(player: p);
+      addTearDown(controller.dispose);
+      controller.focusPauseDebounce = _testDebounce;
+      controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+      expect(controller.state.interruptedByTransientFocus, isFalse,
+          reason: 'normal playback needs no hold — it is already foreground');
+
+      controller.onAudioInterruption(_begin(AudioInterruptionType.pause));
+      await _pastDebounce();
+
+      expect(controller.state.interruptedByTransientFocus, isTrue,
+          reason: 'the isolate must stay alive to see the AUDIOFOCUS_GAIN');
+      expect(p.pauseCalls, 1);
+
+      controller.onAudioInterruption(_end(AudioInterruptionType.pause));
+      await _settle();
+
+      expect(p.playCalls, 1, reason: 'the regain still resumes playback');
+      expect(controller.state.interruptedByTransientFocus, isFalse,
+          reason: 'focus is back: playing keeps the service up on its own');
+    });
+
+    test('the hold reaches listeners on the state stream', () async {
+      final p = _RecordingPlayer();
+      final controller = JustAudioPlaybackController(player: p);
+      addTearDown(controller.dispose);
+      controller.focusPauseDebounce = _testDebounce;
+      final held = <bool>[];
+      final sub = controller.stateStream
+          .listen((s) => held.add(s.interruptedByTransientFocus));
+      addTearDown(sub.cancel);
+      controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+
+      controller.onAudioInterruption(_begin(AudioInterruptionType.pause));
+      await _pastDebounce();
+      controller.onAudioInterruption(_end(AudioInterruptionType.pause));
+      await _settle();
+
+      expect(held, contains(true),
+          reason: 'the media session is driven by the stream, not by polling');
+      expect(held.last, isFalse);
+    });
+
+    test('a brief blip absorbed by the regain leaves no hold behind', () async {
+      final p = _RecordingPlayer();
+      final controller = JustAudioPlaybackController(player: p);
+      addTearDown(controller.dispose);
+      controller.focusPauseDebounce = _testDebounce;
+      controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+
+      controller.onAudioInterruption(_begin(AudioInterruptionType.pause));
+      controller.onAudioInterruption(_end(AudioInterruptionType.pause));
+      await _pastDebounce();
+
+      expect(p.pauseCalls, 0);
+      expect(controller.state.interruptedByTransientFocus, isFalse);
+    });
+
+    test('a permanent loss never holds it (another app owns audio now)',
+        () async {
+      final p = _RecordingPlayer();
+      final controller = JustAudioPlaybackController(player: p);
+      addTearDown(controller.dispose);
+      controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+
+      controller.onAudioInterruption(_begin(AudioInterruptionType.unknown));
+      await _settle();
+
+      expect(controller.state.interruptedByTransientFocus, isFalse,
+          reason: 'nothing to recover, so nothing to keep the service up for');
+    });
+
+    test('a transient loss over an already-paused track never holds it',
+        () async {
+      final p = _RecordingPlayer();
+      final controller = JustAudioPlaybackController(player: p);
+      addTearDown(controller.dispose);
+      controller.focusPauseDebounce = _testDebounce;
+      controller.handleEngineState(PlayerState(false, ProcessingState.ready));
+
+      controller.onAudioInterruption(_begin(AudioInterruptionType.pause));
+      await _pastDebounce();
+
+      expect(controller.state.interruptedByTransientFocus, isFalse,
+          reason: 'a user-paused track has no playback to protect');
+    });
+
+    test('a user pause during a transient hold demotes the service', () async {
+      // The battery case the #244 configuration could not express: the user
+      // pauses while another app still holds focus, so there is no longer
+      // anything to resume — the wake lock must be dropped straight away.
+      final p = _RecordingPlayer();
+      final controller = JustAudioPlaybackController(player: p);
+      addTearDown(controller.dispose);
+      controller.focusPauseDebounce = _testDebounce;
+      controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+
+      controller.onAudioInterruption(_begin(AudioInterruptionType.pause));
+      await _pastDebounce();
+      expect(controller.state.interruptedByTransientFocus, isTrue);
+
+      await controller.pause();
+      await _settle();
+
+      expect(controller.state.interruptedByTransientFocus, isFalse);
+
+      controller.onAudioInterruption(_end(AudioInterruptionType.pause));
+      await _settle();
+      expect(p.playCalls, 0,
+          reason: 'a user pause still wins over the later regain');
+    });
+
+    test('a stop releases the hold', () async {
+      final p = _RecordingPlayer();
+      final controller = JustAudioPlaybackController(player: p);
+      addTearDown(controller.dispose);
+      controller.focusPauseDebounce = _testDebounce;
+      controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+
+      controller.onAudioInterruption(_begin(AudioInterruptionType.pause));
+      await _pastDebounce();
+      expect(controller.state.interruptedByTransientFocus, isTrue);
+
+      await controller.stop();
+
+      expect(controller.state.interruptedByTransientFocus, isFalse);
+    });
+
+    test('the hold is bounded when the focus gain never arrives', () async {
+      // An app that grabbed focus and died never sends AUDIOFOCUS_GAIN. Without
+      // a bound that would hold the wake lock for as long as the track stays
+      // paused — the very cost #499 is about.
+      final p = _RecordingPlayer();
+      final controller = JustAudioPlaybackController(player: p);
+      addTearDown(controller.dispose);
+      controller.focusPauseDebounce = _testDebounce;
+      controller.focusHoldTimeout = const Duration(milliseconds: 60);
+      controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+
+      controller.onAudioInterruption(_begin(AudioInterruptionType.pause));
+      await _pastDebounce();
+      expect(controller.state.interruptedByTransientFocus, isTrue);
+
+      await Future<void>.delayed(const Duration(milliseconds: 120));
+
+      expect(controller.state.interruptedByTransientFocus, isFalse,
+          reason: 'the hold must expire on its own, not linger indefinitely');
+
+      // Recovery is given up only as a battery tradeoff: if the isolate is still
+      // alive when focus does come back, playback still resumes.
+      controller.onAudioInterruption(_end(AudioInterruptionType.pause));
+      await _settle();
+      expect(p.playCalls, 1);
+    });
+
+    test('a repeated voice-session loss keeps the hold through to the regain',
+        () async {
+      final p = _RecordingPlayer();
+      final controller = JustAudioPlaybackController(player: p);
+      addTearDown(controller.dispose);
+      controller.focusPauseDebounce = _testDebounce;
+      controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+
+      controller.onAudioInterruption(_begin(AudioInterruptionType.pause));
+      await _pastDebounce();
+      controller.onAudioInterruption(_begin(AudioInterruptionType.pause));
+      await _pastDebounce();
+
+      expect(controller.state.interruptedByTransientFocus, isTrue,
+          reason:
+              'the second loss of one voice session must not drop the hold');
+
+      controller.onAudioInterruption(_end(AudioInterruptionType.pause));
+      await _settle();
+
+      expect(p.playCalls, 1);
+      expect(controller.state.interruptedByTransientFocus, isFalse);
+    });
+  });
 }

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -354,6 +354,66 @@ void main() {
         expect(state.controls, isNot(contains(audio.MediaControl.pause)));
       });
 
+      // #499 — the battery-optimal half of the same policy: with
+      // `androidStopForegroundOnPause: true`, `playing` is the only lever that
+      // keeps the service (and its wake lock) up, so a pause caused by another
+      // app's transient focus must still report playing while a user pause must
+      // not.
+      test('a transient-focus pause keeps the service foreground', () async {
+        await controller.playTracks(<Track>[_track('a')]);
+        await _settle();
+
+        controller.emit(controller.state.copyWith(
+          status: PlaybackStatus.paused,
+          interruptedByTransientFocus: true,
+        ));
+        await _settle();
+
+        final state = handler.playbackState.value;
+        expect(state.playing, isTrue,
+            reason: 'the isolate must survive to process the AUDIOFOCUS_GAIN');
+        expect(state.processingState, audio.AudioProcessingState.ready);
+      });
+
+      test('the service is demoted once the focus hold is released', () async {
+        await controller.playTracks(<Track>[_track('a')]);
+        await _settle();
+
+        controller.emit(controller.state.copyWith(
+          status: PlaybackStatus.paused,
+          interruptedByTransientFocus: true,
+        ));
+        await _settle();
+        expect(handler.playbackState.value.playing, isTrue);
+
+        controller.emit(controller.state.copyWith(
+          interruptedByTransientFocus: false,
+        ));
+        await _settle();
+
+        expect(handler.playbackState.value.playing, isFalse,
+            reason: 'a pause with no focus to recover from holds no wake lock');
+      });
+
+      test('a focus hold never revives a stopped or errored session', () async {
+        await controller.playTracks(<Track>[_track('a')]);
+        await _settle();
+
+        for (final status in <PlaybackStatus>[
+          PlaybackStatus.idle,
+          PlaybackStatus.completed,
+          PlaybackStatus.error,
+        ]) {
+          controller.emit(controller.state.copyWith(
+            status: status,
+            interruptedByTransientFocus: true,
+          ));
+          await _settle();
+          expect(handler.playbackState.value.playing, isFalse,
+              reason: '$status is not a pause worth holding the service for');
+        }
+      });
+
       test('completion and error report not-playing', () async {
         await controller.playTracks(<Track>[_track('a')]);
         await _settle();

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -395,6 +395,70 @@ void main() {
             reason: 'a pause with no focus to recover from holds no wake lock');
       });
 
+      test('a focus hold freezes the position every consumer displays',
+          () async {
+        // The session says `playing` through the hold so the service stays up,
+        // and platform consumers extrapolate the position from speed while it
+        // does. At 1.0 a car's progress bar would run minutes ahead of the audio
+        // during a call and snap back on the resume.
+        await controller.playTracks(<Track>[_track('a')]);
+        await _settle();
+        expect(handler.playbackState.value.speed, 1.0);
+
+        controller.emit(controller.state.copyWith(
+          status: PlaybackStatus.paused,
+          interruptedByTransientFocus: true,
+        ));
+        await _settle();
+
+        final state = handler.playbackState.value;
+        expect(state.playing, isTrue);
+        expect(state.speed, 0.0,
+            reason: 'the audio is stopped, so the displayed position must be');
+        expect(state.position, state.updatePosition,
+            reason: 'a frozen speed means no extrapolation past the real spot');
+      });
+
+      test('entering the hold is pushed even though the controls do not change',
+          () async {
+        // The hold keeps `playing`, the processing state and the controls
+        // identical, so the speed is the only thing that moves — if the push
+        // filter ignored it the platform would never learn the audio stopped.
+        await controller.playTracks(<Track>[_track('a')]);
+        await _settle();
+        final pushed = <audio.PlaybackState>[];
+        final sub = handler.playbackState.listen(pushed.add);
+        addTearDown(sub.cancel);
+
+        controller.emit(controller.state.copyWith(
+          status: PlaybackStatus.paused,
+          interruptedByTransientFocus: true,
+        ));
+        await _settle();
+
+        expect(pushed.last.speed, 0.0);
+        expect(pushed.length, greaterThan(1),
+            reason: 'the speed drop must reach the platform session');
+      });
+
+      test('the speed returns to 1.0 when the interruption ends', () async {
+        await controller.playTracks(<Track>[_track('a')]);
+        await _settle();
+        controller.emit(controller.state.copyWith(
+          status: PlaybackStatus.paused,
+          interruptedByTransientFocus: true,
+        ));
+        await _settle();
+
+        controller.emit(controller.state.copyWith(
+          status: PlaybackStatus.playing,
+          interruptedByTransientFocus: false,
+        ));
+        await _settle();
+
+        expect(handler.playbackState.value.speed, 1.0);
+      });
+
       test('a focus hold never revives a stopped or errored session', () async {
         await controller.playTracks(<Track>[_track('a')]);
         await _settle();


### PR DESCRIPTION
Closes #499.

## What this does

#244 fixed audio-focus recovery with `androidStopForegroundOnPause: false`, which keeps the media service (and its CPU wake lock) alive across *every* pause, including a track left paused for hours. That was the documented tradeoff and the follow-up the roadmap called battery-optimal mode.

`playing` is the only lever `audio_service` gives us over the foreground service (the config flag is fixed at init), so the recovery guarantee now rides on that instead:

- `androidStopForegroundOnPause` goes back to `true`, so an ordinary user pause demotes the service and releases the wake lock right away.
- The controller publishes `PlaybackState.interruptedByTransientFocus` whenever a transient focus loss interrupted playback it intends to resume, and `LinthraAudioHandler._isSessionPlaying` keeps reporting `playing` for exactly that pause. A call, navigation prompt or voice interaction still recovers in the background, with no need to reopen the app.
- The hold is bounded by `focusHoldTimeout` (5 minutes), so an app that grabs focus and dies without ever sending `AUDIOFOCUS_GAIN` can't hold a wake lock indefinitely. The resume arming deliberately survives the expiry, so playback still recovers if the isolate happens to be alive when focus returns.

The hold is armed and released in one place (`_armTransientResume`), right where the resume intent already lived, and stamped onto every state from `_emit`, so no emit path can publish a state that disagrees with it. A user pause, stop, play, permanent focus loss, headphone unplug or cast handoff all release it.

## The position has to be frozen too

Saying `playing` through a pause has one consequence worth spelling out: `audio_service` — and `PlaybackStateCompat` under it — extrapolates the position every consumer *displays* from `updatePosition` + wall clock × speed while the session says it is playing. Left alone, the notification, lock screen and a car's progress bar would run ahead of the audio for the whole hold and snap back on the resume, up to `focusHoldTimeout` of drift during a call.

So the session reports `speed: 0.0` while the engine is paused. That freezes the displayed position exactly where the audio stopped, with no extra pushes or timers, and does not touch the foreground service: `AudioService.setState` calls `enterPlayingState`/`exitPlayingState` off the `playing` boolean alone. Buffering and loading keep 1.0 — they are bounded by the engine's own watchdog and behave as before.

The push filter compares speed too, because entering the hold leaves `playing`, the processing state and the controls identical: the speed is the only thing that moves, and without it the drop would never reach the platform session.

## What does not change

- Playing / buffering / reconnecting / loading still report `playing`, so the screen-off cutout guard from #244 is untouched.
- Gapless, streaming, Android Auto and background playback are not touched.
- The notification stays non-ongoing. `stopForegroundOnPause: true` would allow ongoing again, but with the service demoted on a real pause there is nothing to gain, so it is left as #244 set it.

## Tests

New deterministic focus tests (no platform channel, existing fake-engine harness):

- a sustained transient loss holds the service, the regain releases it
- the hold reaches listeners on the state stream
- a brief screen-off blip absorbed by the regain leaves no hold
- a permanent loss never holds
- a transient loss over an already-paused track never holds
- a user pause during a hold demotes the service, and the later regain still does not resume
- a stop releases the hold
- the hold expires on its own when the focus gain never arrives
- a repeated voice-session loss keeps the hold through to the regain

And on the media session:

- a transient-focus pause keeps the service foreground
- releasing the hold demotes it
- the hold freezes the displayed position, entering it is actually pushed, and the speed returns to 1.0 when the interruption ends
- a hold never revives an idle / completed / errored session

Ran locally with the pinned SDK (3.44.7): `dart format`, `flutter analyze`, `./scripts/check_vendored_packages.sh`, `./scripts/check_secrets.sh` and the full `flutter test` all pass.

## Docs

`docs/battery.md` and `docs/audio-bluetooth-cpu-audit.md` still described the pre-#244 configuration, so both are corrected to match what the code actually does now, and the roadmap item is ticked off.

## Still worth a real-device pass

The unit tests prove the flags are right, not that Android behaves as expected around them — that part is the same class of verification #244 needed. Before undrafting it is worth re-checking on hardware: a text/voice app taking focus and playback coming back on its own, screen-lock playback, Android Auto (including that the progress bar stays put during an interruption), and a long user pause no longer keeping the service in the notification shade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141VqXHYPHC4kuvnJQZm1x3