### PR TITLE
feat(audiobookshelf): connect a server from Settings (#484)

### DIFF
--- a/lib/app/application_container.dart
+++ b/lib/app/application_container.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../core/models/theme_mode_preference.dart';
 import '../core/platform/host_platform.dart';
 import '../data/repositories/app_icon_variant_store_provider.dart';
+import '../data/repositories/audiobookshelf_session_store_provider.dart';
 import '../data/repositories/default_provider_store_provider.dart';
 import '../data/repositories/download_repository_provider.dart';
 import '../data/repositories/favorites_repository_provider.dart';
@@ -69,6 +70,9 @@ List<Override> productionApplicationOverrides({
     sharedPreferencesSubsonicAutoSyncStoreOverride,
     securePlexSessionStoreOverride,
     sharedPreferencesPlexSyncCacheStoreOverride,
+    // The audiobook seam's own credential, stored the same encrypted way as
+    // the music providers' but entirely separate from them.
+    secureAudiobookshelfSessionStoreOverride,
     sharedPreferencesFavoritesStoreOverride,
     remoteFavoritesSyncOverride,
     sharedPreferencesPlaylistStoreOverride,

--- a/lib/app/application_lifecycle.dart
+++ b/lib/app/application_lifecycle.dart
@@ -19,6 +19,7 @@ import '../data/repositories/playlist_repository_provider.dart';
 import '../data/repositories/remote_cache_index_provider.dart';
 import '../features/player/media_artwork_providers.dart';
 import '../features/player/player_providers.dart';
+import '../features/settings/audiobookshelf/audiobookshelf_settings_controller.dart';
 import '../features/settings/jellyfin/jellyfin_settings_controller.dart';
 import '../features/settings/playback/normalize_volume_controller.dart';
 import '../features/settings/plex/plex_settings_controller.dart';
@@ -244,6 +245,9 @@ Future<ApplicationHandle> bootstrapApplication(
       container.read(jellyfinSettingsControllerProvider.notifier).ensureLoaded,
       container.read(subsonicSettingsControllerProvider.notifier).ensureLoaded,
       container.read(plexSettingsControllerProvider.notifier).ensureLoaded,
+      container
+          .read(audiobookshelfSettingsControllerProvider.notifier)
+          .ensureLoaded,
     ]) {
       try {
         await ensureLoaded();

--- a/lib/core/repositories/audiobookshelf_session_store.dart
+++ b/lib/core/repositories/audiobookshelf_session_store.dart
@@ -1,0 +1,24 @@
+import '../models/audiobookshelf_session.dart';
+
+/// Persists the single [AudiobookshelfSession] across app restarts.
+///
+/// Deliberately separate from authentication (which *produces* a session) and
+/// from library fetching (which *uses* one), exactly like the music providers'
+/// session stores: this contract owns only the storage of the signed-in
+/// session, so the tokens have one persistence path that can be made secure in
+/// isolation.
+///
+/// The production binding encrypts on-device; tests and dev use an in-memory
+/// implementation. The user's password is never given to this store — only the
+/// session (server, user, access/refresh tokens) is.
+abstract interface class AudiobookshelfSessionStore {
+  /// The persisted session, or `null` if the user isn't signed in (or the
+  /// stored record was missing/corrupt).
+  Future<AudiobookshelfSession?> read();
+
+  /// Persists [session], replacing any previous one.
+  Future<void> write(AudiobookshelfSession session);
+
+  /// Forgets the signed-in session (sign out).
+  Future<void> clear();
+}

--- a/lib/data/repositories/audiobookshelf_session_store_provider.dart
+++ b/lib/data/repositories/audiobookshelf_session_store_provider.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/repositories/audiobookshelf_session_store.dart';
+import 'in_memory_audiobookshelf_session_store.dart';
+import 'secure_audiobookshelf_session_store.dart';
+
+/// The single [AudiobookshelfSessionStore] the app reads/writes the
+/// Audiobookshelf session through.
+///
+/// Defaults to the in-memory implementation so widget and unit tests stay free
+/// of platform plugins (no `flutter_secure_storage`). The running app overrides
+/// this with [secureAudiobookshelfSessionStoreOverride] so the tokens persist,
+/// at rest, in encrypted storage.
+final audiobookshelfSessionStoreProvider =
+    Provider<AudiobookshelfSessionStore>((ref) {
+  return InMemoryAudiobookshelfSessionStore();
+});
+
+/// Production binding: persists the session tokens in encrypted on-device
+/// storage. Applied in `main`.
+final secureAudiobookshelfSessionStoreOverride =
+    audiobookshelfSessionStoreProvider.overrideWithValue(
+  const SecureAudiobookshelfSessionStore(),
+);

--- a/lib/data/repositories/in_memory_audiobookshelf_session_store.dart
+++ b/lib/data/repositories/in_memory_audiobookshelf_session_store.dart
@@ -1,0 +1,28 @@
+import '../../core/models/audiobookshelf_session.dart';
+import '../../core/repositories/audiobookshelf_session_store.dart';
+
+/// A non-persistent [AudiobookshelfSessionStore] for development and tests.
+///
+/// Holds the session in a single field, so it's forgotten when the instance is
+/// dropped. This is the default binding (mirroring the other session stores);
+/// the running app swaps in `SecureAudiobookshelfSessionStore` so the tokens
+/// survive restarts in encrypted storage.
+class InMemoryAudiobookshelfSessionStore implements AudiobookshelfSessionStore {
+  InMemoryAudiobookshelfSessionStore({AudiobookshelfSession? initialSession})
+      : _session = initialSession;
+
+  AudiobookshelfSession? _session;
+
+  @override
+  Future<AudiobookshelfSession?> read() async => _session;
+
+  @override
+  Future<void> write(AudiobookshelfSession session) async {
+    _session = session;
+  }
+
+  @override
+  Future<void> clear() async {
+    _session = null;
+  }
+}

--- a/lib/data/repositories/secure_audiobookshelf_session_store.dart
+++ b/lib/data/repositories/secure_audiobookshelf_session_store.dart
@@ -1,0 +1,60 @@
+import 'dart:convert';
+
+import '../../core/models/audiobookshelf_session.dart';
+import '../../core/repositories/audiobookshelf_session_store.dart';
+import 'secure_session_storage.dart';
+
+/// An [AudiobookshelfSessionStore] backed by `flutter_secure_storage`.
+///
+/// The session is serialized to JSON and written to platform secure storage
+/// under a single key, through [SecureSessionStorage]: the Android
+/// Keystore-backed store on Android, and libsecret on Linux (the freedesktop
+/// Secret Service natively; inside a Flatpak, libsecret's own portal-keyed
+/// encrypted store). The access and refresh tokens are never at rest in
+/// plaintext (unlike `shared_preferences`) on either platform, and Linthra
+/// writes no file of its own when the platform store is unavailable. This is
+/// the production binding; it's intentionally never touched by tests, which
+/// use the in-memory store so they stay free of platform channels.
+///
+/// A malformed/partial record reads back as `null` (treated as "signed out")
+/// rather than throwing, so a storage glitch can't wedge the app at launch. A
+/// platform store that is missing, locked or denied is a different thing and is
+/// not flattened into "signed out": [SecureSessionStorage] surfaces it as a
+/// `SecureStorageException`, which the caller reports so the user can act on it
+/// (unlock the keyring, sign in again) instead of losing the session silently.
+class SecureAudiobookshelfSessionStore implements AudiobookshelfSessionStore {
+  const SecureAudiobookshelfSessionStore({
+    SecureSessionStorage storage = const SecureSessionStorage(),
+  }) : _storage = storage;
+
+  final SecureSessionStorage _storage;
+
+  static const String _key = 'audiobookshelf_session_v1';
+
+  @override
+  Future<AudiobookshelfSession?> read() async {
+    final String? raw = await _storage.read(key: _key);
+    if (raw == null || raw.isEmpty) {
+      return null;
+    }
+    try {
+      final Object? decoded = jsonDecode(raw);
+      if (decoded is Map<String, dynamic>) {
+        return AudiobookshelfSession.fromJson(decoded);
+      }
+      return null;
+    } on FormatException {
+      return null;
+    }
+  }
+
+  @override
+  Future<void> write(AudiobookshelfSession session) async {
+    await _storage.write(key: _key, value: jsonEncode(session.toJson()));
+  }
+
+  @override
+  Future<void> clear() async {
+    await _storage.delete(key: _key);
+  }
+}

--- a/lib/data/repositories/secure_session_storage.dart
+++ b/lib/data/repositories/secure_session_storage.dart
@@ -6,10 +6,10 @@ import '../../core/repositories/secure_storage_exception.dart';
 /// The one door between Linthra's provider credentials and platform secure
 /// storage.
 ///
-/// Used by the Jellyfin, Navidrome/Subsonic and Plex session stores, which are
-/// the credential path this class exists to hold to one set of rules. (The
-/// GitHub Sponsors token store calls `flutter_secure_storage` directly and is
-/// separate work; it stores no provider credential.)
+/// Used by the Jellyfin, Navidrome/Subsonic, Plex and Audiobookshelf session
+/// stores, which are the credential path this class exists to hold to one set
+/// of rules. (The GitHub Sponsors token store calls `flutter_secure_storage`
+/// directly and is separate work; it stores no provider credential.)
 ///
 /// The rules, stated once:
 ///

--- a/lib/features/settings/audiobookshelf/audiobookshelf_provider_card.dart
+++ b/lib/features/settings/audiobookshelf/audiobookshelf_provider_card.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../source/provider_summary_cards.dart';
+import 'audiobookshelf_settings_controller.dart';
+import 'audiobookshelf_settings_section.dart';
+import 'audiobookshelf_settings_state.dart';
+
+/// The Audiobookshelf connection as a compact card on the Connections page,
+/// reusing the same [ProviderSummaryCard] shape the music sources use so the
+/// page reads as one list.
+///
+/// It sits under its own "Audiobooks" heading rather than among the music
+/// sources: Audiobookshelf is not a music provider, it doesn't sync into the
+/// music catalog, and nothing about the existing sources changes because it is
+/// here.
+class AudiobookshelfProviderCard extends ConsumerWidget {
+  const AudiobookshelfProviderCard({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AudiobookshelfSettingsState state =
+        ref.watch(audiobookshelfSettingsControllerProvider);
+    final bool connected = state.isConnected;
+
+    void manage() => showProviderSettingsSheet(
+          context,
+          child: const AudiobookshelfSettingsSection(),
+        );
+
+    String? detail;
+    bool detailIsError = false;
+    if (!connected) {
+      detail = 'Sign in to browse your self-hosted audiobooks.';
+    } else if (state.errorMessage != null) {
+      detail = state.errorMessage;
+      detailIsError = true;
+    } else if (state.isLoadingLibraries) {
+      detail = 'Loading your libraries…';
+    } else if (state.libraries.isNotEmpty) {
+      detail = state.libraries.length == 1
+          ? '1 library • ${state.libraries.first.name}'
+          : '${state.libraries.length} libraries';
+    } else if (state.username != null && state.username!.isNotEmpty) {
+      detail = 'Signed in as ${state.username}';
+    } else {
+      detail = state.baseUrl;
+    }
+
+    return ProviderSummaryCard(
+      icon: Icons.headphones_outlined,
+      title: 'Audiobookshelf',
+      statusLabel: connected ? 'Connected' : 'Not connected',
+      statusTone:
+          connected ? ProviderStatusTone.positive : ProviderStatusTone.neutral,
+      detail: detail,
+      detailIsError: detailIsError,
+      onManage: manage,
+      actions: connected
+          ? <Widget>[_ManageAction(onPressed: manage)]
+          : <Widget>[
+              FilledButton(onPressed: manage, child: const Text('Connect')),
+            ],
+    );
+  }
+}
+
+/// The card's explicit "Manage" button. The music cards pair Manage with a
+/// "Sync now" action; Audiobookshelf has nothing to sync into the catalog yet,
+/// so this is the only action it offers.
+class _ManageAction extends StatelessWidget {
+  const _ManageAction({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return OutlinedButton(onPressed: onPressed, child: const Text('Manage'));
+  }
+}

--- a/lib/features/settings/audiobookshelf/audiobookshelf_settings_controller.dart
+++ b/lib/features/settings/audiobookshelf/audiobookshelf_settings_controller.dart
@@ -1,0 +1,321 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/models/audiobookshelf_session.dart';
+import '../../../core/repositories/secure_storage_exception.dart';
+import '../../../core/sources/audiobookshelf/audiobookshelf_api.dart';
+import '../../../core/sources/audiobookshelf/audiobookshelf_exception.dart';
+import '../../../data/repositories/audiobookshelf_session_store_provider.dart';
+import 'audiobookshelf_settings_providers.dart';
+import 'audiobookshelf_settings_state.dart';
+
+/// Drives the Audiobookshelf connection screen: loads any saved session, tests
+/// an address, signs in, lists the libraries, and signs out.
+///
+/// The single coordinator between the three separated concerns — the
+/// authenticator (auth), the session store (persistence), and the client
+/// (library access) — so the UI only ever talks to this controller and its
+/// [AudiobookshelfSettingsState], never to HTTP or storage.
+///
+/// This is the audiobook seam and it stays on its own side of it: nothing here
+/// touches the music providers, the music catalog, or the source preference.
+///
+/// The live [session] (with its tokens) is kept privately for later audiobook
+/// work; it is never exposed through the public [state], never logged, and the
+/// password handed to [signIn] is forwarded once (to obtain the tokens) and
+/// never retained.
+class AudiobookshelfSettingsController
+    extends Notifier<AudiobookshelfSettingsState> {
+  AudiobookshelfSession? _session;
+  late final Future<void> _initialLoad;
+
+  /// The address a [testConnection] last succeeded for, with the status it
+  /// returned. A sign-in for that same address reuses it instead of asking the
+  /// server for `/status` a second time; any other address re-confirms.
+  String? _testedBaseUrl;
+  AudiobookshelfServerStatus? _testedStatus;
+
+  /// The live signed-in session, or `null` when not connected. Callers must not
+  /// log it.
+  AudiobookshelfSession? get session => _session;
+
+  @override
+  AudiobookshelfSettingsState build() {
+    _initialLoad = _loadPersisted();
+    return const AudiobookshelfSettingsState();
+  }
+
+  /// Completes once the persisted session has been loaded (or confirmed
+  /// absent). `main` awaits this at startup so the connection is already known
+  /// by the first frame. Idempotent.
+  Future<void> ensureLoaded() => _initialLoad;
+
+  Future<void> _loadPersisted() async {
+    final AudiobookshelfSession? saved;
+    try {
+      saved = await ref.read(audiobookshelfSessionStoreProvider).read();
+    } catch (error) {
+      // A keyring that is missing, locked or denied must not break startup:
+      // stay disconnected, but say so (statically, credential-free) so a user
+      // who *was* signed in isn't left wondering where their server went. A
+      // missing or corrupt record already reads back as null inside the store
+      // and stays silent.
+      //
+      // Only when nothing has taken over the card in the meantime: a locked
+      // keyring can block this read behind an unlock prompt for as long as the
+      // user leaves it there, and a sign-in that already started (or finished)
+      // in that time owns the state now.
+      if (_session == null &&
+          state.phase == AudiobookshelfConnectionPhase.disconnected &&
+          state.errorMessage == null) {
+        state = AudiobookshelfSettingsState(
+          errorMessage: "Couldn't restore your saved Audiobookshelf sign-in "
+              'from this device. ${_storageRemedy(error)}',
+        );
+      }
+      return;
+    }
+    if (saved == null) {
+      return;
+    }
+    _session = saved;
+    state = AudiobookshelfSettingsState(
+      phase: AudiobookshelfConnectionPhase.connected,
+      baseUrl: saved.baseUrl,
+      username: saved.userName,
+      serverVersion: saved.serverVersion,
+      statusMessage: _connectedMessage(saved.userName),
+    );
+  }
+
+  /// Tests that [url] points at a reachable Audiobookshelf server. Returns
+  /// whether it succeeded; details land in [state].
+  ///
+  /// No credentials are sent: Audiobookshelf answers `/status` unauthenticated,
+  /// which is exactly what makes it safe to check an address the user just
+  /// typed before any password goes near it.
+  Future<bool> testConnection(String url) async {
+    state = AudiobookshelfSettingsState(
+      phase: AudiobookshelfConnectionPhase.testing,
+      baseUrl: url,
+      username: state.username,
+    );
+    try {
+      final AudiobookshelfServerStatus status =
+          await ref.read(audiobookshelfAuthenticatorProvider).testConnection(
+                url,
+              );
+      _testedBaseUrl = url;
+      _testedStatus = status;
+      state = AudiobookshelfSettingsState(
+        phase: AudiobookshelfConnectionPhase.tested,
+        baseUrl: url,
+        username: state.username,
+        serverVersion: status.serverVersion,
+        statusMessage: _reachableMessage(status),
+      );
+      return true;
+    } on AudiobookshelfException catch (error) {
+      _forgetTestedStatus();
+      _setFailure(error.message, kind: error.kind, url: url);
+      return false;
+    }
+  }
+
+  /// Signs in with [url] + [username] + [password], persists the resulting
+  /// session, and flips to connected. Returns whether it succeeded.
+  ///
+  /// The password is forwarded once to obtain the tokens and never stored.
+  Future<bool> signIn({
+    required String url,
+    required String username,
+    required String password,
+  }) async {
+    state = AudiobookshelfSettingsState(
+      phase: AudiobookshelfConnectionPhase.signingIn,
+      baseUrl: url,
+      username: username,
+    );
+    try {
+      final AudiobookshelfSession newSession =
+          await ref.read(audiobookshelfAuthenticatorProvider).signIn(
+                rawUrl: url,
+                username: username,
+                password: password,
+                // Only for the very address the test confirmed, never another.
+                serverStatus: url == _testedBaseUrl ? _testedStatus : null,
+              );
+      try {
+        await ref.read(audiobookshelfSessionStoreProvider).write(newSession);
+      } catch (error) {
+        // The new session couldn't reach the keyring. Adopting it anyway would
+        // look signed in until the next launch and then silently be gone, so
+        // don't: report it and let the user fix the keyring and retry. The
+        // tokens are dropped here rather than kept anywhere else.
+        _setFailure(
+          "Couldn't save your Audiobookshelf sign-in on this device. "
+          '${_storageRemedy(error)}',
+          url: url,
+          username: username,
+        );
+        return false;
+      }
+      _session = newSession;
+      _forgetTestedStatus();
+      state = AudiobookshelfSettingsState(
+        phase: AudiobookshelfConnectionPhase.connected,
+        baseUrl: newSession.baseUrl,
+        username: newSession.userName,
+        serverVersion: newSession.serverVersion,
+        statusMessage: _connectedMessage(newSession.userName),
+      );
+      // Show what the account can actually see straight away, so a successful
+      // sign-in ends on real libraries rather than on "connected, probably".
+      // Fire-and-forget: sign-in returns now and the listing reports itself.
+      unawaited(refreshLibraries());
+      return true;
+    } on AudiobookshelfException catch (error) {
+      _setFailure(error.message,
+          kind: error.kind, url: url, username: username);
+      return false;
+    }
+  }
+
+  /// Lists the libraries this account can see. A no-op when not connected.
+  ///
+  /// A failure here is not a lost connection: the session is still good, the
+  /// listing just didn't come back, so it surfaces as a message and leaves the
+  /// connected state alone.
+  Future<void> refreshLibraries() async {
+    final AudiobookshelfSession? current = _session;
+    if (current == null) return;
+    // A new attempt drops the previous listing's error, so a retry that works
+    // doesn't leave the old failure sitting under a fresh list.
+    state = _connectedState(current, isLoadingLibraries: true);
+    try {
+      final List<AudiobookshelfLibraryDto> libraries =
+          await ref.read(audiobookshelfClientProvider).fetchLibraries(current);
+      // A sign-out (or another sign-in) that landed while this was in flight
+      // owns the state now; don't paint a stale account's libraries over it.
+      if (!identical(_session, current)) return;
+      state = _connectedState(
+        current,
+        libraries: <AudiobookshelfLibrarySummary>[
+          for (final AudiobookshelfLibraryDto library in libraries)
+            AudiobookshelfLibrarySummary(
+              id: library.id,
+              name: library.name,
+              mediaType: library.mediaType,
+            ),
+        ],
+      );
+    } on AudiobookshelfException catch (error) {
+      if (!identical(_session, current)) return;
+      // The listing failed, the session didn't: stay connected and say what
+      // went wrong.
+      state = _connectedState(
+        current,
+        errorMessage: error.message,
+        errorKind: error.kind,
+      );
+    }
+  }
+
+  /// The connected state for [session], rebuilt from the session itself rather
+  /// than copied from the previous state, so a stale error or spinner can't
+  /// survive into it.
+  AudiobookshelfSettingsState _connectedState(
+    AudiobookshelfSession session, {
+    List<AudiobookshelfLibrarySummary>? libraries,
+    bool isLoadingLibraries = false,
+    String? errorMessage,
+    AudiobookshelfErrorKind? errorKind,
+  }) {
+    return AudiobookshelfSettingsState(
+      phase: AudiobookshelfConnectionPhase.connected,
+      baseUrl: session.baseUrl,
+      username: session.userName,
+      serverVersion: session.serverVersion,
+      libraries: libraries ?? state.libraries,
+      isLoadingLibraries: isLoadingLibraries,
+      statusMessage: _connectedMessage(session.userName),
+      errorMessage: errorMessage,
+      errorKind: errorKind,
+    );
+  }
+
+  /// Clears the saved session and resets to the disconnected state.
+  Future<void> clear() async {
+    try {
+      await ref.read(audiobookshelfSessionStoreProvider).clear();
+    } catch (error) {
+      // The tokens would stay in the keyring; report it rather than pretending
+      // the sign-out happened. Nothing else is torn down, so a retry after
+      // unlocking the keyring completes the same sign-out.
+      _setFailure(
+        "Couldn't remove your Audiobookshelf sign-in from this device. "
+        '${_storageRemedy(error)}',
+      );
+      return;
+    }
+    _session = null;
+    _forgetTestedStatus();
+    state = const AudiobookshelfSettingsState(
+      statusMessage: 'Signed out. Your Audiobookshelf settings were cleared.',
+    );
+  }
+
+  void _forgetTestedStatus() {
+    _testedBaseUrl = null;
+    _testedStatus = null;
+  }
+
+  /// The user-facing tail for a secure-storage failure: what went wrong with
+  /// the keyring and what to do about it. Never carries any part of the value
+  /// that was being read or written (see [SecureStorageException]).
+  String _storageRemedy(Object error) =>
+      error is SecureStorageException ? error.remedy : 'Try again.';
+
+  /// Reports an error without dropping an existing connection: a failed test or
+  /// re-auth keeps any session that's still valid, it just surfaces the message.
+  void _setFailure(
+    String message, {
+    AudiobookshelfErrorKind? kind,
+    String? url,
+    String? username,
+  }) {
+    final AudiobookshelfSession? current = _session;
+    if (current != null) {
+      state = _connectedState(current, errorMessage: message, errorKind: kind);
+      return;
+    }
+    state = AudiobookshelfSettingsState(
+      baseUrl: url,
+      username: username,
+      serverVersion: state.serverVersion,
+      errorMessage: message,
+      errorKind: kind,
+    );
+  }
+
+  String _connectedMessage(String? userName) {
+    if (userName == null || userName.isEmpty) {
+      return 'Signed in to Audiobookshelf.';
+    }
+    return 'Signed in as $userName.';
+  }
+
+  String _reachableMessage(AudiobookshelfServerStatus status) {
+    final String? version = status.serverVersion;
+    if (version == null || version.isEmpty) {
+      return 'Reached an Audiobookshelf server. Sign in to continue.';
+    }
+    return 'Reached Audiobookshelf $version. Sign in to continue.';
+  }
+}
+
+final audiobookshelfSettingsControllerProvider = NotifierProvider<
+    AudiobookshelfSettingsController, AudiobookshelfSettingsState>(
+  AudiobookshelfSettingsController.new,
+);

--- a/lib/features/settings/audiobookshelf/audiobookshelf_settings_providers.dart
+++ b/lib/features/settings/audiobookshelf/audiobookshelf_settings_providers.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/sources/audiobookshelf/audiobookshelf_authenticator.dart';
+import '../../../core/sources/audiobookshelf/audiobookshelf_client.dart';
+import '../../../core/sources/audiobookshelf/http_audiobookshelf_client.dart';
+
+/// The HTTP seam for all Audiobookshelf networking.
+///
+/// Defaults to the real [HttpAudiobookshelfClient]; tests override it with a
+/// fake client that returns canned responses, so the whole settings/auth flow
+/// can be exercised without a server. This is the single place production wires
+/// the concrete client — `main` needs no override because the default is
+/// already the real one.
+final audiobookshelfClientProvider = Provider<AudiobookshelfClient>((ref) {
+  return HttpAudiobookshelfClient();
+});
+
+/// Coordinates URL validation + sign-in on top of [audiobookshelfClientProvider].
+///
+/// The settings controller depends on this rather than on the client directly,
+/// keeping authentication (produce a session) separate from the controller's
+/// orchestration (when to test, sign in, persist, clear).
+final audiobookshelfAuthenticatorProvider =
+    Provider<AudiobookshelfAuthenticator>((ref) {
+  return AudiobookshelfAuthenticator(ref.watch(audiobookshelfClientProvider));
+});

--- a/lib/features/settings/audiobookshelf/audiobookshelf_settings_section.dart
+++ b/lib/features/settings/audiobookshelf/audiobookshelf_settings_section.dart
@@ -1,0 +1,442 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/dimens.dart';
+import 'audiobookshelf_settings_controller.dart';
+import 'audiobookshelf_settings_state.dart';
+
+/// The Audiobookshelf connection card in Settings.
+///
+/// Owns the text fields (URL / username / password) but nothing else: every
+/// action is forwarded to [AudiobookshelfSettingsController], and everything
+/// rendered comes from [AudiobookshelfSettingsState]. The widget never touches
+/// HTTP or storage directly, and the password is cleared from memory as soon as
+/// it's used.
+///
+/// Unlike Subsonic, "Test connection" needs only the address: Audiobookshelf
+/// answers `/status` without credentials, so the address can be checked before
+/// a password is typed at all.
+class AudiobookshelfSettingsSection extends ConsumerStatefulWidget {
+  const AudiobookshelfSettingsSection({super.key});
+
+  @override
+  ConsumerState<AudiobookshelfSettingsSection> createState() =>
+      _AudiobookshelfSettingsSectionState();
+}
+
+class _AudiobookshelfSettingsSectionState
+    extends ConsumerState<AudiobookshelfSettingsSection> {
+  final TextEditingController _urlController = TextEditingController();
+  final TextEditingController _usernameController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  bool _obscurePassword = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _urlController.addListener(_onFieldChanged);
+    _usernameController.addListener(_onFieldChanged);
+    _passwordController.addListener(_onFieldChanged);
+    // Opening the connection screen while already signed in is the natural
+    // moment to list the libraries, so the card shows what the account can see
+    // rather than just "connected".
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(_listLibrariesIfNeeded());
+    });
+  }
+
+  /// Lists the libraries for a session restored from storage.
+  ///
+  /// It waits for that restore to finish first: on a cold open the controller
+  /// is still reading the keyring, so a check made right now would see "not
+  /// connected" and never list anything. A session that signed in on this
+  /// screen already listed its libraries, hence the empty check.
+  Future<void> _listLibrariesIfNeeded() async {
+    final AudiobookshelfSettingsController controller =
+        ref.read(audiobookshelfSettingsControllerProvider.notifier);
+    await controller.ensureLoaded();
+    if (!mounted) return;
+    final AudiobookshelfSettingsState state =
+        ref.read(audiobookshelfSettingsControllerProvider);
+    if (state.isConnected &&
+        state.libraries.isEmpty &&
+        !state.isLoadingLibraries) {
+      await controller.refreshLibraries();
+    }
+  }
+
+  void _onFieldChanged() => setState(() {});
+
+  @override
+  void dispose() {
+    _urlController.dispose();
+    _usernameController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  /// The address alone is enough to test; signing in also needs credentials.
+  bool get _canTest => _urlController.text.trim().isNotEmpty;
+
+  bool get _canSignIn =>
+      _canTest &&
+      _usernameController.text.trim().isNotEmpty &&
+      _passwordController.text.isNotEmpty;
+
+  Future<void> _test() async {
+    FocusScope.of(context).unfocus();
+    await ref
+        .read(audiobookshelfSettingsControllerProvider.notifier)
+        .testConnection(_urlController.text);
+  }
+
+  Future<void> _signIn() async {
+    FocusScope.of(context).unfocus();
+    final bool ok = await ref
+        .read(audiobookshelfSettingsControllerProvider.notifier)
+        .signIn(
+          url: _urlController.text,
+          username: _usernameController.text,
+          password: _passwordController.text,
+        );
+    // Don't keep the password in memory once it's been exchanged for tokens.
+    if (ok) {
+      _passwordController.clear();
+    }
+  }
+
+  Future<void> _signOut() async {
+    await ref.read(audiobookshelfSettingsControllerProvider.notifier).clear();
+    _urlController.clear();
+    _usernameController.clear();
+    _passwordController.clear();
+  }
+
+  Future<void> _refreshLibraries() async {
+    await ref
+        .read(audiobookshelfSettingsControllerProvider.notifier)
+        .refreshLibraries();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final AudiobookshelfSettingsState state =
+        ref.watch(audiobookshelfSettingsControllerProvider);
+    final ThemeData theme = Theme.of(context);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Icon(Icons.headphones_outlined,
+                    color: theme.colorScheme.primary),
+                const SizedBox(width: AppSpacing.sm),
+                Text('Audiobookshelf', style: theme.textTheme.titleMedium),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              'Connect your self-hosted Audiobookshelf server to browse your '
+              'audiobooks. Your password is never stored — only the sign-in '
+              'token the server returns is kept, in encrypted storage. This '
+              'connection is separate from your music sources.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            if (state.isConnected)
+              _ConnectedView(
+                state: state,
+                onRefreshLibraries:
+                    state.isLoadingLibraries ? null : _refreshLibraries,
+                onSignOut: (state.isBusy || state.isLoadingLibraries)
+                    ? null
+                    : _signOut,
+              )
+            else
+              _buildForm(state),
+            if (state.errorMessage != null) ...<Widget>[
+              const SizedBox(height: AppSpacing.md),
+              _StatusLine(message: state.errorMessage!, isError: true),
+            ] else if (state.statusMessage != null) ...<Widget>[
+              const SizedBox(height: AppSpacing.md),
+              _StatusLine(message: state.statusMessage!, isError: false),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildForm(AudiobookshelfSettingsState state) {
+    final bool busy = state.isBusy;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        TextField(
+          controller: _urlController,
+          enabled: !busy,
+          keyboardType: TextInputType.url,
+          autocorrect: false,
+          textInputAction: TextInputAction.next,
+          decoration: const InputDecoration(
+            labelText: 'Server URL',
+            hintText: 'https://audiobooks.example.com',
+            prefixIcon: Icon(Icons.dns_outlined),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        TextField(
+          controller: _usernameController,
+          enabled: !busy,
+          autocorrect: false,
+          textInputAction: TextInputAction.next,
+          decoration: const InputDecoration(
+            labelText: 'Username',
+            prefixIcon: Icon(Icons.person_outline),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        TextField(
+          controller: _passwordController,
+          enabled: !busy,
+          obscureText: _obscurePassword,
+          textInputAction: TextInputAction.done,
+          onSubmitted: (_canSignIn && !busy) ? (_) => _signIn() : null,
+          decoration: InputDecoration(
+            labelText: 'Password',
+            prefixIcon: const Icon(Icons.lock_outline),
+            suffixIcon: IconButton(
+              icon: Icon(
+                _obscurePassword
+                    ? Icons.visibility_outlined
+                    : Icons.visibility_off_outlined,
+              ),
+              tooltip: _obscurePassword ? 'Show password' : 'Hide password',
+              onPressed: () =>
+                  setState(() => _obscurePassword = !_obscurePassword),
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        Row(
+          children: <Widget>[
+            Expanded(
+              child: OutlinedButton(
+                onPressed: (_canTest && !busy) ? _test : null,
+                child: _ButtonLabel(
+                  label: 'Test connection',
+                  busy: state.phase == AudiobookshelfConnectionPhase.testing,
+                ),
+              ),
+            ),
+            const SizedBox(width: AppSpacing.sm),
+            Expanded(
+              child: FilledButton(
+                onPressed: (_canSignIn && !busy) ? _signIn : null,
+                child: _ButtonLabel(
+                  label: 'Sign in',
+                  busy: state.phase == AudiobookshelfConnectionPhase.signingIn,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+/// The summary shown once a session exists: which server/user, the libraries
+/// this account can see, and sign-out.
+class _ConnectedView extends StatelessWidget {
+  const _ConnectedView({
+    required this.state,
+    required this.onRefreshLibraries,
+    required this.onSignOut,
+  });
+
+  final AudiobookshelfSettingsState state;
+  final VoidCallback? onRefreshLibraries;
+  final VoidCallback? onSignOut;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Row(
+          children: <Widget>[
+            Icon(Icons.check_circle_outline, color: theme.colorScheme.primary),
+            const SizedBox(width: AppSpacing.sm),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text('Audiobookshelf', style: theme.textTheme.titleSmall),
+                  if (state.username != null && state.username!.isNotEmpty)
+                    Text(
+                      'Signed in as ${state.username}',
+                      style: theme.textTheme.bodySmall,
+                    ),
+                  if (state.baseUrl != null)
+                    Text(
+                      state.baseUrl!,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodySmall?.copyWith(color: muted),
+                    ),
+                  if (state.serverVersion != null &&
+                      state.serverVersion!.isNotEmpty)
+                    Text(
+                      'Server ${state.serverVersion}',
+                      style: theme.textTheme.bodySmall?.copyWith(color: muted),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: AppSpacing.md),
+        _LibrariesView(state: state),
+        const SizedBox(height: AppSpacing.sm),
+        FilledButton.tonalIcon(
+          onPressed: onRefreshLibraries,
+          icon: state.isLoadingLibraries
+              ? const SizedBox.square(
+                  dimension: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.refresh_outlined),
+          label: Text(
+            state.isLoadingLibraries
+                ? 'Loading libraries…'
+                : 'Refresh libraries',
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        OutlinedButton.icon(
+          onPressed: onSignOut,
+          icon: const Icon(Icons.logout_outlined),
+          label: const Text('Sign out & clear'),
+        ),
+      ],
+    );
+  }
+}
+
+/// The libraries this account can see, or a plain line saying there are none
+/// (or none yet) rather than an ambiguous blank.
+class _LibrariesView extends StatelessWidget {
+  const _LibrariesView({required this.state});
+
+  final AudiobookshelfSettingsState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+
+    if (state.libraries.isEmpty) {
+      return Text(
+        state.isLoadingLibraries
+            ? 'Loading your libraries…'
+            : 'No libraries yet. Add one on your Audiobookshelf server, then '
+                'refresh.',
+        style: theme.textTheme.bodySmall?.copyWith(color: muted),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          state.libraries.length == 1
+              ? '1 library'
+              : '${state.libraries.length} libraries',
+          style: theme.textTheme.labelLarge,
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        Wrap(
+          spacing: AppSpacing.sm,
+          runSpacing: AppSpacing.xs,
+          children: <Widget>[
+            for (final AudiobookshelfLibrarySummary library in state.libraries)
+              Chip(
+                visualDensity: VisualDensity.compact,
+                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                avatar: Icon(
+                  library.mediaType == 'podcast'
+                      ? Icons.podcasts_outlined
+                      : Icons.menu_book_outlined,
+                  size: 16,
+                ),
+                label: Text(library.name),
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+/// A button label that swaps to a small spinner while its action runs.
+class _ButtonLabel extends StatelessWidget {
+  const _ButtonLabel({required this.label, required this.busy});
+
+  final String label;
+  final bool busy;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!busy) {
+      return Text(label);
+    }
+    return const SizedBox.square(
+      dimension: 18,
+      child: CircularProgressIndicator(strokeWidth: 2),
+    );
+  }
+}
+
+/// A friendly one-line status or error message under the form.
+class _StatusLine extends StatelessWidget {
+  const _StatusLine({required this.message, required this.isError});
+
+  final String message;
+  final bool isError;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color color =
+        isError ? theme.colorScheme.error : theme.colorScheme.primary;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Icon(
+          isError ? Icons.error_outline : Icons.info_outline,
+          size: 18,
+          color: color,
+        ),
+        const SizedBox(width: AppSpacing.sm),
+        Expanded(
+          child: Text(
+            message,
+            style: theme.textTheme.bodySmall?.copyWith(color: color),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/settings/audiobookshelf/audiobookshelf_settings_state.dart
+++ b/lib/features/settings/audiobookshelf/audiobookshelf_settings_state.dart
@@ -1,0 +1,101 @@
+import '../../../core/sources/audiobookshelf/audiobookshelf_exception.dart';
+
+/// Where the Audiobookshelf connection is in its lifecycle.
+enum AudiobookshelfConnectionPhase {
+  /// No session and nothing in progress.
+  disconnected,
+
+  /// A connection test is running.
+  testing,
+
+  /// A connection test just succeeded (the address is a reachable
+  /// Audiobookshelf server); not signed in / persisted yet.
+  tested,
+
+  /// Sign-in is running.
+  signingIn,
+
+  /// Signed in — a session exists.
+  connected,
+}
+
+/// One library the signed-in user can see, reduced to what the settings UI
+/// shows. Deliberately not the wire DTO: the screen renders a name and a media
+/// type, and nothing here invites the rest of the app to depend on the
+/// Audiobookshelf response shape.
+class AudiobookshelfLibrarySummary {
+  const AudiobookshelfLibrarySummary({
+    required this.id,
+    required this.name,
+    this.mediaType,
+  });
+
+  final String id;
+  final String name;
+
+  /// The library's media type (`book`, `podcast`, …) when the server reports
+  /// one. Shown as a hint only; nothing filters on it yet.
+  final String? mediaType;
+}
+
+/// Immutable snapshot the Audiobookshelf settings UI renders from.
+///
+/// The screen reads this and never reaches into HTTP, the authenticator, or the
+/// session store directly — the controller is the only thing that mutates it.
+///
+/// Security: this state intentionally holds NO secret. There is no access or
+/// refresh token and no password field; only display-safe values (server URL,
+/// username, server version, library names) live here, so nothing sensitive can
+/// leak through the widget tree or a state dump.
+class AudiobookshelfSettingsState {
+  const AudiobookshelfSettingsState({
+    this.phase = AudiobookshelfConnectionPhase.disconnected,
+    this.baseUrl,
+    this.username,
+    this.serverVersion,
+    this.libraries = const <AudiobookshelfLibrarySummary>[],
+    this.isLoadingLibraries = false,
+    this.statusMessage,
+    this.errorMessage,
+    this.errorKind,
+  });
+
+  final AudiobookshelfConnectionPhase phase;
+
+  /// Last connected/tested base URL, used to prefill the field. Not secret.
+  final String? baseUrl;
+
+  /// Connected (or last-entered) username, for prefill/display. Not secret.
+  final String? username;
+
+  /// The server's reported version, when known. Older servers (before v2.6.0)
+  /// don't report one at all, so this stays `null` there.
+  final String? serverVersion;
+
+  /// The libraries this account can see, once listed. Empty until a signed-in
+  /// listing succeeds — an account really can have none, which the UI says
+  /// rather than showing an ambiguous blank.
+  final List<AudiobookshelfLibrarySummary> libraries;
+
+  /// True while the library listing is in flight, so the UI can show progress
+  /// without blocking the rest of the connected view.
+  final bool isLoadingLibraries;
+
+  /// A friendly, non-error status line (e.g. "Signed in as …").
+  final String? statusMessage;
+
+  /// A friendly error line, when the last action failed.
+  final String? errorMessage;
+
+  /// The kind of the last failure, kept for the UI to branch on. The friendly
+  /// [errorMessage] is already secret-free.
+  final AudiobookshelfErrorKind? errorKind;
+
+  bool get isConnected => phase == AudiobookshelfConnectionPhase.connected;
+
+  /// True while a network action is in flight, so the UI can disable inputs and
+  /// show a spinner.
+  bool get isBusy =>
+      phase == AudiobookshelfConnectionPhase.testing ||
+      phase == AudiobookshelfConnectionPhase.signingIn;
+}

--- a/lib/features/settings/hub/connections_settings_screen.dart
+++ b/lib/features/settings/hub/connections_settings_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../app/dimens.dart';
+import '../audiobookshelf/audiobookshelf_provider_card.dart';
 import '../source/provider_summary_cards.dart';
 import 'settings_detail_scaffold.dart';
 
@@ -8,8 +9,9 @@ import 'settings_detail_scaffold.dart';
 ///
 /// Stacks the existing music-source cards — Jellyfin, Navidrome/Subsonic, Plex,
 /// and Local music — each of which already shows status and offers edit /
-/// reconnect / remove behind its own "Manage" sheet. This page only groups the
-/// cards; how a source connects or syncs is unchanged.
+/// reconnect / remove behind its own "Manage" sheet, then the audiobook
+/// connection under its own heading. This page only groups the cards; how a
+/// source connects or syncs is unchanged.
 class ConnectionsSettingsScreen extends StatelessWidget {
   const ConnectionsSettingsScreen({super.key});
 
@@ -18,6 +20,7 @@ class ConnectionsSettingsScreen extends StatelessWidget {
     return const SettingsDetailScaffold(
       title: 'Connections',
       children: <Widget>[
+        _SectionHeading('Music'),
         JellyfinProviderCard(),
         SizedBox(height: AppSpacing.md),
         SubsonicProviderCard(),
@@ -29,7 +32,39 @@ class ConnectionsSettingsScreen extends StatelessWidget {
         // Local music is a connection here, deliberately kept away from the
         // offline-downloads page so it is not confused with offline downloads.
         LocalMusicProviderCard(),
+        SizedBox(height: AppSpacing.lg),
+        // Audiobooks are their own thing, not a music source: Audiobookshelf
+        // has its own session and never syncs into the music catalog, so it
+        // gets its own heading instead of sitting in the list above.
+        _SectionHeading('Audiobooks'),
+        AudiobookshelfProviderCard(),
       ],
+    );
+  }
+}
+
+/// A small group label above a run of cards. Only two groups exist, so this
+/// stays a plain heading rather than a new shared component.
+class _SectionHeading extends StatelessWidget {
+  const _SectionHeading(this.label);
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.only(
+        left: AppSpacing.xs,
+        bottom: AppSpacing.sm,
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.titleSmall?.copyWith(
+          color: theme.colorScheme.primary,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
     );
   }
 }

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -32,7 +32,8 @@ class SettingsScreen extends StatelessWidget {
             SettingsCategoryTile(
               icon: Icons.hub_outlined,
               title: 'Connections',
-              subtitle: 'Jellyfin, Plex, Navidrome/Subsonic, local files',
+              subtitle: 'Jellyfin, Plex, Navidrome/Subsonic, local files, '
+                  'Audiobookshelf',
               onTap: () => context.push(AppRoutes.settingsConnections),
             ),
             const SizedBox(height: AppSpacing.md),

--- a/test/data/repositories/audiobookshelf_session_store_test.dart
+++ b/test/data/repositories/audiobookshelf_session_store_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/audiobookshelf_session.dart';
+import 'package:linthra/data/repositories/in_memory_audiobookshelf_session_store.dart';
+
+const _session = AudiobookshelfSession(
+  baseUrl: 'https://audiobooks.example.com',
+  userId: 'user-1',
+  accessToken: 'tok-1',
+  refreshToken: 'refresh-1',
+  userName: 'alice',
+  defaultLibraryId: 'lib-1',
+  serverVersion: '2.17.0',
+);
+
+void main() {
+  group('InMemoryAudiobookshelfSessionStore', () {
+    test('starts empty by default', () async {
+      final store = InMemoryAudiobookshelfSessionStore();
+      expect(await store.read(), isNull);
+    });
+
+    test('exposes an initial session', () async {
+      final store =
+          InMemoryAudiobookshelfSessionStore(initialSession: _session);
+      expect(await store.read(), _session);
+    });
+
+    test('write then read returns the session', () async {
+      final store = InMemoryAudiobookshelfSessionStore();
+      await store.write(_session);
+      expect(await store.read(), _session);
+    });
+
+    test('a later write replaces the previous session', () async {
+      final store =
+          InMemoryAudiobookshelfSessionStore(initialSession: _session);
+      final other = _session.copyWith(userName: 'bob', accessToken: 'tok-2');
+      await store.write(other);
+      expect(await store.read(), other);
+    });
+
+    test('clear forgets the session (sign out)', () async {
+      final store =
+          InMemoryAudiobookshelfSessionStore(initialSession: _session);
+      await store.clear();
+      expect(await store.read(), isNull);
+    });
+  });
+}

--- a/test/features/settings/audiobookshelf/audiobookshelf_provider_card_test.dart
+++ b/test/features/settings/audiobookshelf/audiobookshelf_provider_card_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/audiobookshelf_session.dart';
+import 'package:linthra/core/sources/audiobookshelf/audiobookshelf_api.dart';
+import 'package:linthra/data/repositories/audiobookshelf_session_store_provider.dart';
+import 'package:linthra/data/repositories/in_memory_audiobookshelf_session_store.dart';
+import 'package:linthra/features/settings/audiobookshelf/audiobookshelf_provider_card.dart';
+import 'package:linthra/features/settings/audiobookshelf/audiobookshelf_settings_providers.dart';
+
+import '../../../core/sources/audiobookshelf/fake_audiobookshelf_client.dart';
+
+const _session = AudiobookshelfSession(
+  baseUrl: 'https://audiobooks.example.com',
+  userId: 'user-1',
+  accessToken: 'tok-1',
+  userName: 'alice',
+  serverVersion: '2.17.0',
+);
+
+Future<void> _pump(
+  WidgetTester tester, {
+  AudiobookshelfSession? savedSession,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        audiobookshelfClientProvider.overrideWithValue(
+          FakeAudiobookshelfClient(
+            serverStatus: const AudiobookshelfServerStatus(
+              serverVersion: '2.17.0',
+              isInitialized: true,
+            ),
+          ),
+        ),
+        audiobookshelfSessionStoreProvider.overrideWithValue(
+          InMemoryAudiobookshelfSessionStore(initialSession: savedSession),
+        ),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(body: AudiobookshelfProviderCard()),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('offers Connect when no server is set up', (tester) async {
+    await _pump(tester);
+
+    expect(find.text('Audiobookshelf'), findsOneWidget);
+    expect(find.text('Not connected'), findsOneWidget);
+    expect(find.text('Connect'), findsOneWidget);
+    expect(find.text('Manage'), findsNothing);
+  });
+
+  testWidgets('shows the signed-in account once connected', (tester) async {
+    await _pump(tester, savedSession: _session);
+
+    expect(find.text('Connected'), findsOneWidget);
+    expect(find.text('Signed in as alice'), findsOneWidget);
+    expect(find.text('Manage'), findsOneWidget);
+  });
+
+  testWidgets('Connect opens the connection form', (tester) async {
+    await _pump(tester);
+
+    await tester.tap(find.text('Connect'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Server URL'), findsOneWidget);
+    expect(find.text('Sign in'), findsOneWidget);
+  });
+
+  testWidgets('never renders the access token', (tester) async {
+    await _pump(tester, savedSession: _session);
+
+    for (final Text text in tester.widgetList<Text>(find.byType(Text))) {
+      expect(text.data ?? '', isNot(contains('tok-1')));
+    }
+  });
+}

--- a/test/features/settings/audiobookshelf/audiobookshelf_settings_controller_test.dart
+++ b/test/features/settings/audiobookshelf/audiobookshelf_settings_controller_test.dart
@@ -1,0 +1,453 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/audiobookshelf_session.dart';
+import 'package:linthra/core/repositories/audiobookshelf_session_store.dart';
+import 'package:linthra/core/repositories/secure_storage_exception.dart';
+import 'package:linthra/core/sources/audiobookshelf/audiobookshelf_api.dart';
+import 'package:linthra/core/sources/audiobookshelf/audiobookshelf_exception.dart';
+import 'package:linthra/data/repositories/audiobookshelf_session_store_provider.dart';
+import 'package:linthra/data/repositories/in_memory_audiobookshelf_session_store.dart';
+import 'package:linthra/features/settings/audiobookshelf/audiobookshelf_settings_controller.dart';
+import 'package:linthra/features/settings/audiobookshelf/audiobookshelf_settings_providers.dart';
+import 'package:linthra/features/settings/audiobookshelf/audiobookshelf_settings_state.dart';
+
+import '../../../core/sources/audiobookshelf/fake_audiobookshelf_client.dart';
+
+const _session = AudiobookshelfSession(
+  baseUrl: 'https://audiobooks.example.com',
+  userId: 'user-1',
+  accessToken: 'tok-1',
+  userName: 'alice',
+  defaultLibraryId: 'lib-1',
+  serverVersion: '2.17.0',
+);
+
+const _status = AudiobookshelfServerStatus(
+  serverVersion: '2.17.0',
+  isInitialized: true,
+);
+
+const _authResult = AudiobookshelfAuthResult(
+  userId: 'user-1',
+  accessToken: 'tok-1',
+  refreshToken: 'refresh-1',
+  userName: 'alice',
+  defaultLibraryId: 'lib-1',
+);
+
+Future<void> _settle() => Future<void>.delayed(Duration.zero);
+
+FakeAudiobookshelfClient _signInReadyClient({
+  List<AudiobookshelfLibraryDto> libraries = const <AudiobookshelfLibraryDto>[],
+}) {
+  return FakeAudiobookshelfClient(
+    serverStatus: _status,
+    authResult: _authResult,
+    libraries: libraries,
+  );
+}
+
+/// A session store standing in for a platform keyring that cannot be used:
+/// missing, locked, or refused by a sandbox. It fails exactly the way
+/// `SecureAudiobookshelfSessionStore` does through `SecureSessionStorage` (a
+/// typed [SecureStorageException]), so these tests exercise the controller's
+/// real failure path rather than a generic thrown object.
+class _UnusableKeyringStore implements AudiobookshelfSessionStore {
+  _UnusableKeyringStore({
+    AudiobookshelfSession? initialSession,
+    this.readFailure,
+    this.writeFailure,
+    this.clearFailure,
+  }) : _session = initialSession;
+
+  AudiobookshelfSession? _session;
+  final SecureStorageException? readFailure;
+  final SecureStorageException? writeFailure;
+  final SecureStorageException? clearFailure;
+
+  @override
+  Future<AudiobookshelfSession?> read() async {
+    if (readFailure != null) throw readFailure!;
+    return _session;
+  }
+
+  @override
+  Future<void> write(AudiobookshelfSession session) async {
+    if (writeFailure != null) throw writeFailure!;
+    _session = session;
+  }
+
+  @override
+  Future<void> clear() async {
+    if (clearFailure != null) throw clearFailure!;
+    _session = null;
+  }
+}
+
+const SecureStorageException _lockedRead = SecureStorageException(
+  operation: SecureStorageOperation.read,
+  failure: SecureStorageFailure.locked,
+);
+
+const SecureStorageException _unavailableWrite = SecureStorageException(
+  operation: SecureStorageOperation.write,
+  failure: SecureStorageFailure.unavailable,
+);
+
+const SecureStorageException _lockedDelete = SecureStorageException(
+  operation: SecureStorageOperation.delete,
+  failure: SecureStorageFailure.locked,
+);
+
+ProviderContainer _container({
+  FakeAudiobookshelfClient? client,
+  AudiobookshelfSessionStore? store,
+}) {
+  final container = ProviderContainer(
+    overrides: <Override>[
+      audiobookshelfClientProvider
+          .overrideWithValue(client ?? FakeAudiobookshelfClient()),
+      audiobookshelfSessionStoreProvider
+          .overrideWithValue(store ?? InMemoryAudiobookshelfSessionStore()),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  group('load', () {
+    test('starts disconnected when nothing is persisted', () async {
+      final container = _container();
+      container.read(audiobookshelfSettingsControllerProvider);
+      await _settle();
+
+      expect(
+        container.read(audiobookshelfSettingsControllerProvider).phase,
+        AudiobookshelfConnectionPhase.disconnected,
+      );
+    });
+
+    test('ensureLoaded restores a persisted session', () async {
+      final container = _container(
+        store: InMemoryAudiobookshelfSessionStore(initialSession: _session),
+      );
+
+      await container
+          .read(audiobookshelfSettingsControllerProvider.notifier)
+          .ensureLoaded();
+
+      final state = container.read(audiobookshelfSettingsControllerProvider);
+      expect(state.phase, AudiobookshelfConnectionPhase.connected);
+      expect(state.username, 'alice');
+      expect(state.baseUrl, 'https://audiobooks.example.com');
+      expect(
+        container
+            .read(audiobookshelfSettingsControllerProvider.notifier)
+            .session,
+        isNotNull,
+      );
+    });
+
+    test('reports an unusable keyring instead of silently signing out',
+        () async {
+      final container = _container(
+        store: _UnusableKeyringStore(readFailure: _lockedRead),
+      );
+
+      await container
+          .read(audiobookshelfSettingsControllerProvider.notifier)
+          .ensureLoaded();
+
+      final state = container.read(audiobookshelfSettingsControllerProvider);
+      expect(state.phase, AudiobookshelfConnectionPhase.disconnected);
+      expect(state.errorMessage, contains('Audiobookshelf'));
+    });
+  });
+
+  group('testConnection', () {
+    test('reports the reached server version without sending credentials',
+        () async {
+      final client = _signInReadyClient();
+      final container = _container(client: client);
+      final notifier =
+          container.read(audiobookshelfSettingsControllerProvider.notifier);
+      await _settle();
+
+      final ok = await notifier.testConnection('audiobooks.example.com');
+
+      expect(ok, isTrue);
+      final state = container.read(audiobookshelfSettingsControllerProvider);
+      expect(state.phase, AudiobookshelfConnectionPhase.tested);
+      expect(state.statusMessage, contains('2.17.0'));
+      // A test never authenticates, so no credential reached the client.
+      expect(client.lastUsername, isNull);
+      expect(client.lastPassword, isNull);
+    });
+
+    test('surfaces a friendly error on failure', () async {
+      final container = _container(
+        client: FakeAudiobookshelfClient(
+          serverStatusError: AudiobookshelfException.notAudiobookshelf(),
+        ),
+      );
+      final notifier =
+          container.read(audiobookshelfSettingsControllerProvider.notifier);
+      await _settle();
+
+      final ok = await notifier.testConnection('example.com');
+
+      expect(ok, isFalse);
+      final state = container.read(audiobookshelfSettingsControllerProvider);
+      expect(state.phase, AudiobookshelfConnectionPhase.disconnected);
+      expect(state.errorKind, AudiobookshelfErrorKind.notAudiobookshelf);
+      expect(state.errorMessage, isNotNull);
+    });
+  });
+
+  group('signIn', () {
+    test('persists the session and never exposes the password or tokens',
+        () async {
+      final store = InMemoryAudiobookshelfSessionStore();
+      final client = _signInReadyClient();
+      final container = _container(client: client, store: store);
+      final notifier =
+          container.read(audiobookshelfSettingsControllerProvider.notifier);
+      await _settle();
+
+      final ok = await notifier.signIn(
+        url: 'audiobooks.example.com',
+        username: 'alice',
+        password: 'hunter2',
+      );
+
+      expect(ok, isTrue);
+      final state = container.read(audiobookshelfSettingsControllerProvider);
+      expect(state.phase, AudiobookshelfConnectionPhase.connected);
+      expect(state.username, 'alice');
+
+      final saved = await store.read();
+      expect(saved, isNotNull);
+      expect(saved!.accessToken, 'tok-1');
+      // Only the session is stored — never the password.
+      expect(saved.toJson().values.contains('hunter2'), isFalse);
+      // And nothing secret rides in the state the UI renders.
+      expect(state.statusMessage, isNot(contains('tok-1')));
+      expect(state.statusMessage, isNot(contains('hunter2')));
+    });
+
+    test('reuses a status already confirmed for the same address', () async {
+      final client = _signInReadyClient();
+      final container = _container(client: client);
+      final notifier =
+          container.read(audiobookshelfSettingsControllerProvider.notifier);
+      await _settle();
+
+      await notifier.testConnection('audiobooks.example.com');
+      await notifier.signIn(
+        url: 'audiobooks.example.com',
+        username: 'alice',
+        password: 'hunter2',
+      );
+
+      expect(client.serverStatusCallCount, 1);
+    });
+
+    test('re-confirms the server when signing in to a different address',
+        () async {
+      final client = _signInReadyClient();
+      final container = _container(client: client);
+      final notifier =
+          container.read(audiobookshelfSettingsControllerProvider.notifier);
+      await _settle();
+
+      await notifier.testConnection('audiobooks.example.com');
+      await notifier.signIn(
+        url: 'other.example.com',
+        username: 'alice',
+        password: 'hunter2',
+      );
+
+      expect(client.serverStatusCallCount, 2);
+    });
+
+    test('lists the account libraries once signed in', () async {
+      final client = _signInReadyClient(
+        libraries: const <AudiobookshelfLibraryDto>[
+          AudiobookshelfLibraryDto(
+            id: 'lib-1',
+            name: 'Audiobooks',
+            mediaType: 'book',
+          ),
+          AudiobookshelfLibraryDto(
+            id: 'lib-2',
+            name: 'Podcasts',
+            mediaType: 'podcast',
+          ),
+        ],
+      );
+      final container = _container(client: client);
+      final notifier =
+          container.read(audiobookshelfSettingsControllerProvider.notifier);
+      await _settle();
+
+      await notifier.signIn(
+        url: 'audiobooks.example.com',
+        username: 'alice',
+        password: 'hunter2',
+      );
+      await _settle();
+
+      final state = container.read(audiobookshelfSettingsControllerProvider);
+      expect(
+        state.libraries.map((library) => library.name),
+        <String>['Audiobooks', 'Podcasts'],
+      );
+      expect(state.isLoadingLibraries, isFalse);
+    });
+
+    test('does not adopt a session the keyring refused to store', () async {
+      final store = _UnusableKeyringStore(writeFailure: _unavailableWrite);
+      final container = _container(client: _signInReadyClient(), store: store);
+      final notifier =
+          container.read(audiobookshelfSettingsControllerProvider.notifier);
+      await _settle();
+
+      final ok = await notifier.signIn(
+        url: 'audiobooks.example.com',
+        username: 'alice',
+        password: 'hunter2',
+      );
+
+      expect(ok, isFalse);
+      final state = container.read(audiobookshelfSettingsControllerProvider);
+      expect(state.phase, AudiobookshelfConnectionPhase.disconnected);
+      expect(state.errorMessage, isNotNull);
+      expect(notifier.session, isNull);
+    });
+
+    test('keeps the current connection when a re-auth fails', () async {
+      final client = _signInReadyClient();
+      final container = _container(
+        client: client,
+        store: InMemoryAudiobookshelfSessionStore(initialSession: _session),
+      );
+      final notifier =
+          container.read(audiobookshelfSettingsControllerProvider.notifier);
+      await notifier.ensureLoaded();
+
+      client.authError = AudiobookshelfException.unauthorized();
+      final ok = await notifier.signIn(
+        url: 'audiobooks.example.com',
+        username: 'alice',
+        password: 'wrong',
+      );
+
+      expect(ok, isFalse);
+      final state = container.read(audiobookshelfSettingsControllerProvider);
+      expect(state.phase, AudiobookshelfConnectionPhase.connected);
+      expect(state.errorMessage, isNotNull);
+      expect(notifier.session, isNotNull);
+    });
+  });
+
+  group('refreshLibraries', () {
+    test('does nothing when not connected', () async {
+      final client = _signInReadyClient();
+      final container = _container(client: client);
+      final notifier =
+          container.read(audiobookshelfSettingsControllerProvider.notifier);
+      await _settle();
+
+      await notifier.refreshLibraries();
+
+      expect(client.lastSession, isNull);
+      expect(
+        container.read(audiobookshelfSettingsControllerProvider).libraries,
+        isEmpty,
+      );
+    });
+
+    test('keeps the connection when the listing fails', () async {
+      final client = _signInReadyClient();
+      final container = _container(
+        client: client,
+        store: InMemoryAudiobookshelfSessionStore(initialSession: _session),
+      );
+      final notifier =
+          container.read(audiobookshelfSettingsControllerProvider.notifier);
+      await notifier.ensureLoaded();
+
+      client.librariesError = AudiobookshelfException.serverError(500);
+      await notifier.refreshLibraries();
+
+      final state = container.read(audiobookshelfSettingsControllerProvider);
+      expect(state.phase, AudiobookshelfConnectionPhase.connected);
+      expect(state.isLoadingLibraries, isFalse);
+      expect(state.errorKind, AudiobookshelfErrorKind.serverError);
+    });
+
+    test('a later successful listing clears the earlier failure', () async {
+      final client = _signInReadyClient(
+        libraries: const <AudiobookshelfLibraryDto>[
+          AudiobookshelfLibraryDto(id: 'lib-1', name: 'Audiobooks'),
+        ],
+      );
+      final container = _container(
+        client: client,
+        store: InMemoryAudiobookshelfSessionStore(initialSession: _session),
+      );
+      final notifier =
+          container.read(audiobookshelfSettingsControllerProvider.notifier);
+      await notifier.ensureLoaded();
+
+      client.librariesError = AudiobookshelfException.serverError(500);
+      await notifier.refreshLibraries();
+      client.librariesError = null;
+      await notifier.refreshLibraries();
+
+      final state = container.read(audiobookshelfSettingsControllerProvider);
+      expect(state.errorMessage, isNull);
+      expect(state.errorKind, isNull);
+      expect(state.libraries.single.name, 'Audiobooks');
+    });
+  });
+
+  group('clear', () {
+    test('signs out and forgets the session', () async {
+      final store =
+          InMemoryAudiobookshelfSessionStore(initialSession: _session);
+      final container = _container(store: store);
+      final notifier =
+          container.read(audiobookshelfSettingsControllerProvider.notifier);
+      await notifier.ensureLoaded();
+
+      await notifier.clear();
+
+      expect(await store.read(), isNull);
+      expect(notifier.session, isNull);
+      final state = container.read(audiobookshelfSettingsControllerProvider);
+      expect(state.phase, AudiobookshelfConnectionPhase.disconnected);
+      expect(state.statusMessage, contains('Signed out'));
+    });
+
+    test('stays connected when the keyring refuses to delete', () async {
+      final container = _container(
+        store: _UnusableKeyringStore(
+          initialSession: _session,
+          clearFailure: _lockedDelete,
+        ),
+      );
+      final notifier =
+          container.read(audiobookshelfSettingsControllerProvider.notifier);
+      await notifier.ensureLoaded();
+
+      await notifier.clear();
+
+      final state = container.read(audiobookshelfSettingsControllerProvider);
+      expect(state.phase, AudiobookshelfConnectionPhase.connected);
+      expect(state.errorMessage, isNotNull);
+      expect(notifier.session, isNotNull);
+    });
+  });
+}

--- a/test/features/settings/audiobookshelf/audiobookshelf_settings_section_test.dart
+++ b/test/features/settings/audiobookshelf/audiobookshelf_settings_section_test.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/audiobookshelf_session.dart';
+import 'package:linthra/core/sources/audiobookshelf/audiobookshelf_api.dart';
+import 'package:linthra/data/repositories/audiobookshelf_session_store_provider.dart';
+import 'package:linthra/data/repositories/in_memory_audiobookshelf_session_store.dart';
+import 'package:linthra/features/settings/audiobookshelf/audiobookshelf_settings_providers.dart';
+import 'package:linthra/features/settings/audiobookshelf/audiobookshelf_settings_section.dart';
+
+import '../../../core/sources/audiobookshelf/fake_audiobookshelf_client.dart';
+
+const _session = AudiobookshelfSession(
+  baseUrl: 'https://audiobooks.example.com',
+  userId: 'user-1',
+  accessToken: 'tok-1',
+  userName: 'alice',
+  serverVersion: '2.17.0',
+);
+
+const _status = AudiobookshelfServerStatus(
+  serverVersion: '2.17.0',
+  isInitialized: true,
+);
+
+const _authResult = AudiobookshelfAuthResult(
+  userId: 'user-1',
+  accessToken: 'tok-1',
+  userName: 'alice',
+);
+
+Future<void> _pump(
+  WidgetTester tester, {
+  FakeAudiobookshelfClient? client,
+  AudiobookshelfSession? savedSession,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        audiobookshelfClientProvider.overrideWithValue(
+          client ??
+              FakeAudiobookshelfClient(
+                serverStatus: _status,
+                authResult: _authResult,
+              ),
+        ),
+        audiobookshelfSessionStoreProvider.overrideWithValue(
+          InMemoryAudiobookshelfSessionStore(initialSession: savedSession),
+        ),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(child: AudiobookshelfSettingsSection()),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('renders the connection form', (tester) async {
+    await _pump(tester);
+
+    expect(find.text('Audiobookshelf'), findsOneWidget);
+    expect(find.text('Server URL'), findsOneWidget);
+    expect(find.text('Username'), findsOneWidget);
+    expect(find.text('Password'), findsOneWidget);
+    expect(find.text('Test connection'), findsOneWidget);
+    expect(find.text('Sign in'), findsOneWidget);
+  });
+
+  testWidgets('Test connection needs only the address, Sign in needs all three',
+      (tester) async {
+    await _pump(tester);
+
+    OutlinedButton test() => tester.widget<OutlinedButton>(
+          find.widgetWithText(OutlinedButton, 'Test connection'),
+        );
+    FilledButton signIn() => tester.widget<FilledButton>(
+          find.widgetWithText(FilledButton, 'Sign in'),
+        );
+
+    expect(test().onPressed, isNull);
+    expect(signIn().onPressed, isNull);
+
+    await tester.enterText(
+      find.byType(TextField).at(0),
+      'audiobooks.example.com',
+    );
+    await tester.pump();
+
+    // The address alone is testable: /status takes no credentials.
+    expect(test().onPressed, isNotNull);
+    expect(signIn().onPressed, isNull);
+
+    await tester.enterText(find.byType(TextField).at(1), 'alice');
+    await tester.enterText(find.byType(TextField).at(2), 'hunter2');
+    await tester.pump();
+
+    expect(signIn().onPressed, isNotNull);
+  });
+
+  testWidgets('signing in shows the account and its libraries', (tester) async {
+    await _pump(
+      tester,
+      client: FakeAudiobookshelfClient(
+        serverStatus: _status,
+        authResult: _authResult,
+        libraries: const <AudiobookshelfLibraryDto>[
+          AudiobookshelfLibraryDto(
+            id: 'lib-1',
+            name: 'Audiobooks',
+            mediaType: 'book',
+          ),
+        ],
+      ),
+    );
+
+    await tester.enterText(
+      find.byType(TextField).at(0),
+      'audiobooks.example.com',
+    );
+    await tester.enterText(find.byType(TextField).at(1), 'alice');
+    await tester.enterText(find.byType(TextField).at(2), 'hunter2');
+    await tester.pump();
+    await tester.tap(find.widgetWithText(FilledButton, 'Sign in'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Signed in as alice'), findsOneWidget);
+    expect(find.text('1 library'), findsOneWidget);
+    expect(find.text('Audiobooks'), findsOneWidget);
+    expect(find.text('Sign out & clear'), findsOneWidget);
+    // The form is gone once connected, so no password field lingers.
+    expect(find.text('Password'), findsNothing);
+  });
+
+  testWidgets('a restored session lists libraries when the sheet opens',
+      (tester) async {
+    final client = FakeAudiobookshelfClient(
+      serverStatus: _status,
+      authResult: _authResult,
+      libraries: const <AudiobookshelfLibraryDto>[
+        AudiobookshelfLibraryDto(id: 'lib-1', name: 'Audiobooks'),
+        AudiobookshelfLibraryDto(id: 'lib-2', name: 'Podcasts'),
+      ],
+    );
+    await _pump(tester, client: client, savedSession: _session);
+
+    expect(find.text('2 libraries'), findsOneWidget);
+    expect(find.text('Podcasts'), findsOneWidget);
+  });
+
+  testWidgets('a failed test connection shows a friendly error',
+      (tester) async {
+    await _pump(
+      tester,
+      client: FakeAudiobookshelfClient(),
+    );
+
+    await tester.enterText(find.byType(TextField).at(0), 'example.com');
+    await tester.pump();
+    await tester.tap(find.widgetWithText(OutlinedButton, 'Test connection'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining("Couldn't reach the server"), findsOneWidget);
+    // Still on the form, nothing pretends to be connected.
+    expect(find.text('Sign in'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Part of #484.

Milestone 1 landed the Audiobookshelf client, URL normalizer, authenticator and session model, but none of it was reachable from the app: nothing in `lib/` outside `core/sources/audiobookshelf/` referenced it. This PR wires that layer up so a server can actually be connected.

Since milestones 2 to 4 never landed on `main`, the navigation move (Library to Music, Audiobooks as its own destination) has nothing to move yet. It follows once there is a browsing surface to put there.

## What's in it

**Session storage.** `AudiobookshelfSessionStore` with the usual trio: interface in `core/repositories`, in-memory default for tests, encrypted production binding through `SecureSessionStorage`. Same rules as the music providers' credentials: nothing plaintext, no Linthra-side fallback, and a locked or missing keyring is reported rather than flattened into "signed out".

**Controller.** `AudiobookshelfSettingsController` loads a saved session, tests an address, signs in, lists the account's libraries and signs out. The state it exposes to the UI holds no secret (server URL, username, server version, library names only), and the password is forwarded once to get the tokens and never retained. A sign-in right after a successful test reuses the confirmed `/status` for that same address instead of asking twice.

**UI.** A connection form (URL / username / password) and a compact card on Settings > Connections, under its own "Audiobooks" heading. "Test connection" only needs the address, since Audiobookshelf answers `/status` without credentials, so an address can be checked before a password is typed. Once connected the card shows the account and the libraries it can see.

**Startup.** The saved session is warmed alongside Jellyfin/Subsonic/Plex, and the encrypted binding is added to the production overrides.

## What it deliberately doesn't touch

The music providers, the music catalog, the source preference and the sync controllers. Audiobookshelf has its own session, its own store and its own seam. Nothing here syncs into `MusicLibraryRepository`.

## Testing

- `flutter analyze`: clean
- `flutter test`: 4302 passing, including 30 new ones (controller, connection form, card, session store)
- `dart format`: clean
- `scripts/check_secrets.sh`: clean

New coverage: keyring failures on read/write/delete, a sign-in the keyring refuses (not adopted), a failed re-auth keeping the existing connection, status reuse vs. re-confirmation on a different address, library listing and its failure path, and checks that no token or password reaches the state or the rendered widgets.

## Branch provenance

Branched directly from current `main` (b333fef), no history from any other branch, no merges, one commit. The diff is 18 files: the audiobook feature (5 files), its session store (4), its tests (4), the two startup wiring lines, the Connections page, the Settings hub subtitle, and one stale doc comment in `secure_session_storage.dart` that listed which stores use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJQP2J5iKUUdJNeNtYnNqA