### PR TITLE
feat(desktop): make queue reordering work with a mouse and a keyboard (#388)

### DIFF
--- a/docs/queue.md
+++ b/docs/queue.md
@@ -50,17 +50,18 @@ History and the current track are not draggable.
 
 On desktop the handle behaves the way a desktop control should: the pointer
 turns into a grab cursor over it, hovering shows what it does, and the row lifts
-onto a shadow while it is being dragged so you can see what you picked up. A
-drop outside the list, or one that would land past either end, simply leaves the
-queue as it was.
+onto a shadow while it is being dragged so you can see what you picked up.
+Dragging past the top or bottom of the list drops the track at that end rather
+than somewhere unexpected, so an overshot drag is never destructive.
 
 **Without a pointer.** Tab to a row's handle and press **Ctrl + ↑ / ↓** (Cmd on
 macOS) to move that row one position. Focus follows the track, so holding the
-chord walks it up or down the queue. The same two moves are exposed to screen
-readers as the row's **Move up** / **Move down** actions, and a row at either
-end only offers the move that goes somewhere. Keyboard, screen reader and drag
-all run through the same queue edit, so nothing behaves differently depending on
-how you reached it.
+chord walks it up or down the queue (the sheet scrolls along to keep the track
+you are moving in view). The same two moves are exposed to screen readers as the
+row's **Move up** / **Move down** actions. Unlike a drag, a keyboard move at an
+endpoint does nothing at all: a row at either end only offers the move that goes
+somewhere. Keyboard, screen reader and drag all run through the same queue edit,
+so nothing behaves differently depending on how you reached it.
 
 - **Shuffle stays coherent.** While shuffle is on, you reorder the *shuffled*
   (effective) order. Turning shuffle **off** restores the original

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -48,6 +48,20 @@ Drag an **upcoming** track by its handle to a new position. The current track is
 untouched and keeps playing — reordering only changes the order of what follows.
 History and the current track are not draggable.
 
+On desktop the handle behaves the way a desktop control should: the pointer
+turns into a grab cursor over it, hovering shows what it does, and the row lifts
+onto a shadow while it is being dragged so you can see what you picked up. A
+drop outside the list, or one that would land past either end, simply leaves the
+queue as it was.
+
+**Without a pointer.** Tab to a row's handle and press **Ctrl + ↑ / ↓** (Cmd on
+macOS) to move that row one position. Focus follows the track, so holding the
+chord walks it up or down the queue. The same two moves are exposed to screen
+readers as the row's **Move up** / **Move down** actions, and a row at either
+end only offers the move that goes somewhere. Keyboard, screen reader and drag
+all run through the same queue edit, so nothing behaves differently depending on
+how you reached it.
+
 - **Shuffle stays coherent.** While shuffle is on, you reorder the *shuffled*
   (effective) order. Turning shuffle **off** restores the original
   pre-shuffle order, which drops a manual reorder — that's the defined meaning of

--- a/lib/features/player/widgets/queue_sheet.dart
+++ b/lib/features/player/widgets/queue_sheet.dart
@@ -394,6 +394,37 @@ class _UpNextListState extends ConsumerState<_UpNextList> {
     _followWalkTo(to, delta);
   }
 
+  /// Applies a pointer drop, carrying keyboard focus along with the row that
+  /// held it.
+  ///
+  /// Focus nodes are per position, so a drag changes which track the focused
+  /// node belongs to. Left alone, a Ctrl+Arrow after a drag reorders whichever
+  /// neighbour slid under the focus rather than the track just dropped. The
+  /// remap covers any focused row, not only the dragged one: a drag past a
+  /// focused row shifts that row too.
+  ///
+  /// Nothing happens when no handle has focus, so a plain mouse drag never
+  /// pulls focus into the list.
+  void _moveByPointer(int from, int to) {
+    final int focused =
+        _handleFocusNodes.indexWhere((FocusNode node) => node.hasFocus);
+    if (!_move(from, to)) return;
+    if (focused < 0) return;
+    _followWalkTo(_positionAfterMove(focused, from: from, to: to), to - from);
+  }
+
+  /// Where row [index] ends up once the row at [from] is moved to [to].
+  static int _positionAfterMove(
+    int index, {
+    required int from,
+    required int to,
+  }) {
+    if (index == from) return to;
+    if (from < index && index <= to) return index - 1;
+    if (to <= index && index < from) return index + 1;
+    return index;
+  }
+
   /// Scrolls the moved track's handle into view and gives it focus, so a held
   /// chord keeps walking the same track.
   ///
@@ -424,7 +455,7 @@ class _UpNextListState extends ConsumerState<_UpNextList> {
     final List<Track> tracks = widget.tracks;
     return SliverReorderableList(
       itemCount: tracks.length,
-      onReorderItem: (int oldIndex, int newIndex) => _move(oldIndex, newIndex),
+      onReorderItem: _moveByPointer,
       proxyDecorator: _liftedRow,
       itemBuilder: (context, index) => _UpNextTile(
         // Index-qualified so the same track queued twice never produces a
@@ -529,6 +560,15 @@ class _UpNextTile extends StatelessWidget {
   }
 }
 
+/// The modifier the move chord is spelled with on [platform].
+///
+/// Both modifiers stay registered everywhere — an unused activator costs
+/// nothing — but the hint has to name the one that actually works here. On
+/// macOS Ctrl+Arrow belongs to Mission Control and never reaches the app, so a
+/// hint saying Ctrl there would point people at a chord the OS eats.
+String _moveModifierLabel(TargetPlatform platform) =>
+    platform == TargetPlatform.macOS ? 'Cmd' : 'Ctrl';
+
 /// Asks for the focused queue row to move [delta] positions (-1 up, +1 down).
 class _MoveQueueItemIntent extends Intent {
   const _MoveQueueItemIntent(this.delta);
@@ -614,7 +654,8 @@ class _ReorderHandle extends StatelessWidget {
                   child: ReorderableDragStartListener(
                     index: index,
                     child: Tooltip(
-                      message: 'Reorder (drag, or Ctrl + ↑ / ↓)',
+                      message: 'Reorder (drag, or '
+                          '${_moveModifierLabel(theme.platform)} + ↑ / ↓)',
                       // Hover only. The default long-press trigger puts a
                       // long-press recognizer in the arena next to the drag
                       // listener, and on a handle the press *is* the drag: the

--- a/lib/features/player/widgets/queue_sheet.dart
+++ b/lib/features/player/widgets/queue_sheet.dart
@@ -317,6 +317,30 @@ class _UpNextList extends ConsumerStatefulWidget {
 class _UpNextListState extends ConsumerState<_UpNextList> {
   final List<FocusNode> _handleFocusNodes = <FocusNode>[];
 
+  /// Where a keyboard walk started from and where it has actually put the
+  /// track, while the list catches up.
+  ///
+  /// The queue reaches this sheet through a stream, so a move is applied to the
+  /// queue before any frame rebuilds the rows with it. A held chord repeats
+  /// faster than that: the second press is fired by a handle still carrying the
+  /// pre-move index, and taking it at face value would move the track back
+  /// where it came from. [_walkOrigin] is that stale index, [_walkLanded] is
+  /// where the track really is, and both are dropped the moment the rebuild
+  /// makes the widgets truthful again.
+  int? _walkOrigin;
+  int? _walkLanded;
+
+  @override
+  void didUpdateWidget(_UpNextList oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // A reorder always produces a new list, so a changed identity means the
+    // rows now carry post-move indices and the walk state has served its turn.
+    if (!identical(widget.tracks, oldWidget.tracks)) {
+      _walkOrigin = null;
+      _walkLanded = null;
+    }
+  }
+
   @override
   void dispose() {
     for (final FocusNode node in _handleFocusNodes) {
@@ -344,23 +368,53 @@ class _UpNextListState extends ConsumerState<_UpNextList> {
   /// Out-of-range moves are dropped here as well as in the queue model, so a
   /// keyboard press at either end of the list, or an index left stale by a
   /// queue that changed under the open sheet, is simply harmless.
-  void _move(int from, int to, {bool followFocus = false}) {
+  bool _move(int from, int to) {
     final int count = widget.tracks.length;
-    if (from < 0 || from >= count) return;
-    if (to < 0 || to >= count || to == from) return;
+    if (from < 0 || from >= count) return false;
+    if (to < 0 || to >= count || to == from) return false;
     ref.read(playbackControllerProvider).reorderQueue(from, to);
-    if (followFocus) _focusHandleAt(to);
+    return true;
   }
 
-  /// Puts keyboard focus back on the moved track's handle, after the frame that
-  /// rebuilds the list — before it, the destination row is still the old track.
-  /// A row scrolled out of view has no element to focus; skipping is fine,
-  /// the move itself already happened.
-  void _focusHandleAt(int index) {
+  /// Moves the track the handle on row [rowIndex] belongs to by [delta]
+  /// positions — the keyboard and screen-reader route.
+  ///
+  /// [rowIndex] is only a starting point: while a walk is in flight the rows
+  /// still report their pre-move indices, so the real source comes from
+  /// [_walkLanded]. The substitution is guarded on [_walkOrigin] so a press on
+  /// some *other* row inside that same window is still taken at face value.
+  void _moveBy(int rowIndex, int delta) {
+    final int from = _walkLanded != null && rowIndex == _walkOrigin
+        ? _walkLanded!
+        : rowIndex;
+    final int to = from + delta;
+    if (!_move(from, to)) return;
+    _walkOrigin = rowIndex;
+    _walkLanded = to;
+    _followWalkTo(to, delta);
+  }
+
+  /// Scrolls the moved track's handle into view and gives it focus, so a held
+  /// chord keeps walking the same track.
+  ///
+  /// The scroll is the part that makes this hold up on a long queue. Focus can
+  /// only land on a row the sliver has actually built, and a walk that never
+  /// scrolls eventually pushes the track past the built range: focus would stay
+  /// behind on the row a *different* track just slid into, and the next press
+  /// would move that one instead. Keeping the walking row on screen keeps its
+  /// destination within the built range, one row at a time.
+  void _followWalkTo(int index, int delta) {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted || index >= _handleFocusNodes.length) return;
       final FocusNode node = _handleFocusNodes[index];
-      if (node.context == null) return;
+      final BuildContext? handle = node.context;
+      if (handle == null) return;
+      Scrollable.ensureVisible(
+        handle,
+        alignmentPolicy: delta > 0
+            ? ScrollPositionAlignmentPolicy.keepVisibleAtEnd
+            : ScrollPositionAlignmentPolicy.keepVisibleAtStart,
+      );
       node.requestFocus();
     });
   }
@@ -370,7 +424,7 @@ class _UpNextListState extends ConsumerState<_UpNextList> {
     final List<Track> tracks = widget.tracks;
     return SliverReorderableList(
       itemCount: tracks.length,
-      onReorderItem: _move,
+      onReorderItem: (int oldIndex, int newIndex) => _move(oldIndex, newIndex),
       proxyDecorator: _liftedRow,
       itemBuilder: (context, index) => _UpNextTile(
         // Index-qualified so the same track queued twice never produces a
@@ -383,7 +437,7 @@ class _UpNextListState extends ConsumerState<_UpNextList> {
         onPlay: () => ref.read(playbackControllerProvider).playFromQueue(index),
         onRemove: () =>
             ref.read(playbackControllerProvider).removeFromQueue(index),
-        onMoveBy: (int delta) => _move(index, index + delta, followFocus: true),
+        onMoveBy: (int delta) => _moveBy(index, delta),
       ),
     );
   }

--- a/lib/features/player/widgets/queue_sheet.dart
+++ b/lib/features/player/widgets/queue_sheet.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../app/dimens.dart';
@@ -123,30 +125,7 @@ class QueueSheet extends ConsumerWidget {
                         if (upNext.isEmpty)
                           const SliverToBoxAdapter(child: _NothingUpNext())
                         else
-                          SliverReorderableList(
-                            itemCount: upNext.length,
-                            onReorderItem: (int oldIndex, int newIndex) {
-                              ref
-                                  .read(playbackControllerProvider)
-                                  .reorderQueue(oldIndex, newIndex);
-                            },
-                            itemBuilder: (context, index) => _UpNextTile(
-                              // Index-qualified so the same track queued twice
-                              // never produces a duplicate key (which would crash
-                              // the reorderable list).
-                              key: ValueKey<String>(
-                                'queue-$index-${upNext[index].id}',
-                              ),
-                              track: upNext[index],
-                              index: index,
-                              onPlay: () => ref
-                                  .read(playbackControllerProvider)
-                                  .playFromQueue(index),
-                              onRemove: () => ref
-                                  .read(playbackControllerProvider)
-                                  .removeFromQueue(index),
-                            ),
-                          ),
+                          _UpNextList(tracks: upNext),
                         const SliverToBoxAdapter(
                           child: SizedBox(height: AppSpacing.md),
                         ),
@@ -314,6 +293,124 @@ class _HistoryTile extends StatelessWidget {
   }
 }
 
+/// The reorderable "Up next" list.
+///
+/// Stateful for one reason: keyboard reordering. A pointer drag carries the row
+/// under the pointer, so the framework keeps the gesture aimed at the right
+/// track by itself. A keyboard move is a jump instead — the list rebuilds with
+/// the moved track a row away — so focus has to be handed to the row it landed
+/// on, or a second Ctrl+Arrow would move whatever slid into the old position.
+///
+/// The focus nodes are per *position*, not per track, which is what makes that
+/// work: after the rebuild the node at the destination index is the moved
+/// track's handle. Keying them by track would mean a new node per queue edit,
+/// and a duplicate node whenever the same song is queued twice.
+class _UpNextList extends ConsumerStatefulWidget {
+  const _UpNextList({required this.tracks});
+
+  final List<Track> tracks;
+
+  @override
+  ConsumerState<_UpNextList> createState() => _UpNextListState();
+}
+
+class _UpNextListState extends ConsumerState<_UpNextList> {
+  final List<FocusNode> _handleFocusNodes = <FocusNode>[];
+
+  @override
+  void dispose() {
+    for (final FocusNode node in _handleFocusNodes) {
+      node.dispose();
+    }
+    super.dispose();
+  }
+
+  /// The handle focus node for row [index], grown on demand. The list only ever
+  /// grows within one sheet: a shrinking queue leaves spare nodes parked, which
+  /// costs nothing and keeps the indices stable.
+  FocusNode _focusNodeAt(int index) {
+    while (_handleFocusNodes.length <= index) {
+      _handleFocusNodes.add(
+        FocusNode(debugLabel: 'queue-handle-${_handleFocusNodes.length}'),
+      );
+    }
+    return _handleFocusNodes[index];
+  }
+
+  /// Moves the up-next track at [from] to [to] (both 0-based into up-next,
+  /// [to] being the destination after removal — the index a normalised
+  /// reorderable list reports, and the one [PlaybackQueue.reorderUpNext] takes).
+  ///
+  /// Out-of-range moves are dropped here as well as in the queue model, so a
+  /// keyboard press at either end of the list, or an index left stale by a
+  /// queue that changed under the open sheet, is simply harmless.
+  void _move(int from, int to, {bool followFocus = false}) {
+    final int count = widget.tracks.length;
+    if (from < 0 || from >= count) return;
+    if (to < 0 || to >= count || to == from) return;
+    ref.read(playbackControllerProvider).reorderQueue(from, to);
+    if (followFocus) _focusHandleAt(to);
+  }
+
+  /// Puts keyboard focus back on the moved track's handle, after the frame that
+  /// rebuilds the list — before it, the destination row is still the old track.
+  /// A row scrolled out of view has no element to focus; skipping is fine,
+  /// the move itself already happened.
+  void _focusHandleAt(int index) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || index >= _handleFocusNodes.length) return;
+      final FocusNode node = _handleFocusNodes[index];
+      if (node.context == null) return;
+      node.requestFocus();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final List<Track> tracks = widget.tracks;
+    return SliverReorderableList(
+      itemCount: tracks.length,
+      onReorderItem: _move,
+      proxyDecorator: _liftedRow,
+      itemBuilder: (context, index) => _UpNextTile(
+        // Index-qualified so the same track queued twice never produces a
+        // duplicate key (which would crash the reorderable list).
+        key: ValueKey<String>('queue-$index-${tracks[index].id}'),
+        track: tracks[index],
+        index: index,
+        count: tracks.length,
+        handleFocusNode: _focusNodeAt(index),
+        onPlay: () => ref.read(playbackControllerProvider).playFromQueue(index),
+        onRemove: () =>
+            ref.read(playbackControllerProvider).removeFromQueue(index),
+        onMoveBy: (int delta) => _move(index, index + delta, followFocus: true),
+      ),
+    );
+  }
+}
+
+/// The row being dragged: lifted off the list on a shadow so it reads as picked
+/// up rather than merely highlighted. Desktop pointers have no haptics and no
+/// long-press wind-up, so this elevation is the only feedback that the drag
+/// actually took.
+Widget _liftedRow(Widget child, int index, Animation<double> animation) {
+  return AnimatedBuilder(
+    animation: animation,
+    builder: (BuildContext context, Widget? child) {
+      final ColorScheme scheme = Theme.of(context).colorScheme;
+      final double t = Curves.easeInOut.transform(animation.value);
+      return Material(
+        elevation: t * 6,
+        color: Color.lerp(scheme.surface, scheme.surfaceContainerHighest, t),
+        shadowColor: scheme.shadow,
+        borderRadius: BorderRadius.circular(AppRadii.sm),
+        child: child,
+      );
+    },
+    child: child,
+  );
+}
+
 /// An upcoming track: tap to play now, an X to remove it from the queue, and a
 /// drag handle to reorder. Removing only drops the queue entry — it never
 /// deletes the track from the library or its offline copy.
@@ -321,15 +418,23 @@ class _UpNextTile extends StatelessWidget {
   const _UpNextTile({
     required this.track,
     required this.index,
+    required this.count,
+    required this.handleFocusNode,
     required this.onPlay,
     required this.onRemove,
+    required this.onMoveBy,
     super.key,
   });
 
   final Track track;
   final int index;
+  final int count;
+  final FocusNode handleFocusNode;
   final VoidCallback onPlay;
   final VoidCallback onRemove;
+
+  /// Moves this row by [delta] positions (-1 up, +1 down).
+  final ValueChanged<int> onMoveBy;
 
   @override
   Widget build(BuildContext context) {
@@ -357,17 +462,135 @@ class _UpNextTile extends StatelessWidget {
               tooltip: 'Remove from queue',
               onPressed: onRemove,
             ),
-            ReorderableDragStartListener(
+            _ReorderHandle(
               index: index,
-              child: const Padding(
-                padding: EdgeInsets.only(left: AppSpacing.xs),
-                child: Icon(
-                  Icons.drag_handle,
-                  semanticLabel: 'Reorder',
-                ),
-              ),
+              count: count,
+              focusNode: handleFocusNode,
+              onMoveBy: onMoveBy,
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Asks for the focused queue row to move [delta] positions (-1 up, +1 down).
+class _MoveQueueItemIntent extends Intent {
+  const _MoveQueueItemIntent(this.delta);
+
+  final int delta;
+}
+
+/// The reorder affordance on an up-next row: a pointer drag target that is also
+/// a real focusable control.
+///
+/// Dragging is the fast path and stays exactly what it was. The rest is what a
+/// drag alone cannot serve: **Ctrl + ↑ / ↓** (Cmd on macOS) moves the focused
+/// row without a pointer, and the same two moves are offered as custom
+/// semantics actions so a screen reader can reorder the queue too. Both routes
+/// run through the same controller call the drag does, so there is one reorder
+/// path, not a keyboard copy of one.
+///
+/// The chord takes a modifier on purpose: a bare arrow inside a scrolling sheet
+/// belongs to focus traversal and scrolling, and stealing it would trade one
+/// accessible behaviour for another.
+class _ReorderHandle extends StatelessWidget {
+  const _ReorderHandle({
+    required this.index,
+    required this.count,
+    required this.focusNode,
+    required this.onMoveBy,
+  });
+
+  final int index;
+  final int count;
+  final FocusNode focusNode;
+  final ValueChanged<int> onMoveBy;
+
+  /// Shortcuts sit *above* the focus node, not inside it: a key event travels
+  /// up from the focused node, so a [Shortcuts] below it would never see one.
+  static const Map<ShortcutActivator, Intent> _shortcuts =
+      <ShortcutActivator, Intent>{
+    SingleActivator(LogicalKeyboardKey.arrowUp, control: true):
+        _MoveQueueItemIntent(-1),
+    SingleActivator(LogicalKeyboardKey.arrowDown, control: true):
+        _MoveQueueItemIntent(1),
+    SingleActivator(LogicalKeyboardKey.arrowUp, meta: true):
+        _MoveQueueItemIntent(-1),
+    SingleActivator(LogicalKeyboardKey.arrowDown, meta: true):
+        _MoveQueueItemIntent(1),
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final bool canMoveUp = index > 0;
+    final bool canMoveDown = index < count - 1;
+    return Shortcuts(
+      shortcuts: _shortcuts,
+      child: Actions(
+        actions: <Type, Action<Intent>>{
+          _MoveQueueItemIntent: CallbackAction<_MoveQueueItemIntent>(
+            onInvoke: (_MoveQueueItemIntent intent) {
+              onMoveBy(intent.delta);
+              return null;
+            },
+          ),
+        },
+        // Not a semantics container: the actions merge up into the row's own
+        // node, so a screen reader reads one row that happens to be movable
+        // rather than a stray control beside it. The ends of the list offer
+        // only the move that exists.
+        child: Semantics(
+          customSemanticsActions: <CustomSemanticsAction, VoidCallback>{
+            if (canMoveUp)
+              const CustomSemanticsAction(label: 'Move up'): () => onMoveBy(-1),
+            if (canMoveDown)
+              const CustomSemanticsAction(label: 'Move down'): () =>
+                  onMoveBy(1),
+          },
+          child: Focus(
+            focusNode: focusNode,
+            child: Builder(
+              builder: (BuildContext context) {
+                final bool focused = Focus.of(context).hasFocus;
+                return MouseRegion(
+                  cursor: SystemMouseCursors.grab,
+                  child: ReorderableDragStartListener(
+                    index: index,
+                    child: Tooltip(
+                      message: 'Reorder (drag, or Ctrl + ↑ / ↓)',
+                      // Hover only. The default long-press trigger puts a
+                      // long-press recognizer in the arena next to the drag
+                      // listener, and on a handle the press *is* the drag: the
+                      // tooltip wins and the row never lifts. Hover is the
+                      // desktop trigger anyway, and the handle is still named
+                      // for screen readers either way.
+                      triggerMode: TooltipTriggerMode.manual,
+                      child: Container(
+                        margin: const EdgeInsets.only(left: AppSpacing.xs),
+                        padding: const EdgeInsets.all(AppSpacing.xs),
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(AppRadii.sm),
+                          border: Border.all(
+                            width: 2,
+                            color: focused
+                                ? theme.colorScheme.primary
+                                : Colors.transparent,
+                          ),
+                        ),
+                        child: const Icon(
+                          Icons.drag_handle,
+                          semanticLabel: 'Reorder',
+                        ),
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
         ),
       ),
     );

--- a/test/core/models/playback_queue_test.dart
+++ b/test/core/models/playback_queue_test.dart
@@ -237,6 +237,48 @@ void main() {
       expect(queue.reorderUpNext(-1, 0), same(queue));
     });
 
+    test('repeated reorderUpNext() calls keep the queue whole', () {
+      // A drag-and-drop session is many small moves, each one landing on the
+      // queue the previous one produced. Walking a track down the list and
+      // back up again must return the same set of tracks in a sane order —
+      // never a lost, duplicated, or half-moved entry — with the playing track
+      // where it started.
+      PlaybackQueue queue = PlaybackQueue.of(
+        [_track('a'), _track('b'), _track('c'), _track('d'), _track('e')],
+      );
+
+      for (int i = 0; i < 3; i++) {
+        queue = queue.reorderUpNext(i, i + 1);
+      }
+      expect(
+          queue.upNext, [_track('c'), _track('d'), _track('e'), _track('b')]);
+
+      for (int i = 3; i > 0; i--) {
+        queue = queue.reorderUpNext(i, i - 1);
+      }
+
+      expect(queue.current, _track('a'));
+      expect(
+          queue.upNext, [_track('b'), _track('c'), _track('d'), _track('e')]);
+      expect(queue.currentIndex, 0);
+    });
+
+    test('reorderUpNext() while shuffled leaves the original order alone', () {
+      final queue = PlaybackQueue.of(
+        [_track('a'), _track('b'), _track('c'), _track('d')],
+      ).shuffled(Random(3));
+      final List<Track> before = List<Track>.of(queue.originalOrder!);
+
+      // Reordering the shuffled (effective) order is a change to what plays
+      // next, not to the order shuffle will be undone back to.
+      final updated = queue.reorderUpNext(0, 2);
+
+      expect(updated.isShuffled, isTrue);
+      expect(updated.originalOrder, before);
+      expect(updated.current, queue.current);
+      expect(updated.unshuffled().tracks, before);
+    });
+
     test('jumpToUpNext() makes an upcoming track current', () {
       final queue = PlaybackQueue.of(
         [_track('a'), _track('b'), _track('c'), _track('d')],

--- a/test/features/player/queue_sheet_test.dart
+++ b/test/features/player/queue_sheet_test.dart
@@ -1,5 +1,7 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/playlist.dart';
@@ -72,6 +74,33 @@ Future<void> _dragToEdge(
   await tester.pumpAndSettle();
   await gesture.up();
   await tester.pumpAndSettle();
+}
+
+/// Gives the up-next drag handle at [index] keyboard focus, the way Tab would.
+Future<void> _focusHandle(WidgetTester tester, int index) async {
+  final Finder handles = find.byIcon(Icons.drag_handle);
+  Focus.of(tester.element(handles.at(index))).requestFocus();
+  await tester.pumpAndSettle();
+}
+
+/// Presses Ctrl + Arrow Up/Down, the chord that moves the focused row.
+Future<void> _pressMoveChord(WidgetTester tester, {required bool down}) async {
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+  await tester.sendKeyEvent(
+    down ? LogicalKeyboardKey.arrowDown : LogicalKeyboardKey.arrowUp,
+  );
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+  await tester.pumpAndSettle();
+}
+
+/// The custom semantics actions offered on the row rendering [title].
+Set<String> _customActionsOn(WidgetTester tester, String title) {
+  return tester
+      .getSemantics(find.text(title))
+      .getSemanticsData()
+      .customSemanticsActionIds!
+      .map((int id) => CustomSemanticsAction.getAction(id)!.label!)
+      .toSet();
 }
 
 void main() {
@@ -286,6 +315,179 @@ void main() {
       expect(find.textContaining('api_key'), findsNothing);
       expect(find.textContaining('https://'), findsNothing);
       expect(find.textContaining('jellyfin:'), findsNothing);
+    });
+    testWidgets('Ctrl+Arrow moves the focused row without a pointer',
+        (tester) async {
+      final controller = FakePlaybackController();
+      await controller
+          .playTracks([_track('A'), _track('B'), _track('C'), _track('D')]);
+
+      await _open(tester, controller);
+      // Focus B's handle (the first up-next row) and push it down twice.
+      await _focusHandle(tester, 0);
+      await _pressMoveChord(tester, down: true);
+
+      expect(controller.state.upNext.map((Track t) => t.id).toList(),
+          <String>['C', 'B', 'D']);
+      // Focus followed B to its new row, so the second press moves B again
+      // rather than whatever slid into the row it left.
+      await _pressMoveChord(tester, down: true);
+
+      expect(controller.state.upNext.map((Track t) => t.id).toList(),
+          <String>['C', 'D', 'B']);
+      // The current track never moves, and nothing restarted: A is still the
+      // only track playback was ever handed.
+      expect(controller.state.currentTrack, _track('A'));
+      expect(controller.playedTracks, <Track>[_track('A')]);
+    });
+
+    testWidgets('Ctrl+Arrow up walks a row back to the top', (tester) async {
+      final controller = FakePlaybackController();
+      await controller
+          .playTracks([_track('A'), _track('B'), _track('C'), _track('D')]);
+
+      await _open(tester, controller);
+      await _focusHandle(tester, 2); // D
+      await _pressMoveChord(tester, down: false);
+      await _pressMoveChord(tester, down: false);
+
+      expect(controller.state.upNext.map((Track t) => t.id).toList(),
+          <String>['D', 'B', 'C']);
+    });
+
+    testWidgets('a move chord at either end of the queue is a no-op',
+        (tester) async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('A'), _track('B'), _track('C')]);
+
+      await _open(tester, controller);
+      // Up from the first up-next row, and down from the last: both would land
+      // outside the list, so both are dropped rather than clamped onto a
+      // neighbour or pushed past the playing track.
+      await _focusHandle(tester, 0);
+      await _pressMoveChord(tester, down: false);
+      await _focusHandle(tester, 1);
+      await _pressMoveChord(tester, down: true);
+
+      expect(controller.state.upNext.map((Track t) => t.id).toList(),
+          <String>['B', 'C']);
+      expect(controller.state.currentTrack, _track('A'));
+    });
+
+    testWidgets('repeated moves in a row leave the queue coherent',
+        (tester) async {
+      final controller = FakePlaybackController();
+      await controller.playTracks(
+        <Track>[
+          for (final String id in <String>['A', 'B', 'C', 'D', 'E']) _track(id)
+        ],
+      );
+
+      await _open(tester, controller);
+      // Eight moves back to back, changing direction and hitting both ends:
+      // every one lands on the queue the previous one left behind, so a stale
+      // index would show up as a lost or duplicated track.
+      await _focusHandle(tester, 0);
+      for (int i = 0; i < 3; i++) {
+        await _pressMoveChord(tester, down: true);
+      }
+      for (int i = 0; i < 5; i++) {
+        await _pressMoveChord(tester, down: false);
+      }
+
+      expect(controller.state.upNext.map((Track t) => t.id).toList(),
+          <String>['B', 'C', 'D', 'E']);
+      expect(controller.state.currentTrack, _track('A'));
+      expect(controller.playedTracks, <Track>[_track('A')]);
+    });
+
+    testWidgets('shuffled queues reorder the order that is actually playing',
+        (tester) async {
+      final controller = FakePlaybackController();
+      await controller
+          .playTracks([_track('A'), _track('B'), _track('C'), _track('D')]);
+      controller.setShuffleEnabled(true);
+      final List<String> shuffled =
+          controller.state.upNext.map((Track t) => t.id).toList();
+
+      await _open(tester, controller);
+      await _focusHandle(tester, 0);
+      await _pressMoveChord(tester, down: true);
+
+      // The first two swap; shuffle stays on and the current track is untouched.
+      expect(controller.state.upNext.map((Track t) => t.id).toList(),
+          <String>[shuffled[1], shuffled[0], shuffled[2]]);
+      expect(controller.state.shuffleEnabled, isTrue);
+      expect(controller.state.currentTrack, _track('A'));
+    });
+
+    testWidgets('rows offer move actions, and only the ones that exist',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      final controller = FakePlaybackController();
+      await controller
+          .playTracks([_track('A'), _track('B'), _track('C'), _track('D')]);
+
+      await _open(tester, controller);
+
+      // A screen reader gets the same two moves the keyboard chord does.
+      expect(
+          _customActionsOn(tester, 'Song C'), <String>{'Move up', 'Move down'});
+      // The ends of the list only offer the move that goes somewhere.
+      expect(_customActionsOn(tester, 'Song B'), <String>{'Move down'});
+      expect(_customActionsOn(tester, 'Song D'), <String>{'Move up'});
+
+      handle.dispose();
+    });
+
+    testWidgets('the drag handle answers a screen reader move', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('A'), _track('B'), _track('C')]);
+
+      await _open(tester, controller);
+      final int moveDown = tester
+          .getSemantics(find.text('Song B'))
+          .getSemanticsData()
+          .customSemanticsActionIds!
+          .firstWhere(
+            (int id) =>
+                CustomSemanticsAction.getAction(id)!.label == 'Move down',
+          );
+      tester.semantics.performAction(
+        find.semantics.byLabel(RegExp('Song B')),
+        SemanticsAction.customAction,
+        args: moveDown,
+      );
+      await tester.pumpAndSettle();
+
+      expect(controller.state.upNext.map((Track t) => t.id).toList(),
+          <String>['C', 'B']);
+
+      handle.dispose();
+    });
+
+    testWidgets('the handle shows a grab cursor and a hover hint',
+        (tester) async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('A'), _track('B')]);
+
+      await _open(tester, controller);
+
+      final TestGesture mouse =
+          await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await mouse.addPointer();
+      addTearDown(mouse.removePointer);
+      await mouse.moveTo(tester.getCenter(find.byIcon(Icons.drag_handle)));
+      await tester.pumpAndSettle();
+
+      // Desktop affordance: the pointer says the handle is draggable before the
+      // drag starts, and hovering spells out the keyboard alternative.
+      expect(
+        RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1),
+        SystemMouseCursors.grab,
+      );
+      expect(find.textContaining('Ctrl'), findsOneWidget);
     });
   });
 }

--- a/test/features/player/queue_sheet_test.dart
+++ b/test/features/player/queue_sheet_test.dart
@@ -22,6 +22,7 @@ Future<void> _open(
   WidgetTester tester,
   FakePlaybackController controller, {
   InMemoryPlaylistStore? store,
+  TargetPlatform? platform,
 }) async {
   await tester.pumpWidget(
     ProviderScope(
@@ -30,6 +31,7 @@ Future<void> _open(
         if (store != null) playlistStoreProvider.overrideWithValue(store),
       ],
       child: MaterialApp(
+        theme: platform == null ? null : ThemeData(platform: platform),
         home: Scaffold(
           body: Builder(
             builder: (context) => TextButton(
@@ -108,6 +110,14 @@ Future<void> _pressMoveChord(WidgetTester tester, {required bool down}) async {
   );
   await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
   await tester.pumpAndSettle();
+}
+
+/// The reorder handle's hover hint, which spells out the keyboard chord.
+String _moveHint(WidgetTester tester) {
+  return tester
+      .widgetList<Tooltip>(find.byType(Tooltip))
+      .map((Tooltip t) => t.message ?? '')
+      .firstWhere((String m) => m.contains('Reorder'));
 }
 
 /// The custom semantics actions offered on the row rendering [title].
@@ -547,6 +557,94 @@ void main() {
       expect(upNext..remove('01'), <String>[
         for (int i = 2; i < 30; i++) i.toString().padLeft(2, '0'),
       ]);
+    });
+    testWidgets('a chord after a pointer drag moves the track that was dragged',
+        (tester) async {
+      final controller = FakePlaybackController();
+      await controller.playTracks(
+        [_track('A'), _track('B'), _track('C'), _track('D'), _track('E')],
+      );
+
+      await _open(tester, controller);
+      // Focus B's handle, then drag B to the end with the mouse. Focus nodes
+      // are per position, so without a handoff the focus would be left on the
+      // row C slid into and the chord below would move C (or, at the top of
+      // the list, do nothing at all).
+      await _focusHandle(tester, 0);
+      await _dragToEdge(tester, from: 0, toEnd: true);
+      expect(controller.state.upNext.map((Track t) => t.id).toList(),
+          <String>['C', 'D', 'E', 'B']);
+
+      await _pressMoveChord(tester, down: false);
+
+      expect(controller.state.upNext.map((Track t) => t.id).toList(),
+          <String>['C', 'D', 'B', 'E']);
+    });
+
+    testWidgets('a drag past a focused row carries that row along',
+        (tester) async {
+      final controller = FakePlaybackController();
+      await controller.playTracks(
+        [_track('A'), _track('B'), _track('C'), _track('D'), _track('E')],
+      );
+
+      await _open(tester, controller);
+      // Focus D, then drag B from the top past it. D is now one row higher, so
+      // the chord has to follow D rather than stay on the index it used to sit
+      // at — which E has since slid into.
+      await _focusHandle(tester, 2); // up next is [B, C, D, E]
+      await _dragToEdge(tester, from: 0, toEnd: true);
+      expect(controller.state.upNext.map((Track t) => t.id).toList(),
+          <String>['C', 'D', 'E', 'B']);
+
+      await _pressMoveChord(tester, down: false);
+
+      // D moved up. Staying on the stale index would have moved E instead,
+      // giving [C, E, D, B].
+      expect(controller.state.upNext.map((Track t) => t.id).toList(),
+          <String>['D', 'C', 'E', 'B']);
+    });
+
+    testWidgets('a mouse drag alone never pulls focus into the queue',
+        (tester) async {
+      final controller = FakePlaybackController();
+      await controller
+          .playTracks([_track('A'), _track('B'), _track('C'), _track('D')]);
+
+      await _open(tester, controller);
+      await _dragToEdge(tester, from: 0, toEnd: true);
+
+      // Nothing was focused before the drag, so nothing is after it: the
+      // handoff only moves focus that already existed.
+      expect(
+        find
+            .byIcon(Icons.drag_handle)
+            .evaluate()
+            .any((Element e) => Focus.of(e).hasFocus),
+        isFalse,
+      );
+    });
+
+    testWidgets('the hover hint names the modifier that works on this platform',
+        (tester) async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('A'), _track('B')]);
+
+      await _open(tester, controller, platform: TargetPlatform.macOS);
+
+      // Ctrl + arrow is Mission Control on macOS and never reaches the app, so
+      // a hint naming it would send people to a chord the OS eats.
+      expect(_moveHint(tester), contains('Cmd'));
+      expect(_moveHint(tester), isNot(contains('Ctrl')));
+    });
+
+    testWidgets('the hover hint says Ctrl on Linux', (tester) async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('A'), _track('B')]);
+
+      await _open(tester, controller, platform: TargetPlatform.linux);
+
+      expect(_moveHint(tester), contains('Ctrl'));
     });
   });
 }

--- a/test/features/player/queue_sheet_test.dart
+++ b/test/features/player/queue_sheet_test.dart
@@ -83,6 +83,23 @@ Future<void> _focusHandle(WidgetTester tester, int index) async {
   await tester.pumpAndSettle();
 }
 
+/// Holds Ctrl + Arrow Down for [repeats] extra auto-repeats, with no frame
+/// between them.
+///
+/// The queue reaches the sheet through a stream, so nothing has rebuilt the
+/// rows by the time the repeat arrives: this is the real shape of a held key,
+/// and the one case a press-then-pump test cannot reach.
+Future<void> _holdMoveChordDown(WidgetTester tester, {int repeats = 1}) async {
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowDown);
+  for (int i = 0; i < repeats; i++) {
+    await tester.sendKeyRepeatEvent(LogicalKeyboardKey.arrowDown);
+  }
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.arrowDown);
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+  await tester.pumpAndSettle();
+}
+
 /// Presses Ctrl + Arrow Up/Down, the chord that moves the focused row.
 Future<void> _pressMoveChord(WidgetTester tester, {required bool down}) async {
   await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
@@ -488,6 +505,48 @@ void main() {
         SystemMouseCursors.grab,
       );
       expect(find.textContaining('Ctrl'), findsOneWidget);
+    });
+    testWidgets('a held chord keeps walking the same track', (tester) async {
+      final controller = FakePlaybackController();
+      await controller
+          .playTracks([_track('A'), _track('B'), _track('C'), _track('D')]);
+
+      await _open(tester, controller);
+      await _focusHandle(tester, 0);
+      // Two presses, no frame in between. Reading the source index off the
+      // handle that fired would apply the second move to the queue the first
+      // one already changed, and land B back where it started.
+      await _holdMoveChordDown(tester);
+
+      expect(controller.state.upNext.map((Track t) => t.id).toList(),
+          <String>['C', 'D', 'B']);
+    });
+
+    testWidgets('a walk past the bottom of the sheet still moves one track',
+        (tester) async {
+      final controller = FakePlaybackController();
+      await controller.playTracks(<Track>[
+        for (int i = 0; i < 30; i++) _track(i.toString().padLeft(2, '0')),
+      ]);
+
+      await _open(tester, controller);
+      await _focusHandle(tester, 0);
+      // Twelve rows is further than the sheet shows at once. Focus can only
+      // land on a row the sliver built, so without scrolling the walk strands
+      // itself partway down and starts moving whichever track slid into the
+      // row it left.
+      for (int i = 0; i < 12; i++) {
+        await _pressMoveChord(tester, down: true);
+      }
+
+      final List<String> upNext =
+          controller.state.upNext.map((Track t) => t.id).toList();
+      expect(upNext.indexOf('01'), 12);
+      // Nothing else moved, and nothing was lost on the way down.
+      expect(upNext.length, 29);
+      expect(upNext..remove('01'), <String>[
+        for (int i = 2; i < 30; i++) i.toString().padLeft(2, '0'),
+      ]);
     });
   });
 }


### PR DESCRIPTION
Closes #388. Part of #376 (PR 4, desktop UX).

## What this is

The Up Next list was already reorderable, but the handle was built for a thumb: no cursor change, no lift while dragging, and no way to move a row at all without a pointer. This makes the same list behave like a desktop control.

- grab cursor and a hover tooltip on the handle, so a mouse user can see it is draggable before trying
- the dragged row lifts onto a shadow (`proxyDecorator`). Desktop pointers have no haptics and no long-press wind-up, so this is the only feedback that the drag actually took
- **Ctrl + ↑ / ↓** (Cmd on macOS, and the hint says so per platform) moves the focused row, with focus following the track and the sheet scrolling along, so the chord can be held to walk a row up or down the queue
- the same two moves as **Move up** / **Move down** semantics actions, and only the one that goes somewhere at either end of the list

No second desktop queue implementation: every route calls the existing `PlaybackController.reorderQueue` / `PlaybackQueue.reorderUpNext`, so drag, keyboard and screen reader all take the same path. The current track and playback are untouched, and shuffle/repeat keep the semantics they already had.

## Things worth a look in review

**The tooltip is hover-only** (`TooltipTriggerMode.manual`). The default long-press trigger puts a long-press recognizer in the arena next to the drag listener, and on a handle the press *is* the drag: the tooltip wins the arena and the row never lifts. This broke the two existing drag tests, which is how it was caught. Hover is the desktop trigger anyway, and the handle stays named for screen readers either way.

**The chord takes a modifier on purpose.** A bare arrow inside a scrolling sheet belongs to focus traversal and scrolling, so stealing it would trade one accessible behaviour for another.

**Focus is positional, and that is the hard part.** The up-next list is stateful because a pointer drag carries the row under the pointer while a keyboard move is a jump. The nodes are per position rather than per track (the same song can legitimately be queued twice), so anything that reorders the list changes which track a focused node belongs to. Three things fall out of that, all covered by tests:

- a held chord repeats faster than the queue reaches the sheet through its `StreamProvider`, so the second press arrives at a row still reporting its pre-move index. The list tracks where a walk started and where it actually landed, and drops both once a rebuild makes the indices truthful.
- focus can only land on a row the sliver built, so the moved row is scrolled into view before it takes focus. Without that, a long walk strands itself partway down and starts moving the wrong track.
- a pointer drag remaps the focused row through the move it just applied, covering both a drag of the focused row and a drag past it. It only fires when a handle already had focus, so a plain mouse drag never pulls focus into the list.

## Tests

Widget tests in `test/features/player/queue_sheet_test.dart`:

- the chord moves the focused row, and focus follows the track (a second press moves the same track)
- walking a row back up to the top
- a chord at either end is a no-op, not a clamp onto a neighbour or a push past the playing track
- a held chord (`sendKeyRepeatEvent`, no pump) keeps walking one track instead of undoing itself
- a walk of twelve rows down a 30-track queue moves one track twelve rows and leaves the other 28 alone
- a chord after a pointer drag moves the track that was dragged; a drag past a focused row carries that row along; a mouse drag alone never pulls focus into the list
- reordering a shuffled queue reorders the order actually playing, shuffle stays on
- rows offer the move actions, and only the ones that exist; a screen reader `Move down` actually reorders
- the handle reports a grab cursor on hover, and the hint names Cmd on macOS and Ctrl on Linux

Model tests in `test/core/models/playback_queue_test.dart`:

- repeated `reorderUpNext()` calls keep the queue whole (no lost, duplicated or half-moved entry)
- reordering while shuffled leaves `originalOrder` alone, so a later unshuffle still restores it

`docs/queue.md` covers the desktop and keyboard behaviour under Reordering, including that an overshot drag clamps to the end of the list while a keyboard move at an endpoint does nothing.

## Checks

Run locally against the pinned Flutter 3.44.7:

- `dart format --set-exit-if-changed .`
- `flutter analyze` (no issues)
- `flutter test` (4368 passing)

Android is untouched: this is the same widget on both platforms, and the whole suite passes.

## Review history

Codex raised five findings across two rounds. All five were real, all were reproduced with a failing test before being fixed, and all threads are resolved. Codex has since hit its account usage limit for code reviews, so later pushes will not get a review pass from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGaoXaopecxf5D6Mv9Deb4