### PR TITLE
feat(audiobookshelf): browse the books on a connected server (#484)

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../features/appearance/appearance_settings_screen.dart';
+import '../features/audiobooks/audiobooks_screen.dart';
 import '../features/downloads/downloads_screen.dart';
 import '../features/favorites/favorites_screen.dart';
 import '../features/library/album_detail_screen.dart';
@@ -151,6 +152,10 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                     path: 'connections',
                     builder: (context, state) =>
                         const ConnectionsSettingsScreen(),
+                  ),
+                  GoRoute(
+                    path: 'audiobooks',
+                    builder: (context, state) => const AudiobooksScreen(),
                   ),
                   GoRoute(
                     path: 'playback',

--- a/lib/app/routes.dart
+++ b/lib/app/routes.dart
@@ -66,6 +66,12 @@ abstract final class AppRoutes {
   /// Navidrome/Subsonic, local files). A child of [settings].
   static const String settingsConnections = '/settings/connections';
 
+  /// The audiobook browser for a connected Audiobookshelf server. Reached
+  /// from the connection card on [settingsConnections], so it is a child of
+  /// [settings] and keeps the bottom nav. It lives here only until Audiobooks
+  /// gets its own destination (its own change, agreed on issue #484).
+  static const String audiobooks = '/settings/audiobooks';
+
   /// "Music & playback" — default source and playback behaviour. A child of
   /// [settings].
   static const String settingsPlayback = '/settings/playback';

--- a/lib/core/sources/audiobookshelf/audiobookshelf_api.dart
+++ b/lib/core/sources/audiobookshelf/audiobookshelf_api.dart
@@ -190,15 +190,25 @@ class AudiobookshelfLibraryItemDto {
 class AudiobookshelfLibraryItemsPage {
   const AudiobookshelfLibraryItemsPage({
     required this.items,
+    required this.rawCount,
     required this.total,
     required this.page,
   });
 
+  /// The books that could be read. Shorter than [rawCount] when the server
+  /// sent a record this parser had to skip.
   final List<AudiobookshelfLibraryItemDto> items;
 
+  /// How many entries the server actually sent on this page, before any were
+  /// skipped. This, not [items], is what says how far through the library a
+  /// caller has read: a page whose every record was unreadable still consumed
+  /// its slice of the library, and counting the parsed books instead would
+  /// strand everything after it.
+  final int rawCount;
+
   /// How many items the whole (filtered) library has, per the server. Falls
-  /// back to the number parsed on this page when the server omits it, so
-  /// "have we got everything?" never reads as "there are more" forever.
+  /// back to this page's [rawCount] when the server omits it, so "have we got
+  /// everything?" never reads as "there are more" forever.
   final int total;
 
   /// The zero-based page index this response answered.
@@ -211,8 +221,10 @@ class AudiobookshelfLibraryItemsPage {
     final Object? results = json['results'];
     final List<AudiobookshelfLibraryItemDto> items =
         <AudiobookshelfLibraryItemDto>[];
+    int rawCount = 0;
     if (results is List) {
       for (final Object? entry in results) {
+        rawCount++;
         if (entry is! Map<String, dynamic>) continue;
         final AudiobookshelfLibraryItemDto? item =
             AudiobookshelfLibraryItemDto.fromJson(entry);
@@ -225,7 +237,8 @@ class AudiobookshelfLibraryItemsPage {
     final Object? page = json['page'];
     return AudiobookshelfLibraryItemsPage(
       items: items,
-      total: total is int && total >= 0 ? total : items.length,
+      rawCount: rawCount,
+      total: total is int && total >= 0 ? total : rawCount,
       page: page is int && page >= 0 ? page : requestedPage,
     );
   }

--- a/lib/core/sources/audiobookshelf/audiobookshelf_api.dart
+++ b/lib/core/sources/audiobookshelf/audiobookshelf_api.dart
@@ -77,8 +77,8 @@ class AudiobookshelfAuthResult {
 }
 
 /// One entry from `GET /api/libraries` — enough to let a user pick which
-/// library to browse. Item-level fetching (and the domain-model mapping that
-/// goes with it) is out of scope for this PR; see the tracking issue.
+/// library to browse. The items inside one are fetched separately, as
+/// [AudiobookshelfLibraryItemDto]s.
 class AudiobookshelfLibraryDto {
   const AudiobookshelfLibraryDto({
     required this.id,
@@ -90,7 +90,8 @@ class AudiobookshelfLibraryDto {
   final String name;
 
   /// The library's configured media type (e.g. `book`, `podcast`), when
-  /// reported. Not yet used to filter — this PR only lists what's there.
+  /// reported. The audiobook browser shows the `book` libraries; a library
+  /// that doesn't report a type is treated as one rather than hidden.
   final String? mediaType;
 
   /// Parses one library entry, or returns `null` when the id or name are
@@ -106,6 +107,152 @@ class AudiobookshelfLibraryDto {
       mediaType: _coerceString(json['mediaType']),
     );
   }
+}
+
+/// One book from `GET /api/libraries/{id}/items`, reduced to what a listing
+/// needs. Deliberately not the whole item: Audiobookshelf sends the audio
+/// files, the chapter list, the library-file records and the user's progress
+/// with every entry, and none of that belongs in a browse list. The domain
+/// model that does carry chapters and playback data comes with milestone 2.
+class AudiobookshelfLibraryItemDto {
+  const AudiobookshelfLibraryItemDto({
+    required this.id,
+    required this.title,
+    this.subtitle,
+    this.authorName,
+    this.narratorName,
+    this.seriesName,
+    this.duration,
+  });
+
+  /// The library item's id: the handle every later call (cover, playback,
+  /// progress) uses.
+  final String id;
+
+  final String title;
+  final String? subtitle;
+
+  /// The author(s), already joined into one display string by the server on a
+  /// minified response, or joined here from `authors[]` when a server sends
+  /// the full shape instead.
+  final String? authorName;
+
+  /// The narrator(s), same two shapes as [authorName]. Worth showing for an
+  /// audiobook: the same title read by a different narrator is a different
+  /// listen.
+  final String? narratorName;
+
+  /// The series this book belongs to, when the server reports one.
+  final String? seriesName;
+
+  /// Total running time, when reported. `null` on a book the server hasn't
+  /// finished scanning, which the UI renders as no duration rather than 0:00.
+  final Duration? duration;
+
+  /// Parses one library item, or returns `null` when there is no id or no
+  /// title (the two things a row can't be drawn without), so a single
+  /// unscanned or malformed entry is skipped instead of failing the page.
+  static AudiobookshelfLibraryItemDto? fromJson(Map<String, dynamic> json) {
+    final String? id = _coerceString(json['id']);
+    if (id == null) return null;
+
+    final Object? media = json['media'];
+    final Map<String, dynamic> mediaMap =
+        media is Map<String, dynamic> ? media : const <String, dynamic>{};
+    final Object? metadata = mediaMap['metadata'];
+    final Map<String, dynamic> meta =
+        metadata is Map<String, dynamic> ? metadata : const <String, dynamic>{};
+
+    final String? title = _coerceString(meta['title']);
+    if (title == null) return null;
+
+    return AudiobookshelfLibraryItemDto(
+      id: id,
+      title: title,
+      subtitle: _coerceString(meta['subtitle']),
+      // `authorName`/`narratorName` are what a minified listing sends (the
+      // shape this client asks for); the `authors`/`narrators` fallbacks keep
+      // a full response readable too, so the parser doesn't depend on the
+      // query string staying exactly as it is.
+      authorName: _coerceString(meta['authorName']) ??
+          _joinNames(meta['authors'], key: 'name'),
+      narratorName:
+          _coerceString(meta['narratorName']) ?? _joinNames(meta['narrators']),
+      seriesName: _coerceString(meta['seriesName']) ??
+          _joinNames(meta['series'], key: 'name'),
+      duration: _coerceDuration(mediaMap['duration']),
+    );
+  }
+}
+
+/// One page of `GET /api/libraries/{id}/items`: the items plus enough of the
+/// envelope to know whether more of the library is still waiting.
+class AudiobookshelfLibraryItemsPage {
+  const AudiobookshelfLibraryItemsPage({
+    required this.items,
+    required this.total,
+    required this.page,
+  });
+
+  final List<AudiobookshelfLibraryItemDto> items;
+
+  /// How many items the whole (filtered) library has, per the server. Falls
+  /// back to the number parsed on this page when the server omits it, so
+  /// "have we got everything?" never reads as "there are more" forever.
+  final int total;
+
+  /// The zero-based page index this response answered.
+  final int page;
+
+  static AudiobookshelfLibraryItemsPage fromJson(
+    Map<String, dynamic> json, {
+    required int requestedPage,
+  }) {
+    final Object? results = json['results'];
+    final List<AudiobookshelfLibraryItemDto> items =
+        <AudiobookshelfLibraryItemDto>[];
+    if (results is List) {
+      for (final Object? entry in results) {
+        if (entry is! Map<String, dynamic>) continue;
+        final AudiobookshelfLibraryItemDto? item =
+            AudiobookshelfLibraryItemDto.fromJson(entry);
+        // One bad record is skipped, never thrown: a half-scanned book can't
+        // cost the user the rest of the page.
+        if (item != null) items.add(item);
+      }
+    }
+    final Object? total = json['total'];
+    final Object? page = json['page'];
+    return AudiobookshelfLibraryItemsPage(
+      items: items,
+      total: total is int && total >= 0 ? total : items.length,
+      page: page is int && page >= 0 ? page : requestedPage,
+    );
+  }
+}
+
+/// Joins a list of names into one display string.
+///
+/// Handles both shapes Audiobookshelf uses for these fields: a list of plain
+/// strings (`narrators`) and a list of objects with a name (`authors`,
+/// `series`). Returns `null` when nothing usable is in there.
+String? _joinNames(Object? value, {String? key}) {
+  if (value is! List) return null;
+  final List<String> names = <String>[];
+  for (final Object? entry in value) {
+    final String? name = key == null
+        ? _coerceString(entry)
+        : (entry is Map<String, dynamic> ? _coerceString(entry[key]) : null);
+    if (name != null) names.add(name);
+  }
+  return names.isEmpty ? null : names.join(', ');
+}
+
+/// Reads a duration in (possibly fractional) seconds, or `null` when it is
+/// absent, the wrong type, or not a positive length.
+Duration? _coerceDuration(Object? value) {
+  if (value is! num || !value.isFinite || value <= 0) return null;
+  return Duration(milliseconds: (value * 1000).round());
 }
 
 /// Reads [value] as a non-blank [String], or `null` for anything else

--- a/lib/core/sources/audiobookshelf/audiobookshelf_client.dart
+++ b/lib/core/sources/audiobookshelf/audiobookshelf_client.dart
@@ -31,4 +31,14 @@ abstract interface class AudiobookshelfClient {
   Future<List<AudiobookshelfLibraryDto>> fetchLibraries(
     AudiobookshelfSession session,
   );
+
+  /// Fetches one page of the books in [libraryId], title-sorted, with [page]
+  /// zero-based. A library can hold thousands of books, so this is paged
+  /// rather than "everything at once".
+  Future<AudiobookshelfLibraryItemsPage> fetchLibraryItems(
+    AudiobookshelfSession session, {
+    required String libraryId,
+    required int limit,
+    required int page,
+  });
 }

--- a/lib/core/sources/audiobookshelf/audiobookshelf_endpoints.dart
+++ b/lib/core/sources/audiobookshelf/audiobookshelf_endpoints.dart
@@ -34,10 +34,33 @@ abstract final class AudiobookshelfEndpoints {
   /// Requires the `Authorization: Bearer <accessToken>` header.
   static Uri libraries(String baseUrl) => _join(baseUrl, _librariesPath);
 
-  /// `GET /api/libraries/{id}/items` — the items in one library. Requires
-  /// the `Authorization: Bearer <accessToken>` header.
-  static Uri libraryItems(String baseUrl, String libraryId) =>
-      _join(baseUrl, '/api/libraries/$libraryId/items');
+  /// `GET /api/libraries/{id}/items`: one page of the items in one library.
+  /// Requires the `Authorization: Bearer <accessToken>` header.
+  ///
+  /// The query is what makes this usable on a real library:
+  ///  - `minified=1` drops the audio files, chapters and library-file records
+  ///    from every entry (a listing needs none of them) and gives the
+  ///    pre-joined `authorName` / `narratorName` a row actually renders;
+  ///  - `sort` + `desc=0` order by title on the server, so paging stays
+  ///    consistent instead of each page being sorted on its own;
+  ///  - `limit` + `page` (zero-based) keep one request bounded on a library
+  ///    with thousands of books.
+  static Uri libraryItems(
+    String baseUrl,
+    String libraryId, {
+    required int limit,
+    required int page,
+  }) {
+    return _join(baseUrl, '/api/libraries/$libraryId/items').replace(
+      queryParameters: <String, String>{
+        'minified': '1',
+        'sort': 'media.metadata.title',
+        'desc': '0',
+        'limit': '$limit',
+        'page': '$page',
+      },
+    );
+  }
 
   static Uri _join(String baseUrl, String path) => Uri.parse('$baseUrl$path');
 }

--- a/lib/core/sources/audiobookshelf/http_audiobookshelf_client.dart
+++ b/lib/core/sources/audiobookshelf/http_audiobookshelf_client.dart
@@ -110,6 +110,32 @@ class HttpAudiobookshelfClient implements AudiobookshelfClient {
     return libraries;
   }
 
+  @override
+  Future<AudiobookshelfLibraryItemsPage> fetchLibraryItems(
+    AudiobookshelfSession session, {
+    required String libraryId,
+    required int limit,
+    required int page,
+  }) async {
+    final Uri uri = AudiobookshelfEndpoints.libraryItems(
+      session.baseUrl,
+      libraryId,
+      limit: limit,
+      page: page,
+    );
+    final http.Response response = await _send(
+      () => _client.get(uri, headers: <String, String>{
+        'Accept': 'application/json',
+        'Authorization': 'Bearer ${session.accessToken}',
+      }),
+    );
+    _checkStatus(response);
+    return AudiobookshelfLibraryItemsPage.fromJson(
+      _decodeObject(response),
+      requestedPage: page,
+    );
+  }
+
   Future<http.Response> _send(
     Future<http.Response> Function() request,
   ) async {

--- a/lib/features/audiobooks/audiobooks_library_controller.dart
+++ b/lib/features/audiobooks/audiobooks_library_controller.dart
@@ -1,0 +1,260 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/audiobookshelf_session.dart';
+import '../../core/sources/audiobookshelf/audiobookshelf_api.dart';
+import '../../core/sources/audiobookshelf/audiobookshelf_exception.dart';
+import '../settings/audiobookshelf/audiobookshelf_settings_controller.dart';
+import '../settings/audiobookshelf/audiobookshelf_settings_providers.dart';
+import 'audiobooks_library_state.dart';
+
+/// Drives the audiobook browser: picks a library and pages through its books.
+///
+/// It reads the live session from the connection controller (the one place a
+/// signed-in Audiobookshelf session lives) and never touches storage, HTTP
+/// headers or the tokens itself. Nothing here goes near the music providers,
+/// the music catalog or the source preference: this is the audiobook seam,
+/// same as the connection screen.
+///
+/// Listing only. Opening a book, chapters and playback come with the domain
+/// model in the next milestone.
+class AudiobooksLibraryController extends Notifier<AudiobooksLibraryState> {
+  /// How many books one request asks for. Big enough that most libraries
+  /// arrive in a single page, small enough that a large one doesn't spend
+  /// seconds parsing before the first row appears.
+  static const int pageSize = 100;
+
+  /// The page index the next [loadMore] asks for. Counted rather than
+  /// derived from the number of loaded books: a page can come back one book
+  /// short because a half-scanned record was skipped, and dividing by
+  /// [pageSize] would then ask for the same page again.
+  int _nextPage = 1;
+
+  @override
+  AudiobooksLibraryState build() => const AudiobooksLibraryState();
+
+  /// Loads the libraries and the first page of the selected one.
+  ///
+  /// Called when the screen opens. Already-loaded state is kept unless
+  /// [force] is set (pull to refresh / the refresh action), so returning to
+  /// the screen doesn't re-fetch the whole library.
+  Future<void> load({bool force = false}) async {
+    final AudiobookshelfSettingsController connection =
+        ref.read(audiobookshelfSettingsControllerProvider.notifier);
+    // A cold open is still reading the keyring: without this the check below
+    // would see "not connected" and offer the connection to a signed-in user.
+    await connection.ensureLoaded();
+    final AudiobookshelfSession? session = connection.session;
+    if (session == null) {
+      state = const AudiobooksLibraryState();
+      return;
+    }
+    if (state.hasLoaded && !force && state.errorMessage == null) return;
+
+    state = state.copyWith(isConnected: true, isLoading: true);
+    final List<AudiobookshelfLibraryDto> libraries;
+    try {
+      libraries =
+          await ref.read(audiobookshelfClientProvider).fetchLibraries(session);
+    } on AudiobookshelfException catch (error) {
+      _fail(session, connection, error);
+      return;
+    }
+    if (_isStale(session, connection)) return;
+
+    final List<AudiobookLibrarySummary> bookLibraries =
+        <AudiobookLibrarySummary>[
+      for (final AudiobookshelfLibraryDto library in libraries)
+        // A library that reports no media type at all is treated as books
+        // rather than hidden: the browser would otherwise show nothing on a
+        // server whose response is a shape older than the one documented.
+        if (library.mediaType == null || library.mediaType == 'book')
+          AudiobookLibrarySummary(id: library.id, name: library.name),
+    ];
+    if (bookLibraries.isEmpty) {
+      state = const AudiobooksLibraryState(
+        isConnected: true,
+        hasLoaded: true,
+      );
+      return;
+    }
+
+    state = state.copyWith(
+      libraries: bookLibraries,
+      selectedLibraryId: _pickLibrary(bookLibraries, session),
+      books: const <AudiobookSummary>[],
+      totalBooks: 0,
+    );
+    await _loadFirstPage(session, connection);
+  }
+
+  /// Switches to another library and loads its first page. A no-op for the
+  /// library already showing.
+  Future<void> selectLibrary(String libraryId) async {
+    if (libraryId == state.selectedLibraryId) return;
+    final AudiobookshelfSettingsController connection =
+        ref.read(audiobookshelfSettingsControllerProvider.notifier);
+    final AudiobookshelfSession? session = connection.session;
+    if (session == null) {
+      state = const AudiobooksLibraryState();
+      return;
+    }
+    state = state.copyWith(
+      selectedLibraryId: libraryId,
+      books: const <AudiobookSummary>[],
+      totalBooks: 0,
+      isLoading: true,
+    );
+    await _loadFirstPage(session, connection);
+  }
+
+  /// Appends the next page. A no-op when everything is already loaded or a
+  /// request is already running, so a keen scroller can't fire two.
+  Future<void> loadMore() async {
+    if (!state.hasMore || state.isLoading || state.isLoadingMore) return;
+    final String? libraryId = state.selectedLibraryId;
+    if (libraryId == null) return;
+    final AudiobookshelfSettingsController connection =
+        ref.read(audiobookshelfSettingsControllerProvider.notifier);
+    final AudiobookshelfSession? session = connection.session;
+    if (session == null) {
+      state = const AudiobooksLibraryState();
+      return;
+    }
+
+    final int nextPage = _nextPage;
+    state = state.copyWith(isLoadingMore: true);
+    try {
+      final AudiobookshelfLibraryItemsPage page =
+          await ref.read(audiobookshelfClientProvider).fetchLibraryItems(
+                session,
+                libraryId: libraryId,
+                limit: pageSize,
+                page: nextPage,
+              );
+      if (_isStale(session, connection)) return;
+      // The library it was fetched for may have been switched away from
+      // while this was in flight; those books belong to the other list.
+      if (libraryId != state.selectedLibraryId) return;
+      _nextPage = nextPage + 1;
+      final List<AudiobookSummary> books = <AudiobookSummary>[
+        ...state.books,
+        ..._toSummaries(page.items),
+      ];
+      state = state.copyWith(
+        books: books,
+        // An empty page means the server has nothing more to give, whatever
+        // its total says (skipped malformed records make the two disagree).
+        // Settling the total on what arrived ends the paging instead of
+        // leaving a "Load more" that fetches nothing forever.
+        totalBooks: page.items.isEmpty ? books.length : page.total,
+        isLoadingMore: false,
+      );
+    } on AudiobookshelfException catch (error) {
+      if (_isStale(session, connection)) return;
+      // The books already on screen stay there; only the footer reports that
+      // the next page didn't come.
+      state = state.copyWith(
+        isLoadingMore: false,
+        errorMessage: error.message,
+        errorKind: error.kind,
+      );
+    }
+  }
+
+  /// Re-fetches the libraries and the current library's first page.
+  Future<void> refresh() => load(force: true);
+
+  Future<void> _loadFirstPage(
+    AudiobookshelfSession session,
+    AudiobookshelfSettingsController connection,
+  ) async {
+    final String? libraryId = state.selectedLibraryId;
+    if (libraryId == null) {
+      state = state.copyWith(isLoading: false, hasLoaded: true);
+      return;
+    }
+    try {
+      final AudiobookshelfLibraryItemsPage page =
+          await ref.read(audiobookshelfClientProvider).fetchLibraryItems(
+                session,
+                libraryId: libraryId,
+                limit: pageSize,
+                page: 0,
+              );
+      if (_isStale(session, connection)) return;
+      if (libraryId != state.selectedLibraryId) return;
+      _nextPage = 1;
+      state = state.copyWith(
+        books: _toSummaries(page.items),
+        totalBooks: page.total,
+        isLoading: false,
+        hasLoaded: true,
+      );
+    } on AudiobookshelfException catch (error) {
+      _fail(session, connection, error);
+    }
+  }
+
+  /// The library to open: the one already chosen if it still exists, then the
+  /// account's default, then the first. A user who picked a library keeps it
+  /// across a refresh.
+  String _pickLibrary(
+    List<AudiobookLibrarySummary> libraries,
+    AudiobookshelfSession session,
+  ) {
+    final String? current = state.selectedLibraryId;
+    for (final AudiobookLibrarySummary library in libraries) {
+      if (library.id == current) return library.id;
+    }
+    for (final AudiobookLibrarySummary library in libraries) {
+      if (library.id == session.defaultLibraryId) return library.id;
+    }
+    return libraries.first.id;
+  }
+
+  void _fail(
+    AudiobookshelfSession session,
+    AudiobookshelfSettingsController connection,
+    AudiobookshelfException error,
+  ) {
+    if (_isStale(session, connection)) return;
+    state = state.copyWith(
+      isLoading: false,
+      isLoadingMore: false,
+      hasLoaded: true,
+      errorMessage: error.message,
+      errorKind: error.kind,
+    );
+  }
+
+  /// Whether a sign-out (or a sign-in as somebody else) landed while a
+  /// request was in flight. The response belongs to the old account, so it is
+  /// dropped rather than painted over whatever owns the screen now.
+  bool _isStale(
+    AudiobookshelfSession session,
+    AudiobookshelfSettingsController connection,
+  ) =>
+      !identical(connection.session, session);
+
+  List<AudiobookSummary> _toSummaries(
+    List<AudiobookshelfLibraryItemDto> items,
+  ) {
+    return <AudiobookSummary>[
+      for (final AudiobookshelfLibraryItemDto item in items)
+        AudiobookSummary(
+          id: item.id,
+          title: item.title,
+          subtitle: item.subtitle,
+          author: item.authorName,
+          narrator: item.narratorName,
+          series: item.seriesName,
+          duration: item.duration,
+        ),
+    ];
+  }
+}
+
+final audiobooksLibraryControllerProvider =
+    NotifierProvider<AudiobooksLibraryController, AudiobooksLibraryState>(
+  AudiobooksLibraryController.new,
+);

--- a/lib/features/audiobooks/audiobooks_library_controller.dart
+++ b/lib/features/audiobooks/audiobooks_library_controller.dart
@@ -29,6 +29,17 @@ class AudiobooksLibraryController extends Notifier<AudiobooksLibraryState> {
   /// [pageSize] would then ask for the same page again.
   int _nextPage = 1;
 
+  /// Bumped whenever what the screen is showing changes underneath a request:
+  /// a different account, a refresh, another library. A response carrying an
+  /// older generation is dropped, so no in-flight page can land on a list it
+  /// doesn't belong to (or leave a spinner running on one).
+  int _generation = 0;
+
+  /// The session the loaded state belongs to. A session that isn't this exact
+  /// one means a different sign-in owns the screen now, and none of the books
+  /// or library names on it may be shown to it.
+  AudiobookshelfSession? _loadedFor;
+
   @override
   AudiobooksLibraryState build() => const AudiobooksLibraryState();
 
@@ -36,7 +47,8 @@ class AudiobooksLibraryController extends Notifier<AudiobooksLibraryState> {
   ///
   /// Called when the screen opens. Already-loaded state is kept unless
   /// [force] is set (pull to refresh / the refresh action), so returning to
-  /// the screen doesn't re-fetch the whole library.
+  /// the screen doesn't re-fetch the whole library. A sign-in as somebody
+  /// else always re-fetches: the cache belongs to the account that filled it.
   Future<void> load({bool force = false}) async {
     final AudiobookshelfSettingsController connection =
         ref.read(audiobookshelfSettingsControllerProvider.notifier);
@@ -45,21 +57,38 @@ class AudiobooksLibraryController extends Notifier<AudiobooksLibraryState> {
     await connection.ensureLoaded();
     final AudiobookshelfSession? session = connection.session;
     if (session == null) {
+      _forget();
       state = const AudiobooksLibraryState();
       return;
     }
-    if (state.hasLoaded && !force && state.errorMessage == null) return;
+    final bool sameAccount = identical(session, _loadedFor);
+    if (sameAccount &&
+        state.hasLoaded &&
+        !force &&
+        state.errorMessage == null) {
+      return;
+    }
 
-    state = state.copyWith(isConnected: true, isLoading: true);
+    final int generation = _begin(session);
+    // A different account: nothing of the previous one survives into this
+    // load, not its books, not its library names, not which library was open.
+    state = sameAccount
+        ? state.copyWith(
+            isConnected: true,
+            isLoading: true,
+            isLoadingMore: false,
+          )
+        : const AudiobooksLibraryState(isConnected: true, isLoading: true);
+
     final List<AudiobookshelfLibraryDto> libraries;
     try {
       libraries =
           await ref.read(audiobookshelfClientProvider).fetchLibraries(session);
     } on AudiobookshelfException catch (error) {
-      _fail(session, connection, error);
+      _fail(generation, session, connection, error);
       return;
     }
-    if (_isStale(session, connection)) return;
+    if (_isStale(generation, session, connection)) return;
 
     final List<AudiobookLibrarySummary> bookLibraries =
         <AudiobookLibrarySummary>[
@@ -84,7 +113,7 @@ class AudiobooksLibraryController extends Notifier<AudiobooksLibraryState> {
       books: const <AudiobookSummary>[],
       totalBooks: 0,
     );
-    await _loadFirstPage(session, connection);
+    await _loadFirstPage(generation, session, connection);
   }
 
   /// Switches to another library and loads its first page. A no-op for the
@@ -95,16 +124,21 @@ class AudiobooksLibraryController extends Notifier<AudiobooksLibraryState> {
         ref.read(audiobookshelfSettingsControllerProvider.notifier);
     final AudiobookshelfSession? session = connection.session;
     if (session == null) {
+      _forget();
       state = const AudiobooksLibraryState();
       return;
     }
+    final int generation = _begin(session);
     state = state.copyWith(
       selectedLibraryId: libraryId,
       books: const <AudiobookSummary>[],
       totalBooks: 0,
       isLoading: true,
+      // A page still in flight for the previous library is abandoned by the
+      // new generation, so its spinner must not be left running here.
+      isLoadingMore: false,
     );
-    await _loadFirstPage(session, connection);
+    await _loadFirstPage(generation, session, connection);
   }
 
   /// Appends the next page. A no-op when everything is already loaded or a
@@ -117,10 +151,14 @@ class AudiobooksLibraryController extends Notifier<AudiobooksLibraryState> {
         ref.read(audiobookshelfSettingsControllerProvider.notifier);
     final AudiobookshelfSession? session = connection.session;
     if (session == null) {
+      _forget();
       state = const AudiobooksLibraryState();
       return;
     }
 
+    // A continuation of what is already on screen, so it joins the current
+    // generation rather than starting one.
+    final int generation = _generation;
     final int nextPage = _nextPage;
     state = state.copyWith(isLoadingMore: true);
     try {
@@ -131,10 +169,7 @@ class AudiobooksLibraryController extends Notifier<AudiobooksLibraryState> {
                 limit: pageSize,
                 page: nextPage,
               );
-      if (_isStale(session, connection)) return;
-      // The library it was fetched for may have been switched away from
-      // while this was in flight; those books belong to the other list.
-      if (libraryId != state.selectedLibraryId) return;
+      if (_isStale(generation, session, connection)) return;
       _nextPage = nextPage + 1;
       final List<AudiobookSummary> books = <AudiobookSummary>[
         ...state.books,
@@ -150,7 +185,7 @@ class AudiobooksLibraryController extends Notifier<AudiobooksLibraryState> {
         isLoadingMore: false,
       );
     } on AudiobookshelfException catch (error) {
-      if (_isStale(session, connection)) return;
+      if (_isStale(generation, session, connection)) return;
       // The books already on screen stay there; only the footer reports that
       // the next page didn't come.
       state = state.copyWith(
@@ -165,6 +200,7 @@ class AudiobooksLibraryController extends Notifier<AudiobooksLibraryState> {
   Future<void> refresh() => load(force: true);
 
   Future<void> _loadFirstPage(
+    int generation,
     AudiobookshelfSession session,
     AudiobookshelfSettingsController connection,
   ) async {
@@ -181,8 +217,7 @@ class AudiobooksLibraryController extends Notifier<AudiobooksLibraryState> {
                 limit: pageSize,
                 page: 0,
               );
-      if (_isStale(session, connection)) return;
-      if (libraryId != state.selectedLibraryId) return;
+      if (_isStale(generation, session, connection)) return;
       _nextPage = 1;
       state = state.copyWith(
         books: _toSummaries(page.items),
@@ -191,7 +226,7 @@ class AudiobooksLibraryController extends Notifier<AudiobooksLibraryState> {
         hasLoaded: true,
       );
     } on AudiobookshelfException catch (error) {
-      _fail(session, connection, error);
+      _fail(generation, session, connection, error);
     }
   }
 
@@ -212,12 +247,28 @@ class AudiobooksLibraryController extends Notifier<AudiobooksLibraryState> {
     return libraries.first.id;
   }
 
+  /// Starts a new generation of requests for [session]: whatever was in
+  /// flight for the previous one no longer owns the screen.
+  int _begin(AudiobookshelfSession session) {
+    _loadedFor = session;
+    _nextPage = 1;
+    return ++_generation;
+  }
+
+  /// Drops everything tied to a session that is gone.
+  void _forget() {
+    _loadedFor = null;
+    _nextPage = 1;
+    _generation++;
+  }
+
   void _fail(
+    int generation,
     AudiobookshelfSession session,
     AudiobookshelfSettingsController connection,
     AudiobookshelfException error,
   ) {
-    if (_isStale(session, connection)) return;
+    if (_isStale(generation, session, connection)) return;
     state = state.copyWith(
       isLoading: false,
       isLoadingMore: false,
@@ -227,14 +278,16 @@ class AudiobooksLibraryController extends Notifier<AudiobooksLibraryState> {
     );
   }
 
-  /// Whether a sign-out (or a sign-in as somebody else) landed while a
-  /// request was in flight. The response belongs to the old account, so it is
-  /// dropped rather than painted over whatever owns the screen now.
+  /// Whether a response still belongs on screen: a newer generation (a
+  /// refresh, another library, another account) or a sign-out that landed
+  /// while it was in flight means it doesn't, so it is dropped rather than
+  /// painted over whatever owns the screen now.
   bool _isStale(
+    int generation,
     AudiobookshelfSession session,
     AudiobookshelfSettingsController connection,
   ) =>
-      !identical(connection.session, session);
+      generation != _generation || !identical(connection.session, session);
 
   List<AudiobookSummary> _toSummaries(
     List<AudiobookshelfLibraryItemDto> items,

--- a/lib/features/audiobooks/audiobooks_library_controller.dart
+++ b/lib/features/audiobooks/audiobooks_library_controller.dart
@@ -29,6 +29,12 @@ class AudiobooksLibraryController extends Notifier<AudiobooksLibraryState> {
   /// [pageSize] would then ask for the same page again.
   int _nextPage = 1;
 
+  /// How many entries the server has sent for the current library, skipped
+  /// records included. Paging is measured against this rather than against
+  /// the books on screen, so a page nothing could be read from still moves
+  /// the list forward instead of ending it.
+  int _rawRead = 0;
+
   /// Bumped whenever what the screen is showing changes underneath a request:
   /// a different account, a refresh, another library. A response carrying an
   /// older generation is dropped, so no in-flight page can land on a list it
@@ -112,6 +118,7 @@ class AudiobooksLibraryController extends Notifier<AudiobooksLibraryState> {
       selectedLibraryId: _pickLibrary(bookLibraries, session),
       books: const <AudiobookSummary>[],
       totalBooks: 0,
+      hasMore: false,
     );
     await _loadFirstPage(generation, session, connection);
   }
@@ -131,6 +138,7 @@ class AudiobooksLibraryController extends Notifier<AudiobooksLibraryState> {
     final int generation = _begin(session);
     state = state.copyWith(
       selectedLibraryId: libraryId,
+      hasMore: false,
       books: const <AudiobookSummary>[],
       totalBooks: 0,
       isLoading: true,
@@ -171,17 +179,11 @@ class AudiobooksLibraryController extends Notifier<AudiobooksLibraryState> {
               );
       if (_isStale(generation, session, connection)) return;
       _nextPage = nextPage + 1;
-      final List<AudiobookSummary> books = <AudiobookSummary>[
-        ...state.books,
-        ..._toSummaries(page.items),
-      ];
+      _rawRead += page.rawCount;
       state = state.copyWith(
-        books: books,
-        // An empty page means the server has nothing more to give, whatever
-        // its total says (skipped malformed records make the two disagree).
-        // Settling the total on what arrived ends the paging instead of
-        // leaving a "Load more" that fetches nothing forever.
-        totalBooks: page.items.isEmpty ? books.length : page.total,
+        books: <AudiobookSummary>[...state.books, ..._toSummaries(page.items)],
+        totalBooks: page.total,
+        hasMore: _hasMore(page),
         isLoadingMore: false,
       );
     } on AudiobookshelfException catch (error) {
@@ -219,9 +221,11 @@ class AudiobooksLibraryController extends Notifier<AudiobooksLibraryState> {
               );
       if (_isStale(generation, session, connection)) return;
       _nextPage = 1;
+      _rawRead = page.rawCount;
       state = state.copyWith(
         books: _toSummaries(page.items),
         totalBooks: page.total,
+        hasMore: _hasMore(page),
         isLoading: false,
         hasLoaded: true,
       );
@@ -247,11 +251,21 @@ class AudiobooksLibraryController extends Notifier<AudiobooksLibraryState> {
     return libraries.first.id;
   }
 
+  /// Whether the server has pages left for the library being read.
+  ///
+  /// A page that sent nothing is the end, whatever the total says. Otherwise
+  /// it is what the server has sent so far against what it says is there: a
+  /// page whose records were all skipped still counts as read, so the books
+  /// after it stay reachable.
+  bool _hasMore(AudiobookshelfLibraryItemsPage page) =>
+      page.rawCount > 0 && _rawRead < page.total;
+
   /// Starts a new generation of requests for [session]: whatever was in
   /// flight for the previous one no longer owns the screen.
   int _begin(AudiobookshelfSession session) {
     _loadedFor = session;
     _nextPage = 1;
+    _rawRead = 0;
     return ++_generation;
   }
 
@@ -259,6 +273,7 @@ class AudiobooksLibraryController extends Notifier<AudiobooksLibraryState> {
   void _forget() {
     _loadedFor = null;
     _nextPage = 1;
+    _rawRead = 0;
     _generation++;
   }
 

--- a/lib/features/audiobooks/audiobooks_library_state.dart
+++ b/lib/features/audiobooks/audiobooks_library_state.dart
@@ -54,6 +54,7 @@ class AudiobooksLibraryState {
     this.selectedLibraryId,
     this.books = const <AudiobookSummary>[],
     this.totalBooks = 0,
+    this.hasMore = false,
     this.errorMessage,
     this.errorKind,
   });
@@ -85,14 +86,19 @@ class AudiobooksLibraryState {
   /// How many books the selected library holds in total, per the server.
   final int totalBooks;
 
+  /// Whether the server still has pages this list hasn't read.
+  ///
+  /// Reported by the controller from how many entries the server actually
+  /// sent, not derived from [books] against [totalBooks]: a page whose every
+  /// record was unreadable leaves those two disagreeing forever, and reading
+  /// exhaustion off them would either loop or strand the rest of the library.
+  final bool hasMore;
+
   /// A friendly error line, when the last attempt failed.
   final String? errorMessage;
 
   /// The kind of that failure, for the UI to branch on without matching text.
   final AudiobookshelfErrorKind? errorKind;
-
-  /// True when the server says there are more books than have been loaded.
-  bool get hasMore => books.length < totalBooks;
 
   AudiobooksLibraryState copyWith({
     bool? isConnected,
@@ -103,6 +109,7 @@ class AudiobooksLibraryState {
     String? selectedLibraryId,
     List<AudiobookSummary>? books,
     int? totalBooks,
+    bool? hasMore,
     String? errorMessage,
     AudiobookshelfErrorKind? errorKind,
   }) {
@@ -115,6 +122,7 @@ class AudiobooksLibraryState {
       selectedLibraryId: selectedLibraryId ?? this.selectedLibraryId,
       books: books ?? this.books,
       totalBooks: totalBooks ?? this.totalBooks,
+      hasMore: hasMore ?? this.hasMore,
       // Errors are cleared explicitly rather than carried: every copyWith
       // that doesn't pass one is starting a fresh attempt, and a stale
       // failure must not sit under a list that has since loaded.

--- a/lib/features/audiobooks/audiobooks_library_state.dart
+++ b/lib/features/audiobooks/audiobooks_library_state.dart
@@ -1,0 +1,125 @@
+import '../../core/sources/audiobookshelf/audiobookshelf_exception.dart';
+
+/// One book as the browse list renders it.
+///
+/// Deliberately not the wire DTO and deliberately not a playback model: the
+/// list shows a title, who wrote and read it, which series it belongs to and
+/// how long it runs. Chapters, audio files and progress arrive with the
+/// domain model in the next milestone, and nothing here invites the rest of
+/// the app to depend on Audiobookshelf's response shape in the meantime.
+class AudiobookSummary {
+  const AudiobookSummary({
+    required this.id,
+    required this.title,
+    this.subtitle,
+    this.author,
+    this.narrator,
+    this.series,
+    this.duration,
+  });
+
+  /// The Audiobookshelf library-item id. Not shown; it is the handle the
+  /// later playback work will open the book with.
+  final String id;
+
+  final String title;
+  final String? subtitle;
+  final String? author;
+  final String? narrator;
+  final String? series;
+
+  /// Total running time, when the server reported one.
+  final Duration? duration;
+}
+
+/// One library the user can browse, reduced to what the picker shows.
+class AudiobookLibrarySummary {
+  const AudiobookLibrarySummary({required this.id, required this.name});
+
+  final String id;
+  final String name;
+}
+
+/// Immutable snapshot the audiobook browser renders from.
+///
+/// Security: like the connection state, this holds no secret. The session and
+/// its tokens stay behind the controller; only display-safe values live here.
+class AudiobooksLibraryState {
+  const AudiobooksLibraryState({
+    this.isConnected = false,
+    this.hasLoaded = false,
+    this.isLoading = false,
+    this.isLoadingMore = false,
+    this.libraries = const <AudiobookLibrarySummary>[],
+    this.selectedLibraryId,
+    this.books = const <AudiobookSummary>[],
+    this.totalBooks = 0,
+    this.errorMessage,
+    this.errorKind,
+  });
+
+  /// Whether an Audiobookshelf session exists at all. False means the screen
+  /// offers the connection instead of an empty list.
+  final bool isConnected;
+
+  /// Whether a listing attempt has finished. Separates "nothing yet" from
+  /// "this library really is empty", which look identical otherwise.
+  final bool hasLoaded;
+
+  /// True while the first page (or a refresh) is in flight.
+  final bool isLoading;
+
+  /// True while a further page is being appended, so the list stays on screen
+  /// and only its footer shows progress.
+  final bool isLoadingMore;
+
+  /// The book libraries this account can see.
+  final List<AudiobookLibrarySummary> libraries;
+
+  /// Which of [libraries] is being shown.
+  final String? selectedLibraryId;
+
+  /// The books loaded so far, in the server's title order.
+  final List<AudiobookSummary> books;
+
+  /// How many books the selected library holds in total, per the server.
+  final int totalBooks;
+
+  /// A friendly error line, when the last attempt failed.
+  final String? errorMessage;
+
+  /// The kind of that failure, for the UI to branch on without matching text.
+  final AudiobookshelfErrorKind? errorKind;
+
+  /// True when the server says there are more books than have been loaded.
+  bool get hasMore => books.length < totalBooks;
+
+  AudiobooksLibraryState copyWith({
+    bool? isConnected,
+    bool? hasLoaded,
+    bool? isLoading,
+    bool? isLoadingMore,
+    List<AudiobookLibrarySummary>? libraries,
+    String? selectedLibraryId,
+    List<AudiobookSummary>? books,
+    int? totalBooks,
+    String? errorMessage,
+    AudiobookshelfErrorKind? errorKind,
+  }) {
+    return AudiobooksLibraryState(
+      isConnected: isConnected ?? this.isConnected,
+      hasLoaded: hasLoaded ?? this.hasLoaded,
+      isLoading: isLoading ?? this.isLoading,
+      isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+      libraries: libraries ?? this.libraries,
+      selectedLibraryId: selectedLibraryId ?? this.selectedLibraryId,
+      books: books ?? this.books,
+      totalBooks: totalBooks ?? this.totalBooks,
+      // Errors are cleared explicitly rather than carried: every copyWith
+      // that doesn't pass one is starting a fresh attempt, and a stale
+      // failure must not sit under a list that has since loaded.
+      errorMessage: errorMessage,
+      errorKind: errorKind,
+    );
+  }
+}

--- a/lib/features/audiobooks/audiobooks_screen.dart
+++ b/lib/features/audiobooks/audiobooks_screen.dart
@@ -225,7 +225,12 @@ class _BookList extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    if (state.books.isEmpty) {
+    final bool hasFooter = state.hasMore || state.errorMessage != null;
+    // Only really empty when there is also nothing left to fetch. A first
+    // page whose every record was unreadable comes back with no books but
+    // more to come, and calling that "empty" would strand the rest of the
+    // library behind a footer this never drew.
+    if (state.books.isEmpty && !hasFooter) {
       return const EmptyState(
         icon: Icons.menu_book_outlined,
         title: 'No audiobooks yet',
@@ -234,7 +239,6 @@ class _BookList extends ConsumerWidget {
       );
     }
 
-    final bool hasFooter = state.hasMore || state.errorMessage != null;
     return RefreshIndicator(
       onRefresh: () =>
           ref.read(audiobooksLibraryControllerProvider.notifier).refresh(),
@@ -315,6 +319,18 @@ class _ListFooter extends ConsumerWidget {
                   ?.copyWith(color: theme.colorScheme.error),
             ),
             const SizedBox(height: AppSpacing.sm),
+          ] else if (state.books.isEmpty && state.hasMore) ...<Widget>[
+            // Every record on this page was unreadable (a half-scanned book,
+            // say). Say so plainly and keep the next page reachable.
+            Text(
+              "Nothing on this page could be read. There's more in this "
+              'library, though.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.sm),
           ],
           if (state.isLoadingMore)
             const SizedBox.square(
@@ -329,7 +345,10 @@ class _ListFooter extends ConsumerWidget {
                     .loadMore(),
               ),
               child: Text(
-                'Load more (${state.books.length} of ${state.totalBooks})',
+                state.books.isEmpty
+                    ? 'Load the next page'
+                    : 'Load more (${state.books.length} of '
+                        '${state.totalBooks})',
               ),
             ),
         ],

--- a/lib/features/audiobooks/audiobooks_screen.dart
+++ b/lib/features/audiobooks/audiobooks_screen.dart
@@ -1,0 +1,354 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../app/dimens.dart';
+import '../../app/routes.dart';
+import '../../shared/layout/adaptive_layout.dart';
+import '../../shared/widgets/empty_state.dart';
+import 'audiobooks_library_controller.dart';
+import 'audiobooks_library_state.dart';
+
+/// Browses the books on a connected Audiobookshelf server.
+///
+/// Listing only: this is the second half of the Audiobookshelf connection
+/// milestone, so a row shows what the book is and nothing opens yet. Playback,
+/// chapters and resume position arrive with the domain model next.
+///
+/// It is reached from Settings › Connections for now. When Audiobooks gets its
+/// own navigation destination (its own reviewable change, agreed on the
+/// tracking issue), this screen moves there unchanged.
+class AudiobooksScreen extends ConsumerStatefulWidget {
+  const AudiobooksScreen({super.key});
+
+  @override
+  ConsumerState<AudiobooksScreen> createState() => _AudiobooksScreenState();
+}
+
+class _AudiobooksScreenState extends ConsumerState<AudiobooksScreen> {
+  @override
+  void initState() {
+    super.initState();
+    // After the first frame: the controller awaits the keyring read, and
+    // mutating a provider during build is not allowed.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(
+        ref.read(audiobooksLibraryControllerProvider.notifier).load(),
+      );
+    });
+  }
+
+  Future<void> _refresh() =>
+      ref.read(audiobooksLibraryControllerProvider.notifier).refresh();
+
+  @override
+  Widget build(BuildContext context) {
+    final AudiobooksLibraryState state =
+        ref.watch(audiobooksLibraryControllerProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Audiobooks'),
+        actions: <Widget>[
+          if (state.isConnected)
+            IconButton(
+              onPressed: state.isLoading ? null : _refresh,
+              icon: const Icon(Icons.refresh_outlined),
+              tooltip: 'Refresh',
+            ),
+        ],
+      ),
+      body: AdaptiveContentWidth(child: _Body(state: state)),
+    );
+  }
+}
+
+class _Body extends ConsumerWidget {
+  const _Body({required this.state});
+
+  final AudiobooksLibraryState state;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!state.isConnected) {
+      return const _NotConnectedView();
+    }
+    if (state.isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    // Nothing loaded and something went wrong: the error *is* the screen.
+    // A failure with books already on it is reported under the list instead,
+    // so a page that didn't arrive can't take the ones that did off screen.
+    if (state.books.isEmpty && state.errorMessage != null) {
+      return _ErrorView(
+        message: state.errorMessage!,
+        onRetry: () =>
+            ref.read(audiobooksLibraryControllerProvider.notifier).refresh(),
+      );
+    }
+    if (state.libraries.isEmpty) {
+      return const EmptyState(
+        icon: Icons.menu_book_outlined,
+        title: 'No audiobook libraries',
+        message: 'This account can\'t see a book library on your '
+            'Audiobookshelf server yet. Add one there, then refresh.',
+      );
+    }
+
+    return Column(
+      children: <Widget>[
+        // Only worth the row when there is a choice to make.
+        if (state.libraries.length > 1) _LibraryPicker(state: state),
+        Expanded(child: _BookList(state: state)),
+      ],
+    );
+  }
+}
+
+/// The connection isn't set up (or was signed out): say so and point at the
+/// one place that fixes it, rather than showing an empty list.
+class _NotConnectedView extends StatelessWidget {
+  const _NotConnectedView();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            const EmptyState(
+              icon: Icons.headphones_outlined,
+              title: 'No Audiobookshelf server',
+              message: 'Connect your self-hosted Audiobookshelf server to '
+                  'browse your audiobooks here.',
+            ),
+            FilledButton.icon(
+              onPressed: () => context.go(AppRoutes.settingsConnections),
+              icon: const Icon(Icons.link_outlined),
+              label: const Text('Set up the connection'),
+            ),
+            const SizedBox(height: AppSpacing.xl),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The listing failed with nothing to show: the message plus a way to try
+/// again. The session is still fine, only the request wasn't.
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Center(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(AppSpacing.xl),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(Icons.error_outline, size: 40, color: theme.colorScheme.error),
+            const SizedBox(height: AppSpacing.md),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: AppSpacing.md),
+            FilledButton.tonalIcon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh_outlined),
+              label: const Text('Try again'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Which library is being browsed, when the account can see more than one.
+class _LibraryPicker extends ConsumerWidget {
+  const _LibraryPicker({required this.state});
+
+  final AudiobooksLibraryState state;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.md,
+        AppSpacing.sm,
+        AppSpacing.md,
+        0,
+      ),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          children: <Widget>[
+            for (final AudiobookLibrarySummary library in state.libraries)
+              Padding(
+                padding: const EdgeInsets.only(right: AppSpacing.sm),
+                child: ChoiceChip(
+                  label: Text(library.name),
+                  selected: library.id == state.selectedLibraryId,
+                  onSelected: (bool selected) {
+                    if (!selected) return;
+                    unawaited(
+                      ref
+                          .read(audiobooksLibraryControllerProvider.notifier)
+                          .selectLibrary(library.id),
+                    );
+                  },
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _BookList extends ConsumerWidget {
+  const _BookList({required this.state});
+
+  final AudiobooksLibraryState state;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (state.books.isEmpty) {
+      return const EmptyState(
+        icon: Icons.menu_book_outlined,
+        title: 'No audiobooks yet',
+        message: 'This library is empty. Add books on your Audiobookshelf '
+            'server and scan it, then refresh.',
+      );
+    }
+
+    final bool hasFooter = state.hasMore || state.errorMessage != null;
+    return RefreshIndicator(
+      onRefresh: () =>
+          ref.read(audiobooksLibraryControllerProvider.notifier).refresh(),
+      child: ListView.builder(
+        itemCount: state.books.length + (hasFooter ? 1 : 0),
+        itemBuilder: (BuildContext context, int index) {
+          if (index >= state.books.length) {
+            return _ListFooter(state: state);
+          }
+          return _BookTile(book: state.books[index]);
+        },
+      ),
+    );
+  }
+}
+
+/// One book. Nothing opens yet (the listing is this milestone, playback is
+/// the next one), so the row is deliberately not tappable.
+class _BookTile extends StatelessWidget {
+  const _BookTile({required this.book});
+
+  final AudiobookSummary book;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final String? subtitle = _subtitleOf(book);
+    final String? length = formatBookDuration(book.duration);
+
+    return ListTile(
+      leading: CircleAvatar(
+        backgroundColor: theme.colorScheme.primary.withValues(alpha: 0.12),
+        foregroundColor: theme.colorScheme.primary,
+        child: const Icon(Icons.menu_book_outlined),
+      ),
+      title: Text(book.title, maxLines: 2, overflow: TextOverflow.ellipsis),
+      subtitle: subtitle == null
+          ? null
+          : Text(subtitle, maxLines: 2, overflow: TextOverflow.ellipsis),
+      trailing: length == null
+          ? null
+          : Text(length, style: theme.textTheme.bodySmall),
+    );
+  }
+
+  /// The one supporting line: who wrote it, the series it's part of, and who
+  /// reads it, in that order and only when the server reported them.
+  static String? _subtitleOf(AudiobookSummary book) {
+    final List<String> parts = <String>[
+      if (book.author != null) book.author!,
+      if (book.series != null) book.series!,
+      if (book.narrator != null) 'Read by ${book.narrator}',
+    ];
+    if (parts.isEmpty) return book.subtitle;
+    return parts.join(' • ');
+  }
+}
+
+/// The tail of the list: whatever the last page attempt left behind, more to
+/// load, a spinner, or the failure that stopped it.
+class _ListFooter extends ConsumerWidget {
+  const _ListFooter({required this.state});
+
+  final AudiobooksLibraryState state;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.all(AppSpacing.md),
+      child: Column(
+        children: <Widget>[
+          if (state.errorMessage != null) ...<Widget>[
+            Text(
+              state.errorMessage!,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: theme.colorScheme.error),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+          ],
+          if (state.isLoadingMore)
+            const SizedBox.square(
+              dimension: 24,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          else if (state.hasMore)
+            OutlinedButton(
+              onPressed: () => unawaited(
+                ref
+                    .read(audiobooksLibraryControllerProvider.notifier)
+                    .loadMore(),
+              ),
+              child: Text(
+                'Load more (${state.books.length} of ${state.totalBooks})',
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Renders a running time the way a listener reads one: "11h 42m", "48m", or
+/// "3m" for something very short. `null` when the server didn't report one, so
+/// the row shows nothing rather than a made-up 0:00.
+String? formatBookDuration(Duration? duration) {
+  if (duration == null || duration <= Duration.zero) return null;
+  final int hours = duration.inHours;
+  final int minutes = duration.inMinutes.remainder(60);
+  if (hours > 0) {
+    return minutes > 0 ? '${hours}h ${minutes}m' : '${hours}h';
+  }
+  // Under a minute still reads as a minute: a book that short is a scanning
+  // artifact, and "0m" looks like a bug.
+  return '${minutes < 1 ? 1 : minutes}m';
+}

--- a/lib/features/settings/audiobookshelf/audiobookshelf_provider_card.dart
+++ b/lib/features/settings/audiobookshelf/audiobookshelf_provider_card.dart
@@ -61,11 +61,13 @@ class AudiobookshelfProviderCard extends ConsumerWidget {
       actions: connected
           ? <Widget>[
               _ManageAction(onPressed: manage),
-              // The way into the books themselves. It sits here only until
-              // Audiobooks gets its own navigation destination, its own
-              // change agreed on the tracking issue.
+              // The way into the books themselves. Pushed, like every other
+              // Settings detail page, so Back returns to this card rather
+              // than to the Settings hub. It sits here only until Audiobooks
+              // gets its own navigation destination, its own change agreed
+              // on the tracking issue.
               FilledButton(
-                onPressed: () => context.go(AppRoutes.audiobooks),
+                onPressed: () => context.push(AppRoutes.audiobooks),
                 child: const Text('Browse'),
               ),
             ]

--- a/lib/features/settings/audiobookshelf/audiobookshelf_provider_card.dart
+++ b/lib/features/settings/audiobookshelf/audiobookshelf_provider_card.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
+import '../../../app/routes.dart';
 import '../source/provider_summary_cards.dart';
 import 'audiobookshelf_settings_controller.dart';
 import 'audiobookshelf_settings_section.dart';
@@ -57,7 +59,16 @@ class AudiobookshelfProviderCard extends ConsumerWidget {
       detailIsError: detailIsError,
       onManage: manage,
       actions: connected
-          ? <Widget>[_ManageAction(onPressed: manage)]
+          ? <Widget>[
+              _ManageAction(onPressed: manage),
+              // The way into the books themselves. It sits here only until
+              // Audiobooks gets its own navigation destination, its own
+              // change agreed on the tracking issue.
+              FilledButton(
+                onPressed: () => context.go(AppRoutes.audiobooks),
+                child: const Text('Browse'),
+              ),
+            ]
           : <Widget>[
               FilledButton(onPressed: manage, child: const Text('Connect')),
             ],
@@ -66,8 +77,8 @@ class AudiobookshelfProviderCard extends ConsumerWidget {
 }
 
 /// The card's explicit "Manage" button. The music cards pair Manage with a
-/// "Sync now" action; Audiobookshelf has nothing to sync into the catalog yet,
-/// so this is the only action it offers.
+/// "Sync now" action; Audiobookshelf has nothing to sync into the music
+/// catalog and never will, so it pairs with "Browse" instead.
 class _ManageAction extends StatelessWidget {
   const _ManageAction({required this.onPressed});
 

--- a/test/core/sources/audiobookshelf/fake_audiobookshelf_client.dart
+++ b/test/core/sources/audiobookshelf/fake_audiobookshelf_client.dart
@@ -14,6 +14,7 @@ class FakeAudiobookshelfClient implements AudiobookshelfClient {
     this.serverStatusError,
     this.authError,
     this.librariesError,
+    this.libraryItemsError,
   });
 
   AudiobookshelfServerStatus? serverStatus;
@@ -22,6 +23,12 @@ class FakeAudiobookshelfClient implements AudiobookshelfClient {
   AudiobookshelfException? serverStatusError;
   AudiobookshelfException? authError;
   AudiobookshelfException? librariesError;
+  AudiobookshelfException? libraryItemsError;
+
+  /// Canned item pages by library id. A library with no entry here answers
+  /// with an empty page, the same as a library with nothing in it.
+  final Map<String, List<AudiobookshelfLibraryItemDto>> itemsByLibrary =
+      <String, List<AudiobookshelfLibraryItemDto>>{};
 
   // Recorded inputs.
   String? lastBaseUrl;
@@ -33,6 +40,11 @@ class FakeAudiobookshelfClient implements AudiobookshelfClient {
   /// authenticator reuses a status the caller already fetched instead of
   /// asking again.
   int serverStatusCallCount = 0;
+
+  /// Every [fetchLibraryItems] call, in order, so a test can assert what was
+  /// asked for (which library, which page).
+  final List<({String libraryId, int limit, int page})> itemRequests =
+      <({String libraryId, int limit, int page})>[];
 
   @override
   Future<AudiobookshelfServerStatus> fetchServerStatus(
@@ -72,5 +84,30 @@ class FakeAudiobookshelfClient implements AudiobookshelfClient {
     lastSession = session;
     if (librariesError != null) throw librariesError!;
     return libraries;
+  }
+
+  @override
+  Future<AudiobookshelfLibraryItemsPage> fetchLibraryItems(
+    AudiobookshelfSession session, {
+    required String libraryId,
+    required int limit,
+    required int page,
+  }) async {
+    lastSession = session;
+    itemRequests.add((libraryId: libraryId, limit: limit, page: page));
+    if (libraryItemsError != null) throw libraryItemsError!;
+    final List<AudiobookshelfLibraryItemDto> all =
+        itemsByLibrary[libraryId] ?? const <AudiobookshelfLibraryItemDto>[];
+    // Page the canned list the way the server would, so a test can drive the
+    // real "load more" path instead of a special case.
+    final int start = page * limit;
+    final List<AudiobookshelfLibraryItemDto> slice = start >= all.length
+        ? const <AudiobookshelfLibraryItemDto>[]
+        : all.sublist(start, (start + limit).clamp(0, all.length));
+    return AudiobookshelfLibraryItemsPage(
+      items: slice,
+      total: all.length,
+      page: page,
+    );
   }
 }

--- a/test/core/sources/audiobookshelf/fake_audiobookshelf_client.dart
+++ b/test/core/sources/audiobookshelf/fake_audiobookshelf_client.dart
@@ -30,11 +30,13 @@ class FakeAudiobookshelfClient implements AudiobookshelfClient {
   final Map<String, List<AudiobookshelfLibraryItemDto>> itemsByLibrary =
       <String, List<AudiobookshelfLibraryItemDto>>{};
 
-  /// Reports this as the page's `total` instead of the canned list's length,
-  /// so a test can reproduce the real server's disagreement between the two:
-  /// records the parser skipped (half-scanned, no title) are counted by the
-  /// server but never arrive.
-  int? totalOverride;
+  /// Exact pages by library id, for the cases the sliced list above can't
+  /// express: a page the parser skipped every record on (items shorter than
+  /// `rawCount`), or a server total that disagrees with what arrives. Takes
+  /// precedence over [itemsByLibrary]; a page index past the end answers
+  /// empty, as the server would.
+  final Map<String, List<AudiobookshelfLibraryItemsPage>> pagesByLibrary =
+      <String, List<AudiobookshelfLibraryItemsPage>>{};
 
   // Recorded inputs.
   String? lastBaseUrl;
@@ -102,6 +104,19 @@ class FakeAudiobookshelfClient implements AudiobookshelfClient {
     lastSession = session;
     itemRequests.add((libraryId: libraryId, limit: limit, page: page));
     if (libraryItemsError != null) throw libraryItemsError!;
+    final List<AudiobookshelfLibraryItemsPage>? canned =
+        pagesByLibrary[libraryId];
+    if (canned != null) {
+      if (page >= canned.length) {
+        return AudiobookshelfLibraryItemsPage(
+          items: const <AudiobookshelfLibraryItemDto>[],
+          rawCount: 0,
+          total: canned.isEmpty ? 0 : canned.last.total,
+          page: page,
+        );
+      }
+      return canned[page];
+    }
     final List<AudiobookshelfLibraryItemDto> all =
         itemsByLibrary[libraryId] ?? const <AudiobookshelfLibraryItemDto>[];
     // Page the canned list the way the server would, so a test can drive the
@@ -112,7 +127,8 @@ class FakeAudiobookshelfClient implements AudiobookshelfClient {
         : all.sublist(start, (start + limit).clamp(0, all.length));
     return AudiobookshelfLibraryItemsPage(
       items: slice,
-      total: totalOverride ?? all.length,
+      rawCount: slice.length,
+      total: all.length,
       page: page,
     );
   }

--- a/test/core/sources/audiobookshelf/fake_audiobookshelf_client.dart
+++ b/test/core/sources/audiobookshelf/fake_audiobookshelf_client.dart
@@ -30,6 +30,12 @@ class FakeAudiobookshelfClient implements AudiobookshelfClient {
   final Map<String, List<AudiobookshelfLibraryItemDto>> itemsByLibrary =
       <String, List<AudiobookshelfLibraryItemDto>>{};
 
+  /// Reports this as the page's `total` instead of the canned list's length,
+  /// so a test can reproduce the real server's disagreement between the two:
+  /// records the parser skipped (half-scanned, no title) are counted by the
+  /// server but never arrive.
+  int? totalOverride;
+
   // Recorded inputs.
   String? lastBaseUrl;
   String? lastUsername;
@@ -106,7 +112,7 @@ class FakeAudiobookshelfClient implements AudiobookshelfClient {
         : all.sublist(start, (start + limit).clamp(0, all.length));
     return AudiobookshelfLibraryItemsPage(
       items: slice,
-      total: all.length,
+      total: totalOverride ?? all.length,
       page: page,
     );
   }

--- a/test/core/sources/audiobookshelf/http_audiobookshelf_client_test.dart
+++ b/test/core/sources/audiobookshelf/http_audiobookshelf_client_test.dart
@@ -268,4 +268,206 @@ void main() {
       expect(libraries, isEmpty);
     });
   });
+
+  group('fetchLibraryItems', () {
+    Map<String, dynamic> book({
+      String id = 'item-1',
+      String title = 'The Hobbit',
+    }) {
+      return <String, dynamic>{
+        'id': id,
+        'mediaType': 'book',
+        'media': <String, dynamic>{
+          'duration': 40230.5,
+          'metadata': <String, dynamic>{
+            'title': title,
+            'subtitle': 'or There and Back Again',
+            'authorName': 'J. R. R. Tolkien',
+            'narratorName': 'Rob Inglis',
+            'seriesName': 'Middle-earth',
+          },
+        },
+      };
+    }
+
+    test('parses a page, and asks for a minified, title-sorted page', () async {
+      http.Request? captured;
+      final client = _client(MockClient((http.Request request) async {
+        captured = request;
+        return _json(<String, dynamic>{
+          'results': <Map<String, dynamic>>[book()],
+          'total': 42,
+          'page': 0,
+        });
+      }));
+
+      final page = await client.fetchLibraryItems(
+        _session,
+        libraryId: 'lib-1',
+        limit: 100,
+        page: 0,
+      );
+
+      expect(page.total, 42);
+      expect(page.page, 0);
+      expect(page.items, hasLength(1));
+      final item = page.items.single;
+      expect(item.id, 'item-1');
+      expect(item.title, 'The Hobbit');
+      expect(item.subtitle, 'or There and Back Again');
+      expect(item.authorName, 'J. R. R. Tolkien');
+      expect(item.narratorName, 'Rob Inglis');
+      expect(item.seriesName, 'Middle-earth');
+      expect(item.duration, const Duration(milliseconds: 40230500));
+
+      expect(captured!.headers['Authorization'], 'Bearer tok-abc');
+      expect(captured!.url.path, '/api/libraries/lib-1/items');
+      expect(captured!.url.queryParameters, <String, String>{
+        'minified': '1',
+        'sort': 'media.metadata.title',
+        'desc': '0',
+        'limit': '100',
+        'page': '0',
+      });
+    });
+
+    test('reads the full (non-minified) author/narrator/series shape too',
+        () async {
+      // A response that sends the objects rather than the pre-joined names:
+      // the parser must not depend on the query string staying as it is.
+      final client = _client(MockClient((_) async {
+        return _json(<String, dynamic>{
+          'results': <Map<String, dynamic>>[
+            <String, dynamic>{
+              'id': 'item-1',
+              'media': <String, dynamic>{
+                'metadata': <String, dynamic>{
+                  'title': 'Good Omens',
+                  'authors': <Map<String, dynamic>>[
+                    <String, dynamic>{'id': 'a1', 'name': 'Terry Pratchett'},
+                    <String, dynamic>{'id': 'a2', 'name': 'Neil Gaiman'},
+                  ],
+                  'narrators': <String>['Martin Jarvis'],
+                  'series': <Map<String, dynamic>>[
+                    <String, dynamic>{'id': 's1', 'name': 'Discworld'},
+                  ],
+                },
+              },
+            },
+          ],
+          'total': 1,
+        });
+      }));
+
+      final page = await client.fetchLibraryItems(
+        _session,
+        libraryId: 'lib-1',
+        limit: 100,
+        page: 0,
+      );
+
+      final item = page.items.single;
+      expect(item.authorName, 'Terry Pratchett, Neil Gaiman');
+      expect(item.narratorName, 'Martin Jarvis');
+      expect(item.seriesName, 'Discworld');
+      // Nothing reported a length: no invented 0:00.
+      expect(item.duration, isNull);
+    });
+
+    test('skips an entry with no title instead of failing the page', () async {
+      final client = _client(MockClient((_) async {
+        return _json(<String, dynamic>{
+          'results': <Map<String, dynamic>>[
+            book(),
+            // Scanned but not yet identified: no metadata title.
+            <String, dynamic>{'id': 'item-2', 'media': <String, dynamic>{}},
+          ],
+          'total': 2,
+        });
+      }));
+
+      final page = await client.fetchLibraryItems(
+        _session,
+        libraryId: 'lib-1',
+        limit: 100,
+        page: 0,
+      );
+
+      expect(page.items, hasLength(1));
+      expect(page.items.single.id, 'item-1');
+      // The server's own count is kept: it counts the book that was skipped.
+      expect(page.total, 2);
+    });
+
+    test('an unrecognized shape is an empty page, not an error', () async {
+      final client = _client(MockClient((_) async {
+        return _json(<String, dynamic>{'somethingElse': true});
+      }));
+
+      final page = await client.fetchLibraryItems(
+        _session,
+        libraryId: 'lib-1',
+        limit: 100,
+        page: 2,
+      );
+
+      expect(page.items, isEmpty);
+      expect(page.total, 0);
+      // No page echoed back: the one that was asked for.
+      expect(page.page, 2);
+    });
+
+    test('a rejected token surfaces as unauthorized', () async {
+      final client = _client(MockClient((_) async {
+        return _json(<String, dynamic>{'error': 'nope'}, status: 401);
+      }));
+
+      await expectLater(
+        client.fetchLibraryItems(
+          _session,
+          libraryId: 'lib-1',
+          limit: 100,
+          page: 0,
+        ),
+        throwsA(
+          isA<AudiobookshelfException>().having(
+            (AudiobookshelfException e) => e.kind,
+            'kind',
+            AudiobookshelfErrorKind.unauthorized,
+          ),
+        ),
+      );
+    });
+
+    test('a non-ASCII title survives a body with no charset header', () async {
+      final client = _client(MockClient((_) async {
+        return http.Response.bytes(
+          utf8.encode(jsonEncode(<String, dynamic>{
+            'results': <Map<String, dynamic>>[
+              <String, dynamic>{
+                'id': 'item-1',
+                'media': <String, dynamic>{
+                  'metadata': <String, dynamic>{
+                    'title': 'L\u2019\u00c9tranger',
+                    'authorName': 'Albert Camus',
+                  },
+                },
+              },
+            ],
+            'total': 1,
+          })),
+          200,
+        );
+      }));
+
+      final page = await client.fetchLibraryItems(
+        _session,
+        libraryId: 'lib-1',
+        limit: 100,
+        page: 0,
+      );
+
+      expect(page.items.single.title, 'L\u2019\u00c9tranger');
+    });
+  });
 }

--- a/test/core/sources/audiobookshelf/http_audiobookshelf_client_test.dart
+++ b/test/core/sources/audiobookshelf/http_audiobookshelf_client_test.dart
@@ -397,6 +397,9 @@ void main() {
       expect(page.items.single.id, 'item-1');
       // The server's own count is kept: it counts the book that was skipped.
       expect(page.total, 2);
+      // And so does the raw count, which is what says how far through the
+      // library this page read.
+      expect(page.rawCount, 2);
     });
 
     test('an unrecognized shape is an empty page, not an error', () async {
@@ -412,6 +415,7 @@ void main() {
       );
 
       expect(page.items, isEmpty);
+      expect(page.rawCount, 0);
       expect(page.total, 0);
       // No page echoed back: the one that was asked for.
       expect(page.page, 2);

--- a/test/features/audiobooks/audiobooks_library_controller_test.dart
+++ b/test/features/audiobooks/audiobooks_library_controller_test.dart
@@ -8,6 +8,7 @@ import 'package:linthra/data/repositories/audiobookshelf_session_store_provider.
 import 'package:linthra/data/repositories/in_memory_audiobookshelf_session_store.dart';
 import 'package:linthra/features/audiobooks/audiobooks_library_controller.dart';
 import 'package:linthra/features/audiobooks/audiobooks_library_state.dart';
+import 'package:linthra/features/settings/audiobookshelf/audiobookshelf_settings_controller.dart';
 import 'package:linthra/features/settings/audiobookshelf/audiobookshelf_settings_providers.dart';
 
 import '../../core/sources/audiobookshelf/fake_audiobookshelf_client.dart';
@@ -242,6 +243,91 @@ void main() {
     });
   });
 
+  group('a different account', () {
+    test('never shows the previous account its books or library names',
+        () async {
+      final client = FakeAudiobookshelfClient(
+        serverStatus: const AudiobookshelfServerStatus(
+          serverVersion: '2.17.0',
+          isInitialized: true,
+        ),
+        authResult: const AudiobookshelfAuthResult(
+          userId: 'user-2',
+          accessToken: 'tok-2',
+          userName: 'bob',
+          defaultLibraryId: 'lib-bob',
+        ),
+        libraries: <AudiobookshelfLibraryDto>[_bookLibrary],
+      );
+      client.itemsByLibrary['lib-books'] = <AudiobookshelfLibraryItemDto>[
+        _book('item-1', 'Alice only'),
+      ];
+      final container = _container(client: client);
+      final AudiobooksLibraryController controller =
+          container.read(audiobooksLibraryControllerProvider.notifier);
+      final AudiobookshelfSettingsController connection =
+          container.read(audiobookshelfSettingsControllerProvider.notifier);
+
+      await controller.load();
+      expect(
+        container.read(audiobooksLibraryControllerProvider).books.single.title,
+        'Alice only',
+      );
+
+      // Sign out, then sign in as somebody else on the same device.
+      await connection.clear();
+      client.libraries = const <AudiobookshelfLibraryDto>[
+        AudiobookshelfLibraryDto(
+          id: 'lib-bob',
+          name: "Bob's books",
+          mediaType: 'book',
+        ),
+      ];
+      client.itemsByLibrary['lib-bob'] = <AudiobookshelfLibraryItemDto>[
+        _book('item-9', 'Bob only'),
+      ];
+      await connection.signIn(
+        url: 'https://audiobooks.example.com',
+        username: 'bob',
+        password: 'hunter2',
+      );
+
+      // No force: the screen just being reopened must still re-fetch.
+      await controller.load();
+
+      final AudiobooksLibraryState state =
+          container.read(audiobooksLibraryControllerProvider);
+      expect(state.books.single.title, 'Bob only');
+      expect(state.selectedLibraryId, 'lib-bob');
+      expect(
+        state.libraries.map((AudiobookLibrarySummary l) => l.name),
+        <String>["Bob's books"],
+      );
+    });
+
+    test('a sign-out empties the browser', () async {
+      final client = FakeAudiobookshelfClient(
+        libraries: <AudiobookshelfLibraryDto>[_bookLibrary],
+      );
+      client.itemsByLibrary['lib-books'] = _books(1);
+      final container = _container(client: client);
+      final AudiobooksLibraryController controller =
+          container.read(audiobooksLibraryControllerProvider.notifier);
+
+      await controller.load();
+      await container
+          .read(audiobookshelfSettingsControllerProvider.notifier)
+          .clear();
+      await controller.load();
+
+      final AudiobooksLibraryState state =
+          container.read(audiobooksLibraryControllerProvider);
+      expect(state.isConnected, isFalse);
+      expect(state.books, isEmpty);
+      expect(state.libraries, isEmpty);
+    });
+  });
+
   group('selectLibrary', () {
     test('switches library and replaces the list', () async {
       final client = FakeAudiobookshelfClient(
@@ -336,6 +422,36 @@ void main() {
       // Nothing left to ask for.
       await controller.loadMore();
       expect(client.itemRequests, hasLength(2));
+    });
+
+    test('switching library mid-page leaves no spinner behind', () async {
+      const int pageSize = AudiobooksLibraryController.pageSize;
+      final client = FakeAudiobookshelfClient(
+        libraries: <AudiobookshelfLibraryDto>[_bookLibrary, _otherBookLibrary],
+      );
+      client.itemsByLibrary['lib-books'] = _books(pageSize + 5);
+      client.itemsByLibrary['lib-kids'] = <AudiobookshelfLibraryItemDto>[
+        _book('kid-1', 'Matilda'),
+      ];
+      final container = _container(client: client);
+      final AudiobooksLibraryController controller =
+          container.read(audiobooksLibraryControllerProvider.notifier);
+
+      await controller.load();
+
+      // The next page of the first library is still in flight when the user
+      // picks another one.
+      final Future<void> pending = controller.loadMore();
+      final Future<void> switched = controller.selectLibrary('lib-kids');
+      await Future.wait(<Future<void>>[pending, switched]);
+
+      final AudiobooksLibraryState state =
+          container.read(audiobooksLibraryControllerProvider);
+      expect(state.selectedLibraryId, 'lib-kids');
+      expect(state.books.single.title, 'Matilda');
+      // The abandoned page must not leave the footer spinning, which would
+      // also block every later page.
+      expect(state.isLoadingMore, isFalse);
     });
 
     test('a failed page keeps the books already on screen', () async {

--- a/test/features/audiobooks/audiobooks_library_controller_test.dart
+++ b/test/features/audiobooks/audiobooks_library_controller_test.dart
@@ -1,0 +1,364 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/audiobookshelf_session.dart';
+import 'package:linthra/core/repositories/audiobookshelf_session_store.dart';
+import 'package:linthra/core/sources/audiobookshelf/audiobookshelf_api.dart';
+import 'package:linthra/core/sources/audiobookshelf/audiobookshelf_exception.dart';
+import 'package:linthra/data/repositories/audiobookshelf_session_store_provider.dart';
+import 'package:linthra/data/repositories/in_memory_audiobookshelf_session_store.dart';
+import 'package:linthra/features/audiobooks/audiobooks_library_controller.dart';
+import 'package:linthra/features/audiobooks/audiobooks_library_state.dart';
+import 'package:linthra/features/settings/audiobookshelf/audiobookshelf_settings_providers.dart';
+
+import '../../core/sources/audiobookshelf/fake_audiobookshelf_client.dart';
+
+const _session = AudiobookshelfSession(
+  baseUrl: 'https://audiobooks.example.com',
+  userId: 'user-1',
+  accessToken: 'tok-1',
+  userName: 'alice',
+  defaultLibraryId: 'lib-books',
+);
+
+const _bookLibrary = AudiobookshelfLibraryDto(
+  id: 'lib-books',
+  name: 'Audiobooks',
+  mediaType: 'book',
+);
+
+const _otherBookLibrary = AudiobookshelfLibraryDto(
+  id: 'lib-kids',
+  name: 'Kids',
+  mediaType: 'book',
+);
+
+const _podcastLibrary = AudiobookshelfLibraryDto(
+  id: 'lib-pods',
+  name: 'Podcasts',
+  mediaType: 'podcast',
+);
+
+AudiobookshelfLibraryItemDto _book(String id, String title) =>
+    AudiobookshelfLibraryItemDto(
+      id: id,
+      title: title,
+      authorName: 'An Author',
+      duration: const Duration(hours: 9, minutes: 12),
+    );
+
+List<AudiobookshelfLibraryItemDto> _books(int count) =>
+    <AudiobookshelfLibraryItemDto>[
+      for (int i = 0; i < count; i++) _book('item-$i', 'Book $i'),
+    ];
+
+ProviderContainer _container({
+  required FakeAudiobookshelfClient client,
+  AudiobookshelfSessionStore? store,
+}) {
+  final container = ProviderContainer(
+    overrides: <Override>[
+      audiobookshelfClientProvider.overrideWithValue(client),
+      audiobookshelfSessionStoreProvider.overrideWithValue(
+        store ?? InMemoryAudiobookshelfSessionStore(initialSession: _session),
+      ),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+/// A container whose Audiobookshelf connection is signed out.
+ProviderContainer _signedOutContainer(FakeAudiobookshelfClient client) =>
+    _container(
+      client: client,
+      store: InMemoryAudiobookshelfSessionStore(),
+    );
+
+void main() {
+  group('load', () {
+    test('offers the connection when no server is signed in', () async {
+      final client = FakeAudiobookshelfClient();
+      final container = _signedOutContainer(client);
+
+      await container.read(audiobooksLibraryControllerProvider.notifier).load();
+
+      final AudiobooksLibraryState state =
+          container.read(audiobooksLibraryControllerProvider);
+      expect(state.isConnected, isFalse);
+      expect(state.books, isEmpty);
+      // Nothing was asked of the server without a session.
+      expect(client.itemRequests, isEmpty);
+    });
+
+    test('lists the first page of the default library', () async {
+      final client = FakeAudiobookshelfClient(
+        libraries: <AudiobookshelfLibraryDto>[
+          _otherBookLibrary,
+          _bookLibrary,
+        ],
+      );
+      client.itemsByLibrary['lib-books'] = <AudiobookshelfLibraryItemDto>[
+        _book('item-1', 'The Hobbit'),
+      ];
+      final container = _container(client: client);
+
+      await container.read(audiobooksLibraryControllerProvider.notifier).load();
+
+      final AudiobooksLibraryState state =
+          container.read(audiobooksLibraryControllerProvider);
+      expect(state.isConnected, isTrue);
+      expect(state.hasLoaded, isTrue);
+      expect(state.isLoading, isFalse);
+      // The account's default library wins over "the first one listed".
+      expect(state.selectedLibraryId, 'lib-books');
+      expect(state.books.single.title, 'The Hobbit');
+      expect(state.books.single.author, 'An Author');
+      expect(
+          state.books.single.duration, const Duration(hours: 9, minutes: 12));
+      expect(state.hasMore, isFalse);
+      expect(
+        client.itemRequests.single,
+        (
+          libraryId: 'lib-books',
+          limit: AudiobooksLibraryController.pageSize,
+          page: 0,
+        ),
+      );
+    });
+
+    test('leaves podcast libraries out of the audiobook browser', () async {
+      final client = FakeAudiobookshelfClient(
+        libraries: <AudiobookshelfLibraryDto>[_podcastLibrary, _bookLibrary],
+      );
+      final container = _container(client: client);
+
+      await container.read(audiobooksLibraryControllerProvider.notifier).load();
+
+      final AudiobooksLibraryState state =
+          container.read(audiobooksLibraryControllerProvider);
+      expect(
+        state.libraries.map((AudiobookLibrarySummary l) => l.id),
+        <String>['lib-books'],
+      );
+    });
+
+    test('keeps a library that reports no media type', () async {
+      // An older or unusual server that doesn't send mediaType must not leave
+      // the browser looking empty.
+      final client = FakeAudiobookshelfClient(
+        libraries: const <AudiobookshelfLibraryDto>[
+          AudiobookshelfLibraryDto(id: 'lib-x', name: 'Books'),
+        ],
+      );
+      final container = _container(client: client);
+
+      await container.read(audiobooksLibraryControllerProvider.notifier).load();
+
+      expect(
+        container.read(audiobooksLibraryControllerProvider).selectedLibraryId,
+        'lib-x',
+      );
+    });
+
+    test('says so when the account has no book library', () async {
+      final client = FakeAudiobookshelfClient(
+        libraries: <AudiobookshelfLibraryDto>[_podcastLibrary],
+      );
+      final container = _container(client: client);
+
+      await container.read(audiobooksLibraryControllerProvider.notifier).load();
+
+      final AudiobooksLibraryState state =
+          container.read(audiobooksLibraryControllerProvider);
+      expect(state.isConnected, isTrue);
+      expect(state.hasLoaded, isTrue);
+      expect(state.libraries, isEmpty);
+      expect(state.errorMessage, isNull);
+      expect(client.itemRequests, isEmpty);
+    });
+
+    test('surfaces a failed listing without dropping the connection', () async {
+      final client = FakeAudiobookshelfClient(
+        libraries: <AudiobookshelfLibraryDto>[_bookLibrary],
+        libraryItemsError: AudiobookshelfException.serverError(502),
+      );
+      final container = _container(client: client);
+
+      await container.read(audiobooksLibraryControllerProvider.notifier).load();
+
+      final AudiobooksLibraryState state =
+          container.read(audiobooksLibraryControllerProvider);
+      expect(state.isConnected, isTrue);
+      expect(state.isLoading, isFalse);
+      expect(state.errorMessage, contains('HTTP 502'));
+      expect(state.errorKind, AudiobookshelfErrorKind.serverError);
+    });
+
+    test('a second load keeps what is there, a refresh re-fetches', () async {
+      final client = FakeAudiobookshelfClient(
+        libraries: <AudiobookshelfLibraryDto>[_bookLibrary],
+      );
+      client.itemsByLibrary['lib-books'] = _books(2);
+      final container = _container(client: client);
+      final AudiobooksLibraryController controller =
+          container.read(audiobooksLibraryControllerProvider.notifier);
+
+      await controller.load();
+      await controller.load();
+      expect(client.itemRequests, hasLength(1));
+
+      await controller.refresh();
+      expect(client.itemRequests, hasLength(2));
+      expect(
+        container.read(audiobooksLibraryControllerProvider).books,
+        hasLength(2),
+      );
+    });
+
+    test('a retry after a failure re-fetches without asking for a refresh',
+        () async {
+      final client = FakeAudiobookshelfClient(
+        libraries: <AudiobookshelfLibraryDto>[_bookLibrary],
+        libraryItemsError: AudiobookshelfException.serverError(500),
+      );
+      client.itemsByLibrary['lib-books'] = _books(1);
+      final container = _container(client: client);
+      final AudiobooksLibraryController controller =
+          container.read(audiobooksLibraryControllerProvider.notifier);
+
+      await controller.load();
+      expect(
+        container.read(audiobooksLibraryControllerProvider).errorMessage,
+        isNotNull,
+      );
+
+      client.libraryItemsError = null;
+      await controller.load();
+
+      final AudiobooksLibraryState state =
+          container.read(audiobooksLibraryControllerProvider);
+      expect(state.errorMessage, isNull);
+      expect(state.books, hasLength(1));
+    });
+  });
+
+  group('selectLibrary', () {
+    test('switches library and replaces the list', () async {
+      final client = FakeAudiobookshelfClient(
+        libraries: <AudiobookshelfLibraryDto>[_bookLibrary, _otherBookLibrary],
+      );
+      client.itemsByLibrary['lib-books'] = _books(3);
+      client.itemsByLibrary['lib-kids'] = <AudiobookshelfLibraryItemDto>[
+        _book('kid-1', 'Matilda'),
+      ];
+      final container = _container(client: client);
+      final AudiobooksLibraryController controller =
+          container.read(audiobooksLibraryControllerProvider.notifier);
+
+      await controller.load();
+      await controller.selectLibrary('lib-kids');
+
+      final AudiobooksLibraryState state =
+          container.read(audiobooksLibraryControllerProvider);
+      expect(state.selectedLibraryId, 'lib-kids');
+      expect(state.books.single.title, 'Matilda');
+      expect(state.totalBooks, 1);
+    });
+
+    test('picking the library already open asks the server for nothing',
+        () async {
+      final client = FakeAudiobookshelfClient(
+        libraries: <AudiobookshelfLibraryDto>[_bookLibrary],
+      );
+      client.itemsByLibrary['lib-books'] = _books(1);
+      final container = _container(client: client);
+      final AudiobooksLibraryController controller =
+          container.read(audiobooksLibraryControllerProvider.notifier);
+
+      await controller.load();
+      await controller.selectLibrary('lib-books');
+
+      expect(client.itemRequests, hasLength(1));
+    });
+
+    test('a refresh keeps the library the user picked', () async {
+      final client = FakeAudiobookshelfClient(
+        libraries: <AudiobookshelfLibraryDto>[_bookLibrary, _otherBookLibrary],
+      );
+      client.itemsByLibrary['lib-kids'] = <AudiobookshelfLibraryItemDto>[
+        _book('kid-1', 'Matilda'),
+      ];
+      final container = _container(client: client);
+      final AudiobooksLibraryController controller =
+          container.read(audiobooksLibraryControllerProvider.notifier);
+
+      await controller.load();
+      await controller.selectLibrary('lib-kids');
+      await controller.refresh();
+
+      expect(
+        container.read(audiobooksLibraryControllerProvider).selectedLibraryId,
+        'lib-kids',
+      );
+    });
+  });
+
+  group('loadMore', () {
+    test('appends the next page and then stops offering one', () async {
+      const int pageSize = AudiobooksLibraryController.pageSize;
+      final client = FakeAudiobookshelfClient(
+        libraries: <AudiobookshelfLibraryDto>[_bookLibrary],
+      );
+      client.itemsByLibrary['lib-books'] = _books(pageSize + 5);
+      final container = _container(client: client);
+      final AudiobooksLibraryController controller =
+          container.read(audiobooksLibraryControllerProvider.notifier);
+
+      await controller.load();
+      expect(
+        container.read(audiobooksLibraryControllerProvider).books,
+        hasLength(pageSize),
+      );
+      expect(
+        container.read(audiobooksLibraryControllerProvider).hasMore,
+        isTrue,
+      );
+
+      await controller.loadMore();
+
+      final AudiobooksLibraryState state =
+          container.read(audiobooksLibraryControllerProvider);
+      expect(state.books, hasLength(pageSize + 5));
+      expect(state.hasMore, isFalse);
+      expect(state.isLoadingMore, isFalse);
+      expect(client.itemRequests.last.page, 1);
+
+      // Nothing left to ask for.
+      await controller.loadMore();
+      expect(client.itemRequests, hasLength(2));
+    });
+
+    test('a failed page keeps the books already on screen', () async {
+      const int pageSize = AudiobooksLibraryController.pageSize;
+      final client = FakeAudiobookshelfClient(
+        libraries: <AudiobookshelfLibraryDto>[_bookLibrary],
+      );
+      client.itemsByLibrary['lib-books'] = _books(pageSize + 1);
+      final container = _container(client: client);
+      final AudiobooksLibraryController controller =
+          container.read(audiobooksLibraryControllerProvider.notifier);
+
+      await controller.load();
+      client.libraryItemsError = AudiobookshelfException.notReachable();
+      await controller.loadMore();
+
+      final AudiobooksLibraryState state =
+          container.read(audiobooksLibraryControllerProvider);
+      expect(state.books, hasLength(pageSize));
+      expect(state.isLoadingMore, isFalse);
+      expect(state.errorMessage, isNotNull);
+      // Still offered: the page can be retried.
+      expect(state.hasMore, isTrue);
+    });
+  });
+}

--- a/test/features/audiobooks/audiobooks_library_controller_test.dart
+++ b/test/features/audiobooks/audiobooks_library_controller_test.dart
@@ -424,6 +424,64 @@ void main() {
       expect(client.itemRequests, hasLength(2));
     });
 
+    test('a page nothing could be read from does not end the library',
+        () async {
+      // The middle page's records were all skipped by the parser. Ending the
+      // paging there would strand every book after it.
+      final client = FakeAudiobookshelfClient(
+        libraries: <AudiobookshelfLibraryDto>[_bookLibrary],
+      );
+      client.pagesByLibrary['lib-books'] = <AudiobookshelfLibraryItemsPage>[
+        AudiobookshelfLibraryItemsPage(
+          items: <AudiobookshelfLibraryItemDto>[_book('item-1', 'First')],
+          rawCount: 1,
+          total: 3,
+          page: 0,
+        ),
+        const AudiobookshelfLibraryItemsPage(
+          items: <AudiobookshelfLibraryItemDto>[],
+          rawCount: 1,
+          total: 3,
+          page: 1,
+        ),
+        AudiobookshelfLibraryItemsPage(
+          items: <AudiobookshelfLibraryItemDto>[_book('item-3', 'Last')],
+          rawCount: 1,
+          total: 3,
+          page: 2,
+        ),
+      ];
+      final container = _container(client: client);
+      final AudiobooksLibraryController controller =
+          container.read(audiobooksLibraryControllerProvider.notifier);
+
+      await controller.load();
+      expect(
+        container.read(audiobooksLibraryControllerProvider).hasMore,
+        isTrue,
+      );
+
+      await controller.loadMore();
+      // Nothing was added, but the library is not over.
+      expect(
+        container.read(audiobooksLibraryControllerProvider).books.single.title,
+        'First',
+      );
+      expect(
+        container.read(audiobooksLibraryControllerProvider).hasMore,
+        isTrue,
+      );
+
+      await controller.loadMore();
+      final AudiobooksLibraryState state =
+          container.read(audiobooksLibraryControllerProvider);
+      expect(
+        state.books.map((AudiobookSummary b) => b.title),
+        <String>['First', 'Last'],
+      );
+      expect(state.hasMore, isFalse);
+    });
+
     test('switching library mid-page leaves no spinner behind', () async {
       const int pageSize = AudiobooksLibraryController.pageSize;
       final client = FakeAudiobookshelfClient(

--- a/test/features/audiobooks/audiobooks_screen_test.dart
+++ b/test/features/audiobooks/audiobooks_screen_test.dart
@@ -1,0 +1,216 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/audiobookshelf_session.dart';
+import 'package:linthra/core/sources/audiobookshelf/audiobookshelf_api.dart';
+import 'package:linthra/core/sources/audiobookshelf/audiobookshelf_exception.dart';
+import 'package:linthra/data/repositories/audiobookshelf_session_store_provider.dart';
+import 'package:linthra/data/repositories/in_memory_audiobookshelf_session_store.dart';
+import 'package:linthra/features/audiobooks/audiobooks_library_controller.dart';
+import 'package:linthra/features/audiobooks/audiobooks_screen.dart';
+import 'package:linthra/features/settings/audiobookshelf/audiobookshelf_settings_providers.dart';
+
+import '../../core/sources/audiobookshelf/fake_audiobookshelf_client.dart';
+
+const _session = AudiobookshelfSession(
+  baseUrl: 'https://audiobooks.example.com',
+  userId: 'user-1',
+  accessToken: 'tok-1',
+  userName: 'alice',
+  defaultLibraryId: 'lib-books',
+);
+
+const _bookLibrary = AudiobookshelfLibraryDto(
+  id: 'lib-books',
+  name: 'Audiobooks',
+  mediaType: 'book',
+);
+
+const _otherBookLibrary = AudiobookshelfLibraryDto(
+  id: 'lib-kids',
+  name: 'Kids',
+  mediaType: 'book',
+);
+
+AudiobookshelfLibraryItemDto _book(
+  String id,
+  String title, {
+  String? author,
+  String? narrator,
+  String? series,
+  Duration? duration,
+}) {
+  return AudiobookshelfLibraryItemDto(
+    id: id,
+    title: title,
+    authorName: author,
+    narratorName: narrator,
+    seriesName: series,
+    duration: duration,
+  );
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required FakeAudiobookshelfClient client,
+  AudiobookshelfSession? savedSession = _session,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        audiobookshelfClientProvider.overrideWithValue(client),
+        audiobookshelfSessionStoreProvider.overrideWithValue(
+          InMemoryAudiobookshelfSessionStore(initialSession: savedSession),
+        ),
+      ],
+      child: const MaterialApp(home: AudiobooksScreen()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('lists the books on the connected server', (tester) async {
+    final client = FakeAudiobookshelfClient(
+      libraries: <AudiobookshelfLibraryDto>[_bookLibrary],
+    );
+    client.itemsByLibrary['lib-books'] = <AudiobookshelfLibraryItemDto>[
+      _book(
+        'item-1',
+        'The Hobbit',
+        author: 'J. R. R. Tolkien',
+        narrator: 'Rob Inglis',
+        series: 'Middle-earth',
+        duration: const Duration(hours: 11, minutes: 5),
+      ),
+    ];
+
+    await _pump(tester, client: client);
+
+    expect(find.text('Audiobooks'), findsWidgets);
+    expect(find.text('The Hobbit'), findsOneWidget);
+    expect(
+      find.text('J. R. R. Tolkien • Middle-earth • Read by Rob Inglis'),
+      findsOneWidget,
+    );
+    expect(find.text('11h 5m'), findsOneWidget);
+  });
+
+  testWidgets('offers the connection when no server is signed in',
+      (tester) async {
+    await _pump(
+      tester,
+      client: FakeAudiobookshelfClient(),
+      savedSession: null,
+    );
+
+    expect(find.text('No Audiobookshelf server'), findsOneWidget);
+    expect(find.text('Set up the connection'), findsOneWidget);
+  });
+
+  testWidgets('says an empty library is empty, not broken', (tester) async {
+    final client = FakeAudiobookshelfClient(
+      libraries: <AudiobookshelfLibraryDto>[_bookLibrary],
+    );
+
+    await _pump(tester, client: client);
+
+    expect(find.text('No audiobooks yet'), findsOneWidget);
+  });
+
+  testWidgets('a failed listing offers a retry', (tester) async {
+    final client = FakeAudiobookshelfClient(
+      libraries: <AudiobookshelfLibraryDto>[_bookLibrary],
+      libraryItemsError: AudiobookshelfException.notReachable(),
+    );
+    client.itemsByLibrary['lib-books'] = <AudiobookshelfLibraryItemDto>[
+      _book('item-1', 'The Hobbit'),
+    ];
+
+    await _pump(tester, client: client);
+    expect(find.text('Try again'), findsOneWidget);
+
+    client.libraryItemsError = null;
+    await tester.tap(find.text('Try again'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('The Hobbit'), findsOneWidget);
+    expect(find.text('Try again'), findsNothing);
+  });
+
+  testWidgets('picking another library swaps the list', (tester) async {
+    final client = FakeAudiobookshelfClient(
+      libraries: <AudiobookshelfLibraryDto>[_bookLibrary, _otherBookLibrary],
+    );
+    client.itemsByLibrary['lib-books'] = <AudiobookshelfLibraryItemDto>[
+      _book('item-1', 'The Hobbit'),
+    ];
+    client.itemsByLibrary['lib-kids'] = <AudiobookshelfLibraryItemDto>[
+      _book('kid-1', 'Matilda'),
+    ];
+
+    await _pump(tester, client: client);
+    expect(find.text('The Hobbit'), findsOneWidget);
+
+    await tester.tap(find.text('Kids'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Matilda'), findsOneWidget);
+    expect(find.text('The Hobbit'), findsNothing);
+  });
+
+  testWidgets('offers the rest of a big library, then loads it',
+      (tester) async {
+    const int pageSize = AudiobooksLibraryController.pageSize;
+    final client = FakeAudiobookshelfClient(
+      libraries: <AudiobookshelfLibraryDto>[_bookLibrary],
+    );
+    client.itemsByLibrary['lib-books'] = <AudiobookshelfLibraryItemDto>[
+      for (int i = 0; i < pageSize + 1; i++) _book('item-$i', 'Book $i'),
+    ];
+
+    await _pump(tester, client: client);
+
+    final Finder loadMore = find.textContaining('Load more');
+    await tester.scrollUntilVisible(loadMore, 300);
+    expect(
+      find.text('Load more ($pageSize of ${pageSize + 1})'),
+      findsOneWidget,
+    );
+
+    await tester.tap(loadMore);
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Load more'), findsNothing);
+    expect(client.itemRequests.last.page, 1);
+  });
+
+  testWidgets('never renders the access token', (tester) async {
+    final client = FakeAudiobookshelfClient(
+      libraries: <AudiobookshelfLibraryDto>[_bookLibrary],
+    );
+    client.itemsByLibrary['lib-books'] = <AudiobookshelfLibraryItemDto>[
+      _book('item-1', 'The Hobbit'),
+    ];
+
+    await _pump(tester, client: client);
+
+    for (final Text text in tester.widgetList<Text>(find.byType(Text))) {
+      expect(text.data ?? '', isNot(contains('tok-1')));
+    }
+  });
+
+  group('formatBookDuration', () {
+    test('reads the way a listener reads a running time', () {
+      expect(formatBookDuration(null), isNull);
+      expect(formatBookDuration(Duration.zero), isNull);
+      expect(formatBookDuration(const Duration(seconds: 20)), '1m');
+      expect(formatBookDuration(const Duration(minutes: 48)), '48m');
+      expect(formatBookDuration(const Duration(hours: 3)), '3h');
+      expect(
+        formatBookDuration(const Duration(hours: 11, minutes: 42)),
+        '11h 42m',
+      );
+    });
+  });
+}

--- a/test/features/audiobooks/audiobooks_screen_test.dart
+++ b/test/features/audiobooks/audiobooks_screen_test.dart
@@ -126,8 +126,14 @@ void main() {
     final client = FakeAudiobookshelfClient(
       libraries: <AudiobookshelfLibraryDto>[_bookLibrary],
     );
-    client.itemsByLibrary['lib-books'] = <AudiobookshelfLibraryItemDto>[];
-    client.totalOverride = 5;
+    client.pagesByLibrary['lib-books'] = <AudiobookshelfLibraryItemsPage>[
+      const AudiobookshelfLibraryItemsPage(
+        items: <AudiobookshelfLibraryItemDto>[],
+        rawCount: 3,
+        total: 5,
+        page: 0,
+      ),
+    ];
 
     await _pump(tester, client: client);
 

--- a/test/features/audiobooks/audiobooks_screen_test.dart
+++ b/test/features/audiobooks/audiobooks_screen_test.dart
@@ -118,6 +118,23 @@ void main() {
     expect(find.text('No audiobooks yet'), findsOneWidget);
   });
 
+  testWidgets('a page of unreadable records keeps the rest reachable',
+      (tester) async {
+    // Every record on the first page was skipped by the parser (half-scanned
+    // books), but the server says the library has more. Calling that "empty"
+    // would strand the books on the next page.
+    final client = FakeAudiobookshelfClient(
+      libraries: <AudiobookshelfLibraryDto>[_bookLibrary],
+    );
+    client.itemsByLibrary['lib-books'] = <AudiobookshelfLibraryItemDto>[];
+    client.totalOverride = 5;
+
+    await _pump(tester, client: client);
+
+    expect(find.text('No audiobooks yet'), findsNothing);
+    expect(find.text('Load the next page'), findsOneWidget);
+  });
+
   testWidgets('a failed listing offers a retry', (tester) async {
     final client = FakeAudiobookshelfClient(
       libraries: <AudiobookshelfLibraryDto>[_bookLibrary],

--- a/test/features/settings/audiobookshelf/audiobookshelf_provider_card_test.dart
+++ b/test/features/settings/audiobookshelf/audiobookshelf_provider_card_test.dart
@@ -61,6 +61,15 @@ void main() {
     expect(find.text('Connected'), findsOneWidget);
     expect(find.text('Signed in as alice'), findsOneWidget);
     expect(find.text('Manage'), findsOneWidget);
+    // The way into the books themselves, offered only once there is a server
+    // to browse.
+    expect(find.text('Browse'), findsOneWidget);
+  });
+
+  testWidgets('offers no Browse without a connection', (tester) async {
+    await _pump(tester);
+
+    expect(find.text('Browse'), findsNothing);
   });
 
   testWidgets('Connect opens the connection form', (tester) async {


### PR DESCRIPTION
Milestone 1 on #484 is "connection + library browsing". The connection half landed in #588, so this is the browsing half: a connected Audiobookshelf server is finally something you can look at instead of just a status card.

Branched fresh off current `main`, no history from anywhere else, and the diff is only the files this needs (no editor config, no generated assets, no tooling, no unrelated cleanup).

## What's in it

**Client**

`fetchLibraryItems` on `AudiobookshelfClient`, paged and sorted on the server: `minified=1&sort=media.metadata.title&desc=0&limit&page`. Minified drops the audio files, chapters and library-file records from every entry (a listing needs none of them) and gives the pre-joined `authorName` / `narratorName` a row actually renders. Sorting server-side keeps paging consistent instead of each page being sorted on its own.

**Parsing**

`AudiobookshelfLibraryItemDto` reads both shapes a server can send: the pre-joined names from a minified page, and the `authors` / `narrators` / `series` objects from a full one, so the parser doesn't quietly depend on the query string staying exactly as it is. An entry with no id or no title is skipped rather than thrown, so one half-scanned book can't cost the rest of the page. A missing duration stays null instead of becoming an invented 0:00.

**Controller**

`AudiobooksLibraryController` picks a library (the one you last chose, then the account's default, then the first), loads the first page and appends the next on demand. Podcast libraries stay out of the audiobook browser; a library that reports no media type at all is kept rather than hidden, so an older server doesn't look empty. A response that arrives after a sign-out is dropped instead of painted over whoever owns the screen now, same guard the connection controller uses.

**Screen**

Title, author, series, narrator and running time per row, a chip picker when the account can see more than one book library, pull to refresh, "Load more" with a count, and real empty and error states instead of a blank list. A failed page keeps the books already on screen and reports itself in the footer. Nothing is tappable yet: opening a book is the domain-model milestone.

## Where it lives

Reached from the Audiobookshelf card on Settings > Connections (`/settings/audiobooks`). The navigation move, renaming Library to Music and giving Audiobooks its own destination, is its own reviewable change as agreed on the issue, and this screen moves there unchanged when it lands.

## Scope

- The music providers, the music catalog and the source preference are untouched.
- No secret reaches the widget layer: the session and its tokens stay behind the connection controller, and there's a test asserting no token string is ever rendered.
- Cover art is deliberately not in here. Fetching one needs the bearer token in the image request, and I'd rather design that seam alongside playback than smuggle a token into the widget tree for a thumbnail.

## Testing

- `flutter analyze`: clean
- `dart format --set-exit-if-changed lib test`: clean
- `flutter test`: all 4379 pass

New coverage: client parsing (both metadata shapes, skipped entries, unrecognized shape, 401, UTF-8 title with no charset header), controller (default library choice, podcast filtering, paging, library switching, failure paths, sign-out staleness), and screen (list contents, empty library, retry after failure, library switch, load more, no token rendered).

Closes nothing on its own: #484 stays open for the milestones after this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjCGo7JXSnjHC2xYDjrUgZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjCGo7JXSnjHC2xYDjrUgZ)_