### PR TITLE
Release/packaging tooling: benchmark summary polish, version sync, Flathub update process (#338, #452, #453)

### DIFF
--- a/.github/workflows/android-release-build.yml
+++ b/.github/workflows/android-release-build.yml
@@ -313,7 +313,7 @@ jobs:
       # the GitHub Actions run page reads as a release that did not build —
       # never confused with an APK build failure (the build never ran). The
       # contributor sees the same wording locally because they ran the same
-      # script (see docs/release-process.md §3 step 9). We pass --no-app-info
+      # script (see docs/release-process.md §3 step 10). We pass --no-app-info
       # here because the AppInfo drift is already covered by the CI workflow's
       # `flutter test` step (test/core/app_info_version_test.dart).
       - name: Verify the tag matches pubspec.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,18 @@ jobs:
       - name: Test the release artifact verifier
         run: python3 test/tooling/verify_release_containment_test.py
 
+      # The release version is written down in five places (pubspec, the About
+      # screen, the Play changelog, the F-Droid entry, the AppStream release
+      # entry a software centre shows). Nothing fails to build when one of them
+      # is left behind (the listing just tells people the wrong thing), so it
+      # is checked here rather than at submission time (#452). Local twin:
+      # `python3 scripts/check_release_metadata_sync.py`.
+      - name: Check release metadata is in sync
+        run: python3 scripts/check_release_metadata_sync.py
+
+      - name: Test the release metadata checker
+        run: python3 test/tooling/check_release_metadata_sync_test.py
+
   release-bump-guard:
     name: Release bump touches only version files
     runs-on: ubuntu-latest

--- a/.github/workflows/large-library-sql.yml
+++ b/.github/workflows/large-library-sql.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     paths:
       - 'tools/large_library/**'
+      - 'test/tooling/large_library_benchmark_test.py'
       - '.github/workflows/large-library-sql.yml'
   push:
     branches: [main]
     paths:
       - 'tools/large_library/**'
+      - 'test/tooling/large_library_benchmark_test.py'
       - '.github/workflows/large-library-sql.yml'
 
 permissions:
@@ -19,6 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+
+      # Cheap and offline, so it runs before the 200k fixture is built: if the
+      # summary block is broken there is no point spending minutes on timings.
+      - name: Test benchmark summary rendering
+        run: python3 test/tooling/large_library_benchmark_test.py
 
       - name: Generate 200k-track catalog
         run: >-

--- a/.github/workflows/prepare-release-bump.yml
+++ b/.github/workflows/prepare-release-bump.yml
@@ -128,6 +128,17 @@ jobs:
           chmod +x scripts/release_preflight.sh
           ./scripts/release_preflight.sh "v${VERSION_NAME}"
 
+      # Every surface that names the version has to agree before the PR is
+      # opened: the About screen, the Play changelog, the F-Droid entry and the
+      # AppStream release entry a software centre shows (#452). Local twin:
+      # `python3 scripts/check_release_metadata_sync.py`.
+      - name: Check release metadata is in sync
+        env:
+          VERSION_NAME: ${{ inputs.version_name }}
+        run: |
+          set -euo pipefail
+          python3 scripts/check_release_metadata_sync.py --tag "v${VERSION_NAME}"
+
       - name: Fail if nothing changed
         env:
           VERSION_FULL: ${{ steps.encode.outputs.full }}
@@ -154,7 +165,8 @@ jobs:
           # has the remote-tracking ref it needs; silently ignore if absent.
           git fetch origin "$BRANCH" 2>/dev/null || true
           git checkout -B "$BRANCH"
-          git add -A pubspec.yaml lib/core/app_info.dart fastlane/metadata metadata
+          git add -A pubspec.yaml lib/core/app_info.dart fastlane/metadata metadata \
+            linux/packaging
           git commit -m "chore(release): prepare v${VERSION_NAME}"
           git push --force-with-lease -u origin "$BRANCH"
 

--- a/.github/workflows/prepare-release-bump.yml
+++ b/.github/workflows/prepare-release-bump.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: boolean
         default: false
+      release_date:
+        description: "AppStream release date, YYYY-MM-DD (UTC). Empty uses the day this runs; set it when the release will be published on another day."
+        required: false
+        type: string
+        default: ""
 
 # Need write to push the release branch and open the PR. Nothing else is touched.
 permissions:
@@ -109,6 +114,7 @@ jobs:
           VERSION_NAME: ${{ inputs.version_name }}
           CHANGELOG_TEXT: ${{ inputs.changelog_text }}
           FORCE_CHANGELOG: ${{ inputs.force_changelog }}
+          RELEASE_DATE: ${{ inputs.release_date }}
         run: |
           set -euo pipefail
           args=("$VERSION_NAME")
@@ -117,6 +123,14 @@ jobs:
           fi
           if [ "${FORCE_CHANGELOG}" = "true" ]; then
             args+=("--force-changelog")
+          fi
+          # The AppStream entry records when the release is *published*, which
+          # is not necessarily the day this workflow runs: the bump PR still has
+          # to be reviewed, merged and tagged. Left empty it stamps today, and
+          # a re-run keeps whatever date is already recorded, so a release that
+          # lands later is corrected by passing the date here (#452).
+          if [ -n "${RELEASE_DATE}" ]; then
+            args+=("--release-date" "$RELEASE_DATE")
           fi
           python3 scripts/prepare_release_bump.py "${args[@]}"
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ The full index of Linthra's docs. New to the project? Start with the
 | PR security surface guard | [pr-security-guard.md](./pr-security-guard.md) |
 | F-Droid readiness | [fdroid-readiness.md](./fdroid-readiness.md) |
 | Google Play readiness | [play-store-readiness.md](./play-store-readiness.md) |
+| Flathub updates (release to published Flatpak) | [flathub-update-process.md](./flathub-update-process.md) |
 
 ## Licensing & legal
 

--- a/docs/flathub-update-process.md
+++ b/docs/flathub-update-process.md
@@ -1,0 +1,205 @@
+# From an upstream release to a Flathub update
+
+Issues: #453, #452  
+Parent: #376
+
+How a normal Linthra release becomes a reviewed Flatpak update, and who owns
+what along the way. It is written for a maintainer doing this the first time,
+so every command is spelled out.
+
+This page does **not** repeat the Android/F-Droid release steps. Cutting the
+release itself (version bump, tag, GitHub Release) is
+[release-process.md](./release-process.md); this page starts from the tag that
+already exists and ends at a published Flatpak.
+
+Related pages, each with a different job:
+
+* [flatpak-development.md](./flatpak-development.md): building, installing and
+  debugging the Flatpak on your own machine.
+* [flatpak-ci.md](./flatpak-ci.md): what the automated Flatpak build proves on
+  every packaging PR, and how to reproduce it locally.
+* [flatpak-offline-build.md](./flatpak-offline-build.md): why the sandboxed
+  build needs no network, and how that is audited.
+* [`flatpak/README.md`](../flatpak/README.md): what each packaging file is and
+  why the manifest looks the way it does.
+
+## Current state
+
+Linthra is **not on Flathub yet**. The packaging in this repository builds,
+installs and launches, and CI validates it on every packaging PR, but the
+submission itself is still open work: the submission repository (#451), the
+Flathub linter run (#449), real Linux screenshots (#437), the metadata accuracy
+pass (#450), the final permission audit (#455) and the submission (#456).
+
+So the steps below are split: everything under
+[In this repository](#1-in-this-repository-linthra) is live today and should be
+followed for every release. Everything under
+[In the Flathub repository](#2-in-the-flathub-repository) describes the shape
+of the update once #451 and #456 have landed, and should be re-read (and
+corrected) when they do.
+
+## Who owns what
+
+| Thing | Lives in | Source of truth |
+| --- | --- | --- |
+| App source, version, tag | `TheZupZup/Linthra` | `pubspec.yaml` |
+| AppStream listing (`<release>`, description, screenshots) | `TheZupZup/Linthra` | `linux/packaging/io.github.thezupzup.linthra.metainfo.xml` |
+| Desktop entry, icon | `TheZupZup/Linthra` | `linux/packaging/` |
+| Development manifest (builds the working checkout) | `TheZupZup/Linthra` | `flatpak/io.github.thezupzup.linthra.yml`, generated from `flatpak/flatpak-flutter.yml` |
+| Published manifest (builds a tagged release) | `flathub/io.github.thezupzup.linthra` (once #451 lands) | the Linthra tag it pins |
+
+The two manifests differ in exactly one thing that matters here: the one in
+this repository builds `type: dir`, the checkout you are standing in, so it has
+no version of its own to keep in step. The published one pins a Linthra git
+tag, which is what makes a Flathub update a deliberate, reviewable change
+rather than something that follows `main`.
+
+## 1. In this repository (Linthra)
+
+### 1.1 Cut the release
+
+Follow [release-process.md §3](./release-process.md#3-pre-tag-checklist). The
+version bump writes the AppStream release entry along with everything else:
+
+```sh
+python3 scripts/prepare_release_bump.py 0.2.7
+```
+
+Merge that PR, then tag, exactly as the release process describes. The tag is
+what the Flathub manifest will point at.
+
+### 1.2 Check every surface names that release
+
+```sh
+python3 scripts/check_release_metadata_sync.py --tag v0.2.7
+```
+
+This reads `pubspec.yaml`, `lib/core/app_info.dart`, the Play changelog, the
+F-Droid entry and the AppStream `<release>` list, and reports every
+disagreement at once. CI runs it on every push, so it should already be green;
+run it here because the AppStream entry is the one a software centre shows for
+the build people just installed, and a stale entry breaks nothing else.
+
+### 1.3 Regenerate the pinned sources, if the inputs changed
+
+Only needed when `.flutter-version` or `pubspec.lock` changed since the last
+release:
+
+```sh
+./scripts/regenerate_flatpak_sources.sh
+```
+
+This needs network access (it pins every dependency by URL and sha256) and
+rewrites `flatpak/io.github.thezupzup.linthra.yml` and `flatpak/generated/`.
+Commit the result in its own PR. Never hand-edit the generated manifest; see
+[`flatpak/README.md`](../flatpak/README.md#regenerating-the-pinned-sources).
+
+### 1.4 Validate the packaging metadata
+
+```sh
+python3 scripts/check_linux_runner.py
+python3 test/tooling/check_linux_runner_test.py
+
+desktop-file-validate linux/packaging/io.github.thezupzup.linthra.desktop
+appstreamcli validate linux/packaging/io.github.thezupzup.linthra.metainfo.xml
+```
+
+`check_linux_runner.py` holds the app id, binary name, window title, desktop
+entry, icon and their install steps to their real sources of truth.
+`appstreamcli validate` is the upstream AppStream check; Flathub's own linter
+is stricter, and is step 1.6.
+
+### 1.5 Build and smoke-test the Flatpak
+
+The full local sequence is in
+[flatpak-ci.md](./flatpak-ci.md#reproduce-the-build-locally). The short form,
+from `flatpak/`:
+
+```sh
+flatpak-builder --user --install-deps-from=flathub --install-deps-only \
+  --force-clean flatpak-builder-ci io.github.thezupzup.linthra.yml
+
+rm -rf -- flatpak-builder-ci repo-ci
+flatpak-builder --user --force-clean --disable-cache --disable-rofiles-fuse \
+  --repo=repo-ci flatpak-builder-ci io.github.thezupzup.linthra.yml
+
+flatpak build-update-repo repo-ci
+bash ../scripts/flatpak_launch_smoke.sh repo-ci
+```
+
+Then install it and use it as a person would, because CI cannot: play a local
+file, connect a server you actually run, check that credentials survive a
+restart. The manual list is
+[manual-test-checklist.md](./manual-test-checklist.md), and the sandbox-specific
+notes are in
+[`flatpak/README.md`](../flatpak/README.md#network-access-and-endpoint-validation).
+
+### 1.6 Run the Flathub linter
+
+Flathub runs `flatpak-builder-lint` on the submission and treats its warnings
+as failures. Wiring that into CI is #449; until that lands, run it by hand
+against the manifest and the exported repository:
+
+```sh
+flatpak run --command=flatpak-builder-lint org.flatpak.Builder \
+  manifest flatpak/io.github.thezupzup.linthra.yml
+flatpak run --command=flatpak-builder-lint org.flatpak.Builder \
+  repo flatpak/repo-ci
+```
+
+Fix what it reports in this repository, not in the Flathub one: the
+submission manifest should be a thin wrapper around packaging that is already
+clean here.
+
+## 2. In the Flathub repository
+
+Once #451 and #456 have landed, Flathub hosts
+`flathub/io.github.thezupzup.linthra`, and Linthra's entry there is a manifest
+that pins a tag of this repository instead of building a local directory.
+
+An update is then one small pull request **in that repository**:
+
+1. Point the Linthra source at the new tag (and its commit, when the manifest
+   pins one).
+2. Refresh anything else the release changed: the Flutter SDK module and the
+   pinned pub sources, if step 1.3 regenerated them.
+3. Open the PR. Flathub's build bot builds it and publishes a test build to a
+   per-PR remote.
+4. Install that test build and repeat the smoke checks from step 1.5 against
+   the artifact Flathub actually built.
+5. Get the PR reviewed and merged. Nothing here is auto-merged, and nothing in
+   this repository pushes to Flathub on its own.
+
+After it publishes, install the real thing from Flathub and confirm the version
+the About screen shows is the release you tagged, and that the software centre
+shows the `<release>` entry from step 1.1.
+
+No credentials from this repository are involved at any point. The Flathub PR
+is made with a maintainer's own GitHub account, and Flathub signs and publishes
+the build itself.
+
+## When an update goes wrong
+
+Flathub publishes from its own build of a tagged source, so a bad update is
+fixed in whichever repository actually holds the mistake.
+
+**A packaging mistake** (wrong tag, a source that no longer resolves, a
+permission that should not have changed): revert that pull request in the
+Flathub repository, which returns the published manifest to the previous
+release, and let the build bot republish. Nothing in this repository changes.
+
+**An app bug that reached the published build**: fix it upstream and cut a new
+patch release (§1), then point Flathub at the new tag. Do not rewrite the
+`<release>` entry of the version people already installed: add the new one
+above it, so the listing stays an accurate history. If the bad version needs to
+be withdrawn as well, that is a Flathub-side end-of-life/rollback request, not
+an edit to this repository.
+
+**Something is wrong but you are not sure which side**: build the tag locally
+with the development manifest (step 1.5). If it reproduces there, it is an
+upstream bug; if it only happens in the Flathub build, the difference is in the
+published manifest.
+
+Either way, prefer fixing forward with a new release over holding a broken
+build in place: users get updates from Flathub automatically, and a revert that
+pins the previous tag is itself an update.

--- a/docs/flathub-update-process.md
+++ b/docs/flathub-update-process.md
@@ -138,7 +138,8 @@ notes are in
 
 Flathub runs `flatpak-builder-lint` on the submission and treats its warnings
 as failures. Wiring that into CI is #449; until that lands, run it by hand
-against the manifest and the exported repository:
+from the repository root (step 1.5 left you in `flatpak/`), against the
+manifest and the repository it exported:
 
 ```sh
 flatpak run --command=flatpak-builder-lint org.flatpak.Builder \

--- a/docs/flatpak-development.md
+++ b/docs/flatpak-development.md
@@ -6,7 +6,7 @@ variant) without layering anything onto the host image. Everything here also
 works on Fedora Workstation and other distributions — see
 [Other distributions](#other-distributions) for the one command that differs.
 
-Three docs, three jobs:
+Four docs, four jobs:
 
 * **This page** — the contributor workflow: host tools, build, install, run,
   rebuild, clean, debug.
@@ -16,6 +16,9 @@ Three docs, three jobs:
 * [`linux-desktop.md`](./linux-desktop.md) — the **native** Flutter Linux
   build, which is a different thing with different dependencies. See
   [Native Linux vs Flatpak](#native-linux-vs-flatpak) before mixing the two.
+* [`flathub-update-process.md`](./flathub-update-process.md): how a tagged
+  Linthra release becomes a reviewed Flathub update, and which repository each
+  step happens in.
 
 > Flatpak packaging is in progress ([issue #376](https://github.com/TheZupZup/Linthra/issues/376)).
 > The committed manifest builds, installs and launches the real app with

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -343,7 +343,9 @@ NOT publish a release; those still happen manually after the PR is merged.
 The workflow refuses to run when the tag already exists locally or on origin,
 when `pubspec.yaml` is already at the requested version, when `app_info.dart`
 has no `_devVersionName` to update, or when an existing Fastlane changelog
-would be overwritten without `--force-changelog`. See
+would be overwritten without `--force-changelog` (`--keep-changelog` leaves
+written notes alone instead, for a re-run that only has to fix the other
+metadata). See
 [scripts/prepare_release_bump.py](../scripts/prepare_release_bump.py) for the
 full safety list — that is the same script the workflow invokes, so you can
 run it locally:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -400,9 +400,10 @@ the canonical source of truth for what the bump must contain.
    it must match the tag.
 4. **Add the AppStream release entry** at the top of `<releases>` in
    `linux/packaging/io.github.thezupzup.linthra.metainfo.xml`, e.g.
-   `<release version="0.1.0-alpha.31" date="2026-09-09"/>`. Newest entry first;
-   a pre-release also carries `type="development"` so a software centre does
-   not offer an alpha as the current stable build. This is the version
+   `<release version="0.1.0-alpha.31" date="2026-09-09" type="development"/>`.
+   Newest entry first; a pre-release carries `type="development"`, as above, so
+   a software centre does not offer an alpha as the current stable build, and a
+   stable release leaves the attribute off. This is the version
    GNOME Software, KDE Discover and Flathub show for the installed app. Verify
    the whole set agrees with `python3 scripts/check_release_metadata_sync.py`.
 5. **Regenerate committed generated files** (Drift `*.g.dart`) so they match the

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -307,7 +307,7 @@ the version bump in a merged PR **before** creating the tag is what stops the
 The fast path is the manual **Prepare release bump** GitHub Action
 (`.github/workflows/prepare-release-bump.yml`). It runs the same edits a
 contributor would do by hand — pubspec, in-app mirror, Fastlane changelog,
-F-Droid metadata — and opens a draft PR. It does NOT create the tag and does
+F-Droid metadata, AppStream release entry — and opens a draft PR. It does NOT create the tag and does
 NOT publish a release; those still happen manually after the PR is merged.
 
 1. **Run the workflow** — GitHub Actions ▸ *Prepare release bump* ▸ *Run workflow*.
@@ -346,9 +346,17 @@ run it locally:
 
 ```sh
 python3 scripts/prepare_release_bump.py 0.1.0-alpha.37
-# (optionally with --changelog "..." or --force-changelog)
+# (optionally with --changelog "...", --force-changelog, or --release-date)
 ./scripts/release_preflight.sh v0.1.0-alpha.37
+python3 scripts/check_release_metadata_sync.py --tag v0.1.0-alpha.37
 ```
+
+The last command is the version-drift check: it reads every file that names the
+release version (pubspec, `app_info.dart`, the Fastlane changelog, the F-Droid
+entry, the AppStream `<release>` entry a software centre shows) and reports all
+of the disagreements at once. CI runs it on every push, and the prepare
+workflow runs it before opening the PR, so a listing that still advertises last
+month's version cannot reach Flathub quietly.
 
 ### Manual flow (the long form)
 
@@ -380,46 +388,53 @@ the canonical source of truth for what the bump must contain.
    GitHub-Release body can live under `docs/release-notes/vX.Y.Z*.md` (see the
    [v0.1.0-alpha.9 notes](./release-notes/v0.1.0-alpha.9.md)); the version inside
    it must match the tag.
-4. **Regenerate committed generated files** (Drift `*.g.dart`) so they match the
+4. **Add the AppStream release entry** at the top of `<releases>` in
+   `linux/packaging/io.github.thezupzup.linthra.metainfo.xml`, e.g.
+   `<release version="0.1.0-alpha.31" date="2026-09-09"/>`. Newest entry first;
+   a pre-release also carries `type="development"` so a software centre does
+   not offer an alpha as the current stable build. This is the version
+   GNOME Software, KDE Discover and Flathub show for the installed app. Verify
+   the whole set agrees with `python3 scripts/check_release_metadata_sync.py`.
+5. **Regenerate committed generated files** (Drift `*.g.dart`) so they match the
    schema at the tagged commit — run the
    [Generate Drift files workflow](../README.md#generating-drift-files-in-ci) or
    `dart run build_runner build --delete-conflicting-outputs` locally, and commit
    the result. The committed output means the F-Droid build needs no `build_runner`
    prebuild (see [fdroid-build-recipe.md §4](./fdroid-build-recipe.md#4-reproducibility-notes)).
-5. **Open the version-bump PR and wait for CI green**
+6. **Open the version-bump PR and wait for CI green**
    (`flutter analyze`, `flutter test`, formatting) — this includes the
    version-drift test from step 2.
-6. **Confirm licensing** is still accurate if dependencies changed — re-run the
+7. **Confirm licensing** is still accurate if dependencies changed — re-run the
    [dependency & license audit](./dependency-license-audit.md).
-7. **Merge the version-bump PR.** Do **not** tag yet — see the warning box
+8. **Merge the version-bump PR.** Do **not** tag yet — see the warning box
    below.
-8. **Pull latest `main` locally** so the tag points at the merged bump:
+9. **Pull latest `main` locally** so the tag points at the merged bump:
 
    ```sh
    git checkout main
    git pull origin main
    ```
 
-9. **Run the release preflight script** — the same script the GitHub release
-   workflow runs, so any mismatch fails locally with the same wording instead
-   of wasting a tag:
+10. **Run the release preflight script** — the same script the GitHub release
+    workflow runs, so any mismatch fails locally with the same wording instead
+    of wasting a tag:
 
-   ```sh
-   ./scripts/release_preflight.sh v0.1.0-alpha.31
-   # OK: v0.1.0-alpha.31 matches pubspec.yaml version 0.1.0-alpha.31+100031.
-   # ...
-   # Next safe commands:
-   #   git tag -a v0.1.0-alpha.31 -m "Linthra 0.1.0-alpha.31"
-   #   git push origin v0.1.0-alpha.31
-   ```
+    ```sh
+    ./scripts/release_preflight.sh v0.1.0-alpha.31
+    # OK: v0.1.0-alpha.31 matches pubspec.yaml version 0.1.0-alpha.31+100031.
+    # ...
+    # Next safe commands:
+    #   git tag -a v0.1.0-alpha.31 -m "Linthra 0.1.0-alpha.31"
+    #   git push origin v0.1.0-alpha.31
+    ```
 
-   The preflight is pure bash — it needs **no** Flutter/Dart toolchain. It
-   checks the same things CI checks: tag shape, canonical `versionCode`,
-   `pubspec.yaml` `version:`, and (locally — CI's `flutter test` already
-   covers it) `AppInfo._devVersionName`. On any mismatch it prints the
-   pushed tag, the expected `pubspec.yaml` version, the actual `pubspec.yaml`
-   version, and the exact fix; nothing is tagged.
-10. **Create the annotated tag (§2)** — `vX.Y.Z(-suffix.N)` must equal the
+    The preflight is pure bash — it needs **no** Flutter/Dart toolchain. It
+    checks the same things CI checks: tag shape, canonical `versionCode`,
+    `pubspec.yaml` `version:`, and (locally — CI's `flutter test` already
+    covers it) `AppInfo._devVersionName`. On any mismatch it prints the
+    pushed tag, the expected `pubspec.yaml` version, the actual `pubspec.yaml`
+    version, and the exact fix; nothing is tagged.
+11. **Create the annotated tag (§2)** — `vX.Y.Z(-suffix.N)` must equal the
     `versionName` you set in `pubspec.yaml` (step 2). The tag build re-verifies
     the match (§4) and fails fast if they diverge.
 
@@ -428,11 +443,11 @@ the canonical source of truth for what the bump must contain.
     git push origin v0.1.0-alpha.31
     ```
 
-11. **Watch GitHub Actions.** The Android Release Build workflow runs
+12. **Watch GitHub Actions.** The Android Release Build workflow runs
     automatically on a `v*` tag push, re-verifies `pubspec.yaml` matches the
     tag (§4), builds the APK/AAB, and attaches them to a Release (pre-release
     for alpha/beta/rc; existing Release only for stable).
-12. **Install the APK and smoke-test** the build before announcing.
+13. **Install the APK and smoke-test** the build before announcing.
 
 > **Warnings (the "lost-tag" failure mode).**
 >
@@ -714,8 +729,8 @@ consume our signed artifacts:
 | Dependency-update PR touches only `pubspec.lock` | **Automatic** on `deps/*` PRs only (`ci.yml`, job `dependency-guard`; `scripts/check_dependency_update_files.sh`). |
 | Debug APK build + build-output verification | Manual (`workflow_dispatch`) + on PRs (`android-debug-apk.yml`; a "Verify build output exists" step rejects a missing/empty APK). |
 | Release APK/AAB build | **Manual** (`workflow_dispatch`) **and automatic on `v*` tags** (`android-release-build.yml`). |
-| Preparing the version-bump PR (pubspec, in-app mirror, Fastlane changelog, F-Droid `CurrentVersion`) | **Manual** (`workflow_dispatch`, `prepare-release-bump.yml`); opens a draft PR but never tags, builds, or publishes. The same edits are reproducible locally with `scripts/prepare_release_bump.py`. |
-| Verifying the tag matches `pubspec.yaml` (versionName/versionCode) | **Automatic** on a `v*` tag build (`scripts/release_preflight.sh`, encoding-checked against `tool/version_from_tag.dart`); fails fast on a mismatch and the workflow summary explicitly says "Version mismatch: release was not built." so it is not confused with an APK build failure. The same script is intended to be run locally before tagging (§3 step 9). Both manual and tag builds take the version from `pubspec.yaml`. |
+| Preparing the version-bump PR (pubspec, in-app mirror, Fastlane changelog, F-Droid `CurrentVersion`, AppStream `<release>`) | **Manual** (`workflow_dispatch`, `prepare-release-bump.yml`); opens a draft PR but never tags, builds, or publishes. The same edits are reproducible locally with `scripts/prepare_release_bump.py`. |
+| Verifying the tag matches `pubspec.yaml` (versionName/versionCode) | **Automatic** on a `v*` tag build (`scripts/release_preflight.sh`, encoding-checked against `tool/version_from_tag.dart`); fails fast on a mismatch and the workflow summary explicitly says "Version mismatch: release was not built." so it is not confused with an APK build failure. The same script is intended to be run locally before tagging (§3 step 10). Both manual and tag builds take the version from `pubspec.yaml`. |
 | Verifying the shipped artifacts carry the Cast containment | **Automatic**: on every release build (`android-release-build.yml`, before the artifacts are uploaded) and again on the published assets during a stable publication (`publish-stable-release.yml`, which records every SHA-256 in the job summary). Local twin: `python3 scripts/verify_release_containment.py dist/*.apk dist/*.aab`. See [release-artifact-verification.md](./release-artifact-verification.md). |
 | Attaching APK/AAB to a Release | **Automatic** on a `v*` tag build. Alpha/beta/rc tags attach (debug- or release-signed) to a **pre-release**; stable tags attach **release-signed** assets to an existing Release only. |
 | Linux `.tar.gz` build + attach to a Release | **Automatic**, via `workflow_dispatch` (`linux-desktop-build.yml` `release_tag` input, job `package-linux-release`) — see §4a. `publish-stable-release.yml` dispatches it for every stable release; `android-release-build.yml`'s `attach-release` job dispatches it for a directly-pushed alpha/beta/rc tag. Not wired to `push: tags` or `release: published` — a `GITHUB_TOKEN`-authored tag push/Release doesn't reliably start either. |
@@ -763,7 +778,7 @@ checks (`test/core/app_info_version_test.dart`); the cross-file F-Droid
 invariants — monotonic `versionCode`, per-ABI `base*10 + rank`, stable release
 asset names, tracked `pubspec.lock` (`test/tooling/fdroid_release_guardrails_test.dart`);
 and the tag↔`pubspec.yaml` preflight (`scripts/release_preflight.sh`, run on a
-`v*` tag and locally before tagging — §3 step 9, §4).
+`v*` tag and locally before tagging — §3 step 10, §4).
 
 - **Lockfile drift** — `flutter pub get --enforce-lockfile` (CI `flutter` job;
   also in `scripts/verify_android.sh` and `android-debug-apk.yml`). Fails if a

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -315,7 +315,11 @@ NOT publish a release; those still happen manually after the PR is merged.
    and paste a hand-written **changelog text**. For a **stable** release (e.g.
    `v0.1.1`) do **not** leave the changelog empty: the empty-input default is an
    alpha-worded, "not on F-Droid yet" maintenance note that is wrong for a stable,
-   on-F-Droid release.
+   on-F-Droid release. **Release date** is optional and only feeds the AppStream
+   `<release>` entry: leave it empty to stamp the day the workflow runs, or set
+   it when you already know the release will be published on another day. A
+   re-run keeps a date that is already recorded, so correcting one afterwards
+   means passing the intended date explicitly.
 2. **Review the generated PR** (`chore(release): prepare v0.1.0-alpha.37`).
    Confirm the computed `versionCode`, the updated files, and the changelog
    body. Edit the changelog in the PR if you want to refine it.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -330,6 +330,10 @@ NOT publish a release; those still happen manually after the PR is merged.
    resulting APK and smoke-test.
 8. **Update `fdroiddata`** to the new tag/version if the F-Droid submission has
    landed (see [fdroid-submission.md](./fdroid-submission.md)).
+9. **Update the Flatpak/Flathub packaging** from the same tag once Linthra is
+   on Flathub (see
+   [flathub-update-process.md](./flathub-update-process.md)). The version bump
+   in step 1 already wrote the AppStream release entry that listing shows.
 
 > **The workflow never creates the tag.** The tag is created only after the
 > bump PR is merged. Never publish a release tag before the bump PR is

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -158,7 +158,9 @@ connections for user-configured Jellyfin, Navidrome/Subsonic, and Plex servers.
 The full contributor workflow — host tools, build, install, run, rebuild,
 clean/uninstall and debugging, written for Fedora Atomic (Kinoite/Silverblue)
 and usable anywhere else — is
-[docs/flatpak-development.md](../docs/flatpak-development.md). The short
+[docs/flatpak-development.md](../docs/flatpak-development.md). Turning a tagged
+release into a published Flatpak is a different walk, in
+[docs/flathub-update-process.md](../docs/flathub-update-process.md). The short
 version, run from this directory:
 
 ```bash

--- a/linux/packaging/io.github.thezupzup.linthra.metainfo.xml
+++ b/linux/packaging/io.github.thezupzup.linthra.metainfo.xml
@@ -21,8 +21,16 @@
   Screenshots are omitted until there are Linux captures; inventing them from
   the Android set would misrepresent the desktop window.
 
+  The <releases> list is maintained by scripts/prepare_release_bump.py, which
+  adds this release's entry when it bumps pubspec.yaml, and it is held to the
+  rest of the release metadata (pubspec, About screen, Play changelog, F-Droid
+  entry) by scripts/check_release_metadata_sync.py, which CI runs on every push
+  (#452). Newest entry first; a pre-release carries type="development" so a
+  software centre does not offer an alpha as the current stable build.
+
   Validate after editing:
     appstreamcli validate linux/packaging/io.github.thezupzup.linthra.metainfo.xml
+    python3 scripts/check_release_metadata_sync.py
 -->
 <component type="desktop-application">
   <id>io.github.thezupzup.linthra</id>

--- a/scripts/check_release_bump_files.sh
+++ b/scripts/check_release_bump_files.sh
@@ -4,12 +4,13 @@
 # a version bump is supposed to touch.
 #
 # The "Prepare release bump" workflow (and its local twin
-# scripts/prepare_release_bump.py) edits exactly four files:
+# scripts/prepare_release_bump.py) edits exactly these files:
 #
 #   * pubspec.yaml                                            (version: line)
 #   * lib/core/app_info.dart                                  (_devVersionName)
 #   * fastlane/metadata/android/en-US/changelogs/<code>.txt   (Fastlane changelog)
 #   * metadata/io.github.thezupzup.linthra.yml                (F-Droid Current*)
+#   * linux/packaging/<app-id>.metainfo.xml                   (AppStream release)
 #
 # A release-bump PR that also carries an unrelated source/UI change is almost
 # always a mistake: those changes belong in their own PR so the release commit
@@ -56,6 +57,7 @@ is_allowed() {
     pubspec.yaml|pubspec.lock|\
     lib/core/app_info.dart|\
     metadata/io.github.thezupzup.linthra.yml|\
+    linux/packaging/*.metainfo.xml|\
     fastlane/metadata/android/*/changelogs/*.txt|\
     docs/release-notes/*)
       return 0 ;;
@@ -86,6 +88,7 @@ fi
   echo "  - pubspec.yaml, pubspec.lock"
   echo "  - lib/core/app_info.dart"
   echo "  - metadata/io.github.thezupzup.linthra.yml"
+  echo "  - linux/packaging/<app-id>.metainfo.xml"
   echo "  - fastlane/metadata/android/<locale>/changelogs/<versionCode>.txt"
   echo "  - docs/release-notes/**"
   echo

--- a/scripts/check_release_metadata_sync.py
+++ b/scripts/check_release_metadata_sync.py
@@ -224,29 +224,50 @@ def check_appstream(root, version_name):
     return problems
 
 
+def _source_entry(text, start):
+    """The rest of the YAML list item that begins before `start`.
+
+    Bounded at the next `- ` item so a key is never read out of the following
+    source: the Flutter SDK source right below Linthra's carries a `tag:` of
+    its own, and picking that one up would report a confident, wrong version.
+    """
+    tail = text[start:]
+    next_item = re.search(r"^[ \t]*-[ \t]", tail, flags=re.MULTILINE)
+    return tail[: next_item.start()] if next_item else tail
+
+
 def check_flatpak_manifest(root, version_name):
     """Guard the day the manifest stops building the working checkout.
 
-    The committed manifest builds `type: dir` — the checkout itself — so its
+    The committed manifest builds `type: dir`, the checkout itself, so its
     source version *is* the pubspec version and cannot drift. A Flathub
     submission manifest (#451) pins Linthra's own git tag instead, and that one
     can point at last month's release while everything else says otherwise. So
     the check is conditional: it only fires once such a source exists.
+
+    A Linthra source with no tag at all is reported rather than skipped. It is
+    the same failure in its quietest form: nothing then says which release the
+    manifest builds, and a check that stayed silent about it would be claiming
+    a synchronization it never established.
     """
     text = _read(root, FLATPAK_MANIFEST)
     if text is None:
         return []
     problems = []
     for match in re.finditer(
-        r"url:\s*\S*github\.com/TheZupZup/Linthra(?:\.git)?\s*$",
+        r"^[ \t]*(?:-[ \t]*)?url:[ \t]*\S*github\.com/TheZupZup/Linthra(?:\.git)?[ \t]*$",
         text,
         flags=re.MULTILINE | re.IGNORECASE,
     ):
-        tail = text[match.end() : match.end() + 400]
-        tag = re.search(r"^\s*tag:\s*'?\"?(?P<tag>[^'\"\s]+)", tail, re.MULTILINE)
-        if tag is None:
-            continue
+        entry = _source_entry(text, match.end())
+        tag = re.search(r"^\s*tag:\s*'?\"?(?P<tag>[^'\"\s]+)", entry, re.MULTILINE)
         expected = "v{}".format(version_name)
+        if tag is None:
+            problems.append(
+                "{}: the Linthra source has no tag:, so nothing says which "
+                "release it builds; pin {}.".format(FLATPAK_MANIFEST, expected)
+            )
+            continue
         if tag.group("tag") not in (expected, version_name):
             problems.append(
                 "{}: the Linthra source is pinned to {}, expected {}.".format(

--- a/scripts/check_release_metadata_sync.py
+++ b/scripts/check_release_metadata_sync.py
@@ -322,8 +322,13 @@ def main(argv=None):
         print(file=sys.stderr)
         print(
             "Fix: python3 scripts/prepare_release_bump.py <version>\n"
-            "     (writes pubspec, app_info, the Fastlane changelog, the "
-            "F-Droid metadata and the AppStream release entry)",
+            "     writes pubspec, app_info, the Fastlane changelog, the "
+            "F-Droid\n"
+            "     metadata and the AppStream release entry. Add "
+            "--keep-changelog when\n"
+            "     the release notes are already written: without it the script\n"
+            "     refuses rather than touch them, and the rest of the metadata\n"
+            "     stays unfixed.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/check_release_metadata_sync.py
+++ b/scripts/check_release_metadata_sync.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""check_release_metadata_sync.py: one release version, everywhere (#452).
+
+A Linthra release version is written down in five places, and every one of them
+is read by something different:
+
+  * pubspec.yaml                      `version: NAME+CODE`, the source of truth
+  * lib/core/app_info.dart            what the About screen shows
+  * fastlane/.../changelogs/CODE.txt  what Google Play shows
+  * metadata/<app-id>.yml             what F-Droid's update checker compares
+  * linux/packaging/*.metainfo.xml    what software centres and Flathub show
+
+They drift silently. Nothing fails to build when the AppStream `<release>` entry
+still names last month's version: the Flatpak builds, installs and runs, and a
+software centre simply tells everyone the wrong thing about what they just
+installed. Flathub then carries that listing.
+
+So this script reads all five and reports every disagreement at once, with the
+command that fixes them (`scripts/prepare_release_bump.py`, which writes all
+five). It is read-only: it never edits a file, never runs git, and makes no
+network calls.
+
+Usage
+-----
+
+    python3 scripts/check_release_metadata_sync.py
+    python3 scripts/check_release_metadata_sync.py --tag v0.2.6
+    python3 scripts/check_release_metadata_sync.py --repo-root /path/to/checkout
+
+`--tag` additionally asserts the tag about to be pushed is the one the
+repository is prepared for; without it the pubspec version is the reference.
+Exit code 0 means everything agrees, 1 means it does not.
+
+The version-to-versionCode encoding and the F-Droid VercodeOperation transform
+are imported from prepare_release_bump.py rather than re-implemented, so the
+check and the fix can never disagree about the rules.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from prepare_release_bump import (
+    VersionError,
+    appstream_releases,
+    fdroid_current_version_code,
+    is_prerelease,
+    parse_release_date,
+    version_from_tag,
+)
+
+APP_ID = "io.github.thezupzup.linthra"
+
+PUBSPEC = Path("pubspec.yaml")
+APP_INFO = Path("lib/core/app_info.dart")
+FDROID = Path("metadata") / f"{APP_ID}.yml"
+METAINFO = Path("linux/packaging") / f"{APP_ID}.metainfo.xml"
+FLATPAK_MANIFEST = Path("flatpak") / f"{APP_ID}.yml"
+
+_PUBSPEC_VERSION = re.compile(r"^version:\s*(\S+)\s*$", re.MULTILINE)
+_DEV_VERSION_NAME = re.compile(r"_devVersionName\s*=\s*'([^']*)'")
+_FDROID_CURRENT_VERSION = re.compile(r"^CurrentVersion:\s*(\S+)\s*$", re.MULTILINE)
+_FDROID_CURRENT_CODE = re.compile(r"^CurrentVersionCode:\s*(\d+)\s*$", re.MULTILINE)
+
+
+def pubspec_version(text):
+    """Return (versionName, versionCode) from a pubspec `version:` line."""
+    match = _PUBSPEC_VERSION.search(text)
+    if match is None:
+        raise VersionError("pubspec.yaml has no `version:` line.")
+    raw = match.group(1)
+    if "+" not in raw:
+        raise VersionError(
+            'pubspec.yaml version "{}" has no "+versionCode" suffix.'.format(raw)
+        )
+    name, _, code = raw.partition("+")
+    if not code.isdigit():
+        raise VersionError(
+            'pubspec.yaml versionCode "{}" is not a number.'.format(code)
+        )
+    return name, int(code)
+
+
+def _read(root, relative):
+    path = root / relative
+    if not path.exists():
+        return None
+    return path.read_text()
+
+
+def check_app_info(root, version_name):
+    text = _read(root, APP_INFO)
+    if text is None:
+        return ["{} is missing.".format(APP_INFO)]
+    match = _DEV_VERSION_NAME.search(text)
+    if match is None:
+        return ["{} has no _devVersionName declaration.".format(APP_INFO)]
+    if match.group(1) != version_name:
+        return [
+            "{}: _devVersionName is {}, expected {} (the About screen would "
+            "show the wrong version).".format(APP_INFO, match.group(1), version_name)
+        ]
+    return []
+
+
+def check_changelog(root, version_code):
+    relative = Path(
+        "fastlane/metadata/android/en-US/changelogs/{}.txt".format(version_code)
+    )
+    path = root / relative
+    if not path.exists():
+        return [
+            "{} is missing (Play would ship this release with no release "
+            "notes).".format(relative)
+        ]
+    if not path.read_text().strip():
+        return ["{} is empty.".format(relative)]
+    return []
+
+
+def check_fdroid(root, version_name, version_code):
+    text = _read(root, FDROID)
+    if text is None:
+        # Not every checkout carries the draft F-Droid entry.
+        return []
+    problems = []
+    current = _FDROID_CURRENT_VERSION.search(text)
+    if current is None:
+        problems.append("{} has no CurrentVersion line.".format(FDROID))
+    elif current.group(1) != version_name:
+        problems.append(
+            "{}: CurrentVersion is {}, expected {}.".format(
+                FDROID, current.group(1), version_name
+            )
+        )
+
+    code = _FDROID_CURRENT_CODE.search(text)
+    expected = fdroid_current_version_code(text, version_code)
+    if code is None:
+        problems.append("{} has no CurrentVersionCode line.".format(FDROID))
+    elif int(code.group(1)) != expected:
+        problems.append(
+            "{}: CurrentVersionCode is {}, expected {} (versionCode {} through "
+            "the declared VercodeOperation).".format(
+                FDROID, code.group(1), expected, version_code
+            )
+        )
+    return problems
+
+
+def check_appstream(root, version_name):
+    """The listing half: newest entry first, and it names this release."""
+    text = _read(root, METAINFO)
+    if text is None:
+        return []
+    releases = appstream_releases(text)
+    if releases is None:
+        return ["{} has no <releases> block.".format(METAINFO)]
+    if not releases:
+        return ["{}: <releases> is empty.".format(METAINFO)]
+
+    problems = []
+    seen = set()
+    previous_code = None
+    for _, attributes in releases:
+        version = attributes.get("version")
+        if not version:
+            problems.append("{}: a <release> entry has no version.".format(METAINFO))
+            continue
+        if version in seen:
+            problems.append("{}: version {} is listed twice.".format(METAINFO, version))
+        seen.add(version)
+
+        try:
+            _, code = version_from_tag(version)
+        except VersionError:
+            problems.append(
+                "{}: release version {} is not a Linthra release version.".format(
+                    METAINFO, version
+                )
+            )
+            continue
+
+        date = attributes.get("date")
+        if not date:
+            problems.append("{}: release {} has no date.".format(METAINFO, version))
+        else:
+            try:
+                parse_release_date(date)
+            except VersionError as err:
+                problems.append("{}: release {}: {}".format(METAINFO, version, err))
+
+        # A pre-release offered as the current stable build is how an alpha
+        # ends up installed by someone who wanted a release.
+        development = attributes.get("type") == "development"
+        if is_prerelease(version) and not development:
+            problems.append(
+                '{}: release {} is a pre-release and needs type="development".'.format(
+                    METAINFO, version
+                )
+            )
+        if not is_prerelease(version) and development:
+            problems.append(
+                "{}: release {} is a stable version but is marked "
+                'type="development".'.format(METAINFO, version)
+            )
+
+        if previous_code is not None and code >= previous_code:
+            problems.append(
+                "{}: release {} is listed after a lower version; entries must "
+                "be newest first.".format(METAINFO, version)
+            )
+        previous_code = code
+
+    newest = releases[0][1].get("version")
+    if newest != version_name:
+        problems.append(
+            "{}: newest <release> is {}, expected {} (software centres and "
+            "Flathub read this entry).".format(METAINFO, newest, version_name)
+        )
+    return problems
+
+
+def check_flatpak_manifest(root, version_name):
+    """Guard the day the manifest stops building the working checkout.
+
+    The committed manifest builds `type: dir` — the checkout itself — so its
+    source version *is* the pubspec version and cannot drift. A Flathub
+    submission manifest (#451) pins Linthra's own git tag instead, and that one
+    can point at last month's release while everything else says otherwise. So
+    the check is conditional: it only fires once such a source exists.
+    """
+    text = _read(root, FLATPAK_MANIFEST)
+    if text is None:
+        return []
+    problems = []
+    for match in re.finditer(
+        r"url:\s*\S*github\.com/TheZupZup/Linthra(?:\.git)?\s*$",
+        text,
+        flags=re.MULTILINE | re.IGNORECASE,
+    ):
+        tail = text[match.end() : match.end() + 400]
+        tag = re.search(r"^\s*tag:\s*'?\"?(?P<tag>[^'\"\s]+)", tail, re.MULTILINE)
+        if tag is None:
+            continue
+        expected = "v{}".format(version_name)
+        if tag.group("tag") not in (expected, version_name):
+            problems.append(
+                "{}: the Linthra source is pinned to {}, expected {}.".format(
+                    FLATPAK_MANIFEST, tag.group("tag"), expected
+                )
+            )
+    return problems
+
+
+def check(root, tag=None):
+    """Return every disagreement found, as user-readable lines."""
+    pubspec = _read(root, PUBSPEC)
+    if pubspec is None:
+        return ["{} is missing; is --repo-root a Linthra checkout?".format(PUBSPEC)]
+
+    version_name, version_code = pubspec_version(pubspec)
+    expected_name, expected_code = version_from_tag(version_name)
+
+    problems = []
+    if expected_code != version_code:
+        problems.append(
+            "pubspec.yaml: versionCode is {}, expected {} for version {}.".format(
+                version_code, expected_code, version_name
+            )
+        )
+    if tag is not None:
+        tag_name, _ = version_from_tag(tag)
+        if tag_name != expected_name:
+            problems.append(
+                "tag {} does not match pubspec version {}.".format(tag, version_name)
+            )
+
+    problems += check_app_info(root, version_name)
+    problems += check_changelog(root, version_code)
+    problems += check_fdroid(root, version_name, version_code)
+    problems += check_appstream(root, version_name)
+    problems += check_flatpak_manifest(root, version_name)
+    return problems
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check that pubspec, About screen, Play changelog, F-Droid "
+            "metadata and the AppStream listing all name the same release."
+        )
+    )
+    parser.add_argument(
+        "--tag",
+        default="",
+        help="Release tag to check against, e.g. v0.2.6 (default: none).",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="Repository root (default: the checkout this script lives in).",
+    )
+    args = parser.parse_args(argv)
+
+    root = args.repo_root.resolve()
+    try:
+        problems = check(root, args.tag or None)
+    except VersionError as err:
+        print("ERROR: {}".format(err), file=sys.stderr)
+        return 1
+
+    if problems:
+        print("ERROR: release metadata disagrees about the version:", file=sys.stderr)
+        print(file=sys.stderr)
+        for problem in problems:
+            print("  - {}".format(problem), file=sys.stderr)
+        print(file=sys.stderr)
+        print(
+            "Fix: python3 scripts/prepare_release_bump.py <version>\n"
+            "     (writes pubspec, app_info, the Fastlane changelog, the "
+            "F-Droid metadata and the AppStream release entry)",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("OK: every release surface names the same version.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/prepare_release_bump.py
+++ b/scripts/prepare_release_bump.py
@@ -333,7 +333,14 @@ _RELEASES_BLOCK = re.compile(
     r"(?P<indent>[ \t]*)<releases>[ \t]*\r?\n(?P<body>.*?)(?P<closing>[ \t]*</releases>)",
     re.DOTALL,
 )
-_RELEASE_ENTRY = re.compile(r"<release\b[^>]*?/?>")
+# A release entry is either self-closing or a pair wrapping child elements
+# (AppStream allows a <description>, <url>, <issues> inside one). Matching
+# the whole element means an entry with children is seen once, and can be
+# rewritten without leaving its children orphaned.
+_RELEASE_ENTRY = re.compile(
+    r"<release\b[^>]*?/>|<release\b[^>]*?>.*?</release\s*>", re.DOTALL
+)
+_RELEASE_OPEN_TAG = re.compile(r"<release\b[^>]*?/?>")
 _ATTRIBUTE = re.compile(r'([A-Za-z_:][-\w:.]*)\s*=\s*"([^"]*)"')
 
 
@@ -363,7 +370,8 @@ def parse_release_date(value):
 def appstream_releases(text):
     """Return the `<release .../>` entries of an AppStream document, in order.
 
-    Each entry is `(raw_tag, attributes)`. Returns None when the document has no
+    Each entry is `(element, attributes)`, the attributes being those of its
+    opening tag. Returns None when the document has no
     `<releases>` block at all, so a caller can tell "no releases listed" from
     "this file is not shaped the way we think it is".
     """
@@ -371,21 +379,22 @@ def appstream_releases(text):
     if block is None:
         return None
     return [
-        (tag, dict(_ATTRIBUTE.findall(tag)))
-        for tag in _RELEASE_ENTRY.findall(block.group("body"))
+        (element, dict(_ATTRIBUTE.findall(_RELEASE_OPEN_TAG.match(element).group(0))))
+        for element in _RELEASE_ENTRY.findall(block.group("body"))
     ]
 
 
-def _release_entry(version_name, release_date):
-    """The `<release/>` tag for one release.
+def _release_entry(version_name, release_date, self_closing=True):
+    """The `<release>` tag for one release.
 
     Pre-releases are marked `type="development"` so a software centre does not
-    offer an alpha as if it were the current stable build.
+    offer an alpha as if it were the current stable build. `self_closing` is
+    False when the tag opens an element that has children to keep.
     """
     attributes = 'version="{}" date="{}"'.format(version_name, release_date)
     if is_prerelease(version_name):
         attributes += ' type="development"'
-    return "<release {}/>".format(attributes)
+    return "<release {}{}>".format(attributes, "/" if self_closing else "")
 
 
 def update_appstream_release(path, version_name, release_date):
@@ -426,10 +435,14 @@ def update_appstream_release(path, version_name, release_date):
     # The date already in the file wins over today: it is the date that release
     # was published, and only an explicit --release-date may rewrite it.
     date = release_date or existing_attributes.get("date") or today_utc()
-    entry = _release_entry(version_name, date)
     if existing is not None:
-        new_body = body.replace(existing, entry, 1)
+        # Rewrite the attributes, not the element: an entry that wraps a
+        # <description> keeps it, and the file stays well-formed XML.
+        open_tag = _RELEASE_OPEN_TAG.match(existing).group(0)
+        entry = _release_entry(version_name, date, self_closing=open_tag.endswith("/>"))
+        new_body = body.replace(existing, existing.replace(open_tag, entry, 1), 1)
     else:
+        entry = _release_entry(version_name, date)
         indent = _entry_indent(body, block.group("indent"))
         new_body = "{}{}\n{}".format(indent, entry, body)
 

--- a/scripts/prepare_release_bump.py
+++ b/scripts/prepare_release_bump.py
@@ -22,6 +22,7 @@ Usage:
     python3 scripts/prepare_release_bump.py 0.1.0-alpha.37 \
         --changelog "Linthra 0.1.0-alpha.37 — fixed X."
     python3 scripts/prepare_release_bump.py 0.1.0-alpha.37 --force-changelog
+    python3 scripts/prepare_release_bump.py 0.1.0-alpha.37 --keep-changelog
     python3 scripts/prepare_release_bump.py 0.1.0-alpha.37 --release-date 2026-09-09
 
 Drift between all of those (and the release tag) is checked by
@@ -175,18 +176,26 @@ def default_changelog(version_name):
     ).format(name=version_name)
 
 
-def create_changelog(path, version_name, body, allow_overwrite):
+def create_changelog(path, version_name, body, allow_overwrite, keep_existing):
     """Write the Fastlane changelog at `path`.
 
     Returns True if the file was created or changed. Raises if the file already
     exists with different content and `allow_overwrite` is False — the workflow
     must opt into clobbering an existing changelog.
+
+    `keep_existing` leaves a changelog that is already there exactly as it is.
+    That is what a re-run needs when the release notes were written by hand and
+    something *else* (the AppStream entry, the F-Droid code) still has to be
+    fixed: without it the only ways through are failing here or overwriting
+    real notes with the generated default.
     """
     raw = body if body else default_changelog(version_name)
     content = raw.rstrip() + "\n"
     if path.exists():
         existing = path.read_text()
         if existing == content:
+            return False
+        if keep_existing:
             return False
         if not allow_overwrite:
             raise VersionError(
@@ -336,6 +345,11 @@ def is_prerelease(version_name):
     return match.group(4) is not None
 
 
+def today_utc():
+    """Today's date in UTC, so two machines bumping at once agree."""
+    return dt.datetime.now(dt.timezone.utc).date().isoformat()
+
+
 def parse_release_date(value):
     """Validate a YYYY-MM-DD release date and return it normalised."""
     try:
@@ -379,8 +393,13 @@ def update_appstream_release(path, version_name, release_date):
 
     Newest first, which is the order the file already uses and the order
     software centres read. An entry that already names `version_name` is
-    rewritten in place (date, development marker) rather than duplicated, so
-    re-running the script is safe.
+    rewritten in place rather than duplicated, so re-running the script is
+    safe.
+
+    `release_date` is the date to record, or None to stamp a *new* entry with
+    today (UTC) and leave an entry that is already there on the date it has. A
+    release that already shipped therefore keeps its published date through a
+    re-run on another day; changing one is a deliberate --release-date.
 
     Returns True if the file changed. A missing file returns False silently, as
     with the F-Droid metadata: a checkout may not carry the Linux packaging.
@@ -396,15 +415,18 @@ def update_appstream_release(path, version_name, release_date):
         )
 
     body = block.group("body")
-    entry = _release_entry(version_name, release_date)
-    existing = next(
+    existing, existing_attributes = next(
         (
-            tag
+            (tag, attributes)
             for tag, attributes in appstream_releases(text)
             if attributes.get("version") == version_name
         ),
-        None,
+        (None, {}),
     )
+    # The date already in the file wins over today: it is the date that release
+    # was published, and only an explicit --release-date may rewrite it.
+    date = release_date or existing_attributes.get("date") or today_utc()
+    entry = _release_entry(version_name, date)
     if existing is not None:
         new_body = body.replace(existing, entry, 1)
     else:
@@ -433,7 +455,14 @@ def _rel(repo, path):
         return str(path)
 
 
-def prepare(repo, raw_version, changelog_body, allow_overwrite, release_date):
+def prepare(
+    repo,
+    raw_version,
+    changelog_body,
+    allow_overwrite,
+    keep_changelog,
+    release_date,
+):
     """Run the full bump against `repo`. Returns (versionName, code, changed)."""
     if raw_version.startswith("v"):
         raise VersionError(
@@ -474,7 +503,9 @@ def prepare(repo, raw_version, changelog_body, allow_overwrite, release_date):
         changed.append(_rel(repo, pubspec))
     if update_app_info(app_info, version_name):
         changed.append(_rel(repo, app_info))
-    if create_changelog(changelog, version_name, changelog_body, allow_overwrite):
+    if create_changelog(
+        changelog, version_name, changelog_body, allow_overwrite, keep_changelog
+    ):
         changed.append(_rel(repo, changelog))
     if update_fdroid_metadata(fdroid, version_name, version_code):
         changed.append(_rel(repo, fdroid))
@@ -506,6 +537,14 @@ def main(argv=None):
         help="Overwrite the Fastlane changelog if it already exists.",
     )
     parser.add_argument(
+        "--keep-changelog",
+        action="store_true",
+        help=(
+            "Leave an existing Fastlane changelog alone instead of failing. "
+            "Use to repair other metadata without touching written notes."
+        ),
+    )
+    parser.add_argument(
         "--release-date",
         default="",
         help=(
@@ -522,16 +561,25 @@ def main(argv=None):
 
     repo = args.repo_root.resolve()
     try:
+        if args.keep_changelog and args.force_changelog:
+            raise VersionError(
+                "--keep-changelog and --force-changelog contradict each other; "
+                "pass one."
+            )
+        if args.keep_changelog and args.changelog:
+            raise VersionError(
+                "--keep-changelog leaves the existing changelog alone, so "
+                "--changelog would be ignored; pass one."
+            )
         release_date = (
-            parse_release_date(args.release_date)
-            if args.release_date
-            else dt.datetime.now(dt.timezone.utc).date().isoformat()
+            parse_release_date(args.release_date) if args.release_date else None
         )
         version_name, version_code, changed = prepare(
             repo,
             args.version,
             args.changelog,
             args.force_changelog,
+            args.keep_changelog,
             release_date,
         )
     except VersionError as err:

--- a/scripts/prepare_release_bump.py
+++ b/scripts/prepare_release_bump.py
@@ -7,6 +7,7 @@ Updates every file that must agree on the release version:
   * lib/core/app_info.dart                                  (`_devVersionName`)
   * fastlane/metadata/android/en-US/changelogs/<code>.txt   (Fastlane changelog)
   * metadata/io.github.thezupzup.linthra.yml                (F-Droid CurrentVersion/Code)
+  * linux/packaging/<app-id>.metainfo.xml                   (AppStream <release>)
 
 Then prints the next safe command — the release preflight — so a contributor
 running the script locally sees the same workflow the GitHub Action runs.
@@ -21,6 +22,10 @@ Usage:
     python3 scripts/prepare_release_bump.py 0.1.0-alpha.37 \
         --changelog "Linthra 0.1.0-alpha.37 — fixed X."
     python3 scripts/prepare_release_bump.py 0.1.0-alpha.37 --force-changelog
+    python3 scripts/prepare_release_bump.py 0.1.0-alpha.37 --release-date 2026-09-09
+
+Drift between all of those (and the release tag) is checked by
+scripts/check_release_metadata_sync.py, which CI runs on every push.
 
 The version-to-versionCode encoding mirrors tool/version_from_tag.dart and
 scripts/release_preflight.sh; see docs/release-process.md §1.
@@ -29,6 +34,7 @@ scripts/release_preflight.sh; see docs/release-process.md §1.
 from __future__ import annotations
 
 import argparse
+import datetime as dt
 import re
 import sys
 from pathlib import Path
@@ -192,7 +198,7 @@ def create_changelog(path, version_name, body, allow_overwrite):
     return True
 
 
-def _fdroid_current_version_code(text, base_version_code):
+def fdroid_current_version_code(text, base_version_code):
     """Return the CurrentVersionCode F-Droid will use for this metadata.
 
     Linthra's F-Droid entry uses VercodeOperation to turn one canonical base
@@ -285,7 +291,7 @@ def update_fdroid_metadata(path, version_name, version_code):
             "F-Droid metadata at {} has no `CurrentVersionCode:` line; "
             "refusing to guess.".format(path)
         )
-    fdroid_version_code = _fdroid_current_version_code(text, version_code)
+    fdroid_version_code = fdroid_current_version_code(text, version_code)
     new_text = re.sub(
         r"^CurrentVersion:.*$",
         "CurrentVersion: {}".format(version_name),
@@ -306,6 +312,120 @@ def update_fdroid_metadata(path, version_name, version_code):
     return True
 
 
+# AppStream release entries (#452).
+#
+# Matched with regexes rather than round-tripped through ElementTree on
+# purpose: linux/packaging/<app-id>.metainfo.xml is hand-maintained and carries
+# a long explanatory comment block, and an XML round-trip would reflow the whole
+# file into an unreviewable diff every release. These patterns read the one
+# shape the file actually uses, and anything they cannot find is reported
+# instead of guessed at.
+_RELEASES_BLOCK = re.compile(
+    r"(?P<indent>[ \t]*)<releases>[ \t]*\r?\n(?P<body>.*?)(?P<closing>[ \t]*</releases>)",
+    re.DOTALL,
+)
+_RELEASE_ENTRY = re.compile(r"<release\b[^>]*?/?>")
+_ATTRIBUTE = re.compile(r'([A-Za-z_:][-\w:.]*)\s*=\s*"([^"]*)"')
+
+
+def is_prerelease(version_name):
+    """Whether `version_name` carries an -alpha.N / -beta.N / -rc.N suffix."""
+    match = _TAG_PATTERN.match(version_name.strip())
+    if match is None:
+        raise VersionError('Malformed version "{}".'.format(version_name))
+    return match.group(4) is not None
+
+
+def parse_release_date(value):
+    """Validate a YYYY-MM-DD release date and return it normalised."""
+    try:
+        return dt.date.fromisoformat(value.strip()).isoformat()
+    except ValueError:
+        raise VersionError(
+            'Malformed release date "{}"; expected YYYY-MM-DD.'.format(value)
+        ) from None
+
+
+def appstream_releases(text):
+    """Return the `<release .../>` entries of an AppStream document, in order.
+
+    Each entry is `(raw_tag, attributes)`. Returns None when the document has no
+    `<releases>` block at all, so a caller can tell "no releases listed" from
+    "this file is not shaped the way we think it is".
+    """
+    block = _RELEASES_BLOCK.search(text)
+    if block is None:
+        return None
+    return [
+        (tag, dict(_ATTRIBUTE.findall(tag)))
+        for tag in _RELEASE_ENTRY.findall(block.group("body"))
+    ]
+
+
+def _release_entry(version_name, release_date):
+    """The `<release/>` tag for one release.
+
+    Pre-releases are marked `type="development"` so a software centre does not
+    offer an alpha as if it were the current stable build.
+    """
+    attributes = 'version="{}" date="{}"'.format(version_name, release_date)
+    if is_prerelease(version_name):
+        attributes += ' type="development"'
+    return "<release {}/>".format(attributes)
+
+
+def update_appstream_release(path, version_name, release_date):
+    """Add or refresh this release's entry in the AppStream metainfo file.
+
+    Newest first, which is the order the file already uses and the order
+    software centres read. An entry that already names `version_name` is
+    rewritten in place (date, development marker) rather than duplicated, so
+    re-running the script is safe.
+
+    Returns True if the file changed. A missing file returns False silently, as
+    with the F-Droid metadata: a checkout may not carry the Linux packaging.
+    """
+    if not path.exists():
+        return False
+    text = path.read_text()
+    block = _RELEASES_BLOCK.search(text)
+    if block is None:
+        raise VersionError(
+            "AppStream metainfo at {} has no <releases> block; refusing to "
+            "guess where the release entry belongs.".format(path)
+        )
+
+    body = block.group("body")
+    entry = _release_entry(version_name, release_date)
+    existing = next(
+        (
+            tag
+            for tag, attributes in appstream_releases(text)
+            if attributes.get("version") == version_name
+        ),
+        None,
+    )
+    if existing is not None:
+        new_body = body.replace(existing, entry, 1)
+    else:
+        indent = _entry_indent(body, block.group("indent"))
+        new_body = "{}{}\n{}".format(indent, entry, body)
+
+    if new_body == body:
+        return False
+    start, end = block.span("body")
+    path.write_text(text[:start] + new_body + text[end:])
+    return True
+
+
+def _entry_indent(body, block_indent):
+    """Indent a new `<release/>` line to match the entries already there."""
+    match = re.search(r"^([ \t]*)<release\b", body, flags=re.MULTILINE)
+    if match is not None:
+        return match.group(1)
+    return block_indent + "  "
+
+
 def _rel(repo, path):
     try:
         return str(path.relative_to(repo))
@@ -313,7 +433,7 @@ def _rel(repo, path):
         return str(path)
 
 
-def prepare(repo, raw_version, changelog_body, allow_overwrite):
+def prepare(repo, raw_version, changelog_body, allow_overwrite, release_date):
     """Run the full bump against `repo`. Returns (versionName, code, changed)."""
     if raw_version.startswith("v"):
         raise VersionError(
@@ -347,6 +467,7 @@ def prepare(repo, raw_version, changelog_body, allow_overwrite):
         / "{}.txt".format(version_code)
     )
     fdroid = repo / "metadata" / "io.github.thezupzup.linthra.yml"
+    metainfo = repo / "linux" / "packaging" / "io.github.thezupzup.linthra.metainfo.xml"
 
     changed = []
     if update_pubspec(pubspec, version_name, version_code):
@@ -357,6 +478,8 @@ def prepare(repo, raw_version, changelog_body, allow_overwrite):
         changed.append(_rel(repo, changelog))
     if update_fdroid_metadata(fdroid, version_name, version_code):
         changed.append(_rel(repo, fdroid))
+    if update_appstream_release(metainfo, version_name, release_date):
+        changed.append(_rel(repo, metainfo))
     return version_name, version_code, changed
 
 
@@ -364,7 +487,8 @@ def main(argv=None):
     parser = argparse.ArgumentParser(
         description=(
             "Prepare a Linthra release version bump (pubspec, app_info, "
-            "Fastlane changelog, F-Droid metadata). Does not tag or build."
+            "Fastlane changelog, F-Droid metadata, AppStream release entry). "
+            "Does not tag or build."
         )
     )
     parser.add_argument(
@@ -382,6 +506,13 @@ def main(argv=None):
         help="Overwrite the Fastlane changelog if it already exists.",
     )
     parser.add_argument(
+        "--release-date",
+        default="",
+        help=(
+            "Release date for the AppStream entry, YYYY-MM-DD. Empty -> today (UTC)."
+        ),
+    )
+    parser.add_argument(
         "--repo-root",
         type=Path,
         default=Path(__file__).resolve().parent.parent,
@@ -391,11 +522,17 @@ def main(argv=None):
 
     repo = args.repo_root.resolve()
     try:
+        release_date = (
+            parse_release_date(args.release_date)
+            if args.release_date
+            else dt.datetime.now(dt.timezone.utc).date().isoformat()
+        )
         version_name, version_code, changed = prepare(
             repo,
             args.version,
             args.changelog,
             args.force_changelog,
+            release_date,
         )
     except VersionError as err:
         print("ERROR: {}".format(err), file=sys.stderr)

--- a/scripts/release_preflight.sh
+++ b/scripts/release_preflight.sh
@@ -34,7 +34,7 @@
 # This is the local twin of the GitHub Actions "Verify the tag matches
 # pubspec.yaml" step in .github/workflows/android-release-build.yml: that step
 # runs THIS script, so CI and a contributor's pre-tag check fail with the same
-# wording. See docs/release-process.md §3 step 9.
+# wording. See docs/release-process.md §3 step 10.
 
 set -euo pipefail
 

--- a/test/tooling/check_release_metadata_sync_test.py
+++ b/test/tooling/check_release_metadata_sync_test.py
@@ -242,6 +242,23 @@ class SyncTest(unittest.TestCase):
         self.assertEqual(len(problems), 1)
         self.assertIn("marked", problems[0])
 
+    def test_an_entry_that_wraps_a_description_is_read_as_one_entry(self):
+        # AppStream allows child elements inside a <release>. The attributes
+        # that matter are the opening tag's, and a <url type="..."> inside the
+        # description must not be mistaken for one of them.
+        problems = self.repo(
+            releases=[
+                '    <release version="0.2.6" date="2026-09-08">',
+                "      <description>",
+                "        <p>Folder browsing.</p>",
+                "      </description>",
+                '      <url type="details">https://example.invalid/notes</url>',
+                "    </release>",
+                '    <release version="0.2.5" date="2026-09-06"/>',
+            ]
+        ).problems()
+        self.assertEqual(problems, [])
+
     def test_missing_releases_block_is_reported(self):
         repo = self.repo()
         repo.write(

--- a/test/tooling/check_release_metadata_sync_test.py
+++ b/test/tooling/check_release_metadata_sync_test.py
@@ -278,6 +278,36 @@ class SyncTest(unittest.TestCase):
         self.assertEqual(len(problems), 1)
         self.assertIn("pinned to v0.2.4, expected v0.2.6", problems[0])
 
+    def test_manifest_source_without_a_tag_is_reported(self):
+        # The quiet version of the same drift: nothing says which release the
+        # manifest builds, so there is no synchronization to confirm.
+        problems = self.repo(
+            flatpak="modules:\n"
+            "  - name: linthra\n"
+            "    sources:\n"
+            "      - type: git\n"
+            "        url: https://github.com/TheZupZup/Linthra.git\n"
+            "      - type: git\n"
+            "        url: https://github.com/flutter/flutter.git\n"
+            "        tag: '3.44.7'\n"
+            "        dest: flutter\n"
+        ).problems()
+        self.assertEqual(len(problems), 1)
+        self.assertIn("no tag:", problems[0])
+        # Not the Flutter SDK's tag from the source below it.
+        self.assertNotIn("3.44.7", problems[0])
+
+    def test_a_commented_out_source_is_not_read_as_one(self):
+        problems = self.repo(
+            flatpak="modules:\n"
+            "  - name: linthra\n"
+            "    sources:\n"
+            "      # url: https://github.com/TheZupZup/Linthra.git\n"
+            "      - type: dir\n"
+            "        path: ..\n"
+        ).problems()
+        self.assertEqual(problems, [])
+
     def test_manifest_pinned_to_this_release_is_accepted(self):
         problems = self.repo(
             flatpak="modules:\n"

--- a/test/tooling/check_release_metadata_sync_test.py
+++ b/test/tooling/check_release_metadata_sync_test.py
@@ -13,7 +13,9 @@ the network.
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
 import sys
 import tempfile
 import unittest
@@ -293,6 +295,18 @@ class SyncTest(unittest.TestCase):
             checker.main(["--repo-root", str(repo.root)]),
             1,
         )
+
+    def test_main_offers_a_fix_that_works_with_written_release_notes(self):
+        # Reported drift is often AppStream-only, next to a hand-written Play
+        # changelog. Without --keep-changelog the bump script refuses rather
+        # than touch those notes, so the advertised fix has to name it.
+        repo = self.repo(app_info_version="0.2.5")
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            self.assertEqual(checker.main(["--repo-root", str(repo.root)]), 1)
+        message = stderr.getvalue()
+        self.assertIn("prepare_release_bump.py", message)
+        self.assertIn("--keep-changelog", message)
 
     def test_main_exits_zero_on_a_consistent_checkout(self):
         repo = self.repo()

--- a/test/tooling/check_release_metadata_sync_test.py
+++ b/test/tooling/check_release_metadata_sync_test.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/check_release_metadata_sync.py (#452).
+
+    python3 test/tooling/check_release_metadata_sync_test.py
+
+The script's whole job is to notice that two files disagree about the release
+version, so every test builds a small fixture checkout, breaks exactly one of
+those files, and asserts the disagreement is reported (and that a matching
+checkout reports nothing). Fixtures are written to a temporary directory: the
+real repository is never touched, and nothing here runs git, builds, or reaches
+the network.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+
+sys.path.insert(0, str(SCRIPTS))
+
+
+def _load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / filename)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load("check_release_metadata_sync", "check_release_metadata_sync.py")
+
+APP_ID = "io.github.thezupzup.linthra"
+
+METAINFO = """<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>{app_id}</id>
+  <releases>
+{entries}
+  </releases>
+</component>
+"""
+
+FDROID = """Name: Linthra
+RepoType: git
+VercodeOperation:
+  - "%c*10 + 1"
+  - "%c*10 + 2"
+  - "%c*10 + 3"
+
+CurrentVersion: {version}
+CurrentVersionCode: {code}
+"""
+
+
+def metainfo(entries):
+    return METAINFO.format(app_id=APP_ID, entries="\n".join(entries))
+
+
+class FixtureRepo:
+    """A checkout with just the files the checker reads."""
+
+    def __init__(self, root: Path):
+        self.root = root
+
+    def write(self, relative: str, content: str) -> Path:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        return path
+
+    def problems(self, tag: str | None = None) -> list[str]:
+        return checker.check(self.root, tag)
+
+
+class SyncTest(unittest.TestCase):
+    def repo(
+        self,
+        *,
+        version: str = "0.2.6",
+        code: int = 206999,
+        app_info_version: str | None = None,
+        changelog_code: int | None = None,
+        fdroid_version: str | None = None,
+        fdroid_code: int | None = None,
+        releases: list[str] | None = None,
+        flatpak: str | None = None,
+    ) -> FixtureRepo:
+        directory = Path(tempfile.mkdtemp(prefix="release_metadata_sync_"))
+        self.addCleanup(_rmtree, directory)
+        repo = FixtureRepo(directory)
+
+        repo.write("pubspec.yaml", f"name: linthra\nversion: {version}+{code}\n")
+        repo.write(
+            "lib/core/app_info.dart",
+            "abstract final class AppInfo {\n"
+            f"  static const String _devVersionName = '{app_info_version or version}';\n"
+            "}\n",
+        )
+        repo.write(
+            "fastlane/metadata/android/en-US/changelogs/"
+            f"{changelog_code if changelog_code is not None else code}.txt",
+            "Linthra maintenance update.\n",
+        )
+        repo.write(
+            f"metadata/{APP_ID}.yml",
+            FDROID.format(
+                version=fdroid_version or version,
+                code=fdroid_code if fdroid_code is not None else code * 10 + 3,
+            ),
+        )
+        repo.write(
+            f"linux/packaging/{APP_ID}.metainfo.xml",
+            metainfo(
+                releases
+                if releases is not None
+                else [f'    <release version="{version}" date="2026-09-08"/>']
+            ),
+        )
+        if flatpak is not None:
+            repo.write(f"flatpak/{APP_ID}.yml", flatpak)
+        return repo
+
+    def test_a_consistent_checkout_reports_nothing(self):
+        self.assertEqual(self.repo().problems(), [])
+
+    def test_matching_tag_reports_nothing(self):
+        self.assertEqual(self.repo().problems("v0.2.6"), [])
+
+    def test_mismatched_tag_is_reported(self):
+        problems = self.repo().problems("v0.2.5")
+        self.assertEqual(len(problems), 1)
+        self.assertIn("does not match pubspec version 0.2.6", problems[0])
+
+    def test_hand_edited_version_code_is_reported(self):
+        problems = self.repo(code=206000).problems()
+        self.assertTrue(any("expected 206999" in p for p in problems), problems)
+
+    def test_about_screen_version_drift_is_reported(self):
+        problems = self.repo(app_info_version="0.2.5").problems()
+        self.assertEqual(len(problems), 1)
+        self.assertIn("_devVersionName is 0.2.5", problems[0])
+
+    def test_missing_play_changelog_is_reported(self):
+        problems = self.repo(changelog_code=205999).problems()
+        self.assertEqual(len(problems), 1)
+        self.assertIn("206999.txt is missing", problems[0])
+
+    def test_empty_play_changelog_is_reported(self):
+        repo = self.repo()
+        repo.write("fastlane/metadata/android/en-US/changelogs/206999.txt", "\n")
+        problems = repo.problems()
+        self.assertEqual(len(problems), 1)
+        self.assertIn("is empty", problems[0])
+
+    def test_fdroid_version_drift_is_reported(self):
+        problems = self.repo(fdroid_version="0.2.5").problems()
+        self.assertEqual(len(problems), 1)
+        self.assertIn("CurrentVersion is 0.2.5", problems[0])
+
+    def test_fdroid_untransformed_version_code_is_reported(self):
+        # The base code, not the highest per-ABI code F-Droid actually records.
+        problems = self.repo(fdroid_code=206999).problems()
+        self.assertEqual(len(problems), 1)
+        self.assertIn("expected 2069993", problems[0])
+
+    def test_missing_fdroid_metadata_is_not_an_error(self):
+        repo = self.repo()
+        (repo.root / "metadata" / f"{APP_ID}.yml").unlink()
+        self.assertEqual(repo.problems(), [])
+
+    def test_stale_appstream_entry_is_reported(self):
+        problems = self.repo(
+            releases=['    <release version="0.2.5" date="2026-09-06"/>']
+        ).problems()
+        self.assertEqual(len(problems), 1)
+        self.assertIn("newest <release> is 0.2.5", problems[0])
+
+    def test_entries_listed_oldest_first_are_reported(self):
+        problems = self.repo(
+            releases=[
+                '    <release version="0.2.5" date="2026-09-06"/>',
+                '    <release version="0.2.6" date="2026-09-08"/>',
+            ]
+        ).problems()
+        self.assertTrue(any("newest first" in p for p in problems), problems)
+
+    def test_duplicate_entry_is_reported(self):
+        problems = self.repo(
+            releases=[
+                '    <release version="0.2.6" date="2026-09-08"/>',
+                '    <release version="0.2.6" date="2026-09-07"/>',
+            ]
+        ).problems()
+        self.assertTrue(any("listed twice" in p for p in problems), problems)
+
+    def test_entry_without_a_date_is_reported(self):
+        problems = self.repo(releases=['    <release version="0.2.6"/>']).problems()
+        self.assertEqual(len(problems), 1)
+        self.assertIn("has no date", problems[0])
+
+    def test_malformed_date_is_reported(self):
+        problems = self.repo(
+            releases=['    <release version="0.2.6" date="08/09/2026"/>']
+        ).problems()
+        self.assertEqual(len(problems), 1)
+        self.assertIn("Malformed release date", problems[0])
+
+    def test_prerelease_without_the_development_marker_is_reported(self):
+        problems = self.repo(
+            version="0.3.0-beta.1",
+            code=300301,
+            releases=['    <release version="0.3.0-beta.1" date="2026-09-09"/>'],
+        ).problems()
+        self.assertEqual(len(problems), 1)
+        self.assertIn('type="development"', problems[0])
+
+    def test_prerelease_with_the_development_marker_is_accepted(self):
+        problems = self.repo(
+            version="0.3.0-beta.1",
+            code=300301,
+            releases=[
+                '    <release version="0.3.0-beta.1" date="2026-09-09" '
+                'type="development"/>'
+            ],
+        ).problems()
+        self.assertEqual(problems, [])
+
+    def test_stable_release_marked_as_development_is_reported(self):
+        problems = self.repo(
+            releases=[
+                '    <release version="0.2.6" date="2026-09-08" type="development"/>'
+            ]
+        ).problems()
+        self.assertEqual(len(problems), 1)
+        self.assertIn("marked", problems[0])
+
+    def test_missing_releases_block_is_reported(self):
+        repo = self.repo()
+        repo.write(
+            f"linux/packaging/{APP_ID}.metainfo.xml",
+            f'<component type="desktop-application">\n  <id>{APP_ID}</id>\n</component>\n',
+        )
+        problems = repo.problems()
+        self.assertEqual(len(problems), 1)
+        self.assertIn("no <releases> block", problems[0])
+
+    def test_dir_source_manifest_has_no_version_to_drift(self):
+        problems = self.repo(
+            flatpak="modules:\n"
+            "  - name: linthra\n"
+            "    sources:\n"
+            "      - type: dir\n"
+            "        path: ..\n"
+            "      - type: git\n"
+            "        url: https://github.com/flutter/flutter.git\n"
+            "        tag: '3.44.7'\n"
+            "        dest: flutter\n"
+        ).problems()
+        self.assertEqual(problems, [])
+
+    def test_manifest_pinned_to_another_release_is_reported(self):
+        problems = self.repo(
+            flatpak="modules:\n"
+            "  - name: linthra\n"
+            "    sources:\n"
+            "      - type: git\n"
+            "        url: https://github.com/TheZupZup/Linthra.git\n"
+            "        tag: v0.2.4\n"
+        ).problems()
+        self.assertEqual(len(problems), 1)
+        self.assertIn("pinned to v0.2.4, expected v0.2.6", problems[0])
+
+    def test_manifest_pinned_to_this_release_is_accepted(self):
+        problems = self.repo(
+            flatpak="modules:\n"
+            "  - name: linthra\n"
+            "    sources:\n"
+            "      - type: git\n"
+            "        url: https://github.com/TheZupZup/Linthra.git\n"
+            "        tag: v0.2.6\n"
+        ).problems()
+        self.assertEqual(problems, [])
+
+    def test_main_exits_non_zero_and_names_the_fix(self):
+        repo = self.repo(app_info_version="0.2.5")
+        self.assertEqual(
+            checker.main(["--repo-root", str(repo.root)]),
+            1,
+        )
+
+    def test_main_exits_zero_on_a_consistent_checkout(self):
+        repo = self.repo()
+        self.assertEqual(checker.main(["--repo-root", str(repo.root)]), 0)
+
+    def test_the_real_repository_is_in_sync(self):
+        # The point of the script: this repository, right now.
+        self.assertEqual(checker.check(ROOT), [])
+
+
+def _rmtree(path: Path) -> None:
+    import shutil
+
+    shutil.rmtree(path, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/tooling/flathub_update_process_test.dart
+++ b/test/tooling/flathub_update_process_test.dart
@@ -1,0 +1,80 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Keeps [docs/flathub-update-process.md] honest (#453).
+///
+/// The doc's whole value is that a maintainer can follow it command by command
+/// on the day of a release. That makes it exactly the kind of file that rots
+/// silently: rename a script, move a doc, and the walkthrough still reads fine
+/// while telling someone to run something that no longer exists. So every path
+/// it names is checked to exist, and the pages that should point at it are
+/// checked to still do so.
+void main() {
+  late String doc;
+
+  setUpAll(() {
+    doc = File('docs/flathub-update-process.md').readAsStringSync();
+  });
+
+  test('every repository path the walkthrough names exists', () {
+    final Iterable<RegExpMatch> matches = RegExp(
+      r'(?:scripts|test/tooling|linux/packaging|flatpak)/[\w./-]*[\w]',
+    ).allMatches(doc);
+    expect(matches, isNotEmpty);
+
+    final Set<String> missing = <String>{};
+    for (final RegExpMatch match in matches) {
+      final String path = match.group(0)!;
+      // Build outputs the walkthrough creates as it goes, not committed files.
+      if (path.startsWith('flatpak/repo-ci') ||
+          path.startsWith('flatpak/flatpak-builder-ci')) {
+        continue;
+      }
+      if (!File(path).existsSync() && !Directory(path).existsSync()) {
+        missing.add(path);
+      }
+    }
+    expect(missing, isEmpty, reason: 'named but not in the repository');
+  });
+
+  test('every relative link resolves', () {
+    final Set<String> broken = <String>{};
+    for (final RegExpMatch match
+        in RegExp(r'\]\((\.[^)#]*)(?:#[^)]*)?\)').allMatches(doc)) {
+      final String target = match.group(1)!;
+      final File file = File('docs/$target');
+      if (!file.existsSync()) broken.add(target);
+    }
+    expect(broken, isEmpty);
+  });
+
+  test('the release process hands off to it', () {
+    expect(
+      File('docs/release-process.md').readAsStringSync(),
+      contains('flathub-update-process.md'),
+    );
+  });
+
+  test('it is discoverable from the docs index and the packaging README', () {
+    expect(
+      File('docs/README.md').readAsStringSync(),
+      contains('flathub-update-process.md'),
+    );
+    expect(
+      File('flatpak/README.md').readAsStringSync(),
+      contains('flathub-update-process.md'),
+    );
+  });
+
+  test('it names the version-sync tooling the release depends on', () {
+    // #453 asks for the #452 tooling to be referenced rather than re-explained.
+    expect(doc, contains('scripts/prepare_release_bump.py'));
+    expect(doc, contains('scripts/check_release_metadata_sync.py'));
+  });
+
+  test('it stays honest that nothing is auto-merged or auto-pushed', () {
+    expect(doc, contains('Nothing here is auto-merged'));
+    expect(doc, contains('No credentials from this repository are involved'));
+  });
+}

--- a/test/tooling/large_library_benchmark_test.py
+++ b/test/tooling/large_library_benchmark_test.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Unit tests for the benchmark summary block (#338).
+
+    python3 test/tooling/large_library_benchmark_test.py
+
+`tools/large_library/benchmark_sqlite.py` prints a small summary after the
+per-query lines, and that block is what a contributor (or a CI log reader)
+actually looks at. These tests pin the two things that make it useful: the
+numbers are the ones the labels claim, and the block stays aligned and
+deterministic. `summary_lines` takes plain timings, so none of this needs a
+200k-track fixture or a database.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+BENCHMARK = ROOT / "tools" / "large_library" / "benchmark_sqlite.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("benchmark_sqlite", BENCHMARK)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+benchmark_sqlite = _load()
+
+# (name, average ms, p95 ms, max ms): the shape main() collects per query.
+RESULTS = (
+    ("title prefix", 1.5, 2.0, 4.25),
+    ("artist exact", 0.5, 0.9, 1.75),
+    ("provider album", 2.0, 3.0, 9.5),
+    ("recently added", 0.25, 0.4, 0.75),
+)
+
+
+class SummaryLinesTest(unittest.TestCase):
+    def summary(self, results=RESULTS, track_count=200_000, iterations=200):
+        return benchmark_sqlite.summary_lines(track_count, results, iterations)
+
+    def labelled(self, label: str) -> str:
+        matches = [line for line in self.summary() if line.strip().startswith(label)]
+        self.assertEqual(len(matches), 1, f"expected exactly one {label!r} line")
+        return matches[0]
+
+    def test_counts_are_grouped_for_reading(self):
+        self.assertIn("200,000", self.labelled("tracks:"))
+        self.assertIn("4", self.labelled("queries:"))
+        self.assertIn("200", self.labelled("iterations per query:"))
+
+    def test_summed_averages_add_up_the_per_query_averages(self):
+        # 1.5 + 0.5 + 2.0 + 0.25, not the wall-clock time of 200 iterations.
+        self.assertIn("4.250 ms", self.labelled("sum of query averages:"))
+
+    def test_average_per_query_is_the_mean_of_those_averages(self):
+        self.assertIn("1.062 ms", self.labelled("average per query:"))
+
+    def test_slowest_single_run_reports_the_max_sample_and_its_query(self):
+        line = self.labelled("slowest single run:")
+        self.assertIn("9.500 ms", line)
+        self.assertIn("(provider album)", line)
+
+    def test_no_label_claims_a_total_the_benchmark_never_measures(self):
+        # The old "total query time" label read as wall-clock time while the
+        # value was the sum of the per-query averages (#338).
+        joined = "\n".join(self.summary())
+        self.assertNotIn("total query time", joined)
+
+    def test_values_line_up_in_one_column(self):
+        rows = [line for line in self.summary() if line.startswith("  ")]
+        self.assertEqual(len(rows), 6)
+        # Counts have no unit and end the line; timings are followed by " ms".
+        # Both end their value in the same column, which is what makes the
+        # block scannable in a CI log.
+        ends = {len(line) if " ms" not in line else line.index(" ms") for line in rows}
+        self.assertEqual(len(ends), 1, f"values end at {ends}")
+
+    def test_no_tabs_anywhere(self):
+        # A stray tab used to make the iterations line jump around (#338).
+        self.assertNotIn("\t", "\n".join(self.summary()))
+
+    def test_output_is_deterministic(self):
+        self.assertEqual(self.summary(), self.summary())
+
+    def test_single_query_run_still_renders(self):
+        lines = self.summary(results=(("title prefix", 1.0, 1.2, 1.5),))
+        joined = "\n".join(lines)
+        self.assertIn("sum of query averages:", joined)
+        self.assertIn("1.000 ms", joined)
+        self.assertIn("1.500 ms (title prefix)", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/tooling/prepare_release_bump_test.dart
+++ b/test/tooling/prepare_release_bump_test.dart
@@ -525,6 +525,33 @@ void main() {
     });
   });
 
+  group('prepare-release-bump.yml forwards what the script needs', () {
+    // The workflow is the way this script is normally run, so an option the
+    // script grows is only real once the workflow can pass it.
+    late String workflow;
+
+    setUpAll(() {
+      workflow = File(p.join(
+        repoRoot,
+        '.github',
+        'workflows',
+        'prepare-release-bump.yml',
+      )).readAsStringSync();
+    });
+
+    test('an intended release date can be given and reaches the script', () {
+      // Without it the AppStream entry records the day the workflow ran, and
+      // a re-run keeps that date rather than correcting it (#452).
+      expect(workflow, contains('release_date:'));
+      expect(workflow, contains(r'RELEASE_DATE: ${{ inputs.release_date }}'));
+      expect(workflow, contains(r'args+=("--release-date" "$RELEASE_DATE")'));
+    });
+
+    test('the AppStream file is committed with the rest of the bump', () {
+      expect(workflow, contains('linux/packaging'));
+    });
+  });
+
   group('prepare_release_bump.py — input validation', () {
     test('rejects a leading v', () async {
       final Directory tmp = await _fixtureRepo(

--- a/test/tooling/prepare_release_bump_test.dart
+++ b/test/tooling/prepare_release_bump_test.dart
@@ -480,6 +480,44 @@ void main() {
           metainfoFile(tmp).readAsStringSync(), contains('date="2026-09-06"'));
     });
 
+    test('an entry that wraps a description keeps it', () async {
+      // AppStream allows child elements inside a <release>. Rewriting only the
+      // opening tag keeps them, where replacing the element would have left
+      // the children and </release> orphaned and the XML malformed.
+      final Directory tmp = await fixture(
+        body: '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<component type="desktop-application">\n'
+            '  <releases>\n'
+            '    <release version="0.1.0-alpha.36" date="2026-09-06" '
+            'type="development">\n'
+            '      <description>\n'
+            '        <p>Folder browsing, and a calmer queue.</p>\n'
+            '      </description>\n'
+            '    </release>\n'
+            '  </releases>\n'
+            '</component>\n',
+      );
+      addTearDown(() async => tmp.delete(recursive: true));
+
+      final ProcessResult r = _runScript(
+        script,
+        '0.1.0-alpha.36',
+        repoRoot: tmp.path,
+        extraArgs: <String>['--release-date', '2026-09-09', '--keep-changelog'],
+      );
+      expect(r.exitCode, 0,
+          reason: 'stdout:\n${r.stdout}\nstderr:\n${r.stderr}');
+
+      final String after = metainfoFile(tmp).readAsStringSync();
+      expect(after, contains('<p>Folder browsing, and a calmer queue.</p>'));
+      expect(after, contains('</release>'));
+      expect(after, contains('date="2026-09-09"'));
+      // The rewritten tag still opens the element it opened before.
+      expect(after, isNot(contains('type="development"/>')));
+      expect(XmlIsWellFormed(after).result, isTrue,
+          reason: 'tags left unbalanced:\n$after');
+    });
+
     test('does nothing when the metainfo file is absent', () async {
       final Directory tmp = await _fixtureRepo(
         pubspecVersion: '0.1.0-alpha.36',
@@ -738,5 +776,21 @@ String _findRepoRoot() {
       fail('Could not find repo root from ${Directory.current.path}');
     }
     d = parent;
+  }
+}
+
+/// Cheap well-formedness check: every `<release>` that is not self-closing has
+/// a matching `</release>`. Enough to catch the orphaned-children shape without
+/// pulling an XML parser into the tooling tests.
+class XmlIsWellFormed {
+  XmlIsWellFormed(this.document);
+
+  final String document;
+
+  bool get result {
+    final int opened =
+        RegExp(r'<release\b[^>]*[^/]>').allMatches(document).length;
+    final int closed = RegExp(r'</release\s*>').allMatches(document).length;
+    return opened == closed;
   }
 }

--- a/test/tooling/prepare_release_bump_test.dart
+++ b/test/tooling/prepare_release_bump_test.dart
@@ -7,8 +7,9 @@ import '../../tool/version_from_tag.dart';
 
 /// Specifies `scripts/prepare_release_bump.py` — the Python helper the
 /// `.github/workflows/prepare-release-bump.yml` workflow calls to update
-/// pubspec.yaml, lib/core/app_info.dart, the Fastlane changelog, and the
-/// F-Droid metadata's `CurrentVersion`/`CurrentVersionCode`.
+/// pubspec.yaml, lib/core/app_info.dart, the Fastlane changelog, the F-Droid
+/// metadata's `CurrentVersion`/`CurrentVersionCode`, and the AppStream
+/// `<release>` entry software centres show.
 ///
 /// The script has to agree forever with `tool/version_from_tag.dart` and
 /// `scripts/release_preflight.sh`, so this suite shells out to it against a
@@ -298,6 +299,154 @@ void main() {
     });
   });
 
+  group('prepare_release_bump.py (AppStream release entry, #452)', () {
+    // What a software centre and Flathub read. Left behind, it advertises the
+    // previous release for the build the user just installed.
+    const String metainfo = '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<component type="desktop-application">\n'
+        '  <id>io.github.thezupzup.linthra</id>\n'
+        '  <releases>\n'
+        '    <release version="0.1.0-alpha.36" date="2026-09-06" '
+        'type="development"/>\n'
+        '  </releases>\n'
+        '</component>\n';
+
+    Future<Directory> fixture({String? body}) => _fixtureRepo(
+          pubspecVersion: '0.1.0-alpha.36',
+          pubspecCode: 100036,
+          appInfoVersion: '0.1.0-alpha.36',
+          metainfoBody: body ?? metainfo,
+        );
+
+    File metainfoFile(Directory dir) => File(p.join(dir.path, 'linux',
+        'packaging', 'io.github.thezupzup.linthra.metainfo.xml'));
+
+    test('adds the new release as the newest entry', () async {
+      final Directory tmp = await fixture();
+      addTearDown(() async => tmp.delete(recursive: true));
+
+      final ProcessResult r = _runScript(
+        script,
+        '0.1.0-alpha.37',
+        repoRoot: tmp.path,
+        extraArgs: <String>['--release-date', '2026-09-09'],
+      );
+      expect(r.exitCode, 0,
+          reason: 'stdout:\n${r.stdout}\nstderr:\n${r.stderr}');
+
+      final String after = metainfoFile(tmp).readAsStringSync();
+      expect(
+        after,
+        contains('<release version="0.1.0-alpha.37" date="2026-09-09" '
+            'type="development"/>'),
+      );
+      // Newest first, and the previous entry is kept.
+      expect(after.indexOf('0.1.0-alpha.37'),
+          lessThan(after.indexOf('0.1.0-alpha.36')));
+      expect(after, contains('date="2026-09-06"'));
+    });
+
+    test('marks a stable release as stable', () async {
+      final Directory tmp = await fixture();
+      addTearDown(() async => tmp.delete(recursive: true));
+
+      final ProcessResult r = _runScript(
+        script,
+        '1.0.0',
+        repoRoot: tmp.path,
+        extraArgs: <String>['--release-date', '2026-09-09'],
+      );
+      expect(r.exitCode, 0,
+          reason: 'stdout:\n${r.stdout}\nstderr:\n${r.stderr}');
+      expect(
+        metainfoFile(tmp).readAsStringSync(),
+        contains('<release version="1.0.0" date="2026-09-09"/>'),
+      );
+    });
+
+    test('re-running the same bump does not duplicate the entry', () async {
+      final Directory tmp = await fixture();
+      addTearDown(() async => tmp.delete(recursive: true));
+
+      for (int i = 0; i < 2; i++) {
+        final ProcessResult r = _runScript(
+          script,
+          '0.1.0-alpha.37',
+          repoRoot: tmp.path,
+          extraArgs: <String>['--release-date', '2026-09-09'],
+        );
+        expect(r.exitCode, 0,
+            reason: 'stdout:\n${r.stdout}\nstderr:\n${r.stderr}');
+      }
+
+      final String after = metainfoFile(tmp).readAsStringSync();
+      expect('0.1.0-alpha.37'.allMatches(after).length, 1);
+    });
+
+    test('refreshes the date of an entry that already exists', () async {
+      final Directory tmp = await fixture();
+      addTearDown(() async => tmp.delete(recursive: true));
+
+      final ProcessResult r = _runScript(
+        script,
+        '0.1.0-alpha.36',
+        repoRoot: tmp.path,
+        extraArgs: <String>['--release-date', '2026-09-09'],
+      );
+      expect(r.exitCode, 0,
+          reason: 'stdout:\n${r.stdout}\nstderr:\n${r.stderr}');
+
+      final String after = metainfoFile(tmp).readAsStringSync();
+      expect(after, contains('date="2026-09-09"'));
+      expect(after, isNot(contains('date="2026-09-06"')));
+      expect('0.1.0-alpha.36'.allMatches(after).length, 1);
+    });
+
+    test('does nothing when the metainfo file is absent', () async {
+      final Directory tmp = await _fixtureRepo(
+        pubspecVersion: '0.1.0-alpha.36',
+        pubspecCode: 100036,
+        appInfoVersion: '0.1.0-alpha.36',
+      );
+      addTearDown(() async => tmp.delete(recursive: true));
+
+      final ProcessResult r =
+          _runScript(script, '0.1.0-alpha.37', repoRoot: tmp.path);
+      expect(r.exitCode, 0,
+          reason: 'stdout:\n${r.stdout}\nstderr:\n${r.stderr}');
+      expect(metainfoFile(tmp).existsSync(), isFalse);
+    });
+
+    test('refuses a metainfo file with no <releases> block', () async {
+      final Directory tmp = await fixture(
+        body: '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<component type="desktop-application">\n'
+            '  <id>io.github.thezupzup.linthra</id>\n'
+            '</component>\n',
+      );
+      addTearDown(() async => tmp.delete(recursive: true));
+
+      final ProcessResult r =
+          _runScript(script, '0.1.0-alpha.37', repoRoot: tmp.path);
+      expect(r.exitCode, isNot(0));
+      expect(r.stderr, contains('<releases>'));
+    });
+
+    test('rejects a malformed release date', () async {
+      final Directory tmp = await fixture();
+      addTearDown(() async => tmp.delete(recursive: true));
+
+      final ProcessResult r = _runScript(
+        script,
+        '0.1.0-alpha.37',
+        repoRoot: tmp.path,
+        extraArgs: <String>['--release-date', '09/09/2026'],
+      );
+      expect(r.exitCode, isNot(0));
+      expect(r.stderr, contains('Malformed release date'));
+    });
+  });
+
   group('prepare_release_bump.py — input validation', () {
     test('rejects a leading v', () async {
       final Directory tmp = await _fixtureRepo(
@@ -395,6 +544,7 @@ Future<Directory> _fixtureRepo({
   String? appInfoVersion,
   String? appInfoBody,
   String? fdroidBody,
+  String? metainfoBody,
 }) async {
   final Directory dir =
       await Directory.systemTemp.createTemp('prepare_release_bump_');
@@ -423,6 +573,14 @@ Future<Directory> _fixtureRepo({
     Directory(p.join(dir.path, 'metadata')).createSync(recursive: true);
     File(p.join(dir.path, 'metadata', 'io.github.thezupzup.linthra.yml'))
         .writeAsStringSync(fdroidBody);
+  }
+  if (metainfoBody != null) {
+    Directory(p.join(dir.path, 'linux', 'packaging')).createSync(
+      recursive: true,
+    );
+    File(p.join(dir.path, 'linux', 'packaging',
+            'io.github.thezupzup.linthra.metainfo.xml'))
+        .writeAsStringSync(metainfoBody);
   }
   return dir;
 }

--- a/test/tooling/prepare_release_bump_test.dart
+++ b/test/tooling/prepare_release_bump_test.dart
@@ -251,6 +251,65 @@ void main() {
       expect(changelog.readAsStringSync().trim(), 'new content');
     });
 
+    test('--keep-changelog leaves written notes and still fixes the rest',
+        () async {
+      // The partial-bump case: the notes were written by hand, and something
+      // else (here the F-Droid code) still has to be brought into line.
+      final Directory tmp = await _fixtureRepo(
+        pubspecVersion: '0.1.0-alpha.37',
+        pubspecCode: 100037,
+        appInfoVersion: '0.1.0-alpha.37',
+        fdroidBody: 'Name: Linthra\n'
+            'CurrentVersion: 0.1.0-alpha.36\n'
+            'CurrentVersionCode: 100036\n',
+      );
+      addTearDown(() async => tmp.delete(recursive: true));
+
+      final File changelog = File(p.join(tmp.path, 'fastlane', 'metadata',
+          'android', 'en-US', 'changelogs', '100037.txt'));
+      changelog.writeAsStringSync('Hand-written release notes.\n');
+
+      final ProcessResult r = _runScript(
+        script,
+        '0.1.0-alpha.37',
+        repoRoot: tmp.path,
+        extraArgs: <String>['--keep-changelog'],
+      );
+      expect(r.exitCode, 0,
+          reason: 'stdout:\n${r.stdout}\nstderr:\n${r.stderr}');
+      expect(changelog.readAsStringSync(), 'Hand-written release notes.\n');
+      expect(
+        File(p.join(tmp.path, 'metadata', 'io.github.thezupzup.linthra.yml'))
+            .readAsStringSync(),
+        contains('CurrentVersionCode: 100037'),
+      );
+    });
+
+    test('--keep-changelog still writes a changelog that is not there yet',
+        () async {
+      final Directory tmp = await _fixtureRepo(
+        pubspecVersion: '0.1.0-alpha.36',
+        pubspecCode: 100036,
+        appInfoVersion: '0.1.0-alpha.36',
+      );
+      addTearDown(() async => tmp.delete(recursive: true));
+
+      final ProcessResult r = _runScript(
+        script,
+        '0.1.0-alpha.37',
+        repoRoot: tmp.path,
+        extraArgs: <String>['--keep-changelog'],
+      );
+      expect(r.exitCode, 0,
+          reason: 'stdout:\n${r.stdout}\nstderr:\n${r.stderr}');
+      expect(
+        File(p.join(tmp.path, 'fastlane', 'metadata', 'android', 'en-US',
+                'changelogs', '100037.txt'))
+            .existsSync(),
+        isTrue,
+      );
+    });
+
     test('updates F-Droid CurrentVersion / CurrentVersionCode when present',
         () async {
       final Directory tmp = await _fixtureRepo(
@@ -383,7 +442,7 @@ void main() {
       expect('0.1.0-alpha.37'.allMatches(after).length, 1);
     });
 
-    test('refreshes the date of an entry that already exists', () async {
+    test('refreshes an existing entry when a date is given', () async {
       final Directory tmp = await fixture();
       addTearDown(() async => tmp.delete(recursive: true));
 
@@ -400,6 +459,25 @@ void main() {
       expect(after, contains('date="2026-09-09"'));
       expect(after, isNot(contains('date="2026-09-06"')));
       expect('0.1.0-alpha.36'.allMatches(after).length, 1);
+    });
+
+    test('keeps the recorded date when the bump is re-run', () async {
+      // A release that already shipped keeps its published date, whatever day
+      // the re-run happens on: the prepare workflow passes no --release-date,
+      // so a retry tomorrow must not rewrite release history.
+      final Directory tmp = await fixture();
+      addTearDown(() async => tmp.delete(recursive: true));
+
+      final ProcessResult r = _runScript(
+        script,
+        '0.1.0-alpha.36',
+        repoRoot: tmp.path,
+        extraArgs: <String>['--keep-changelog'],
+      );
+      expect(r.exitCode, 0,
+          reason: 'stdout:\n${r.stdout}\nstderr:\n${r.stderr}');
+      expect(
+          metainfoFile(tmp).readAsStringSync(), contains('date="2026-09-06"'));
     });
 
     test('does nothing when the metainfo file is absent', () async {
@@ -474,6 +552,42 @@ void main() {
           _runScript(script, '0.1.0-alpha.37+100037', repoRoot: tmp.path);
       expect(r.exitCode, isNot(0));
       expect(r.stderr, contains('"+versionCode"'));
+    });
+
+    test('rejects --keep-changelog together with --force-changelog', () async {
+      final Directory tmp = await _fixtureRepo(
+        pubspecVersion: '0.1.0-alpha.36',
+        pubspecCode: 100036,
+        appInfoVersion: '0.1.0-alpha.36',
+      );
+      addTearDown(() async => tmp.delete(recursive: true));
+
+      final ProcessResult r = _runScript(
+        script,
+        '0.1.0-alpha.37',
+        repoRoot: tmp.path,
+        extraArgs: <String>['--keep-changelog', '--force-changelog'],
+      );
+      expect(r.exitCode, isNot(0));
+      expect(r.stderr, contains('contradict each other'));
+    });
+
+    test('rejects --keep-changelog together with --changelog', () async {
+      final Directory tmp = await _fixtureRepo(
+        pubspecVersion: '0.1.0-alpha.36',
+        pubspecCode: 100036,
+        appInfoVersion: '0.1.0-alpha.36',
+      );
+      addTearDown(() async => tmp.delete(recursive: true));
+
+      final ProcessResult r = _runScript(
+        script,
+        '0.1.0-alpha.37',
+        repoRoot: tmp.path,
+        extraArgs: <String>['--keep-changelog', '--changelog', 'text'],
+      );
+      expect(r.exitCode, isNot(0));
+      expect(r.stderr, contains('would be ignored'));
     });
 
     test('rejects a malformed version', () async {

--- a/tools/large_library/README.md
+++ b/tools/large_library/README.md
@@ -17,4 +17,27 @@ python3 tools/large_library/benchmark_sqlite.py \
   --database /tmp/linthra-200k.sqlite
 ```
 
+Each query prints its own line, then a summary block:
+
+```
+benchmark summary
+  tracks:                   200,000
+  queries:                        4
+  iterations per query:         200
+  sum of query averages:      4.250 ms
+  average per query:          1.062 ms
+  slowest single run:         9.500 ms (provider album)
+```
+
+Every query is timed the same number of times and reported as a mean, so
+`sum of query averages` adds up those per-query means rather than the
+wall-clock time the run spent querying, and `slowest single run` is the single
+slowest timed iteration, not the slowest query on average.
+
+The summary rendering has unit tests:
+
+```bash
+python3 test/tooling/large_library_benchmark_test.py
+```
+
 The scripts use only Python's standard library. `schema.sql` is a performance sandbox shaped like the fields Linthra cares about; it is **not** a replacement for the Drift production schema. A useful SQL contribution should show the access pattern it improves and, where practical, the `EXPLAIN QUERY PLAN` result that proves the intended index is used.

--- a/tools/large_library/benchmark_sqlite.py
+++ b/tools/large_library/benchmark_sqlite.py
@@ -7,6 +7,7 @@ import argparse
 import sqlite3
 import statistics
 import time
+from collections.abc import Sequence
 from pathlib import Path
 
 QUERIES: tuple[tuple[str, str, tuple[object, ...]], ...] = (
@@ -38,6 +39,42 @@ def query_plan(
 ) -> str:
     rows = connection.execute(f"EXPLAIN QUERY PLAN {sql}", params).fetchall()
     return " | ".join(str(row[3]) for row in rows)
+
+
+def summary_lines(
+    track_count: int,
+    results: Sequence[tuple[str, float, float, float]],
+    iterations: int,
+) -> list[str]:
+    """Render the summary block printed after the per-query lines.
+
+    Separate from `main` so the wording, the numbers and the alignment can be
+    checked without a database: everything here is derived from `results`.
+    """
+    summed_average_ms = sum(average_ms for _, average_ms, _, _ in results)
+    average_query_ms = summed_average_ms / len(results)
+    slowest_name, _, _, slowest_max_ms = max(results, key=lambda result: result[3])
+
+    # Labels are padded to a fixed width and values are right-aligned inside
+    # one column, so counts and timings line up whatever their magnitude.
+    def row(label: str, value: str, unit: str = "") -> str:
+        return f"  {label + ':':<24}{value:>9}{unit}"
+
+    return [
+        "benchmark summary",
+        row("tracks", f"{track_count:,}"),
+        row("queries", f"{len(results)}"),
+        row("iterations per query", f"{iterations:,}"),
+        # Each query is timed the same number of times and reported as a mean,
+        # so this is the sum of those per-query averages, not the wall-clock
+        # time the benchmark spent querying. Saying so keeps the number
+        # comparable between runs that used a different --iterations.
+        row("sum of query averages", f"{summed_average_ms:.3f}", " ms"),
+        row("average per query", f"{average_query_ms:.3f}", " ms"),
+        # The slowest single timed run, not the slowest query on average: it is
+        # the outlier worth looking at when a run is unexpectedly spiky.
+        row("slowest single run", f"{slowest_max_ms:.3f}", f" ms ({slowest_name})"),
+    ]
 
 
 def benchmark(
@@ -96,18 +133,9 @@ def main() -> None:
                 )
                 failed = True
 
-        total_average_ms = sum(average_ms for _, average_ms, _, _ in results)
-        average_query_ms = total_average_ms / len(results)
-        slowest_name, _, _, slowest_max_ms = max(results, key=lambda result: result[3])
-
         print()
-        print("benchmark summary")
-        print(f"  tracks:            {count:,}")
-        print(f"  queries:           {len(results)}")
-        print(f"  iterations:  	     {args.iterations:,}")
-        print(f"  total query time:  {total_average_ms:8.3f} ms")
-        print(f"  average/query:     {average_query_ms:8.3f} ms")
-        print(f"  slowest query:     {slowest_max_ms:8.3f} ms ({slowest_name})")
+        for line in summary_lines(count, results, args.iterations):
+            print(line)
         if failed:
             raise SystemExit(1)
     finally:


### PR DESCRIPTION
Three related tooling/packaging issues, one commit each.

## #338 large-library benchmark output

The polish pass asked for after #497 landed: `total query time` read like wall-clock time while the value was the sum of the per-query averages, and a stray tab pushed the iterations line out of line.

Labels now name what the numbers actually are (`sum of query averages`, `average per query`, `slowest single run`) and every value is right-aligned in one column, counts included:

```
benchmark summary
  tracks:                   200,000
  queries:                        4
  iterations per query:         200
  sum of query averages:      4.250 ms
  average per query:          1.062 ms
  slowest single run:         9.500 ms (provider album)
```

The rendering moved into `summary_lines()` so it can be tested without a 200k-track fixture. New unit test covers the arithmetic, the alignment and the absence of tabs, and the workflow runs it before building the fixture. The benchmark workload itself is unchanged.

Thanks again @Jeevika1917 for #497, this is just the wording and spacing follow-up on top of it.

## #452 release/version synchronization

A release version is written down in five places: `pubspec.yaml`, the About screen, the Play changelog filename, the F-Droid entry, and the AppStream release entry a software centre shows. Only the first four were maintained by the bump tooling, so the AppStream `<releases>` list drifted by hand, and nothing failed when it did: the Flatpak builds and runs, the listing just advertises the previous release for the build someone installed.

- `prepare_release_bump.py` now writes the AppStream entry too (newest first, `--release-date` for a fixed date, a pre-release marked `type="development"`), and re-running it refreshes the entry instead of duplicating it.
- New `scripts/check_release_metadata_sync.py` reads all five surfaces and reports every disagreement at once, with the command that fixes them. It reuses the encoding and the F-Droid `VercodeOperation` transform from `prepare_release_bump.py` so the check and the fix cannot disagree about the rules. It also guards the day the Flatpak manifest stops building the working checkout: a manifest source pinned to a Linthra git tag has to name this release.
- CI runs the check on every push, and the prepare workflow runs it before opening the bump PR.
- The bump PR guard and the prepare workflow's commit now allow the metainfo file, and the release process documents the AppStream step in both flows.

No auto-merge is introduced anywhere; the bump still lands as a reviewable PR.

## #453 upstream release to Flathub update

Everything needed to publish a Flatpak update existed, but nothing said in what order to use it or which repository each step happens in.

`docs/flathub-update-process.md` walks it end to end: cut the release, check every surface names it, regenerate the pinned sources when the inputs changed, validate the packaging metadata, build and smoke-test, run the Flathub linter, then open the update PR in the Flathub repository. It references the #452 tooling rather than re-explaining the release, links to the existing Flatpak pages instead of duplicating them, and is explicit that Linthra is not on Flathub yet: the steps in this repository are live today, the Flathub-side ones describe the shape of the update once #451 and #456 land. It also covers what to do when an update goes wrong and which side of the split to fix it on.

A guardrail test checks every path and link the walkthrough names still exists, so it cannot quietly start naming scripts the repository no longer has.

## Checks run

- `ruff check scripts tool tools` and `ruff format --check scripts tool tools`
- `flutter analyze` (no issues)
- `flutter test test/tooling` (409 tests)
- every `test/tooling/*_test.py`
- `python3 scripts/check_release_metadata_sync.py` and `python3 scripts/check_linux_runner.py` against this checkout
- the bump script exercised on a fixture checkout (stable, pre-release, re-run, existing entry)

## Not included

#450 is still open on purpose. The AppStream description drift it lists (server streaming) depends on the Linux playback validation in #428/#429/#430, which is not done, so claiming server support in the public listing would be ahead of what is tested on Linux. Screenshots stay out pending #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMEPQXjgU1H4VLyt5UWVc5

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMEPQXjgU1H4VLyt5UWVc5)_