### PR TITLE
Pin cast receivers per device, and write down the hardened design (#575)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ The full index of Linthra's docs. New to the project? Start with the
 | Streaming, buffering & recovery | [streaming.md](./streaming.md) |
 | Queue / Up Next | [queue.md](./queue.md) |
 | Offline cache & downloads | [offline-cache.md](./offline-cache.md) |
-| Cast / Chromecast | [cast.md](./cast.md) · [receiver trust](./cast-receiver-trust.md) · [what a handoff delegates](./cast-media-access.md) |
+| Cast / Chromecast | [cast.md](./cast.md) · [receiver trust](./cast-receiver-trust.md) · [hardened design](./cast-hardened-design.md) · [what a handoff delegates](./cast-media-access.md) |
 | Remote control (drive Linthra from another app) | [remote-control.md](./remote-control.md) |
 | Android Auto | [android-auto.md](./android-auto.md) |
 | Playlists & safe removal | [playlists-and-delete.md](./playlists-and-delete.md) |

--- a/docs/cast-hardened-design.md
+++ b/docs/cast-hardened-design.md
@@ -229,9 +229,12 @@ first time it is used, and required to match every time after
 - **A mismatch never overwrites.** Replacing a pin is `forget()`, behind a
   deliberate user action, never something the trust path does to recover.
 - **An empty fingerprint is a refusal**, not a pin that matches everything.
-- **Formatting is not a security decision.** Case and separators are normalised
-  before comparing, so a cosmetic change in an authenticator cannot read as a
-  swapped device.
+- **Formatting is not a security decision.** Case, colons and whitespace are
+  normalised before comparing, so a cosmetic change in an authenticator cannot
+  read as a swapped device. Deliberately not `-` or `_`: those are digits of a
+  base64url digest, and dropping them could make two different fingerprints
+  compare equal. Anything outside that list fails the comparison, which is a
+  refusal the user can see.
 
 The user-facing half is a distinct failure kind
 (`CastTrustFailureKind.changedReceiver`) with its own message, because unlike

--- a/docs/cast-hardened-design.md
+++ b/docs/cast-hardened-design.md
@@ -1,0 +1,331 @@
+# How casting could actually work again (the hardened design)
+
+Casting is switched off in shipped builds while a reported security issue is
+resolved ([cast.md](cast.md#temporary-containment)).
+[cast-receiver-trust.md](cast-receiver-trust.md) states the rule the app
+enforces: no verified identity, no session, no media. This page is the answer to
+the next question, the one that decides whether the feature ever comes back:
+what would a receiver check have to be, concretely, for it to be worth trusting?
+
+It is a design, not a plan of record. Nothing here is wired into production,
+nothing here changes the containment, and the restoration remains one reviewed
+change ([#575](https://github.com/TheZupZup/Linthra/issues/575)). The report
+itself and the assessment of any specific implementation stay in the private
+advisory.
+
+## The short version
+
+Five layers, each doing one job, and none of them a substitute for another:
+
+| Layer | Question it answers | Where it stands |
+| --- | --- | --- |
+| 1. Transport | Is the channel private? | TLS exists today, and proves nothing about who is on the far end |
+| 2. Device authentication | Is this a genuine Cast receiver? | Not implemented anywhere in the tree, and the package we depend on cannot express the modern challenge |
+| 3. Device pinning | Is it *your* receiver, the same one as last time? | Built and tested (`cast_receiver_pinning.dart`) |
+| 4. Least privilege | If it is, how little can it be handed? | Modelled and documented ([cast-media-access.md](cast-media-access.md)) |
+| 5. Fail-closed boundary | Does any doubt end in silence? | Built and tested (`trust_gated_cast_transport.dart`) |
+
+Layers 3 and 5 are app-side policy, so they were landed ahead of the protocol
+work: when a real handshake arrives it is reviewed on protocol grounds, not on
+whether the plumbing around it is sound. Layer 2 is the missing one, and it is
+the whole of the risk.
+
+## Layer 1: the channel
+
+A Cast receiver listens on TCP 8009 and speaks TLS with a self-signed device
+certificate. Any client therefore has to accept a certificate it cannot chain to
+anything, which is what the `cast` package does today:
+
+```dart
+// package:cast/socket.dart
+final _socket = await SecureSocket.connect(
+  host, port,
+  onBadCertificate: (X509Certificate certificate) => true,
+  timeout: timeout,
+);
+```
+
+That line is not itself the bug. Accepting the certificate is unavoidable; the
+question is what happens next. What matters is that the certificate is not
+thrown away, because layer 2 binds to it. Dart gives us what we need:
+`SecureSocket.peerCertificate` returns the peer's `X509Certificate`, and
+`X509Certificate.der` is its exact DER encoding.
+
+So layer 1's only job in this design is: connect, capture the peer certificate
+DER, and trust nothing yet.
+
+## Layer 2: prove it is a genuine receiver
+
+Google Cast has a device-authentication exchange for exactly this, on the
+`urn:x-cast:com.google.cast.tp.deviceauth` namespace. Every receiver carries a
+manufacturer certificate chaining to a Google Cast root. The sender challenges
+it, and the response is only meaningful because it is signed over the TLS
+certificate the connection is actually using, which is what stops a relay in the
+middle from forwarding somebody else's valid proof.
+
+The exchange, following Chromium's and Open Screen's implementation
+(`cast/sender/channel/cast_auth_util.cc`):
+
+1. **Challenge.** Send `DeviceAuthMessage{challenge: AuthChallenge{sender_nonce,
+   hash_algorithm: SHA256}}`, where `sender_nonce` is 16 bytes from a
+   cryptographic RNG, fresh per connection.
+2. **Response.** The receiver answers `AuthResponse{signature,
+   client_auth_certificate, intermediate_certificate[], sender_nonce,
+   hash_algorithm, crl}`.
+3. **Echo check.** `response.sender_nonce` must equal the nonce we sent. This is
+   the replay defence, and it has to be enforced, not merely compared.
+4. **Chain.** Build the path `client_auth_certificate` +
+   `intermediate_certificate[]` up to a pinned Cast root, and validate it at the
+   current time: signatures, validity windows, `basicConstraints` (CA and path
+   length), and key usage. The leaf must not be a CA and must be allowed to sign.
+5. **Revocation.** The response carries a CRL, itself signed and chaining to the
+   same roots. Check every certificate in the path against it.
+6. **Signature.** Verify `signature` over the byte string
+   `sender_nonce || peer_certificate_DER`, using the leaf's public key,
+   RSASSA-PKCS1-v1_5 with SHA-256. The peer certificate is the one captured in
+   layer 1, which is what ties the proof to this connection.
+7. **Peer certificate sanity.** Reject a self-signed peer certificate with an
+   implausibly long validity window, as upstream does.
+
+Only if all seven hold is there an identity, and even then it is the identity of
+*a* receiver.
+
+### Where we would be stricter than upstream
+
+Two of upstream's defaults are lenient for compatibility reasons that do not
+apply to a music player shipping a fresh implementation:
+
+- **SHA-1 signatures.** `AuthenticateChallengeReply` calls through with
+  `enforce_sha256_checking = false`, so a receiver may answer with a SHA-1
+  signature. We would require SHA-256 and refuse SHA-1. This is a compatibility
+  bet, and the device matrix is where it gets settled: if a supported device
+  cannot do SHA-256, that is a finding, not a reason to quietly relax.
+- **CRL policy.** Upstream defaults to `kCrlOptional`, meaning a missing CRL is
+  tolerated. We would require one, with the honest caveat below.
+
+### What the current dependency cannot do
+
+`cast 2.1.0` declares the namespace (`session.dart` has
+`kNamespaceDeviceauth = 'urn:x-cast:com.google.cast.tp.deviceauth'`) but never
+sends a challenge, and it could not express the modern one if it wanted to. Its
+bundled `cast_channel.proto` carries the pre-nonce shape of the messages:
+
+```proto
+message AuthChallenge {
+}
+
+message AuthResponse {
+  required bytes signature = 1;
+  required bytes client_auth_certificate = 2;
+  repeated bytes client_ca = 3;
+}
+```
+
+No `sender_nonce`, no `hash_algorithm`, no `crl`. A challenge built from this
+proto has no replay protection at all, because there is no nonce to echo. So the
+protocol work is not "call the auth method that is already there": it starts
+with the message definitions.
+
+## The trust anchors
+
+Two roots, both public, both currently used by Chromium and Open Screen:
+
+| Root | Subject | Key | Valid until | SHA-256 of the DER |
+| --- | --- | --- | --- | --- |
+| Cast Root CA | `C=US, ST=California, L=Mountain View, O=Google Inc, OU=Cast, CN=Cast Root CA` | RSA 2048 | 2034-03-28 | `809af14700b3fe2611ad597eb1584d6354313b64ccdb3390f097fa3e5826d6ca` |
+| Eureka Root CA | `C=US, ST=California, L=Mountain View, O=Google Inc, OU=Google TV, CN=Eureka Root CA` | RSA 2048 | 2032-12-12 | `caf6d1e37b532203e01a76bf07187bb731ccd38801565ab2211a2c0ab7f3bc46` |
+
+Both are self-signed with `sha1WithRSAEncryption`, which is not a problem: a
+pinned anchor's own signature is never verified, only its public key is used. The
+Cast root asserts `CA:TRUE, pathlen:2`, which bounds the chain to at most two
+intermediates and is worth enforcing rather than assuming.
+
+They would live in the repository as DER blobs with their digests recorded, the
+same provenance discipline `scripts/check_vendored_packages.sh` already applies
+to `third_party/`. Upstream copies are
+`cast/common/certificate/cast_root_ca_cert_der-inc.h` and
+`eureka_root_ca_der-inc.h` in Open Screen. Two operational notes that belong in
+the design rather than in a surprise five years from now: anchors expire (2032
+and 2034), and Google can add roots. A pinned store needs an owner, a review
+step when it changes, and a build that fails loudly rather than a device that
+stops working mysteriously.
+
+## Doing the cryptography
+
+This is the part to be honest about: there is no pure-Dart RFC 5280 path
+validator to depend on. `pointycastle` (MIT, pure Dart, no native code) has RSA
+PKCS#1 v1.5 verification and the digests; `asn1lib` (no dependencies) parses DER.
+Neither builds or validates a certificate path. That code would be ours.
+
+Two routes were considered.
+
+**Route A, one pure-Dart validator, used on every platform.** Recommended.
+Linthra ships Android and Linux from one codebase, and the F-Droid and Flatpak
+builds have to stay free of proprietary components, so a single implementation
+that behaves identically everywhere is also the only one that gets reviewed once
+rather than twice. The saving grace is that the Cast case is not general PKI: a
+leaf plus at most two intermediates, RSA-2048 throughout, one signature scheme,
+two pinned anchors, no name constraints, no policy mapping, no AIA fetching, no
+OCSP, no hostname matching. Written to that shape and refusing anything outside
+it, the validator is a few hundred lines that a reviewer can hold in their head.
+
+**Route B, the platform's own validator.** On Android, `CertPathValidator` with a
+`TrustAnchor` per pinned root and `Signature.getInstance("SHA256withRSA")`; on
+Linux, OpenSSL through `dart:ffi`. Mature code doing the risky part, which is
+genuinely attractive. It was not chosen because it means two implementations plus
+a platform channel, a security property that differs by platform, and a Flatpak
+build whose behaviour depends on the runtime's libcrypto. Worth revisiting if
+route A's validator turns out to be harder to get right than it looks: that would
+be a real finding, and this is written down so the alternative is not
+rediscovered from scratch.
+
+Whichever route, the review load is the same and it is the highest in this
+document. It gets fixture chains generated at build time, not committed test
+certificates that expire, and negative fixtures for each rejection reason.
+
+## Where the client code lives
+
+Not a fork of `cast 2.1.0`. The changes needed (new message definitions, a
+mandatory challenge, peer certificate capture, binding the session to the proof)
+reach almost everything the package does, while the surface Linthra actually uses
+is small: discover, connect, authenticate, load, status, volume, disconnect. A
+narrow in-repo client implementing exactly that, with authentication mandatory
+rather than optional, is less code to review than the diff against the package
+would be.
+
+Upstream material we would take verbatim, principally the `.proto` definitions,
+goes under `third_party/` with `upstream.patch` and `upstream.sha256`, the
+pattern `third_party/just_audio_media_kit` already follows and CI already checks.
+
+An upstream contribution to the package is worth doing in parallel: it helps
+every other app using it. It is not worth waiting on, because the restoration
+cannot depend on somebody else's release schedule.
+
+## Layer 3: it has to be *your* receiver
+
+This is the layer that is easy to skip and the one that most closely matches what
+users assume is happening.
+
+Device authentication proves the peer holds a genuine Cast certificate. It does
+not say which genuine receiver it is. Discovery is a friendly name and an address
+on a LAN, both unauthenticated, so another real Cast device (a neighbour's, a
+guest's, one plugged in by somebody else) can answer to a familiar name and pass
+the handshake completely honestly. Layer 2 alone would hand it the stream.
+
+So the fingerprint of the certificate a device proved itself with is recorded the
+first time it is used, and required to match every time after
+(`lib/core/services/cast/cast_receiver_pinning.dart`, enforced in
+`TrustGatedCastTransport`). The rules that make it worth having:
+
+- **A store that cannot answer is not a first use.** A read that throws or hangs
+  refuses the connection rather than re-pinning, because otherwise breaking the
+  store is a way to erase the check.
+- **A failed write refuses too, and the write is read back.** Handing out a
+  session that was never recorded would leave the entry unpinned, and the next
+  receiver to answer, whichever one that is, would become the pin. Reading back
+  also settles the race where two connections reach an empty pin together: the
+  store keeps the first, and the second finds out it is not the receiver that got
+  recorded.
+- **A mismatch never overwrites.** Replacing a pin is `forget()`, behind a
+  deliberate user action, never something the trust path does to recover.
+- **An empty fingerprint is a refusal**, not a pin that matches everything.
+- **Formatting is not a security decision.** Case and separators are normalised
+  before comparing, so a cosmetic change in an authenticator cannot read as a
+  swapped device.
+
+The user-facing half is a distinct failure kind
+(`CastTrustFailureKind.changedReceiver`) with its own message, because unlike
+every other refusal this one has an action attached: if you really did replace
+the speaker, forget it and connect again.
+
+Two follow-ons for the restoration: the store has to be persistent (the shipped
+default is in-memory, chosen so that a missing store shortens the memory rather
+than removing the check), and the cast sheet needs the "forget this device"
+affordance the message points at.
+
+## Layer 4: hand over as little as possible
+
+Unchanged from [cast-media-access.md](cast-media-access.md), and worth restating
+because it is the layer people reach for first: for both servers Linthra can cast
+from, what a receiver ends up holding is an account credential, because neither
+Jellyfin nor Subsonic issues a per-item capability. Narrowing that is real
+defence in depth and it is not a substitute for layers 2 and 3. A scoped URL
+handed to a device nobody authenticated is still a handoff to an unknown device.
+
+## Layer 5: any doubt ends in silence
+
+Also unchanged, and already in the tree: `TrustGatedCastTransport` hands out a
+session only after the receiver authenticated, the identity matches both the
+device the user picked and the session it will use, and the pin agrees. Every
+failure closes the session with a bounded cleanup, every outbound operation
+re-checks, trust ends with the connection it was proved over, and the gate owns
+the wording so nothing from a handshake can reach the screen.
+
+## What this design does not fix
+
+Written down deliberately, because a design that only lists its strengths is not
+one you can review:
+
+- **First use is still first use.** Pinning catches a device that changes; it
+  cannot catch an impostor that was there the very first time. Requiring the user
+  to confirm a device the first time it is used narrows the window, and does not
+  close it.
+- **The CRL arrives from the device being checked.** A receiver that wants to
+  hide its own revocation can simply not send one. Requiring a CRL turns that
+  into a refusal rather than a silent pass, which is the best a client can do
+  offline, and it is not the same as fresh revocation data.
+- **A genuine certificate on compromised hardware still passes.** Device
+  authentication attests the manufacturer, not the current state of the device.
+- **Denial of service stays available.** Anything on the LAN can stop casting
+  from working. That is the acceptable failure: this whole design is built so
+  that the failure mode is silence, not a stream going somewhere unknown.
+- **Nothing here reduces what a credential-bearing URL is worth once handed
+  over.** That is layer 4's problem, and it is a server-side one.
+
+## Getting there
+
+Staged, so that each step is reviewable and none of them relaxes the containment:
+
+1. **Vendor the protocol definitions and the trust anchors**, with provenance
+   checks. No behaviour change.
+2. **The validator**, standalone: chain building and validation against pinned
+   anchors, CRL handling, signature verification. Reviewed on its own, with
+   generated fixtures and negative cases. Not reachable from the app.
+3. **The Cast client**, narrow, with the challenge mandatory. Still not wired
+   into production.
+4. **The authenticator** implementing `CastReceiverAuthenticator` on top of 2 and
+   3, plugged into the existing gate. Still not wired into production.
+5. **A persistent pin store and the sheet's forget affordance.**
+6. **Device matrix by hand**, results to the advisory.
+7. **The restoration itself**, per the checklist in
+   [cast-receiver-trust.md](cast-receiver-trust.md#restoration-checklist): the
+   production wiring, `CastContainment.isActive`,
+   `scripts/check_cast_containment.py` and
+   `scripts/verify_release_containment.py` all in one change, then its own
+   release.
+
+Steps 1 through 5 can land while casting stays off, which is the point of
+splitting them: by the time the containment is lifted, everything except the
+device testing has already been reviewed on its own terms.
+
+## Tests
+
+The app-side boundary is covered today
+(`test/core/services/cast/trust_gated_cast_transport_test.dart`), including the
+pinning cases above. The protocol side arrives with the implementation and owes,
+at minimum:
+
+- a response with a missing, empty, or altered `sender_nonce`;
+- a valid response replayed from another connection or another challenge;
+- a signature over the wrong peer certificate, which is the relay case;
+- an untrusted root, an expired certificate, a leaf presented as a CA, a chain
+  longer than the anchor's path length, a chain in the wrong order;
+- a SHA-1 signature, and an unknown hash algorithm;
+- a missing CRL, a CRL that does not verify, and a CRL revoking a certificate in
+  the path;
+- a receiver that completes TLS and never answers the challenge, and one that
+  answers after the timeout;
+- malformed DER at every position, including truncated and oversized inputs.
+
+All of it with generated fixtures. Never with real device certificates, and never
+with anything from the private report.

--- a/docs/cast-receiver-trust.md
+++ b/docs/cast-receiver-trust.md
@@ -55,6 +55,16 @@ protocol rather than about the app's plumbing:
   unexpected) is a failure, never a pass. The shipped implementation is
   `UnverifiedCastReceiverAuthenticator`, which refuses every receiver, because
   nothing here can yet prove one.
+- **`CastReceiverPinStore`** (`lib/core/services/cast/cast_receiver_pinning.dart`)
+  — the layer authentication does not cover. A Cast handshake proves the peer is
+  *a* genuine receiver, never that it is the one the user meant: discovery is a
+  friendly name on a LAN, so another real Cast device can answer to it and pass
+  the handshake honestly. So the fingerprint a device first proved itself with is
+  recorded and required to match afterwards, a store that cannot answer refuses
+  rather than re-pins, a mismatch never overwrites, and replacing a pin is an
+  explicit `forget()` by the user. The shipped default keeps pins in memory,
+  chosen so a missing store shortens the memory rather than removing the check;
+  a restoration supplies a persistent one.
 - **`TrustGatedCastTransport`** (`lib/core/services/cast/trust_gated_cast_transport.dart`)
   — the readiness boundary. It wraps a `CastTransport`: a session is only handed
   out after the receiver authenticated *and* the identity matches both the
@@ -89,8 +99,12 @@ loaded, and no refusal message carries anything from the handshake.
 
 ## Choosing an implementation
 
-The restoration needs something that actually performs the handshake. The
-options, with the trade-offs that matter for Linthra:
+The restoration needs something that actually performs the handshake.
+[cast-hardened-design.md](cast-hardened-design.md) works that through in detail:
+the device-authentication exchange step by step, the two pinned Cast roots with
+their digests, why the current dependency's protocol definitions cannot express
+the modern challenge at all, where the certificate-path validation would come
+from, and what the design still does not fix. The options it weighs, in summary:
 
 | Option | Why it might work | What it costs |
 | --- | --- | --- |
@@ -138,6 +152,9 @@ Restoring casting is one reviewed change, not a revert. It has to:
       handshake, reviewed in the advisory;
 - [ ] put the trust gate in front of the live transport in the production
       wiring, with no path around it and no runtime flag that skips it;
+- [ ] ship a persistent `CastReceiverPinStore` and the cast sheet's "forget this
+      device" action, so pinning survives a restart and a genuinely replaced
+      receiver has a way back that is not a bypass;
 - [ ] flip `CastContainment.isActive` and update the production wiring, the
       transport guards, `scripts/check_cast_containment.py` and
       `scripts/verify_release_containment.py` together — the containment

--- a/docs/cast.md
+++ b/docs/cast.md
@@ -171,7 +171,11 @@ an additional layer, not a substitute for it.
 The trust model, the contract already in the tree (`CastReceiverAuthenticator`
 and the fail-closed `TrustGatedCastTransport`), the implementation options and
 the test matrix are in
-[cast-receiver-trust.md](cast-receiver-trust.md). What a handoff delegates to a
+[cast-receiver-trust.md](cast-receiver-trust.md), and the concrete design for
+what a real receiver check would have to do (the Cast device-authentication
+exchange, the pinned trust anchors, per-device pinning, and where the
+cryptography would come from) is in
+[cast-hardened-design.md](cast-hardened-design.md). What a handoff delegates to a
 receiver, per server, is in [cast-media-access.md](cast-media-access.md).
 
 The reviewed restoration updates `CastContainment`, the production wiring, the

--- a/lib/core/services/cast/cast_receiver_pinning.dart
+++ b/lib/core/services/cast/cast_receiver_pinning.dart
@@ -60,8 +60,8 @@ class InMemoryCastReceiverPinStore implements CastReceiverPinStore {
 
   final Map<String, String> _pins = <String, String>{};
 
-  /// What is currently remembered, for tests and diagnostics. Fingerprints are
-  /// public material, so this leaks nothing.
+  /// What is currently remembered, so a test can show what was pinned.
+  /// Fingerprints are public material, so this leaks nothing.
   @visibleForTesting
   Map<String, String> get pins => Map<String, String>.unmodifiable(_pins);
 
@@ -85,13 +85,17 @@ class InMemoryCastReceiverPinStore implements CastReceiverPinStore {
 /// Puts a certificate fingerprint in one shape so that formatting can never
 /// decide a security question.
 ///
-/// The same digest is written `AB:CD:EF`, `ab-cd-ef` or `ab cd ef` depending on
-/// who printed it. Comparing those literally would make a cosmetic change in an
-/// authenticator read as a swapped device, and (the direction that actually
-/// costs something) would let one device look like two, so a mismatch would
-/// stop being noticeable. Only separators and case are removed: every character
-/// that carries meaning, the algorithm prefix included, is kept, so two
-/// fingerprints that differ in substance still differ here.
+/// The same digest is written `AB:CD:EF`, `ab:cd:ef` or `ab cd ef` depending on
+/// who printed it, and comparing those literally would make a cosmetic change in
+/// an authenticator read as a swapped device. Only case and the two characters
+/// used to separate a printed fingerprint, the colon and whitespace, are
+/// removed.
+///
+/// Deliberately not `-` or `_`, tempting as they look: those are digits of a
+/// base64url digest, and dropping them could make two different fingerprints
+/// compare equal. Everything left out of this list fails the comparison, which
+/// is a refusal the user can see, and refusing a fingerprint written in an
+/// unexpected shape is the safe direction to be wrong in.
 String normalizeCastFingerprint(String fingerprint) {
-  return fingerprint.toLowerCase().replaceAll(RegExp(r'[\s:_-]'), '');
+  return fingerprint.toLowerCase().replaceAll(RegExp(r'[\s:]'), '');
 }

--- a/lib/core/services/cast/cast_receiver_pinning.dart
+++ b/lib/core/services/cast/cast_receiver_pinning.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/foundation.dart';
+
+/// Remembers which receiver certificate a given cast device presented, so that
+/// "a genuine Cast device" can be narrowed to "*your* Cast device".
+///
+/// Receiver authentication (`CastReceiverAuthenticator`) answers a different
+/// question than people assume. Cast's device authentication proves that the
+/// thing on the other end holds a manufacturer certificate chaining to a Cast
+/// root: it is a real, licensed receiver. It does not prove that it is the
+/// receiver the user meant. Discovery is a name and an address on a LAN, both
+/// unauthenticated, so a second genuine receiver (a neighbour's, a guest's, one
+/// plugged in by someone else on the same network) can answer to a familiar
+/// name and pass authentication honestly.
+///
+/// Pinning closes that gap the only way a client can: the first time a device is
+/// used, the fingerprint of the certificate it proved itself with is recorded
+/// against it; every later connection has to present the same one. It is
+/// trust-on-first-use, with all of that model's limits (see
+/// docs/cast-hardened-design.md), and it is still the difference between
+/// noticing a swapped receiver and never being able to.
+///
+/// Fingerprints are not secrets. They are digests of a certificate the device
+/// hands to anyone who connects, so a store needs no encryption, only
+/// integrity and an answer the app can rely on.
+abstract interface class CastReceiverPinStore {
+  /// The fingerprint remembered for [deviceId], or null if this device has not
+  /// been used before.
+  ///
+  /// Throwing is allowed and is treated as "unknown, and not safe to guess":
+  /// the connection is refused rather than re-pinned. A store that cannot answer
+  /// cannot tell a first use apart from a swapped device.
+  Future<String?> pinFor(String deviceId);
+
+  /// Records [fingerprint] as the receiver for [deviceId].
+  ///
+  /// Only ever called for a device with no pin yet, and always with a
+  /// fingerprint already put through [normalizeCastFingerprint], so what is
+  /// stored is canonical. Implementations must not overwrite an existing pin
+  /// here: replacing one is a deliberate act by the user, through [forget], not
+  /// a side effect of connecting.
+  Future<void> remember(String deviceId, String fingerprint);
+
+  /// Drops what is remembered for [deviceId], so the next connection pins
+  /// afresh.
+  ///
+  /// This is the "I replaced my speaker" path, and it belongs behind an explicit
+  /// user action. Nothing in the trust path may call it to recover from a
+  /// mismatch: that would turn the check into a formality.
+  Future<void> forget(String deviceId);
+}
+
+/// A pin store that lasts as long as the app is running.
+///
+/// This is the default so that the absence of a configured store can never mean
+/// the absence of pinning: the worst case is a shorter memory, not a missing
+/// check. A restored cast feature is expected to supply a persistent store; see
+/// docs/cast-hardened-design.md.
+class InMemoryCastReceiverPinStore implements CastReceiverPinStore {
+  InMemoryCastReceiverPinStore();
+
+  final Map<String, String> _pins = <String, String>{};
+
+  /// What is currently remembered, for tests and diagnostics. Fingerprints are
+  /// public material, so this leaks nothing.
+  @visibleForTesting
+  Map<String, String> get pins => Map<String, String>.unmodifiable(_pins);
+
+  @override
+  Future<String?> pinFor(String deviceId) async => _pins[deviceId];
+
+  @override
+  Future<void> remember(String deviceId, String fingerprint) async {
+    // Deliberately not an overwrite: the contract says a pin is only ever
+    // recorded for a device that has none, and an implementation that quietly
+    // replaced one would hide exactly the event this exists to catch.
+    _pins.putIfAbsent(deviceId, () => fingerprint);
+  }
+
+  @override
+  Future<void> forget(String deviceId) async {
+    _pins.remove(deviceId);
+  }
+}
+
+/// Puts a certificate fingerprint in one shape so that formatting can never
+/// decide a security question.
+///
+/// The same digest is written `AB:CD:EF`, `ab-cd-ef` or `ab cd ef` depending on
+/// who printed it. Comparing those literally would make a cosmetic change in an
+/// authenticator read as a swapped device, and (the direction that actually
+/// costs something) would let one device look like two, so a mismatch would
+/// stop being noticeable. Only separators and case are removed: every character
+/// that carries meaning, the algorithm prefix included, is kept, so two
+/// fingerprints that differ in substance still differ here.
+String normalizeCastFingerprint(String fingerprint) {
+  return fingerprint.toLowerCase().replaceAll(RegExp(r'[\s:_-]'), '');
+}

--- a/lib/core/services/cast/cast_receiver_trust.dart
+++ b/lib/core/services/cast/cast_receiver_trust.dart
@@ -23,6 +23,14 @@ enum CastTrustFailureKind {
   /// handoff must not survive.
   identityMismatch,
 
+  /// The receiver proved a genuine identity, and it is not the one this device
+  /// presented last time. Authentication says "a real Cast receiver", never "the
+  /// real Cast receiver you meant": a second genuine device answering to a
+  /// familiar name passes the handshake honestly. This is the one outcome a user
+  /// can clear themselves, by forgetting the device, so it is worth telling
+  /// apart from a mismatch the app caught on its own.
+  changedReceiver,
+
   /// Authentication never finished: the session ended underneath it, the user
   /// moved on, or it ran out of time. An unfinished check is a failed check.
   incomplete,

--- a/lib/core/services/cast/trust_gated_cast_transport.dart
+++ b/lib/core/services/cast/trust_gated_cast_transport.dart
@@ -4,6 +4,7 @@ import '../../models/cast_media.dart';
 import '../../models/cast_playback_status.dart';
 import '../../models/cast_state.dart';
 import '../../models/cast_volume.dart';
+import 'cast_receiver_pinning.dart';
 import 'cast_receiver_trust.dart';
 import 'cast_transport.dart';
 
@@ -21,6 +22,12 @@ import 'cast_transport.dart';
 /// proof made over some other connection, an authentication that never
 /// finishes, a session that dies mid-handshake or after it) is a unit test
 /// rather than a code review.
+///
+/// It also narrows what authentication can honestly claim. A Cast handshake
+/// proves the peer is *a* genuine receiver, not that it is the receiver the user
+/// meant, so the gate additionally pins each device to the certificate it first
+/// proved itself with ([CastReceiverPinStore]) and refuses a device that comes
+/// back as different hardware. See docs/cast-hardened-design.md.
 ///
 /// It also owns what the user is told. A refusal keeps its
 /// [CastTrustFailureKind] and nothing else: the message the sheet shows is
@@ -44,20 +51,35 @@ class TrustGatedCastTransport implements CastTransport {
     required CastTransport delegate,
     CastReceiverAuthenticator authenticator =
         const UnverifiedCastReceiverAuthenticator(),
+    CastReceiverPinStore? pins,
     Duration authenticationTimeout = const Duration(seconds: 10),
+    Duration pinTimeout = const Duration(seconds: 5),
     Duration cleanupTimeout = const Duration(seconds: 5),
   })  : _delegate = delegate,
         _authenticator = authenticator,
+        _pins = pins ?? InMemoryCastReceiverPinStore(),
         _authenticationTimeout = authenticationTimeout,
+        _pinTimeout = pinTimeout,
         _cleanupTimeout = cleanupTimeout;
 
   final CastTransport _delegate;
   final CastReceiverAuthenticator _authenticator;
 
+  /// Which receiver each device is known to be. Defaulted rather than optional
+  /// on purpose: leaving it out shortens how long the app remembers, it never
+  /// turns the check off. A restoration is expected to pass a persistent store.
+  final CastReceiverPinStore _pins;
+
   /// How long a receiver has to prove itself. A handshake that hangs is not a
   /// slow success: it expires as [CastTrustFailureKind.incomplete], the session
   /// is closed, and nothing is handed over.
   final Duration _authenticationTimeout;
+
+  /// How long the pin store gets to answer. Reading which receiver a device is
+  /// supposed to be sits on the connect path, so a store that hangs (a slow
+  /// disk, a lock someone else is holding) must expire into a refusal rather
+  /// than leave the user watching "connecting" forever.
+  final Duration _pinTimeout;
 
   /// How long the refused session gets to close before the refusal is returned
   /// anyway. Closing is cleanup on a path that has already failed, so an
@@ -94,6 +116,13 @@ class TrustGatedCastTransport implements CastTransport {
         _messageFor(CastTrustFailureKind.identityMismatch),
         kind: CastTrustFailureKind.identityMismatch,
       );
+    }
+
+    try {
+      await _checkPin(device, proof.identity);
+    } catch (_) {
+      await _close(session);
+      rethrow;
     }
 
     // The readiness seen during the handshake is carried over deliberately: the
@@ -195,6 +224,86 @@ class TrustGatedCastTransport implements CastTransport {
     }
   }
 
+  /// Narrows "a receiver that authenticated" to "the receiver this device has
+  /// always been".
+  ///
+  /// Authentication proves the peer holds a genuine Cast certificate; it does
+  /// not say which genuine device it is, and discovery, being a friendly name
+  /// on a LAN, says nothing at all. So the fingerprint the proof carries is
+  /// recorded on first use and required to match every time after.
+  ///
+  /// Every uncertainty here is a refusal. A store that throws or hangs is not
+  /// "no pin yet": it cannot tell a first use apart from a swap, so re-pinning
+  /// on its silence would hand an attacker a way to erase the check by breaking
+  /// it. A mismatch never overwrites the pin either: replacing one is
+  /// [CastReceiverPinStore.forget], behind a deliberate user action.
+  Future<void> _checkPin(
+    CastDevice device,
+    CastReceiverIdentity identity,
+  ) async {
+    final String fingerprint = normalizeCastFingerprint(identity.fingerprint);
+    if (fingerprint.isEmpty) {
+      // An identity with nothing to pin would match every device forever. That
+      // is an authenticator bug, and it fails here rather than being recorded.
+      throw CastReceiverTrustException(
+        _messageFor(CastTrustFailureKind.rejected),
+        kind: CastTrustFailureKind.rejected,
+      );
+    }
+
+    final String? known;
+    try {
+      known = await _pins.pinFor(device.id).timeout(_pinTimeout);
+    } catch (_) {
+      throw CastReceiverTrustException(
+        _messageFor(CastTrustFailureKind.incomplete),
+        kind: CastTrustFailureKind.incomplete,
+      );
+    }
+
+    if (known == null) {
+      final String? recorded;
+      try {
+        await _pins.remember(device.id, fingerprint).timeout(_pinTimeout);
+        // Read back rather than assume. Two connections to the same entry can
+        // race here, and a store that refuses to overwrite (as the contract
+        // requires) will have kept the other one's fingerprint: without this,
+        // the loser of that race would carry on believing it had pinned itself.
+        // It also catches a store that accepts a write and drops it.
+        recorded = await _pins.pinFor(device.id).timeout(_pinTimeout);
+      } catch (_) {
+        // Refusing on a failed write keeps the two states the app can be in
+        // honest: either this device is pinned, or it has never been cast to.
+        // Handing out a session that was never recorded would silently pin the
+        // *next* receiver instead, whichever one that is.
+        throw CastReceiverTrustException(
+          _messageFor(CastTrustFailureKind.incomplete),
+          kind: CastTrustFailureKind.incomplete,
+        );
+      }
+      if (recorded == null) {
+        throw CastReceiverTrustException(
+          _messageFor(CastTrustFailureKind.incomplete),
+          kind: CastTrustFailureKind.incomplete,
+        );
+      }
+      if (normalizeCastFingerprint(recorded) != fingerprint) {
+        throw CastReceiverTrustException(
+          _messageFor(CastTrustFailureKind.changedReceiver),
+          kind: CastTrustFailureKind.changedReceiver,
+        );
+      }
+      return;
+    }
+
+    if (normalizeCastFingerprint(known) != fingerprint) {
+      throw CastReceiverTrustException(
+        _messageFor(CastTrustFailureKind.changedReceiver),
+        kind: CastTrustFailureKind.changedReceiver,
+      );
+    }
+  }
+
   /// The only wording a refusal ever reaches the user with. Owned here, chosen
   /// by [CastTrustFailureKind] alone, so nothing an implementation writes into
   /// an exception can travel to the cast sheet.
@@ -208,6 +317,8 @@ class TrustGatedCastTransport implements CastTransport {
       case CastTrustFailureKind.identityMismatch:
         return "Linthra couldn't confirm that this is the device you picked, "
             'so it stopped.';
+      case CastTrustFailureKind.changedReceiver:
+        return _changedReceiverMessage;
       case CastTrustFailureKind.incomplete:
         return _incompleteMessage;
     }
@@ -216,6 +327,10 @@ class TrustGatedCastTransport implements CastTransport {
   static const String _incompleteMessage =
       "Linthra couldn't finish checking that device, so it didn't send "
       'anything to it.';
+
+  static const String _changedReceiverMessage =
+      "This isn't the same device Linthra cast to before, so it stopped. If you "
+      'replaced it, forget it in the cast list and try again.';
 
   static const String _rejectedMessage =
       "Linthra couldn't verify that device, so it didn't send anything to it.";

--- a/test/core/services/cast/trust_gated_cast_transport_test.dart
+++ b/test/core/services/cast/trust_gated_cast_transport_test.dart
@@ -635,10 +635,39 @@ void main() {
       await gate(
         again,
         pins: pins,
-        authenticator: _AcceptingAuthenticator(fingerprint: 'SHA256 AA-BB'),
+        authenticator: _AcceptingAuthenticator(fingerprint: '  SHA256: AA:BB '),
       ).connect(speaker);
 
       expect(again.session.closed, isFalse);
+    });
+
+    test('a base64url digest keeps every character that carries meaning',
+        () async {
+      // Normalising drops colons and whitespace, never `-` or `_`: those are
+      // digits of a base64url digest, and dropping them would let two different
+      // fingerprints compare equal.
+      final InMemoryCastReceiverPinStore pins = InMemoryCastReceiverPinStore();
+      await gate(
+        _FakeTransport(),
+        pins: pins,
+        authenticator: _AcceptingAuthenticator(fingerprint: 'ab-cd_ef'),
+      ).connect(speaker);
+
+      final _FakeTransport impostor = _FakeTransport();
+      await expectLater(
+        gate(
+          impostor,
+          pins: pins,
+          authenticator: _AcceptingAuthenticator(fingerprint: 'abcdef'),
+        ).connect(speaker),
+        throwsA(isA<CastReceiverTrustException>().having(
+          (CastReceiverTrustException e) => e.kind,
+          'kind',
+          CastTrustFailureKind.changedReceiver,
+        )),
+      );
+
+      expect(impostor.session.closed, isTrue);
     });
 
     test('each device is pinned on its own', () async {
@@ -667,7 +696,7 @@ void main() {
         gate(
           transport,
           pins: pins,
-          authenticator: _AcceptingAuthenticator(fingerprint: ' :-: '),
+          authenticator: _AcceptingAuthenticator(fingerprint: ' :: '),
         ).connect(speaker),
         throwsA(isA<CastReceiverTrustException>().having(
           (CastReceiverTrustException e) => e.kind,

--- a/test/core/services/cast/trust_gated_cast_transport_test.dart
+++ b/test/core/services/cast/trust_gated_cast_transport_test.dart
@@ -6,6 +6,7 @@ import 'package:linthra/core/models/cast_playback_status.dart';
 import 'package:linthra/core/models/cast_state.dart';
 import 'package:linthra/core/models/cast_volume.dart';
 import 'package:linthra/core/services/cast/cast_containment.dart';
+import 'package:linthra/core/services/cast/cast_receiver_pinning.dart';
 import 'package:linthra/core/services/cast/cast_receiver_trust.dart';
 import 'package:linthra/core/services/cast/cast_transport.dart';
 import 'package:linthra/core/services/cast/trust_gated_cast_transport.dart';
@@ -37,13 +38,17 @@ void main() {
   TrustGatedCastTransport gate(
     _FakeTransport transport, {
     CastReceiverAuthenticator? authenticator,
+    CastReceiverPinStore? pins,
     Duration timeout = const Duration(milliseconds: 50),
+    Duration pinTimeout = const Duration(milliseconds: 50),
     Duration cleanupTimeout = const Duration(milliseconds: 50),
   }) {
     return TrustGatedCastTransport(
       delegate: transport,
       authenticator: authenticator ?? _AcceptingAuthenticator(),
+      pins: pins,
       authenticationTimeout: timeout,
+      pinTimeout: pinTimeout,
       cleanupTimeout: cleanupTimeout,
     );
   }
@@ -529,6 +534,249 @@ void main() {
     });
   });
 
+  group('the receiver has to stay the same device', () {
+    // Cast device authentication proves the peer holds a genuine receiver
+    // certificate. It does not say which genuine receiver, and discovery, being
+    // a friendly name on a LAN, says nothing at all. Pinning is what turns "a
+    // real Cast device" into "the one this entry has always been".
+
+    test('the first receiver a device presents is remembered', () async {
+      final _FakeTransport transport = _FakeTransport();
+      final InMemoryCastReceiverPinStore pins = InMemoryCastReceiverPinStore();
+
+      await gate(transport, pins: pins).connect(speaker);
+
+      expect(pins.pins[speaker.id], 'sha256aabb');
+    });
+
+    test('the same receiver connects again', () async {
+      final InMemoryCastReceiverPinStore pins = InMemoryCastReceiverPinStore();
+
+      await gate(_FakeTransport(), pins: pins).connect(speaker);
+      final _FakeTransport again = _FakeTransport();
+      final CastSessionHandle session =
+          await gate(again, pins: pins).connect(speaker);
+      await session.loadMedia(media);
+
+      expect(again.session.loaded, <CastMedia>[media]);
+    });
+
+    test('a different receiver on the same entry is refused', () async {
+      final InMemoryCastReceiverPinStore pins = InMemoryCastReceiverPinStore();
+      await gate(_FakeTransport(), pins: pins).connect(speaker);
+
+      final _FakeTransport impostor = _FakeTransport();
+      await expectLater(
+        gate(
+          impostor,
+          pins: pins,
+          authenticator: _AcceptingAuthenticator(fingerprint: 'sha256:cc:dd'),
+        ).connect(speaker),
+        throwsA(isA<CastReceiverTrustException>().having(
+          (CastReceiverTrustException e) => e.kind,
+          'kind',
+          CastTrustFailureKind.changedReceiver,
+        )),
+      );
+
+      expect(impostor.session.closed, isTrue);
+      expect(impostor.session.loaded, isEmpty);
+      // The pin is evidence, not a cache: a device that failed the check does
+      // not get to replace what it failed against.
+      expect(pins.pins[speaker.id], 'sha256aabb');
+    });
+
+    test('the refusal says what the user can do, and nothing else', () async {
+      final InMemoryCastReceiverPinStore pins = InMemoryCastReceiverPinStore();
+      await gate(_FakeTransport(), pins: pins).connect(speaker);
+
+      Object? thrown;
+      try {
+        await gate(
+          _FakeTransport(),
+          pins: pins,
+          authenticator: _AcceptingAuthenticator(fingerprint: 'sha256:cc:dd'),
+        ).connect(speaker);
+      } catch (error) {
+        thrown = error;
+      }
+
+      final String message = (thrown! as CastReceiverTrustException).message;
+      expect(message, contains('forget it'));
+      expect(message, isNot(contains('sha256')));
+      expect(message, isNot(contains('aa:bb')));
+      expect(message, isNot(contains('cc:dd')));
+    });
+
+    test('forgetting a device lets the next receiver pin', () async {
+      final InMemoryCastReceiverPinStore pins = InMemoryCastReceiverPinStore();
+      await gate(_FakeTransport(), pins: pins).connect(speaker);
+
+      // The replaced-my-speaker path, and the only one: deliberate, from the
+      // user, never something the trust check does to recover from a mismatch.
+      await pins.forget(speaker.id);
+      final _FakeTransport replacement = _FakeTransport();
+      await gate(
+        replacement,
+        pins: pins,
+        authenticator: _AcceptingAuthenticator(fingerprint: 'sha256:cc:dd'),
+      ).connect(speaker);
+
+      expect(pins.pins[speaker.id], 'sha256ccdd');
+      expect(replacement.session.closed, isFalse);
+    });
+
+    test('how a fingerprint is written does not make it another device',
+        () async {
+      final InMemoryCastReceiverPinStore pins = InMemoryCastReceiverPinStore();
+      await gate(_FakeTransport(), pins: pins).connect(speaker);
+
+      final _FakeTransport again = _FakeTransport();
+      await gate(
+        again,
+        pins: pins,
+        authenticator: _AcceptingAuthenticator(fingerprint: 'SHA256 AA-BB'),
+      ).connect(speaker);
+
+      expect(again.session.closed, isFalse);
+    });
+
+    test('each device is pinned on its own', () async {
+      final InMemoryCastReceiverPinStore pins = InMemoryCastReceiverPinStore();
+      await gate(_FakeTransport(), pins: pins).connect(speaker);
+
+      final _FakeTransport bedroom = _FakeTransport();
+      await gate(
+        bedroom,
+        pins: pins,
+        authenticator: _AcceptingAuthenticator(fingerprint: 'sha256:cc:dd'),
+      ).connect(other);
+
+      expect(pins.pins[speaker.id], 'sha256aabb');
+      expect(pins.pins[other.id], 'sha256ccdd');
+      expect(bedroom.session.closed, isFalse);
+    });
+
+    test('an identity with nothing to pin is refused', () async {
+      // A fingerprint that normalises to nothing would match every receiver
+      // forever, so it fails here rather than being written down.
+      final _FakeTransport transport = _FakeTransport();
+      final InMemoryCastReceiverPinStore pins = InMemoryCastReceiverPinStore();
+
+      await expectLater(
+        gate(
+          transport,
+          pins: pins,
+          authenticator: _AcceptingAuthenticator(fingerprint: ' :-: '),
+        ).connect(speaker),
+        throwsA(isA<CastReceiverTrustException>().having(
+          (CastReceiverTrustException e) => e.kind,
+          'kind',
+          CastTrustFailureKind.rejected,
+        )),
+      );
+
+      expect(pins.pins, isEmpty);
+      expect(transport.session.closed, isTrue);
+    });
+
+    test('a store that cannot be read refuses instead of re-pinning', () async {
+      // Otherwise breaking the store would be a way to erase the check.
+      final _FakeTransport transport = _FakeTransport();
+
+      await expectLater(
+        gate(transport, pins: _BrokenPinStore(onRead: true)).connect(speaker),
+        throwsA(isA<CastReceiverTrustException>().having(
+          (CastReceiverTrustException e) => e.kind,
+          'kind',
+          CastTrustFailureKind.incomplete,
+        )),
+      );
+
+      expect(transport.session.closed, isTrue);
+      expect(transport.session.loaded, isEmpty);
+    });
+
+    test('a store that cannot be written refuses too', () async {
+      // Handing out a session that was never recorded would leave the entry
+      // unpinned, so whichever receiver answered next would become the pin.
+      final _FakeTransport transport = _FakeTransport();
+
+      await expectLater(
+        gate(transport, pins: _BrokenPinStore(onWrite: true)).connect(speaker),
+        throwsA(isA<CastReceiverTrustException>()),
+      );
+
+      expect(transport.session.closed, isTrue);
+      expect(transport.session.loaded, isEmpty);
+    });
+
+    test('a store that never answers expires into a refusal', () async {
+      final _FakeTransport transport = _FakeTransport();
+
+      await expectLater(
+        gate(
+          transport,
+          pins: _HangingPinStore(),
+          pinTimeout: const Duration(milliseconds: 10),
+        ).connect(speaker),
+        throwsA(isA<CastReceiverTrustException>().having(
+          (CastReceiverTrustException e) => e.kind,
+          'kind',
+          CastTrustFailureKind.incomplete,
+        )),
+      );
+
+      expect(transport.session.closed, isTrue);
+    });
+
+    test('a write that did not take is not a pin', () async {
+      // A store that accepts a write and keeps nothing would leave the entry
+      // unpinned while the app believed it was pinned, so the next receiver to
+      // answer would become the pin.
+      final _FakeTransport transport = _FakeTransport();
+
+      await expectLater(
+        gate(transport, pins: _ForgetfulPinStore()).connect(speaker),
+        throwsA(isA<CastReceiverTrustException>().having(
+          (CastReceiverTrustException e) => e.kind,
+          'kind',
+          CastTrustFailureKind.incomplete,
+        )),
+      );
+
+      expect(transport.session.closed, isTrue);
+    });
+
+    test('losing the race to pin is a refusal, not a pass', () async {
+      // Two connections to the same entry can reach the empty pin together. The
+      // store keeps whichever arrived first, so the other one has to notice it
+      // is not the receiver that got recorded.
+      final _FakeTransport transport = _FakeTransport();
+
+      await expectLater(
+        gate(transport, pins: _RacedPinStore('sha256ccdd')).connect(speaker),
+        throwsA(isA<CastReceiverTrustException>().having(
+          (CastReceiverTrustException e) => e.kind,
+          'kind',
+          CastTrustFailureKind.changedReceiver,
+        )),
+      );
+
+      expect(transport.session.closed, isTrue);
+      expect(transport.session.loaded, isEmpty);
+    });
+
+    test('a recorded pin is never quietly replaced', () async {
+      final InMemoryCastReceiverPinStore pins = InMemoryCastReceiverPinStore();
+
+      await pins.remember(speaker.id, 'sha256:aa:bb');
+      await pins.remember(speaker.id, 'sha256:cc:dd');
+
+      expect(pins.pins[speaker.id], 'sha256:aa:bb');
+    });
+  });
+
   group('CastReceiverIdentity', () {
     test('is bound to the device *and* the connection it was proved on', () {
       final _FakeHandle session = _FakeHandle();
@@ -729,9 +977,18 @@ class _FakeHandle implements CastSessionHandle {
 /// [as] / over [over] to model a device answering for another one, or a proof
 /// made on a different connection.
 class _AcceptingAuthenticator implements CastReceiverAuthenticator {
-  _AcceptingAuthenticator({this.as, this.over, this.after});
+  _AcceptingAuthenticator({
+    this.as,
+    this.over,
+    this.after,
+    this.fingerprint = 'sha256:aa:bb',
+  });
 
   final CastDevice? as;
+
+  /// The digest the proof carries, so a test can play the same receiver twice
+  /// or a different one the second time.
+  final String fingerprint;
 
   /// When set, the check takes this long, so a test can be sure the handshake
   /// observed the session's readiness before it completes.
@@ -754,7 +1011,7 @@ class _AcceptingAuthenticator implements CastReceiverAuthenticator {
     return CastReceiverIdentity(
       deviceId: (as ?? device).id,
       connection: over ?? session,
-      fingerprint: 'sha256:aa:bb',
+      fingerprint: fingerprint,
     );
   }
 }
@@ -827,4 +1084,77 @@ class _HangingAuthenticator implements CastReceiverAuthenticator {
     CastSessionHandle session,
   ) =>
       Completer<CastReceiverIdentity>().future;
+}
+
+/// A pin store that fails the way a real one can: a corrupt file, a database
+/// that will not open, a write that runs out of room.
+class _BrokenPinStore implements CastReceiverPinStore {
+  _BrokenPinStore({this.onRead = false, this.onWrite = false});
+
+  final bool onRead;
+  final bool onWrite;
+
+  @override
+  Future<String?> pinFor(String deviceId) async {
+    if (onRead) throw StateError('pin store unreadable');
+    return null;
+  }
+
+  @override
+  Future<void> remember(String deviceId, String fingerprint) async {
+    if (onWrite) throw StateError('pin store unwritable');
+  }
+
+  @override
+  Future<void> forget(String deviceId) async {}
+}
+
+/// A pin store that never answers, so the refusal has to come from the clock.
+class _HangingPinStore implements CastReceiverPinStore {
+  @override
+  Future<String?> pinFor(String deviceId) => Completer<String?>().future;
+
+  @override
+  Future<void> remember(String deviceId, String fingerprint) =>
+      Completer<void>().future;
+
+  @override
+  Future<void> forget(String deviceId) async {}
+}
+
+/// A store that accepts a write and keeps nothing.
+class _ForgetfulPinStore implements CastReceiverPinStore {
+  @override
+  Future<String?> pinFor(String deviceId) async => null;
+
+  @override
+  Future<void> remember(String deviceId, String fingerprint) async {}
+
+  @override
+  Future<void> forget(String deviceId) async {}
+}
+
+/// A store that looks empty, and by the time the write lands holds somebody
+/// else's fingerprint: the shape of two connections pinning the same entry at
+/// once, with the contract's refusal to overwrite deciding the winner.
+class _RacedPinStore implements CastReceiverPinStore {
+  _RacedPinStore(this.winner);
+
+  final String winner;
+  bool _read = false;
+
+  @override
+  Future<String?> pinFor(String deviceId) async {
+    if (!_read) {
+      _read = true;
+      return null;
+    }
+    return winner;
+  }
+
+  @override
+  Future<void> remember(String deviceId, String fingerprint) async {}
+
+  @override
+  Future<void> forget(String deviceId) async {}
 }


### PR DESCRIPTION
Follow-up to #586. Casting stays contained: nothing here builds a transport, nothing changes the production wiring, and the shipped authenticator still refuses every receiver.

## Why

Receiver authentication answers a narrower question than it looks like it does. A Cast handshake proves the peer holds a genuine manufacturer certificate. It never proves it is the receiver the user meant. Discovery is a friendly name on a LAN, so another real Cast device (a neighbour's, a guest's, one somebody else plugged in) can answer to it and pass the handshake completely honestly.

That gap is app-side policy, so it can be built and tested now, ahead of the protocol work, the same way the trust contract and the fail-closed gate were.

## What's in it

**Per-device pinning** (`lib/core/services/cast/cast_receiver_pinning.dart`, enforced in `TrustGatedCastTransport`). The fingerprint a device first proved itself with is recorded and required to match afterwards. The rules are the interesting part:

- a store that throws or hangs refuses instead of re-pinning, otherwise breaking the store is a way to erase the check
- a failed write refuses, and the write is read back, so a lost write or a lost race cannot leave the entry silently unpinned while the app thinks it is pinned
- a mismatch never overwrites the pin
- an empty fingerprint is a refusal, not a pin that matches everything
- case, colons and whitespace are normalised so formatting cannot decide a security question, but never `-` or `_`, which are digits of a base64url digest: dropping those could make two different fingerprints compare equal
- replacing a pin is an explicit `forget()` by the user

A mismatch gets its own failure kind (`CastTrustFailureKind.changedReceiver`) and its own message, because unlike every other refusal it has an action attached: if you really did replace the speaker, forget it and connect again. The cast sheet's "forget this device" affordance is on the restoration checklist, alongside a persistent store.

The shipped default keeps pins in memory. That is deliberate: a missing store shortens how long the app remembers, it never turns the check off.

**`docs/cast-hardened-design.md`**, the answer to "what would a receiver check have to be for it to be worth trusting?":

- the Cast device-authentication exchange step by step, including the nonce echo and the signature over `sender_nonce || peer_certificate_DER` that binds the proof to the connection
- the two trust anchors (Cast Root CA and Eureka Root CA) with their SHA-256 digests, key sizes and expiry dates, and where they come from upstream
- why `cast 2.1.0` cannot do this today: it declares the deviceauth namespace but never challenges, and its bundled proto has the pre-nonce message shape, so a challenge built from it would have no replay protection at all
- where certificate-path validation would come from, and why one pure-Dart validator beats a per-platform one for a project that ships Android and Linux from one codebase with no proprietary components
- the two places we would be stricter than upstream (require SHA-256, require a CRL)
- a staged plan where steps 1 to 5 all land while casting stays off
- the protocol test matrix
- what the design still does not fix: first use is still first use, the CRL arrives from the device being checked, a genuine certificate on compromised hardware still passes, and anything on the LAN can still deny service

## Checks

- `flutter analyze`: clean
- `flutter test`: 4332 passing, 15 new
- `dart format`: clean
- `scripts/check_cast_containment.py` and `scripts/check_secrets.sh`: pass

Nothing from the private advisory is in the code, the docs or this description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011He1oeTwYcEjJfbhjZmprW