### PR TITLE
feat(linux): choose the audio output device (#402)

### DIFF
--- a/docs/dependency-license-audit.md
+++ b/docs/dependency-license-audit.md
@@ -84,7 +84,7 @@ The specific combinations that need stating rather than assuming:
 
   **No GPL, no LGPL, no proprietary, and no unknown or unverifiable license** in
   the resolved Dart/Flutter set. The single MPL-2.0 package is `dbus 0.7.12`
-  (§3). Counts by dependency kind: 21 direct-main, 3 direct-dev and 134
+  (§3). Counts by dependency kind: 22 direct-main, 3 direct-dev and 133
   transitive hosted packages.
 - **Supersedes the earlier snapshot.** A previous revision of this document
   reported 152 packages against Flutter 3.27.4 and, separately, classified
@@ -139,6 +139,7 @@ published archive (§2).
 | `media_kit_libs_linux`   | `^1.2.1`     | media-kit.dev       | MIT            | Linux native registration for media_kit; links the **system/Flatpak libmpv** built in §5. Ships no prebuilt binary. |
 | `dbus`                   | `^0.7.12`    | canonical.com       | **MPL-2.0**    | D-Bus client behind the Linux MPRIS media session, so desktop shells and media keys can control Linthra. Already in the tree transitively (via `bonsoir_linux`); now declared directly. Compatible with AGPL-3.0-or-later under MPL-2.0 §3.3 — see §1 and §3. |
 | `just_audio_media_kit`   | (vendored)   | — (see §5)          | Unlicense      | Vendored Linux `just_audio` backend. Third-party code — **not** relicensed (§5). |
+| `media_kit`              | `^1.2.6`     | media-kit.dev       | MIT            | The libmpv binding the vendored Linux backend already runs on. Already in the tree transitively (via `just_audio_media_kit`); now declared directly, because Linthra calls its audio output device API for Linux output selection ([#402](https://github.com/thezupzup/linthra/issues/402)). |
 
 > `audio_metadata_reader` was added so a Linux local library shows real titles,
 > artists, albums and durations instead of filenames

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -269,8 +269,21 @@ Four decisions worth knowing:
   device is looked up in the list the host actually reports. If it is not there
   — unplugged headset, a different machine, a renamed sink — Linthra stays on
   the system default, forgets the stored value rather than pushing a name libmpv
-  would reject, and the card says so. A backend that cannot be enumerated at all
-  is *not* treated as "device gone": nothing is cleared and nothing is re-routed.
+  would reject, and the card says so.
+* **"Did not answer" is never read as "device gone".** A backend that cannot be
+  enumerated — including one that does not publish `audio-device-list` before
+  the probe times out — clears nothing, re-routes nothing, and keeps the live
+  selection; the card just reports that it found no outputs. libmpv seeds its
+  own state with a lone `auto` entry, and treating *that* as the real list is
+  exactly how a transient hiccup would look like an unplugged device, so the
+  timeout is deliberately surfaced as a failure instead.
+* **A refused switch is not recorded as done.** Routing reports whether it took
+  effect. If the backend refuses (the device went away between the list and the
+  tap) nothing is stored, playback is still shown where it actually is, the card
+  says the switch did not happen, and the next attempt at that device is a real
+  attempt rather than a no-op.
+* **Choices are serialized.** Two quick picks queue instead of racing, so the
+  later gesture is the one that ends up playing and stored.
 * **Only stable ids are remembered.** PipeWire/PulseAudio node names and ALSA
   `CARD=` names are derived from the hardware and survive a reboot, so they are
   persisted. ALSA's numeric handles (`alsa/hw:1,0`) are card *indexes* that

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -204,10 +204,17 @@ source-specific player exists and credentials remain in the existing resolver.
 
 `just_audio_media_kit` is vendored under `third_party/just_audio_media_kit`
 (and wired in through a `dependency_overrides` path entry) rather than pulled
-from pub.dev. The local delta is two hunks that add
-`JustAudioMediaKit.mpvProperties`, an optional map of libmpv properties applied
-at player creation. Linthra uses it for the defaults below, and the headless CI
-smoke target layers `ao=alsa` on top where there is no PipeWire/Pulse device.
+from pub.dev. The local delta is two small additions:
+
+* `JustAudioMediaKit.mpvProperties`, an optional map of libmpv properties
+  applied at player creation. Linthra uses it for the defaults below, and the
+  headless CI smoke target layers `ao=alsa` on top where there is no
+  PipeWire/Pulse device.
+* `JustAudioMediaKit.livePlayers`, a map of the media_kit `Player`s that
+  currently exist. just_audio's platform interface has no concept of an audio
+  output device, and media_kit's `Player` is private to the plugin, so this is
+  how [Audio output device](#audio-output-device) reaches libmpv's
+  `audio-device-list` and `audio-device`.
 
 ### libmpv properties Linthra sets
 
@@ -235,6 +242,63 @@ version and archive digest, what is and isn't vendored, and how to refresh it.
 pinned toolchain and proves — offline — that the tree is still upstream plus
 that recorded patch.
 
+### Audio output device
+
+Settings → Music & playback → **Audio output** lists the outputs the host offers
+(speakers, headset, HDMI, a USB DAC) and moves playback onto the one the
+listener picks ([issue #402](https://github.com/TheZupZup/Linthra/issues/402)).
+Nothing goes around the backend: the list *is* libmpv's `audio-device-list`, and
+the choice *is* its `audio-device`. Android is untouched — output routing there
+belongs to the system, so the seam reports itself unsupported and the card is
+not rendered at all.
+
+| Piece | File |
+| --- | --- |
+| The seam | `lib/core/services/audio_output_device_service.dart` |
+| Linux implementation | `lib/core/services/linux_audio_output_device_service.dart` |
+| Platform split | `lib/core/services/platform_audio_output_device_service.dart` |
+| Policy (restore, fallback, what is remembered) | `lib/features/settings/playback/audio_output_controller.dart` |
+
+Four decisions worth knowing:
+
+* **Switching moves audio that is already playing.** The chosen device is
+  written to every live player through media_kit's `setAudioDevice`, *and* into
+  `JustAudioMediaKit.mpvProperties`, so a player the engine creates afterwards
+  (a stop/start, a suspend/resume reload, a source switch) starts on it too.
+* **A missing device falls back, quietly and safely.** On launch the saved
+  device is looked up in the list the host actually reports. If it is not there
+  — unplugged headset, a different machine, a renamed sink — Linthra stays on
+  the system default, forgets the stored value rather than pushing a name libmpv
+  would reject, and the card says so. A backend that cannot be enumerated at all
+  is *not* treated as "device gone": nothing is cleared and nothing is re-routed.
+* **Only stable ids are remembered.** PipeWire/PulseAudio node names and ALSA
+  `CARD=` names are derived from the hardware and survive a reboot, so they are
+  persisted. ALSA's numeric handles (`alsa/hw:1,0`) are card *indexes* that
+  renumber when a USB DAC or dock is plugged in; those are applied for the
+  session and deliberately not stored, and the card explains that.
+* **Launch never probes for nothing.** Asking libmpv for its device list is the
+  only slow part, so it happens when the Settings card is opened, or at launch
+  only when there is a saved device to restore. When nothing is playing there is
+  no player to ask, so enumeration builds a short-lived libmpv handle and
+  disposes it — reading the device list never opens an output or makes a sound.
+
+The mapping, the fallback and what gets remembered are covered by
+`test/core/models/audio_output_device_test.dart`,
+`test/core/services/linux_audio_output_device_service_test.dart` and
+`test/features/settings/playback/audio_output_controller_test.dart`. What those
+cannot cover is libmpv itself — `flutter test` runs on the Dart VM without the
+native bundle, so a real `Player` is never built. Check that part on a real
+desktop:
+
+| Check | Expected |
+| --- | --- |
+| Open Settings → Music & playback with nothing playing | The list shows your real outputs, and no sound is produced while it enumerates. |
+| Start a track, then switch output | The audio moves to the new device without the track restarting or losing its position. |
+| Switch output, stop, play something else | The new track still comes out of the chosen device. |
+| Plug in a headset, then press Refresh | The new device appears in the list. |
+| Pick a USB output, quit, unplug it, relaunch | Playback uses the system default and the card says the saved output is unavailable. |
+| Pick a USB output, quit, plug it back in, relaunch | Playback goes back to that output on its own. |
+
 libmpv provides broad codec/container support and PulseAudio/PipeWire output.
 It is a native runtime dependency, not a binary downloaded when Linthra starts.
 The Flatpak manifest therefore builds libmpv as a declared module and bundles
@@ -260,6 +324,7 @@ undeclared network access to an isolated `flatpak-builder` build.
 | Lost folder access | Supported | A selected folder that stops resolving (unmounted drive, deleted folder, revoked portal document) is reported as a recoverable "select it again" state on the Local music card, and the indexed catalog is left alone rather than replaced with an empty scan. |
 | Local tag reading | Supported | `FilesystemLocalMetadataReader` reads title, artist, album artist, album, track number and duration from ID3, Vorbis comments, MP4 atoms, APEv2 and RIFF INFO through `audio_metadata_reader` ([issue #407](https://github.com/TheZupZup/Linthra/issues/407)). An unreadable or untagged file still appears, from its filename. Android is deliberately unchanged: its tags come from the native SAF walk. |
 | Local embedded artwork | Unsupported | Tags are read without pulling cover images out of every file during a scan. Extracting and caching embedded art on desktop is [issue #408](https://github.com/TheZupZup/Linthra/issues/408); tracks keep the placeholder until then. |
+| **Audio output device** | Supported | Settings → Music & playback → Audio output lists libmpv's `audio-device-list` and routes playback with `audio-device` ([issue #402](https://github.com/TheZupZup/Linthra/issues/402)). A saved device is re-applied at launch, and one that is no longer present falls back to the system default. See [Audio output device](#audio-output-device). |
 | Chromecast | Android/iOS only | Already gated in `cast_providers.dart`; Linux keeps the honest "cast unavailable" service. |
 | Share sheet, launcher-icon switching | Android-only, by design | No desktop equivalent; the UI simply omits them. |
 | Desktop layout, keyboard shortcuts | Not started | The existing layout renders in the window and is usable for development. The desktop UX pass is later work in #376. |

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -286,14 +286,24 @@ Four decisions worth knowing:
   later gesture is the one that ends up playing and stored.
 * **Only stable ids are remembered.** PipeWire/PulseAudio node names and ALSA
   `CARD=` names are derived from the hardware and survive a reboot, so they are
-  persisted. ALSA's numeric handles (`alsa/hw:1,0`) are card *indexes* that
-  renumber when a USB DAC or dock is plugged in; those are applied for the
-  session and deliberately not stored, and the card explains that.
+  persisted. Numbers are not: ALSA's `alsa/hw:1,0` handles are card *indexes*
+  that renumber when a USB DAC or dock is plugged in, and a bare numeric target
+  (`pipewire/42`) is a runtime object id the daemon reuses for a different sink
+  after a restart. The startup check can only ask whether a saved id still
+  exists, and a reused number exists while meaning something else — so both are
+  applied for the session and deliberately not stored, and the card explains
+  that.
 * **Launch never probes for nothing.** Asking libmpv for its device list is the
   only slow part, so it happens when the Settings card is opened, or at launch
   only when there is a saved device to restore. When nothing is playing there is
   no player to ask, so enumeration builds a short-lived libmpv handle and
   disposes it — reading the device list never opens an output or makes a sound.
+* **The restore finishes before the first frame.** media_kit builds its player
+  when the first track loads and reads the chosen output at construction, so a
+  restore still in flight then would play the opening seconds on the system
+  default before jumping. Bootstrap waits for it, bounded by a deadline
+  (`_audioOutputRestoreDeadline`) so a wedged backend delays launch by that much
+  and no more; past it the restore still lands and still moves live playback.
 
 The mapping, the fallback and what gets remembered are covered by
 `test/core/models/audio_output_device_test.dart`,

--- a/lib/app/application_container.dart
+++ b/lib/app/application_container.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../core/models/theme_mode_preference.dart';
 import '../core/platform/host_platform.dart';
 import '../data/repositories/app_icon_variant_store_provider.dart';
+import '../data/repositories/audio_output_device_service_provider.dart';
 import '../data/repositories/audiobookshelf_session_store_provider.dart';
 import '../data/repositories/default_provider_store_provider.dart';
 import '../data/repositories/download_repository_provider.dart';
@@ -83,6 +84,7 @@ List<Override> productionApplicationOverrides({
     initialThemeModeProvider.overrideWithValue(storedThemeMode),
     platformLauncherIconServiceOverride,
     platformShareServiceOverride,
+    platformAudioOutputDeviceServiceOverride,
     lyricsServiceOverride,
     // Casting is withheld from production builds by the security
     // containment; see [CastContainment].

--- a/lib/app/application_lifecycle.dart
+++ b/lib/app/application_lifecycle.dart
@@ -239,17 +239,31 @@ Future<ApplicationHandle> bootstrapApplication(
     );
 
     // Re-apply a saved audio output (Linux) so a chosen headset, DAC or HDMI
-    // sink survives a restart without the listener re-picking it. Not awaited:
-    // asking libmpv for its device list is the only slow part of this, and
-    // holding the first frame for it would trade a visible launch delay for a
-    // routing decision that is still applied well before anything plays — the
-    // choice lands on the live player *and* on every player created after it.
-    // It is owned rather than fire-and-forget so shutdown still waits for it.
+    // sink survives a restart without the listener re-picking it.
+    //
+    // Awaited, because the alternative leaks audio: the media_kit player is
+    // built when the first track loads, and it reads the chosen output at
+    // construction. A restore still in flight at that moment means the opening
+    // seconds play on the system default and only then jump to the right
+    // speakers. Waiting here closes that window — a track cannot be started
+    // before the first frame.
+    //
+    // Bounded, because a wedged audio backend must not hold the window shut:
+    // past the deadline launch continues and the restore lands whenever the
+    // backend answers, moving live playback then. It is owned either way, so
+    // shutdown still waits for it.
     //
     // Cheap by design when there is nothing to restore: the controller does not
     // probe the backend just to confirm the system default, and off Linux the
-    // seam is a no-op that never loads libmpv at all.
-    handle.ownPendingWork(_restoreAudioOutput(container));
+    // seam is a no-op that never loads libmpv at all — in both cases this
+    // returns without touching anything.
+    final Future<void> audioOutputRestored = _restoreAudioOutput(container);
+    handle.ownPendingWork(audioOutputRestored);
+    try {
+      await audioOutputRestored.timeout(_audioOutputRestoreDeadline);
+    } on TimeoutException {
+      // Deliberately ignored: see above.
+    }
 
     // Warm the persisted sessions before the first frame so a synced remote
     // track can stream on the first tap. Best-effort and secret-free: a
@@ -343,6 +357,14 @@ Future<ApplicationHandle> bootstrapApplication(
     Error.throwWithStackTrace(error, stackTrace);
   }
 }
+
+/// How long launch waits for a saved audio output to be re-applied.
+///
+/// libmpv publishes its device list while a player initializes, so the normal
+/// cost of this is milliseconds. The deadline exists for the backend that never
+/// answers at all, and is shorter than the enumeration timeout underneath it so
+/// the wait is bounded by *this* value rather than by that one.
+const Duration _audioOutputRestoreDeadline = Duration(milliseconds: 1500);
 
 /// Builds the audio-output controller, which re-applies a saved output device.
 ///

--- a/lib/app/application_lifecycle.dart
+++ b/lib/app/application_lifecycle.dart
@@ -21,6 +21,7 @@ import '../features/player/media_artwork_providers.dart';
 import '../features/player/player_providers.dart';
 import '../features/settings/audiobookshelf/audiobookshelf_settings_controller.dart';
 import '../features/settings/jellyfin/jellyfin_settings_controller.dart';
+import '../features/settings/playback/audio_output_controller.dart';
 import '../features/settings/playback/normalize_volume_controller.dart';
 import '../features/settings/plex/plex_settings_controller.dart';
 import '../features/settings/subsonic/subsonic_settings_controller.dart';
@@ -237,6 +238,19 @@ Future<ApplicationHandle> bootstrapApplication(
       ),
     );
 
+    // Re-apply a saved audio output (Linux) so a chosen headset, DAC or HDMI
+    // sink survives a restart without the listener re-picking it. Not awaited:
+    // asking libmpv for its device list is the only slow part of this, and
+    // holding the first frame for it would trade a visible launch delay for a
+    // routing decision that is still applied well before anything plays — the
+    // choice lands on the live player *and* on every player created after it.
+    // It is owned rather than fire-and-forget so shutdown still waits for it.
+    //
+    // Cheap by design when there is nothing to restore: the controller does not
+    // probe the backend just to confirm the system default, and off Linux the
+    // seam is a no-op that never loads libmpv at all.
+    handle.ownPendingWork(_restoreAudioOutput(container));
+
     // Warm the persisted sessions before the first frame so a synced remote
     // track can stream on the first tap. Best-effort and secret-free: a
     // missing/corrupt record loads as "not connected".
@@ -327,5 +341,18 @@ Future<ApplicationHandle> bootstrapApplication(
     // caller sees.
     await handle.shutdown();
     Error.throwWithStackTrace(error, stackTrace);
+  }
+}
+
+/// Builds the audio-output controller, which re-applies a saved output device.
+///
+/// Failure is swallowed on purpose: an audio backend that will not answer must
+/// never break launch, and the fallback — the system default — is exactly what
+/// the app does without this.
+Future<void> _restoreAudioOutput(ProviderContainer container) async {
+  try {
+    await container.read(audioOutputControllerProvider.future);
+  } catch (_) {
+    // Ignore: playback stays on the system default.
   }
 }

--- a/lib/core/models/audio_output_device.dart
+++ b/lib/core/models/audio_output_device.dart
@@ -34,23 +34,33 @@ class AudioOutputDevice {
 
   /// Whether [id] is stable enough to remember across restarts.
   ///
-  /// PipeWire and PulseAudio node names are derived from the hardware path
+  /// PipeWire and PulseAudio node names are derived from the hardware
   /// (`pipewire/alsa_output.pci-0000_00_1f.3.analog-stereo`,
   /// `pulse/bluez_output.AC_12_2F_...`) and name the same sink after a reboot.
-  /// ALSA's numeric handles do not: `alsa/hw:1,0` is a card *index*, and
-  /// plugging in a USB DAC or a dock renumbers the cards, so a stored one can
-  /// silently point at a different device. Those stay a session-only choice —
-  /// the user can still pick them, Linthra just does not remember them.
+  ///
+  /// Numbers do not. Two shapes are rejected for the same reason:
+  ///
+  ///  * `alsa/hw:1,0` and `alsa/plughw:2,0` are ALSA card/device *indexes*, and
+  ///    plugging in a USB DAC or a dock renumbers the cards.
+  ///  * a device part that is nothing but digits (`pipewire/42`) is a runtime
+  ///    object id, handed out by the daemon and reused for a different sink
+  ///    after it restarts.
+  ///
+  /// Either one can still be *picked* — it just is not remembered, because the
+  /// startup check can only ask whether the saved id still exists, and a reused
+  /// number exists while meaning something else entirely. No real sink is named
+  /// by a bare integer, so nothing stable is lost by this.
   static bool isPersistableId(String id) {
     if (id.isEmpty || id == systemDefaultId) return false;
     final int separator = id.indexOf('/');
     final String device = separator < 0 ? id : id.substring(separator + 1);
     if (device.isEmpty) return false;
-    return !_numericAlsaHandle.hasMatch(device);
+    return !_numericHandle.hasMatch(device);
   }
 
-  /// `hw:1`, `hw:1,0`, `plughw:2,0` — ALSA card/device *indexes*.
-  static final RegExp _numericAlsaHandle = RegExp(r'^(plug)?hw:\d+(,\d+)*$');
+  /// `hw:1`, `hw:1,0`, `plughw:2,0` — ALSA card/device *indexes* — and `42`,
+  /// a bare runtime object id.
+  static final RegExp _numericHandle = RegExp(r'^((plug)?hw:)?\d+(,\d+)*$');
 
   @override
   bool operator ==(Object other) =>

--- a/lib/core/models/audio_output_device.dart
+++ b/lib/core/models/audio_output_device.dart
@@ -1,0 +1,104 @@
+/// One audio output Linthra can send playback to.
+///
+/// The [id] is the backend's own device name — on Linux that is libmpv's
+/// `audio-device` value, e.g. `pipewire/alsa_output.pci-0000_00_1f.3.analog-stereo`.
+/// It is what gets written back to the backend, so it is never localized,
+/// prettified or rebuilt from [label].
+///
+/// [label] is what the listener reads. Backends hand out a description that is
+/// usually already human-readable ("Built-in Audio Analog Stereo"); when one is
+/// missing, [audioOutputDevicesFromBackend] falls back to the device part of the
+/// id rather than showing an empty row.
+class AudioOutputDevice {
+  const AudioOutputDevice({required this.id, required this.label});
+
+  /// The backend's device name. `auto` means "let the system decide".
+  final String id;
+
+  /// The human-readable name shown in Settings.
+  final String label;
+
+  /// libmpv's name for "let the system decide", and the value Linthra falls
+  /// back to whenever a chosen device is gone.
+  static const String systemDefaultId = 'auto';
+
+  /// The always-available choice. Linthra never persists it: no stored value
+  /// already means "system default", so an absent preference and this entry are
+  /// the same state.
+  static const AudioOutputDevice systemDefault = AudioOutputDevice(
+    id: systemDefaultId,
+    label: 'System default',
+  );
+
+  bool get isSystemDefault => id == systemDefaultId;
+
+  /// Whether [id] is stable enough to remember across restarts.
+  ///
+  /// PipeWire and PulseAudio node names are derived from the hardware path
+  /// (`pipewire/alsa_output.pci-0000_00_1f.3.analog-stereo`,
+  /// `pulse/bluez_output.AC_12_2F_...`) and name the same sink after a reboot.
+  /// ALSA's numeric handles do not: `alsa/hw:1,0` is a card *index*, and
+  /// plugging in a USB DAC or a dock renumbers the cards, so a stored one can
+  /// silently point at a different device. Those stay a session-only choice —
+  /// the user can still pick them, Linthra just does not remember them.
+  static bool isPersistableId(String id) {
+    if (id.isEmpty || id == systemDefaultId) return false;
+    final int separator = id.indexOf('/');
+    final String device = separator < 0 ? id : id.substring(separator + 1);
+    if (device.isEmpty) return false;
+    return !_numericAlsaHandle.hasMatch(device);
+  }
+
+  /// `hw:1`, `hw:1,0`, `plughw:2,0` — ALSA card/device *indexes*.
+  static final RegExp _numericAlsaHandle = RegExp(r'^(plug)?hw:\d+(,\d+)*$');
+
+  @override
+  bool operator ==(Object other) =>
+      other is AudioOutputDevice && other.id == id && other.label == label;
+
+  @override
+  int get hashCode => Object.hash(id, label);
+
+  @override
+  String toString() => 'AudioOutputDevice($id, $label)';
+}
+
+/// Maps a backend's raw device list onto Linthra's model.
+///
+/// Kept as a plain function over `(id, description)` records so the mapping —
+/// the part with actual rules in it — is unit-testable without libmpv on the
+/// machine running the tests.
+///
+/// The rules:
+///  - [AudioOutputDevice.systemDefault] is always first and always present,
+///    even on a backend that does not list `auto` itself, because it is the
+///    safe choice the UI must always be able to offer.
+///  - a device with no description is labelled with the device part of its id,
+///    so a row is never blank.
+///  - duplicate ids collapse to the first entry; some backends list the same
+///    sink through more than one alias.
+List<AudioOutputDevice> audioOutputDevicesFromBackend(
+  Iterable<({String id, String description})> entries,
+) {
+  final List<AudioOutputDevice> devices = <AudioOutputDevice>[
+    AudioOutputDevice.systemDefault,
+  ];
+  final Set<String> seen = <String>{AudioOutputDevice.systemDefaultId};
+
+  for (final ({String id, String description}) entry in entries) {
+    final String id = entry.id.trim();
+    if (id.isEmpty || !seen.add(id)) continue;
+    devices.add(
+      AudioOutputDevice(id: id, label: _labelFor(id, entry.description)),
+    );
+  }
+  return devices;
+}
+
+String _labelFor(String id, String description) {
+  final String trimmed = description.trim();
+  if (trimmed.isNotEmpty) return trimmed;
+  final int separator = id.indexOf('/');
+  final String device = separator < 0 ? id : id.substring(separator + 1);
+  return device.isEmpty ? id : device;
+}

--- a/lib/core/repositories/playback_preferences.dart
+++ b/lib/core/repositories/playback_preferences.dart
@@ -6,10 +6,24 @@
 ///  - "Normalize volume": when on, playback applies a track's ReplayGain so
 ///    songs play at a more even loudness. Off by default — the safe choice, so
 ///    audio is never altered unless the listener opts in.
+///  - "Audio output": which output device desktop playback is routed to. Unset
+///    by default, which means the system default.
 abstract interface class PlaybackPreferences {
   /// Whether volume normalization (ReplayGain) is applied during playback.
   /// Defaults to `false`, so audio plays untouched out of the box.
   Future<bool> normalizeVolume();
 
   Future<void> setNormalizeVolume(bool value);
+
+  /// The backend id of the chosen audio output, or `null` for the system
+  /// default.
+  ///
+  /// Only ids that survive a reboot are ever stored here (see
+  /// `AudioOutputDevice.isPersistableId`); a device picked by an unstable
+  /// handle stays a session-only choice, because remembering one would mean
+  /// silently routing to whatever card took that index next boot.
+  Future<String?> audioOutputDeviceId();
+
+  /// Stores [id], or clears the preference when it is `null`.
+  Future<void> setAudioOutputDeviceId(String? id);
 }

--- a/lib/core/services/audio_output_device_service.dart
+++ b/lib/core/services/audio_output_device_service.dart
@@ -1,0 +1,34 @@
+import '../models/audio_output_device.dart';
+
+/// Lists the audio outputs the host offers and moves playback onto one of them.
+///
+/// This is a *routing* seam, not a playback one: it never starts, stops or
+/// re-loads a track. On Linux the implementation drives libmpv's `audio-device`
+/// through media_kit, so switching moves the audio that is already playing.
+///
+/// Android is deliberately not implemented here. Output routing there belongs to
+/// the platform (the system output picker, Bluetooth, Android Auto), and the app
+/// must not fight it — so Android gets [NoopAudioOutputDeviceService] and the
+/// Settings card is simply not shown, exactly like "Share Linthra" off Android.
+///
+/// Implementations must never throw into the UI. A backend that is not ready,
+/// a device that disappeared mid-switch, or a host with no enumeration at all
+/// all end as "no devices" / "nothing happened", never as an error dialog.
+abstract interface class AudioOutputDeviceService {
+  /// Whether this build can enumerate and choose an output. `false` off Linux
+  /// (and in tests), so the UI can hide the card rather than offer a control
+  /// that does nothing.
+  bool get isSupported;
+
+  /// The outputs the host currently offers, [AudioOutputDevice.systemDefault]
+  /// first. Empty when nothing could be enumerated.
+  Future<List<AudioOutputDevice>> devices();
+
+  /// Routes playback to [device].
+  ///
+  /// Applies to audio that is already playing *and* to the next player the
+  /// engine creates, so the choice survives a stop/start without being
+  /// re-applied by the caller. Passing [AudioOutputDevice.systemDefault] hands
+  /// the decision back to the system.
+  Future<void> select(AudioOutputDevice device);
+}

--- a/lib/core/services/audio_output_device_service.dart
+++ b/lib/core/services/audio_output_device_service.dart
@@ -24,11 +24,16 @@ abstract interface class AudioOutputDeviceService {
   /// first. Empty when nothing could be enumerated.
   Future<List<AudioOutputDevice>> devices();
 
-  /// Routes playback to [device].
+  /// Routes playback to [device], reporting whether it actually took effect.
   ///
   /// Applies to audio that is already playing *and* to the next player the
   /// engine creates, so the choice survives a stop/start without being
   /// re-applied by the caller. Passing [AudioOutputDevice.systemDefault] hands
   /// the decision back to the system.
-  Future<void> select(AudioOutputDevice device);
+  ///
+  /// Returns `false` when the backend refused — a device that disappeared
+  /// between the list and the tap, say. Callers must not treat a refused switch
+  /// as done: it is the difference between remembering an output that is
+  /// playing and remembering one that never started.
+  Future<bool> select(AudioOutputDevice device);
 }

--- a/lib/core/services/linux_audio_output_device_service.dart
+++ b/lib/core/services/linux_audio_output_device_service.dart
@@ -1,0 +1,131 @@
+import 'dart:async';
+
+import 'package:just_audio_media_kit/just_audio_media_kit.dart';
+import 'package:media_kit/media_kit.dart';
+
+import '../models/audio_output_device.dart';
+import 'audio_output_device_service.dart';
+
+/// Reads the backend's raw output list as `(id, description)` records.
+typedef LinuxAudioDeviceProbe = Future<List<({String id, String description})>>
+    Function();
+
+/// Writes a device name back to the backend.
+typedef LinuxAudioDeviceApply = Future<void> Function(String deviceId);
+
+/// Linux output-device routing, through media_kit/libmpv.
+///
+/// libmpv already models exactly what this feature needs, so nothing here goes
+/// around the backend: the list is mpv's `audio-device-list` property and the
+/// choice is its `audio-device` property. What just_audio does not model is any
+/// of it — its platform interface has no notion of an output device — so the
+/// live `Player` is reached through `JustAudioMediaKit.livePlayers`, the small
+/// registry Linthra's vendored copy of that plugin keeps
+/// (`third_party/just_audio_media_kit/PATCHES.md`).
+///
+/// A choice is applied in two places on purpose:
+///
+///  * every live player, so audio that is *already playing* moves to the new
+///    output rather than waiting for the next track, and
+///  * `JustAudioMediaKit.mpvProperties`, which media_kit applies to each player
+///    it creates afterwards, so the choice survives the engine tearing a player
+///    down and building a new one (stop, suspend/resume, a source switch).
+///
+/// Enumeration prefers a live player and only builds a throwaway one when
+/// nothing is playing — libmpv reports `audio-device-list` on a fresh handle
+/// without ever opening an output, so listing outputs from Settings never makes
+/// a sound or grabs a device.
+class LinuxAudioOutputDeviceService implements AudioOutputDeviceService {
+  LinuxAudioOutputDeviceService({
+    LinuxAudioDeviceProbe? probe,
+    LinuxAudioDeviceApply? apply,
+  })  : _probe = probe ?? _probeThroughMediaKit,
+        _apply = apply ?? _applyThroughMediaKit;
+
+  final LinuxAudioDeviceProbe _probe;
+  final LinuxAudioDeviceApply _apply;
+
+  /// How long libmpv gets to report its device list before Linthra gives up.
+  ///
+  /// The property is published during player initialization, so this is a
+  /// safety net for a wedged backend, not a normal wait.
+  static const Duration probeTimeout = Duration(seconds: 3);
+
+  @override
+  bool get isSupported => true;
+
+  @override
+  Future<List<AudioOutputDevice>> devices() async {
+    try {
+      return audioOutputDevicesFromBackend(await _probe());
+    } catch (_) {
+      // A backend that cannot be asked is reported as "nothing to show", never
+      // as an error: Settings still renders, it just says it found no outputs.
+      return const <AudioOutputDevice>[];
+    }
+  }
+
+  @override
+  Future<void> select(AudioOutputDevice device) async {
+    try {
+      await _apply(device.id);
+    } catch (_) {
+      // Routing is best-effort. A device that vanished between the list and the
+      // tap leaves playback where it is rather than throwing into Settings.
+    }
+  }
+
+  static Future<List<({String id, String description})>>
+      _probeThroughMediaKit() async {
+    final Iterable<Player> live = JustAudioMediaKit.livePlayers.values;
+    if (live.isNotEmpty) return _readDevices(live.first);
+
+    // Nothing is playing, so there is no player to ask. A bare libmpv handle
+    // reports the device list without initializing an output device.
+    final Player probe = Player();
+    try {
+      return await _readDevices(probe);
+    } finally {
+      await probe.dispose();
+    }
+  }
+
+  static Future<List<({String id, String description})>> _readDevices(
+    Player player,
+  ) async {
+    List<AudioDevice> devices = player.state.audioDevices;
+    if (_isUnpopulated(devices)) {
+      // media_kit seeds the state with a lone `auto` entry and replaces it when
+      // libmpv publishes the real list, so an unpopulated state means "not
+      // reported yet", not "this machine has one output".
+      try {
+        devices = await player.stream.audioDevices
+            .firstWhere((List<AudioDevice> list) => !_isUnpopulated(list))
+            .timeout(probeTimeout);
+      } on TimeoutException {
+        devices = player.state.audioDevices;
+      }
+    }
+    return <({String id, String description})>[
+      for (final AudioDevice device in devices)
+        (id: device.name, description: device.description),
+    ];
+  }
+
+  static bool _isUnpopulated(List<AudioDevice> devices) =>
+      devices.isEmpty ||
+      (devices.length == 1 &&
+          devices.single.name == AudioOutputDevice.systemDefaultId);
+
+  static Future<void> _applyThroughMediaKit(String deviceId) async {
+    // Merged, not assigned: `cache-on-disk=no` (and the smoke's `ao=alsa`) live
+    // in the same map and must survive an output change.
+    JustAudioMediaKit.mpvProperties = <String, String>{
+      ...JustAudioMediaKit.mpvProperties,
+      'audio-device': deviceId,
+    };
+    for (final Player player in JustAudioMediaKit.livePlayers.values.toList()) {
+      await player.setAudioDevice(AudioDevice(deviceId, ''));
+    }
+  }
+}

--- a/lib/core/services/linux_audio_output_device_service.dart
+++ b/lib/core/services/linux_audio_output_device_service.dart
@@ -123,14 +123,18 @@ class LinuxAudioOutputDeviceService implements AudioOutputDeviceService {
           devices.single.name == AudioOutputDevice.systemDefaultId);
 
   static Future<void> _applyThroughMediaKit(String deviceId) async {
+    // Live players first, the property last, and the order is the point: a
+    // player that refuses the device throws out of here before the property is
+    // written, so the *next* player the engine builds does not inherit an id
+    // the backend has just rejected and start up unable to open audio.
+    for (final Player player in JustAudioMediaKit.livePlayers.values.toList()) {
+      await player.setAudioDevice(AudioDevice(deviceId, ''));
+    }
     // Merged, not assigned: `cache-on-disk=no` (and the smoke's `ao=alsa`) live
     // in the same map and must survive an output change.
     JustAudioMediaKit.mpvProperties = <String, String>{
       ...JustAudioMediaKit.mpvProperties,
       'audio-device': deviceId,
     };
-    for (final Player player in JustAudioMediaKit.livePlayers.values.toList()) {
-      await player.setAudioDevice(AudioDevice(deviceId, ''));
-    }
   }
 }

--- a/lib/core/services/linux_audio_output_device_service.dart
+++ b/lib/core/services/linux_audio_output_device_service.dart
@@ -66,12 +66,16 @@ class LinuxAudioOutputDeviceService implements AudioOutputDeviceService {
   }
 
   @override
-  Future<void> select(AudioOutputDevice device) async {
+  Future<bool> select(AudioOutputDevice device) async {
     try {
       await _apply(device.id);
+      return true;
     } catch (_) {
-      // Routing is best-effort. A device that vanished between the list and the
-      // tap leaves playback where it is rather than throwing into Settings.
+      // A device that vanished between the list and the tap leaves playback
+      // where it is rather than throwing into Settings — but the caller is told
+      // it did not happen, so it does not go on to remember an output that
+      // never started.
+      return false;
     }
   }
 
@@ -98,13 +102,14 @@ class LinuxAudioOutputDeviceService implements AudioOutputDeviceService {
       // media_kit seeds the state with a lone `auto` entry and replaces it when
       // libmpv publishes the real list, so an unpopulated state means "not
       // reported yet", not "this machine has one output".
-      try {
-        devices = await player.stream.audioDevices
-            .firstWhere((List<AudioDevice> list) => !_isUnpopulated(list))
-            .timeout(probeTimeout);
-      } on TimeoutException {
-        devices = player.state.audioDevices;
-      }
+      devices = await player.stream.audioDevices
+          .firstWhere((List<AudioDevice> list) => !_isUnpopulated(list))
+          .timeout(probeTimeout);
+      // A timeout is deliberately *not* caught here. Falling back to the seeded
+      // `[auto]` state would read as "this machine has exactly one output",
+      // and a caller comparing a saved device against that list would conclude
+      // it had been removed. A backend that did not answer in time is an
+      // enumeration failure, and `devices()` reports it as one.
     }
     return <({String id, String description})>[
       for (final AudioDevice device in devices)

--- a/lib/core/services/linux_playback_controller.dart
+++ b/lib/core/services/linux_playback_controller.dart
@@ -36,9 +36,11 @@ const Map<String, String> linuxMpvProperties = <String, String>{
 /// [linuxMpvProperties] with anything a caller already configured layered on
 /// top.
 ///
-/// The headless audio smoke sets `ao=alsa` before it builds a controller
-/// (`tool/linux_audio_backend_smoke.dart`). Merging rather than assigning keeps
-/// that working *and* keeps the smoke honest: it exercises the same cache
+/// Two callers configure something. The headless audio smoke sets `ao=alsa`
+/// before it builds a controller (`tool/linux_audio_backend_smoke.dart`), and
+/// `LinuxAudioOutputDeviceService` sets `audio-device` when the listener picks
+/// an output. Merging rather than assigning keeps both working whichever order
+/// they land in — and keeps the smoke honest: it exercises the same cache
 /// configuration production uses, with only the output device swapped.
 Map<String, String> resolveLinuxMpvProperties(Map<String, String> configured) =>
     <String, String>{...linuxMpvProperties, ...configured};

--- a/lib/core/services/noop_audio_output_device_service.dart
+++ b/lib/core/services/noop_audio_output_device_service.dart
@@ -1,0 +1,23 @@
+import '../models/audio_output_device.dart';
+import 'audio_output_device_service.dart';
+
+/// An [AudioOutputDeviceService] that enumerates nothing and routes nothing.
+///
+/// It is the default provider binding (so unit and widget tests stay free of
+/// libmpv) and the real implementation on every platform that has no
+/// app-level output routing — Android included, where the system owns the
+/// output. [isSupported] is `false`, so the Settings card hides itself instead
+/// of showing an empty picker.
+class NoopAudioOutputDeviceService implements AudioOutputDeviceService {
+  const NoopAudioOutputDeviceService();
+
+  @override
+  bool get isSupported => false;
+
+  @override
+  Future<List<AudioOutputDevice>> devices() async =>
+      const <AudioOutputDevice>[];
+
+  @override
+  Future<void> select(AudioOutputDevice device) async {}
+}

--- a/lib/core/services/noop_audio_output_device_service.dart
+++ b/lib/core/services/noop_audio_output_device_service.dart
@@ -19,5 +19,5 @@ class NoopAudioOutputDeviceService implements AudioOutputDeviceService {
       const <AudioOutputDevice>[];
 
   @override
-  Future<void> select(AudioOutputDevice device) async {}
+  Future<bool> select(AudioOutputDevice device) async => false;
 }

--- a/lib/core/services/platform_audio_output_device_service.dart
+++ b/lib/core/services/platform_audio_output_device_service.dart
@@ -1,0 +1,49 @@
+import '../models/audio_output_device.dart';
+import '../platform/host_platform.dart';
+import 'audio_output_device_service.dart';
+import 'linux_audio_output_device_service.dart';
+import 'noop_audio_output_device_service.dart';
+
+/// The default [AudioOutputDeviceService]: real routing on Linux, a safe no-op
+/// everywhere else.
+///
+/// This is the one place that knows about the platform split, mirroring
+/// [PlatformShareService]. Linux gets [LinuxAudioOutputDeviceService], which
+/// drives libmpv's `audio-device`; every other platform — Android included —
+/// gets [NoopAudioOutputDeviceService], so the system keeps owning output
+/// routing there and the Settings card is simply not shown.
+class PlatformAudioOutputDeviceService implements AudioOutputDeviceService {
+  PlatformAudioOutputDeviceService({
+    HostPlatform? host,
+    AudioOutputDeviceService? linuxService,
+    AudioOutputDeviceService fallbackService =
+        const NoopAudioOutputDeviceService(),
+  })  : _host = host,
+        _linuxService = linuxService,
+        _fallbackService = fallbackService;
+
+  /// The platform to route for; null reads the real host. Injectable so the
+  /// split can be exercised for both platforms on one machine.
+  final HostPlatform? _host;
+
+  /// Built lazily: constructing it is cheap, but it is the only object in this
+  /// graph that imports media_kit, so a non-Linux host never touches it.
+  AudioOutputDeviceService? _linuxService;
+  final AudioOutputDeviceService _fallbackService;
+
+  AudioOutputDeviceService get _delegate {
+    if ((_host ?? HostPlatform.current) != HostPlatform.linux) {
+      return _fallbackService;
+    }
+    return _linuxService ??= LinuxAudioOutputDeviceService();
+  }
+
+  @override
+  bool get isSupported => _delegate.isSupported;
+
+  @override
+  Future<List<AudioOutputDevice>> devices() => _delegate.devices();
+
+  @override
+  Future<void> select(AudioOutputDevice device) => _delegate.select(device);
+}

--- a/lib/core/services/platform_audio_output_device_service.dart
+++ b/lib/core/services/platform_audio_output_device_service.dart
@@ -45,5 +45,5 @@ class PlatformAudioOutputDeviceService implements AudioOutputDeviceService {
   Future<List<AudioOutputDevice>> devices() => _delegate.devices();
 
   @override
-  Future<void> select(AudioOutputDevice device) => _delegate.select(device);
+  Future<bool> select(AudioOutputDevice device) => _delegate.select(device);
 }

--- a/lib/data/repositories/audio_output_device_service_provider.dart
+++ b/lib/data/repositories/audio_output_device_service_provider.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/services/audio_output_device_service.dart';
+import '../../core/services/noop_audio_output_device_service.dart';
+import '../../core/services/platform_audio_output_device_service.dart';
+
+/// The single seam the app lists and chooses audio outputs through.
+///
+/// Defaults to the no-op implementation so unit and widget tests never load
+/// libmpv. The running app overrides this with
+/// [platformAudioOutputDeviceServiceOverride], which gives Linux the real
+/// media_kit-backed routing and leaves every other platform on the no-op.
+/// Mirrors the [shareServiceProvider] seam.
+final audioOutputDeviceServiceProvider = Provider<AudioOutputDeviceService>(
+  (ref) => const NoopAudioOutputDeviceService(),
+);
+
+/// Production binding: real output routing on Linux, a safe no-op elsewhere.
+/// Applied in `main`.
+final platformAudioOutputDeviceServiceOverride =
+    audioOutputDeviceServiceProvider.overrideWithValue(
+  PlatformAudioOutputDeviceService(),
+);

--- a/lib/data/repositories/in_memory_playback_preferences.dart
+++ b/lib/data/repositories/in_memory_playback_preferences.dart
@@ -2,10 +2,14 @@ import '../../core/repositories/playback_preferences.dart';
 
 /// A non-persistent [PlaybackPreferences] for development and tests.
 class InMemoryPlaybackPreferences implements PlaybackPreferences {
-  InMemoryPlaybackPreferences({bool normalizeVolume = false})
-      : _normalizeVolume = normalizeVolume;
+  InMemoryPlaybackPreferences({
+    bool normalizeVolume = false,
+    String? audioOutputDeviceId,
+  })  : _normalizeVolume = normalizeVolume,
+        _audioOutputDeviceId = audioOutputDeviceId;
 
   bool _normalizeVolume;
+  String? _audioOutputDeviceId;
 
   @override
   Future<bool> normalizeVolume() async => _normalizeVolume;
@@ -13,5 +17,13 @@ class InMemoryPlaybackPreferences implements PlaybackPreferences {
   @override
   Future<void> setNormalizeVolume(bool value) async {
     _normalizeVolume = value;
+  }
+
+  @override
+  Future<String?> audioOutputDeviceId() async => _audioOutputDeviceId;
+
+  @override
+  Future<void> setAudioOutputDeviceId(String? id) async {
+    _audioOutputDeviceId = (id == null || id.isEmpty) ? null : id;
   }
 }

--- a/lib/data/repositories/shared_preferences_playback_preferences.dart
+++ b/lib/data/repositories/shared_preferences_playback_preferences.dart
@@ -2,13 +2,14 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../core/repositories/playback_preferences.dart';
 
-/// A [PlaybackPreferences] backed by `shared_preferences`. The single choice is
-/// a small bool, so it lives next to the other small user choices in the
-/// key/value store rather than in the SQLite catalog.
+/// A [PlaybackPreferences] backed by `shared_preferences`. The choices are a
+/// small bool and a short device id, so they live next to the other small user
+/// choices in the key/value store rather than in the SQLite catalog.
 class SharedPreferencesPlaybackPreferences implements PlaybackPreferences {
   const SharedPreferencesPlaybackPreferences();
 
   static const String _normalizeVolumeKey = 'playback_normalize_volume';
+  static const String _audioOutputDeviceKey = 'playback_audio_output_device';
 
   @override
   Future<bool> normalizeVolume() async {
@@ -21,5 +22,24 @@ class SharedPreferencesPlaybackPreferences implements PlaybackPreferences {
   Future<void> setNormalizeVolume(bool value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_normalizeVolumeKey, value);
+  }
+
+  @override
+  Future<String?> audioOutputDeviceId() async {
+    final prefs = await SharedPreferences.getInstance();
+    final String? stored = prefs.getString(_audioOutputDeviceKey);
+    // An empty string is not a device; treat it as "system default" so a
+    // half-written value can never route playback nowhere.
+    return (stored == null || stored.isEmpty) ? null : stored;
+  }
+
+  @override
+  Future<void> setAudioOutputDeviceId(String? id) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (id == null || id.isEmpty) {
+      await prefs.remove(_audioOutputDeviceKey);
+      return;
+    }
+    await prefs.setString(_audioOutputDeviceKey, id);
   }
 }

--- a/lib/features/settings/hub/music_and_playback_screen.dart
+++ b/lib/features/settings/hub/music_and_playback_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../app/dimens.dart';
+import '../playback/audio_output_settings_section.dart';
 import '../playback/playback_settings_section.dart';
 import '../source/default_provider_section.dart';
 import '../source/playback_source_strategy_section.dart';
@@ -9,9 +10,10 @@ import 'settings_detail_scaffold.dart';
 /// The "Music & playback" page of the Settings hub.
 ///
 /// Groups the choices about *which* copy of a song plays and *how* it sounds:
-/// the default source, the playback source strategy, and volume normalization.
-/// Each card is the existing section, unchanged — nothing here touches the
-/// playback engine or provider logic.
+/// the default source, the playback source strategy, volume normalization, and
+/// — where the platform lets Linthra route audio itself — which output device
+/// plays. Each card is the existing section, unchanged: nothing here touches
+/// the playback engine or provider logic.
 class MusicAndPlaybackScreen extends StatelessWidget {
   const MusicAndPlaybackScreen({super.key});
 
@@ -25,6 +27,9 @@ class MusicAndPlaybackScreen extends StatelessWidget {
         PlaybackSourceStrategySettingsSection(),
         SizedBox(height: AppSpacing.md),
         PlaybackSettingsSection(),
+        // Renders nothing where output routing belongs to the system (Android).
+        SizedBox(height: AppSpacing.md),
+        AudioOutputSettingsSection(),
       ],
     );
   }

--- a/lib/features/settings/playback/audio_output_controller.dart
+++ b/lib/features/settings/playback/audio_output_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/models/audio_output_device.dart';
@@ -12,6 +14,7 @@ class AudioOutputSettingsState {
     this.selected = AudioOutputDevice.systemDefault,
     this.hasEnumerated = false,
     this.savedDeviceUnavailable = false,
+    this.selectionFailed = false,
   });
 
   /// The outputs the host offers, system default first. Empty either because
@@ -30,6 +33,10 @@ class AudioOutputSettingsState {
   /// choice.
   final bool savedDeviceUnavailable;
 
+  /// Whether the last attempt to route audio was refused by the backend, so
+  /// playback is still on [selected]. Cleared by the next successful choice.
+  final bool selectionFailed;
+
   /// Whether [selected] will still be in effect after a restart. False for the
   /// system default (there is nothing to remember) and for devices named by an
   /// unstable handle, which Linthra deliberately does not store.
@@ -40,6 +47,7 @@ class AudioOutputSettingsState {
     AudioOutputDevice? selected,
     bool? hasEnumerated,
     bool? savedDeviceUnavailable,
+    bool? selectionFailed,
   }) {
     return AudioOutputSettingsState(
       devices: devices ?? this.devices,
@@ -47,6 +55,7 @@ class AudioOutputSettingsState {
       hasEnumerated: hasEnumerated ?? this.hasEnumerated,
       savedDeviceUnavailable:
           savedDeviceUnavailable ?? this.savedDeviceUnavailable,
+      selectionFailed: selectionFailed ?? this.selectionFailed,
     );
   }
 }
@@ -63,7 +72,9 @@ class AudioOutputSettingsState {
 ///    another machine, a renamed sink) is dropped rather than pushed at the
 ///    backend, and playback stays on the system default;
 ///  * a device whose id will not survive a reboot is applied but not stored,
-///    so nothing silently routes to a different card next boot.
+///    so nothing silently routes to a different card next boot;
+///  * a backend that could not be enumerated, or that refused a switch, changes
+///    nothing — neither what is stored nor what is shown as playing.
 ///
 /// [build] is deliberately cheap when nothing is stored: it does not enumerate,
 /// so launching the app never probes the audio backend just to confirm the
@@ -71,8 +82,18 @@ class AudioOutputSettingsState {
 class AudioOutputController extends AsyncNotifier<AudioOutputSettingsState> {
   /// The output currently pushed at the backend. It starts as the system
   /// default because that is what a fresh process is already on, and it is what
-  /// keeps a refresh from re-routing audio it has not been asked to move.
+  /// keeps a refresh from re-routing audio it has not been asked to move. It
+  /// only ever advances on a switch the backend accepted, so a refused one is
+  /// retried rather than assumed done.
   String _appliedId = AudioOutputDevice.systemDefaultId;
+
+  /// Serializes [select] and [refresh].
+  ///
+  /// Both route audio, write the preference and publish state. Two of them in
+  /// flight at once can finish in the opposite order and leave playback on the
+  /// output the listener picked *first*, so they queue instead: the last
+  /// gesture is the last one applied.
+  Future<void> _operations = Future<void>.value();
 
   @override
   Future<AudioOutputSettingsState> build() async {
@@ -84,7 +105,8 @@ class AudioOutputController extends AsyncNotifier<AudioOutputSettingsState> {
         await ref.read(playbackPreferencesProvider).audioOutputDeviceId();
     if (storedId == null) return const AudioOutputSettingsState();
 
-    return _resolve(storedId);
+    // Nothing has been routed yet, so the system default is what is playing.
+    return _resolve(storedId, AudioOutputDevice.systemDefault);
   }
 
   /// Re-reads the host's output list and re-applies the current choice.
@@ -96,17 +118,37 @@ class AudioOutputController extends AsyncNotifier<AudioOutputSettingsState> {
         ref.read(audioOutputDeviceServiceProvider);
     if (!service.isSupported) return;
 
-    final AudioOutputSettingsState current =
-        state.valueOrNull ?? const AudioOutputSettingsState();
-    state = const AsyncValue<AudioOutputSettingsState>.loading()
-        .copyWithPrevious(state);
-    state = await AsyncValue.guard(() async {
-      final String? storedId =
-          await ref.read(playbackPreferencesProvider).audioOutputDeviceId();
-      // Fall back to the live selection when nothing is stored: a device picked
-      // by an unstable id is session-only, and refreshing the list must not
-      // look like the user reset it to the system default.
-      return _resolve(storedId ?? current.selected.id);
+    return _enqueue(() async {
+      // Let an in-flight build settle first: Riverpod publishes its result when
+      // it completes, which would land on top of everything below.
+      try {
+        await future;
+      } catch (_) {
+        // A failed build is not this refresh's problem; it re-enumerates below.
+      }
+
+      final AudioOutputSettingsState current =
+          state.valueOrNull ?? const AudioOutputSettingsState();
+      state = const AsyncValue<AudioOutputSettingsState>.loading()
+          .copyWithPrevious(state);
+      state = await AsyncValue.guard(() async {
+        final String? storedId =
+            await ref.read(playbackPreferencesProvider).audioOutputDeviceId();
+        // Fall back to the live selection when nothing is stored: a device
+        // picked by an unstable id is session-only, and refreshing the list
+        // must not look like the user reset it to the system default.
+        final AudioOutputSettingsState resolved =
+            await _resolve(storedId ?? current.selected.id, current.selected);
+        // Carry the "your saved output is gone" notice across a refresh. By
+        // the time the card is opened the stored id has already been dropped,
+        // so re-deriving the flag here would always come back false and quietly
+        // erase the one explanation the listener has for why playback moved.
+        // The next explicit choice clears it.
+        return resolved.copyWith(
+          savedDeviceUnavailable:
+              resolved.savedDeviceUnavailable || current.savedDeviceUnavailable,
+        );
+      });
     });
   }
 
@@ -116,48 +158,87 @@ class AudioOutputController extends AsyncNotifier<AudioOutputSettingsState> {
         ref.read(audioOutputDeviceServiceProvider);
     if (!service.isSupported) return;
 
-    await _apply(device);
-    await ref.read(playbackPreferencesProvider).setAudioOutputDeviceId(
-          AudioOutputDevice.isPersistableId(device.id) ? device.id : null,
+    return _enqueue(() async {
+      state = const AsyncValue<AudioOutputSettingsState>.loading()
+          .copyWithPrevious(state);
+      final AudioOutputSettingsState current =
+          state.valueOrNull ?? const AudioOutputSettingsState();
+
+      if (!await _apply(device)) {
+        // The backend refused — the device disappeared between the list and the
+        // tap. Playback is still where it was, so nothing is stored and nothing
+        // is shown as switched; the card says the switch did not happen.
+        state = AsyncData<AudioOutputSettingsState>(
+          current.copyWith(selectionFailed: true),
         );
+        return;
+      }
 
-    final AudioOutputSettingsState current =
-        state.valueOrNull ?? const AudioOutputSettingsState();
-    state = AsyncData<AudioOutputSettingsState>(
-      current.copyWith(selected: device, savedDeviceUnavailable: false),
-    );
+      await ref.read(playbackPreferencesProvider).setAudioOutputDeviceId(
+            AudioOutputDevice.isPersistableId(device.id) ? device.id : null,
+          );
+      state = AsyncData<AudioOutputSettingsState>(
+        current.copyWith(
+          selected: device,
+          savedDeviceUnavailable: false,
+          selectionFailed: false,
+        ),
+      );
+    });
   }
 
-  /// Routes to [device] unless the backend is already on it.
+  /// Runs [operation] after every operation already queued.
+  Future<void> _enqueue(Future<void> Function() operation) {
+    final Future<void> queued = _operations.then((_) => operation());
+    // The chain swallows failures so one refused switch cannot wedge every
+    // later choice; the caller still sees the original future.
+    _operations = queued.then((_) {}, onError: (Object _) {});
+    return queued;
+  }
+
+  /// Routes to [device] unless the backend is already on it, reporting whether
+  /// the backend is on it afterwards.
   ///
-  /// Re-asking for the output that is already in use would make every refresh
-  /// (and every launch on a machine that never changed its output) a routing
-  /// call into libmpv for no reason.
-  Future<void> _apply(AudioOutputDevice device) async {
-    if (device.id == _appliedId) return;
-    await ref.read(audioOutputDeviceServiceProvider).select(device);
+  /// Re-asking for the output already in use would make every refresh (and
+  /// every launch on a machine that never changed its output) a routing call
+  /// into libmpv for no reason.
+  Future<bool> _apply(AudioOutputDevice device) async {
+    if (device.id == _appliedId) return true;
+    if (!await ref.read(audioOutputDeviceServiceProvider).select(device)) {
+      return false;
+    }
     _appliedId = device.id;
+    return true;
   }
 
-  Future<AudioOutputSettingsState> _resolve(String desiredId) async {
+  Future<AudioOutputSettingsState> _resolve(
+    String desiredId,
+    AudioOutputDevice currentSelection,
+  ) async {
     final AudioOutputDeviceService service =
         ref.read(audioOutputDeviceServiceProvider);
     final List<AudioOutputDevice> devices = await service.devices();
 
     if (devices.isEmpty) {
       // The backend could not be asked. That is not evidence the chosen device
-      // is gone, so nothing is cleared and nothing is re-routed — the card just
+      // is gone, so nothing is cleared, nothing is re-routed, and the live
+      // selection is kept — dropping it here would make the *next* refresh
+      // route away from an output the listener is still using. The card just
       // reports that it found no outputs.
-      return const AudioOutputSettingsState(hasEnumerated: true);
+      return AudioOutputSettingsState(
+        selected: currentSelection,
+        hasEnumerated: true,
+      );
     }
 
     for (final AudioOutputDevice device in devices) {
       if (device.id != desiredId) continue;
-      await _apply(device);
+      final bool routed = await _apply(device);
       return AudioOutputSettingsState(
         devices: devices,
-        selected: device,
+        selected: routed ? device : currentSelection,
         hasEnumerated: true,
+        selectionFailed: !routed,
       );
     }
 

--- a/lib/features/settings/playback/audio_output_controller.dart
+++ b/lib/features/settings/playback/audio_output_controller.dart
@@ -1,0 +1,183 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/models/audio_output_device.dart';
+import '../../../core/services/audio_output_device_service.dart';
+import '../../../data/repositories/audio_output_device_service_provider.dart';
+import '../../../data/repositories/playback_preferences_provider.dart';
+
+/// What the "Audio output" card shows.
+class AudioOutputSettingsState {
+  const AudioOutputSettingsState({
+    this.devices = const <AudioOutputDevice>[],
+    this.selected = AudioOutputDevice.systemDefault,
+    this.hasEnumerated = false,
+    this.savedDeviceUnavailable = false,
+  });
+
+  /// The outputs the host offers, system default first. Empty either because
+  /// nothing has been enumerated yet ([hasEnumerated] false) or because the
+  /// backend reported none.
+  final List<AudioOutputDevice> devices;
+
+  /// The output playback is currently routed to.
+  final AudioOutputDevice selected;
+
+  /// Whether the device list has been asked for at least once.
+  final bool hasEnumerated;
+
+  /// Whether a previously chosen output was missing at startup, so playback
+  /// fell back to the system default. Surfaced once, then cleared on the next
+  /// choice.
+  final bool savedDeviceUnavailable;
+
+  /// Whether [selected] will still be in effect after a restart. False for the
+  /// system default (there is nothing to remember) and for devices named by an
+  /// unstable handle, which Linthra deliberately does not store.
+  bool get isRemembered => AudioOutputDevice.isPersistableId(selected.id);
+
+  AudioOutputSettingsState copyWith({
+    List<AudioOutputDevice>? devices,
+    AudioOutputDevice? selected,
+    bool? hasEnumerated,
+    bool? savedDeviceUnavailable,
+  }) {
+    return AudioOutputSettingsState(
+      devices: devices ?? this.devices,
+      selected: selected ?? this.selected,
+      hasEnumerated: hasEnumerated ?? this.hasEnumerated,
+      savedDeviceUnavailable:
+          savedDeviceUnavailable ?? this.savedDeviceUnavailable,
+    );
+  }
+}
+
+/// Owns the "Audio output" choice: which device playback is routed to, and
+/// whether that choice is remembered.
+///
+/// The routing itself lives in [AudioOutputDeviceService]; this notifier holds
+/// the policy around it, which is the part worth testing:
+///
+///  * a stored device is re-applied on launch, so the choice survives a restart
+///    without the user re-picking it;
+///  * a stored device that is *not* in the list any more (unplugged headset,
+///    another machine, a renamed sink) is dropped rather than pushed at the
+///    backend, and playback stays on the system default;
+///  * a device whose id will not survive a reboot is applied but not stored,
+///    so nothing silently routes to a different card next boot.
+///
+/// [build] is deliberately cheap when nothing is stored: it does not enumerate,
+/// so launching the app never probes the audio backend just to confirm the
+/// default. The Settings card calls [refresh] when it is opened.
+class AudioOutputController extends AsyncNotifier<AudioOutputSettingsState> {
+  /// The output currently pushed at the backend. It starts as the system
+  /// default because that is what a fresh process is already on, and it is what
+  /// keeps a refresh from re-routing audio it has not been asked to move.
+  String _appliedId = AudioOutputDevice.systemDefaultId;
+
+  @override
+  Future<AudioOutputSettingsState> build() async {
+    final AudioOutputDeviceService service =
+        ref.read(audioOutputDeviceServiceProvider);
+    if (!service.isSupported) return const AudioOutputSettingsState();
+
+    final String? storedId =
+        await ref.read(playbackPreferencesProvider).audioOutputDeviceId();
+    if (storedId == null) return const AudioOutputSettingsState();
+
+    return _resolve(storedId);
+  }
+
+  /// Re-reads the host's output list and re-applies the current choice.
+  ///
+  /// Called when the Settings card is opened and by its refresh action, so a
+  /// device plugged in while the app was running shows up.
+  Future<void> refresh() async {
+    final AudioOutputDeviceService service =
+        ref.read(audioOutputDeviceServiceProvider);
+    if (!service.isSupported) return;
+
+    final AudioOutputSettingsState current =
+        state.valueOrNull ?? const AudioOutputSettingsState();
+    state = const AsyncValue<AudioOutputSettingsState>.loading()
+        .copyWithPrevious(state);
+    state = await AsyncValue.guard(() async {
+      final String? storedId =
+          await ref.read(playbackPreferencesProvider).audioOutputDeviceId();
+      // Fall back to the live selection when nothing is stored: a device picked
+      // by an unstable id is session-only, and refreshing the list must not
+      // look like the user reset it to the system default.
+      return _resolve(storedId ?? current.selected.id);
+    });
+  }
+
+  /// Routes playback to [device] and remembers it when its id is stable.
+  Future<void> select(AudioOutputDevice device) async {
+    final AudioOutputDeviceService service =
+        ref.read(audioOutputDeviceServiceProvider);
+    if (!service.isSupported) return;
+
+    await _apply(device);
+    await ref.read(playbackPreferencesProvider).setAudioOutputDeviceId(
+          AudioOutputDevice.isPersistableId(device.id) ? device.id : null,
+        );
+
+    final AudioOutputSettingsState current =
+        state.valueOrNull ?? const AudioOutputSettingsState();
+    state = AsyncData<AudioOutputSettingsState>(
+      current.copyWith(selected: device, savedDeviceUnavailable: false),
+    );
+  }
+
+  /// Routes to [device] unless the backend is already on it.
+  ///
+  /// Re-asking for the output that is already in use would make every refresh
+  /// (and every launch on a machine that never changed its output) a routing
+  /// call into libmpv for no reason.
+  Future<void> _apply(AudioOutputDevice device) async {
+    if (device.id == _appliedId) return;
+    await ref.read(audioOutputDeviceServiceProvider).select(device);
+    _appliedId = device.id;
+  }
+
+  Future<AudioOutputSettingsState> _resolve(String desiredId) async {
+    final AudioOutputDeviceService service =
+        ref.read(audioOutputDeviceServiceProvider);
+    final List<AudioOutputDevice> devices = await service.devices();
+
+    if (devices.isEmpty) {
+      // The backend could not be asked. That is not evidence the chosen device
+      // is gone, so nothing is cleared and nothing is re-routed — the card just
+      // reports that it found no outputs.
+      return const AudioOutputSettingsState(hasEnumerated: true);
+    }
+
+    for (final AudioOutputDevice device in devices) {
+      if (device.id != desiredId) continue;
+      await _apply(device);
+      return AudioOutputSettingsState(
+        devices: devices,
+        selected: device,
+        hasEnumerated: true,
+      );
+    }
+
+    // The chosen output is not on this machine any more. Fall back to the
+    // system default and forget it, so the next launch does not keep trying a
+    // name that no longer means anything.
+    final bool wasStored = desiredId != AudioOutputDevice.systemDefaultId;
+    if (wasStored) {
+      await ref.read(playbackPreferencesProvider).setAudioOutputDeviceId(null);
+      await _apply(AudioOutputDevice.systemDefault);
+    }
+    return AudioOutputSettingsState(
+      devices: devices,
+      hasEnumerated: true,
+      savedDeviceUnavailable: wasStored,
+    );
+  }
+}
+
+final audioOutputControllerProvider =
+    AsyncNotifierProvider<AudioOutputController, AudioOutputSettingsState>(
+  AudioOutputController.new,
+);

--- a/lib/features/settings/playback/audio_output_settings_section.dart
+++ b/lib/features/settings/playback/audio_output_settings_section.dart
@@ -104,6 +104,15 @@ class _AudioOutputSettingsSectionState
                 color: theme.colorScheme.tertiary,
               ),
             ],
+            if (state.selectionFailed) ...<Widget>[
+              const SizedBox(height: AppSpacing.sm),
+              _Note(
+                icon: Icons.error_outline,
+                text: 'That output could not be used, so playback stayed on '
+                    '${state.selected.label}. Refresh the list and try again.',
+                color: theme.colorScheme.error,
+              ),
+            ],
             if (!state.selected.isSystemDefault && !state.isRemembered) ...[
               const SizedBox(height: AppSpacing.sm),
               _Note(

--- a/lib/features/settings/playback/audio_output_settings_section.dart
+++ b/lib/features/settings/playback/audio_output_settings_section.dart
@@ -1,0 +1,216 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/models/audio_output_device.dart';
+import '../../../data/repositories/audio_output_device_service_provider.dart';
+import 'audio_output_controller.dart';
+
+/// The "Audio output" card on the Music & playback settings page.
+///
+/// Only shown where Linthra can actually route audio itself — Linux, through
+/// libmpv. On Android the system owns output routing (the output picker,
+/// Bluetooth, Android Auto), so the seam reports itself unsupported and this
+/// widget renders nothing rather than offering a control that would fight the
+/// platform.
+///
+/// The card never touches the audio engine directly: it reads and writes the
+/// choice through [AudioOutputController], which applies it to the backend and
+/// decides whether it is stable enough to remember.
+class AudioOutputSettingsSection extends ConsumerStatefulWidget {
+  const AudioOutputSettingsSection({super.key});
+
+  @override
+  ConsumerState<AudioOutputSettingsSection> createState() =>
+      _AudioOutputSettingsSectionState();
+}
+
+class _AudioOutputSettingsSectionState
+    extends ConsumerState<AudioOutputSettingsSection> {
+  @override
+  void initState() {
+    super.initState();
+    // Enumerating means asking libmpv, so it happens when the page is opened
+    // rather than at launch. Deferred past the first frame so building this
+    // widget never drives a provider mid-build.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final AudioOutputSettingsState? current =
+          ref.read(audioOutputControllerProvider).valueOrNull;
+      if (current != null && current.hasEnumerated) return;
+      ref.read(audioOutputControllerProvider.notifier).refresh();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!ref.watch(audioOutputDeviceServiceProvider).isSupported) {
+      return const SizedBox.shrink();
+    }
+
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    final AsyncValue<AudioOutputSettingsState> async =
+        ref.watch(audioOutputControllerProvider);
+    final AudioOutputSettingsState state =
+        async.valueOrNull ?? const AudioOutputSettingsState();
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.md,
+          AppSpacing.md,
+          AppSpacing.md,
+          AppSpacing.sm,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Icon(Icons.speaker_outlined, color: theme.colorScheme.primary),
+                const SizedBox(width: AppSpacing.sm),
+                Expanded(
+                  child: Text(
+                    'Audio output',
+                    style: theme.textTheme.titleMedium,
+                  ),
+                ),
+                IconButton(
+                  tooltip: 'Refresh outputs',
+                  icon: const Icon(Icons.refresh),
+                  onPressed: async.isLoading
+                      ? null
+                      : () => ref
+                          .read(audioOutputControllerProvider.notifier)
+                          .refresh(),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              'Choose which speakers, headset or DAC Linthra plays through. '
+              '"System default" follows whatever your desktop is using.',
+              style: theme.textTheme.bodySmall?.copyWith(color: muted),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            _OutputPicker(state: state, isBusy: async.isLoading),
+            if (state.savedDeviceUnavailable) ...<Widget>[
+              const SizedBox(height: AppSpacing.sm),
+              _Note(
+                icon: Icons.info_outline,
+                text: 'Your saved output is not available right now, so '
+                    'playback is using the system default.',
+                color: theme.colorScheme.tertiary,
+              ),
+            ],
+            if (!state.selected.isSystemDefault && !state.isRemembered) ...[
+              const SizedBox(height: AppSpacing.sm),
+              _Note(
+                icon: Icons.history_toggle_off,
+                text: 'This output is named by a handle that can change when '
+                    'you plug something in, so it is used for this session '
+                    'only.',
+                color: muted,
+              ),
+            ],
+            const SizedBox(height: AppSpacing.xs),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The device list itself: a dropdown once outputs are known, and an honest
+/// line of text before that (or when the backend reported none).
+class _OutputPicker extends ConsumerWidget {
+  const _OutputPicker({required this.state, required this.isBusy});
+
+  final AudioOutputSettingsState state;
+  final bool isBusy;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+
+    if (state.devices.isEmpty) {
+      return Text(
+        state.hasEnumerated
+            ? 'No outputs were reported by the audio backend. Playback uses '
+                'the system default.'
+            : 'Looking for audio outputs…',
+        style: theme.textTheme.bodySmall?.copyWith(color: muted),
+      );
+    }
+
+    // Guard the dropdown's contract: its value has to be one of its items, and
+    // a device can disappear between a refresh and this rebuild.
+    final bool selectedIsListed = state.devices.any(
+      (AudioOutputDevice device) => device.id == state.selected.id,
+    );
+    final String value = selectedIsListed
+        ? state.selected.id
+        : AudioOutputDevice.systemDefaultId;
+
+    return InputDecorator(
+      decoration: const InputDecoration(
+        labelText: 'Output device',
+        border: OutlineInputBorder(),
+        isDense: true,
+      ),
+      child: DropdownButtonHideUnderline(
+        child: DropdownButton<String>(
+          isExpanded: true,
+          value: value,
+          onChanged: isBusy
+              ? null
+              : (String? id) {
+                  if (id == null) return;
+                  final AudioOutputDevice device = state.devices.firstWhere(
+                    (AudioOutputDevice candidate) => candidate.id == id,
+                    orElse: () => AudioOutputDevice.systemDefault,
+                  );
+                  ref
+                      .read(audioOutputControllerProvider.notifier)
+                      .select(device);
+                },
+          items: <DropdownMenuItem<String>>[
+            for (final AudioOutputDevice device in state.devices)
+              DropdownMenuItem<String>(
+                value: device.id,
+                child: Text(device.label, overflow: TextOverflow.ellipsis),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Note extends StatelessWidget {
+  const _Note({required this.icon, required this.text, required this.color});
+
+  final IconData icon;
+  final String text;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Icon(icon, size: 16, color: color),
+        const SizedBox(width: AppSpacing.sm),
+        Expanded(
+          child: Text(
+            text,
+            style: theme.textTheme.bodySmall?.copyWith(color: color),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -648,7 +648,7 @@ packages:
     source: hosted
     version: "0.13.0"
   media_kit:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: media_kit
       sha256: ae9e79597500c7ad6083a3c7b7b7544ddabfceacce7ae5c9709b0ec16a5d6643

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,12 @@ dependencies:
   # the federated adapter means Linux reuses Linthra's existing resolver,
   # fallback, queue and completion controller while Android stays on ExoPlayer.
   just_audio_media_kit: ^2.1.0
+  # Already pulled in by just_audio_media_kit; declared directly because Linthra
+  # calls media_kit's own API for the one thing just_audio's platform interface
+  # does not model — Linux audio output device enumeration and selection (see
+  # LinuxAudioOutputDeviceService). No new code ships for this: it is the same
+  # libmpv binding the Linux engine already runs on.
+  media_kit: ^1.2.6
   # Supplies media_kit's Linux native registration. libmpv is an explicit
   # system/Flatpak runtime dependency; Linthra disables this package's optional
   # mimalloc download in linux/CMakeLists.txt for network-isolated builds.

--- a/test/core/models/audio_output_device_test.dart
+++ b/test/core/models/audio_output_device_test.dart
@@ -91,6 +91,24 @@ void main() {
       );
     });
 
+    test('does not remember a bare numeric target', () {
+      // A PipeWire/PulseAudio object id, not a name: the daemon hands the same
+      // number to a different sink after a restart, and the startup check can
+      // only ask whether the id still exists — which it does, meaning something
+      // else. No real sink is named by a bare integer.
+      expect(AudioOutputDevice.isPersistableId('pipewire/42'), isFalse);
+      expect(AudioOutputDevice.isPersistableId('pulse/7'), isFalse);
+      expect(AudioOutputDevice.isPersistableId('42'), isFalse);
+    });
+
+    test('still remembers a name that merely contains digits', () {
+      expect(
+        AudioOutputDevice.isPersistableId('pipewire/alsa_output.usb-DAC_2'),
+        isTrue,
+      );
+      expect(AudioOutputDevice.isPersistableId('pulse/hdmi2'), isTrue);
+    });
+
     test('does not remember numeric ALSA card handles', () {
       // hw:1,0 is a card *index*: plugging in a USB DAC renumbers it, so a
       // stored value would silently route to a different device next boot.

--- a/test/core/models/audio_output_device_test.dart
+++ b/test/core/models/audio_output_device_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/audio_output_device.dart';
+
+void main() {
+  group('audioOutputDevicesFromBackend', () {
+    test('always offers the system default first', () {
+      final List<AudioOutputDevice> devices = audioOutputDevicesFromBackend(
+        <({String id, String description})>[
+          (id: 'pipewire/alsa_output.usb-DAC', description: 'USB DAC'),
+        ],
+      );
+
+      expect(devices.first, AudioOutputDevice.systemDefault);
+      expect(devices.first.label, 'System default');
+      expect(devices, hasLength(2));
+    });
+
+    test('keeps the backend description as the label', () {
+      final List<AudioOutputDevice> devices = audioOutputDevicesFromBackend(
+        <({String id, String description})>[
+          (
+            id: 'pipewire/alsa_output.pci-0000_00_1f.3.analog-stereo',
+            description: 'Built-in Audio Analog Stereo',
+          ),
+        ],
+      );
+
+      expect(
+          devices[1].id, 'pipewire/alsa_output.pci-0000_00_1f.3.analog-stereo');
+      expect(devices[1].label, 'Built-in Audio Analog Stereo');
+    });
+
+    test('never renders a blank row for a device with no description', () {
+      final List<AudioOutputDevice> devices = audioOutputDevicesFromBackend(
+        <({String id, String description})>[
+          (id: 'alsa/sysdefault:CARD=PCH', description: '   '),
+        ],
+      );
+
+      expect(devices[1].label, 'sysdefault:CARD=PCH');
+    });
+
+    test('collapses the backend\'s own auto entry into the system default', () {
+      // libmpv lists `auto` itself; the list must not show it twice.
+      final List<AudioOutputDevice> devices = audioOutputDevicesFromBackend(
+        <({String id, String description})>[
+          (id: 'auto', description: 'Autoselect device'),
+          (id: 'pulse/headset', description: 'Headset'),
+        ],
+      );
+
+      expect(
+        devices.map((AudioOutputDevice device) => device.id),
+        <String>['auto', 'pulse/headset'],
+      );
+      expect(devices.first.label, 'System default');
+    });
+
+    test('drops duplicate ids and blank ids', () {
+      final List<AudioOutputDevice> devices = audioOutputDevicesFromBackend(
+        <({String id, String description})>[
+          (id: 'pulse/headset', description: 'Headset'),
+          (id: 'pulse/headset', description: 'Headset (alias)'),
+          (id: '  ', description: 'Nothing'),
+        ],
+      );
+
+      expect(devices, hasLength(2));
+      expect(devices[1].label, 'Headset');
+    });
+  });
+
+  group('AudioOutputDevice.isPersistableId', () {
+    test('remembers PipeWire and PulseAudio node names', () {
+      expect(
+        AudioOutputDevice.isPersistableId(
+          'pipewire/alsa_output.pci-0000_00_1f.3.analog-stereo',
+        ),
+        isTrue,
+      );
+      expect(
+        AudioOutputDevice.isPersistableId('pulse/bluez_output.AC_12_2F_00_11'),
+        isTrue,
+      );
+    });
+
+    test('remembers ALSA devices named by card, not by index', () {
+      expect(
+        AudioOutputDevice.isPersistableId('alsa/sysdefault:CARD=PCH'),
+        isTrue,
+      );
+    });
+
+    test('does not remember numeric ALSA card handles', () {
+      // hw:1,0 is a card *index*: plugging in a USB DAC renumbers it, so a
+      // stored value would silently route to a different device next boot.
+      expect(AudioOutputDevice.isPersistableId('alsa/hw:1,0'), isFalse);
+      expect(AudioOutputDevice.isPersistableId('alsa/plughw:2,0'), isFalse);
+      expect(AudioOutputDevice.isPersistableId('alsa/hw:0'), isFalse);
+    });
+
+    test('does not remember the system default or an empty id', () {
+      expect(AudioOutputDevice.isPersistableId('auto'), isFalse);
+      expect(AudioOutputDevice.isPersistableId(''), isFalse);
+      expect(AudioOutputDevice.isPersistableId('pulse/'), isFalse);
+    });
+  });
+}

--- a/test/core/services/linux_audio_output_device_service_test.dart
+++ b/test/core/services/linux_audio_output_device_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/audio_output_device.dart';
 import 'package:linthra/core/services/linux_audio_output_device_service.dart';
@@ -51,26 +53,44 @@ void main() {
         apply: (String id) async => applied = id,
       );
 
-      await service.select(
+      final bool routed = await service.select(
         const AudioOutputDevice(id: 'pulse/headset', label: 'Headset'),
       );
 
       expect(applied, 'pulse/headset');
+      expect(routed, isTrue);
     });
 
-    test('a device that vanished mid-switch leaves playback alone', () async {
+    test('a device that vanished mid-switch reports failure, not an error',
+        () async {
       final LinuxAudioOutputDeviceService service =
           LinuxAudioOutputDeviceService(
         probe: () async => const <({String id, String description})>[],
         apply: (_) async => throw StateError('device is gone'),
       );
 
-      await expectLater(
-        service.select(
+      // Reported rather than thrown, so Settings keeps working — but reported,
+      // so the caller does not go on to remember an output that never started.
+      expect(
+        await service.select(
           const AudioOutputDevice(id: 'pulse/headset', label: 'Headset'),
         ),
-        completes,
+        isFalse,
       );
+    });
+
+    test('a probe that never answers is an enumeration failure', () async {
+      // The real timeout path: `_readDevices` deliberately lets a
+      // TimeoutException out rather than falling back to libmpv's seeded
+      // `[auto]` state, because a caller comparing a saved device against that
+      // one-entry list would conclude the device had been removed.
+      final LinuxAudioOutputDeviceService service =
+          LinuxAudioOutputDeviceService(
+        probe: () async => throw TimeoutException('libmpv never answered'),
+        apply: (_) async {},
+      );
+
+      expect(await service.devices(), isEmpty);
     });
   });
 }

--- a/test/core/services/linux_audio_output_device_service_test.dart
+++ b/test/core/services/linux_audio_output_device_service_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/audio_output_device.dart';
+import 'package:linthra/core/services/linux_audio_output_device_service.dart';
+
+/// The media_kit/libmpv calls themselves are not exercised here: `flutter test`
+/// does not assemble the native Linux bundle, so building a real `Player` would
+/// make these tests depend on libmpv and on the host's sound card. The seams
+/// stand in for exactly those two calls, and what is asserted is the behaviour
+/// around them — how a raw device list becomes the list Settings shows, and
+/// that a backend which fails is reported as "nothing found" rather than an
+/// error thrown into the UI.
+void main() {
+  group('LinuxAudioOutputDeviceService', () {
+    test('reports itself supported', () {
+      expect(LinuxAudioOutputDeviceService().isSupported, isTrue);
+    });
+
+    test('maps the backend list, system default first', () async {
+      final LinuxAudioOutputDeviceService service =
+          LinuxAudioOutputDeviceService(
+        probe: () async => <({String id, String description})>[
+          (id: 'auto', description: 'Autoselect device'),
+          (id: 'pipewire/hdmi', description: 'HDMI / DisplayPort'),
+        ],
+        apply: (_) async {},
+      );
+
+      final List<AudioOutputDevice> devices = await service.devices();
+
+      expect(devices.first, AudioOutputDevice.systemDefault);
+      expect(devices[1].id, 'pipewire/hdmi');
+      expect(devices[1].label, 'HDMI / DisplayPort');
+    });
+
+    test('a backend that cannot be asked reports no devices, not an error',
+        () async {
+      final LinuxAudioOutputDeviceService service =
+          LinuxAudioOutputDeviceService(
+        probe: () async => throw StateError('libmpv is not answering'),
+        apply: (_) async {},
+      );
+
+      expect(await service.devices(), isEmpty);
+    });
+
+    test('passes the device id straight through to the backend', () async {
+      String? applied;
+      final LinuxAudioOutputDeviceService service =
+          LinuxAudioOutputDeviceService(
+        probe: () async => const <({String id, String description})>[],
+        apply: (String id) async => applied = id,
+      );
+
+      await service.select(
+        const AudioOutputDevice(id: 'pulse/headset', label: 'Headset'),
+      );
+
+      expect(applied, 'pulse/headset');
+    });
+
+    test('a device that vanished mid-switch leaves playback alone', () async {
+      final LinuxAudioOutputDeviceService service =
+          LinuxAudioOutputDeviceService(
+        probe: () async => const <({String id, String description})>[],
+        apply: (_) async => throw StateError('device is gone'),
+      );
+
+      await expectLater(
+        service.select(
+          const AudioOutputDevice(id: 'pulse/headset', label: 'Headset'),
+        ),
+        completes,
+      );
+    });
+  });
+}

--- a/test/core/services/platform_audio_output_device_service_test.dart
+++ b/test/core/services/platform_audio_output_device_service_test.dart
@@ -19,7 +19,10 @@ class _RecordingService implements AudioOutputDeviceService {
       const <AudioOutputDevice>[AudioOutputDevice.systemDefault];
 
   @override
-  Future<void> select(AudioOutputDevice device) async => selected = device;
+  Future<bool> select(AudioOutputDevice device) async {
+    selected = device;
+    return true;
+  }
 }
 
 void main() {

--- a/test/core/services/platform_audio_output_device_service_test.dart
+++ b/test/core/services/platform_audio_output_device_service_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/audio_output_device.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/core/services/audio_output_device_service.dart';
+import 'package:linthra/core/services/noop_audio_output_device_service.dart';
+import 'package:linthra/core/services/platform_audio_output_device_service.dart';
+
+/// Records what it was asked to do, so the platform split can be asserted
+/// without loading libmpv.
+class _RecordingService implements AudioOutputDeviceService {
+  _RecordingService({required this.isSupported});
+
+  @override
+  final bool isSupported;
+  AudioOutputDevice? selected;
+
+  @override
+  Future<List<AudioOutputDevice>> devices() async =>
+      const <AudioOutputDevice>[AudioOutputDevice.systemDefault];
+
+  @override
+  Future<void> select(AudioOutputDevice device) async => selected = device;
+}
+
+void main() {
+  group('PlatformAudioOutputDeviceService', () {
+    const AudioOutputDevice headset =
+        AudioOutputDevice(id: 'pulse/headset', label: 'Headset');
+
+    test('on Linux, routes through the media_kit-backed service', () async {
+      final _RecordingService linux = _RecordingService(isSupported: true);
+      final _RecordingService fallback = _RecordingService(isSupported: false);
+      final PlatformAudioOutputDeviceService service =
+          PlatformAudioOutputDeviceService(
+        host: HostPlatform.linux,
+        linuxService: linux,
+        fallbackService: fallback,
+      );
+
+      expect(service.isSupported, isTrue);
+      expect(await service.devices(), hasLength(1));
+      await service.select(headset);
+      expect(linux.selected, headset);
+      expect(fallback.selected, isNull);
+    });
+
+    test('on Android, output routing stays with the system', () async {
+      final _RecordingService linux = _RecordingService(isSupported: true);
+      final PlatformAudioOutputDeviceService service =
+          PlatformAudioOutputDeviceService(
+        host: HostPlatform.android,
+        linuxService: linux,
+      );
+
+      expect(service.isSupported, isFalse);
+      expect(await service.devices(), isEmpty);
+      await service.select(headset);
+      expect(linux.selected, isNull);
+    });
+
+    test('an unsupported desktop platform falls back too', () async {
+      final PlatformAudioOutputDeviceService service =
+          PlatformAudioOutputDeviceService(
+        host: HostPlatform.macOS,
+        linuxService: _RecordingService(isSupported: true),
+      );
+
+      expect(service.isSupported, isFalse);
+    });
+  });
+
+  group('NoopAudioOutputDeviceService', () {
+    test('enumerates nothing and routes nothing', () async {
+      const NoopAudioOutputDeviceService service =
+          NoopAudioOutputDeviceService();
+
+      expect(service.isSupported, isFalse);
+      expect(await service.devices(), isEmpty);
+      await expectLater(
+        service.select(AudioOutputDevice.systemDefault),
+        completes,
+      );
+    });
+  });
+}

--- a/test/features/settings/playback/audio_output_controller_test.dart
+++ b/test/features/settings/playback/audio_output_controller_test.dart
@@ -1,0 +1,302 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/audio_output_device.dart';
+import 'package:linthra/core/services/audio_output_device_service.dart';
+import 'package:linthra/data/repositories/audio_output_device_service_provider.dart';
+import 'package:linthra/data/repositories/in_memory_playback_preferences.dart';
+import 'package:linthra/data/repositories/playback_preferences_provider.dart';
+import 'package:linthra/features/settings/playback/audio_output_controller.dart';
+
+/// A stand-in for libmpv: it reports whatever device list the test sets up and
+/// records every routing call, so the controller's policy can be asserted
+/// without a sound card.
+class _FakeService implements AudioOutputDeviceService {
+  _FakeService({
+    this.isSupported = true,
+    List<AudioOutputDevice>? devices,
+  }) : available = devices ?? <AudioOutputDevice>[];
+
+  @override
+  final bool isSupported;
+
+  List<AudioOutputDevice> available;
+  final List<AudioOutputDevice> routed = <AudioOutputDevice>[];
+  int enumerations = 0;
+
+  @override
+  Future<List<AudioOutputDevice>> devices() async {
+    enumerations++;
+    return available;
+  }
+
+  @override
+  Future<void> select(AudioOutputDevice device) async => routed.add(device);
+}
+
+void main() {
+  const AudioOutputDevice headset = AudioOutputDevice(
+    id: 'pipewire/alsa_output.usb-headset',
+    label: 'USB Headset',
+  );
+  const AudioOutputDevice builtIn = AudioOutputDevice(
+    id: 'pipewire/alsa_output.pci-0000_00_1f.3.analog-stereo',
+    label: 'Built-in Audio',
+  );
+  const AudioOutputDevice unstable = AudioOutputDevice(
+    id: 'alsa/hw:2,0',
+    label: 'Some card',
+  );
+
+  ProviderContainer containerFor(
+    _FakeService service,
+    InMemoryPlaybackPreferences preferences,
+  ) {
+    final ProviderContainer container = ProviderContainer(
+      overrides: <Override>[
+        audioOutputDeviceServiceProvider.overrideWithValue(service),
+        playbackPreferencesProvider.overrideWithValue(preferences),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('AudioOutputController at startup', () {
+    test('does not probe the backend when nothing is saved', () async {
+      final _FakeService service = _FakeService(
+        devices: <AudioOutputDevice>[AudioOutputDevice.systemDefault, headset],
+      );
+      final ProviderContainer container =
+          containerFor(service, InMemoryPlaybackPreferences());
+
+      final AudioOutputSettingsState state =
+          await container.read(audioOutputControllerProvider.future);
+
+      expect(service.enumerations, 0);
+      expect(service.routed, isEmpty);
+      expect(state.selected, AudioOutputDevice.systemDefault);
+      expect(state.hasEnumerated, isFalse);
+    });
+
+    test('re-applies a saved device that is still there', () async {
+      final _FakeService service = _FakeService(
+        devices: <AudioOutputDevice>[
+          AudioOutputDevice.systemDefault,
+          builtIn,
+          headset,
+        ],
+      );
+      final ProviderContainer container = containerFor(
+        service,
+        InMemoryPlaybackPreferences(audioOutputDeviceId: headset.id),
+      );
+
+      final AudioOutputSettingsState state =
+          await container.read(audioOutputControllerProvider.future);
+
+      expect(service.routed, <AudioOutputDevice>[headset]);
+      expect(state.selected, headset);
+      expect(state.savedDeviceUnavailable, isFalse);
+    });
+
+    test('falls back to the system default when the saved device is gone',
+        () async {
+      final _FakeService service = _FakeService(
+        devices: <AudioOutputDevice>[AudioOutputDevice.systemDefault, builtIn],
+      );
+      final InMemoryPlaybackPreferences preferences =
+          InMemoryPlaybackPreferences(audioOutputDeviceId: headset.id);
+      final ProviderContainer container = containerFor(service, preferences);
+
+      final AudioOutputSettingsState state =
+          await container.read(audioOutputControllerProvider.future);
+
+      // Nothing was routed: playback never left the system default, so there
+      // is nothing to move it back to.
+      expect(service.routed, isEmpty);
+      expect(state.selected, AudioOutputDevice.systemDefault);
+      expect(state.savedDeviceUnavailable, isTrue);
+      // Forgotten, so the next launch does not keep chasing a name that no
+      // longer means anything on this machine.
+      expect(await preferences.audioOutputDeviceId(), isNull);
+    });
+
+    test('a backend that reports nothing is not treated as "device gone"',
+        () async {
+      final _FakeService service = _FakeService();
+      final InMemoryPlaybackPreferences preferences =
+          InMemoryPlaybackPreferences(audioOutputDeviceId: headset.id);
+      final ProviderContainer container = containerFor(service, preferences);
+
+      final AudioOutputSettingsState state =
+          await container.read(audioOutputControllerProvider.future);
+
+      expect(service.routed, isEmpty);
+      expect(state.hasEnumerated, isTrue);
+      expect(state.devices, isEmpty);
+      expect(await preferences.audioOutputDeviceId(), headset.id);
+    });
+
+    test('does nothing at all where the platform owns output routing',
+        () async {
+      final _FakeService service = _FakeService(isSupported: false);
+      final ProviderContainer container = containerFor(
+        service,
+        InMemoryPlaybackPreferences(audioOutputDeviceId: headset.id),
+      );
+
+      final AudioOutputSettingsState state =
+          await container.read(audioOutputControllerProvider.future);
+
+      expect(service.enumerations, 0);
+      expect(service.routed, isEmpty);
+      expect(state.selected, AudioOutputDevice.systemDefault);
+    });
+  });
+
+  group('AudioOutputController.select', () {
+    test('routes playback and remembers a stable device', () async {
+      final _FakeService service = _FakeService(
+        devices: <AudioOutputDevice>[AudioOutputDevice.systemDefault, headset],
+      );
+      final InMemoryPlaybackPreferences preferences =
+          InMemoryPlaybackPreferences();
+      final ProviderContainer container = containerFor(service, preferences);
+      await container.read(audioOutputControllerProvider.future);
+
+      await container
+          .read(audioOutputControllerProvider.notifier)
+          .select(headset);
+
+      expect(service.routed, <AudioOutputDevice>[headset]);
+      expect(await preferences.audioOutputDeviceId(), headset.id);
+      expect(
+        container.read(audioOutputControllerProvider).requireValue.selected,
+        headset,
+      );
+    });
+
+    test('applies an unstable device but does not remember it', () async {
+      final _FakeService service = _FakeService(
+        devices: <AudioOutputDevice>[AudioOutputDevice.systemDefault, unstable],
+      );
+      final InMemoryPlaybackPreferences preferences =
+          InMemoryPlaybackPreferences();
+      final ProviderContainer container = containerFor(service, preferences);
+      await container.read(audioOutputControllerProvider.future);
+
+      await container
+          .read(audioOutputControllerProvider.notifier)
+          .select(unstable);
+
+      expect(service.routed, <AudioOutputDevice>[unstable]);
+      expect(await preferences.audioOutputDeviceId(), isNull);
+      expect(
+        container.read(audioOutputControllerProvider).requireValue.isRemembered,
+        isFalse,
+      );
+    });
+
+    test('going back to the system default clears the stored device', () async {
+      final _FakeService service = _FakeService(
+        devices: <AudioOutputDevice>[AudioOutputDevice.systemDefault, headset],
+      );
+      final InMemoryPlaybackPreferences preferences =
+          InMemoryPlaybackPreferences(audioOutputDeviceId: headset.id);
+      final ProviderContainer container = containerFor(service, preferences);
+      await container.read(audioOutputControllerProvider.future);
+
+      await container
+          .read(audioOutputControllerProvider.notifier)
+          .select(AudioOutputDevice.systemDefault);
+
+      expect(
+        service.routed,
+        <AudioOutputDevice>[headset, AudioOutputDevice.systemDefault],
+      );
+      expect(await preferences.audioOutputDeviceId(), isNull);
+    });
+
+    test('re-picking the output already in use does not re-route', () async {
+      final _FakeService service = _FakeService(
+        devices: <AudioOutputDevice>[AudioOutputDevice.systemDefault, headset],
+      );
+      final ProviderContainer container =
+          containerFor(service, InMemoryPlaybackPreferences());
+      await container.read(audioOutputControllerProvider.future);
+
+      await container
+          .read(audioOutputControllerProvider.notifier)
+          .select(headset);
+      await container
+          .read(audioOutputControllerProvider.notifier)
+          .select(headset);
+
+      expect(service.routed, <AudioOutputDevice>[headset]);
+    });
+  });
+
+  group('AudioOutputController.refresh', () {
+    test('picks up a device that was plugged in after launch', () async {
+      final _FakeService service = _FakeService(
+        devices: <AudioOutputDevice>[AudioOutputDevice.systemDefault],
+      );
+      final ProviderContainer container =
+          containerFor(service, InMemoryPlaybackPreferences());
+      await container.read(audioOutputControllerProvider.future);
+
+      service.available = <AudioOutputDevice>[
+        AudioOutputDevice.systemDefault,
+        headset,
+      ];
+      await container.read(audioOutputControllerProvider.notifier).refresh();
+
+      expect(
+        container.read(audioOutputControllerProvider).requireValue.devices,
+        contains(headset),
+      );
+    });
+
+    test('keeps a session-only choice across a refresh', () async {
+      final _FakeService service = _FakeService(
+        devices: <AudioOutputDevice>[AudioOutputDevice.systemDefault, unstable],
+      );
+      final ProviderContainer container =
+          containerFor(service, InMemoryPlaybackPreferences());
+      await container.read(audioOutputControllerProvider.future);
+      await container
+          .read(audioOutputControllerProvider.notifier)
+          .select(unstable);
+
+      await container.read(audioOutputControllerProvider.notifier).refresh();
+
+      // Nothing was stored (the id is unstable), so the refresh must fall back
+      // to the live selection rather than looking like a reset.
+      expect(
+        container.read(audioOutputControllerProvider).requireValue.selected,
+        unstable,
+      );
+    });
+
+    test('reports a chosen device that disappeared while running', () async {
+      final _FakeService service = _FakeService(
+        devices: <AudioOutputDevice>[AudioOutputDevice.systemDefault, headset],
+      );
+      final ProviderContainer container =
+          containerFor(service, InMemoryPlaybackPreferences());
+      await container.read(audioOutputControllerProvider.future);
+      await container
+          .read(audioOutputControllerProvider.notifier)
+          .select(headset);
+
+      service.available = <AudioOutputDevice>[AudioOutputDevice.systemDefault];
+      await container.read(audioOutputControllerProvider.notifier).refresh();
+
+      final AudioOutputSettingsState state =
+          container.read(audioOutputControllerProvider).requireValue;
+      expect(state.selected, AudioOutputDevice.systemDefault);
+      expect(state.savedDeviceUnavailable, isTrue);
+      expect(service.routed.last, AudioOutputDevice.systemDefault);
+    });
+  });
+}

--- a/test/features/settings/playback/audio_output_controller_test.dart
+++ b/test/features/settings/playback/audio_output_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/audio_output_device.dart';
@@ -23,6 +25,14 @@ class _FakeService implements AudioOutputDeviceService {
   final List<AudioOutputDevice> routed = <AudioOutputDevice>[];
   int enumerations = 0;
 
+  /// Whether the backend accepts a switch. `false` stands in for a device that
+  /// disappeared between the list and the tap.
+  bool routingSucceeds = true;
+
+  /// Held futures, so a test can interleave two operations deliberately.
+  final List<Completer<void>> pendingRoutes = <Completer<void>>[];
+  bool holdRouting = false;
+
   @override
   Future<List<AudioOutputDevice>> devices() async {
     enumerations++;
@@ -30,7 +40,16 @@ class _FakeService implements AudioOutputDeviceService {
   }
 
   @override
-  Future<void> select(AudioOutputDevice device) async => routed.add(device);
+  Future<bool> select(AudioOutputDevice device) async {
+    if (holdRouting) {
+      final Completer<void> gate = Completer<void>();
+      pendingRoutes.add(gate);
+      await gate.future;
+    }
+    if (!routingSucceeds) return false;
+    routed.add(device);
+    return true;
+  }
 }
 
 void main() {
@@ -297,6 +316,121 @@ void main() {
       expect(state.selected, AudioOutputDevice.systemDefault);
       expect(state.savedDeviceUnavailable, isTrue);
       expect(service.routed.last, AudioOutputDevice.systemDefault);
+    });
+  });
+
+  group('AudioOutputController when the backend does not cooperate', () {
+    test('a refused switch is neither stored nor shown as playing', () async {
+      final _FakeService service = _FakeService(
+        devices: <AudioOutputDevice>[AudioOutputDevice.systemDefault, headset],
+      )..routingSucceeds = false;
+      final InMemoryPlaybackPreferences preferences =
+          InMemoryPlaybackPreferences();
+      final ProviderContainer container = containerFor(service, preferences);
+      await container.read(audioOutputControllerProvider.future);
+
+      await container
+          .read(audioOutputControllerProvider.notifier)
+          .select(headset);
+
+      final AudioOutputSettingsState state =
+          container.read(audioOutputControllerProvider).requireValue;
+      expect(state.selected, AudioOutputDevice.systemDefault);
+      expect(state.selectionFailed, isTrue);
+      expect(await preferences.audioOutputDeviceId(), isNull);
+    });
+
+    test('a refused switch is retried, not assumed applied', () async {
+      final _FakeService service = _FakeService(
+        devices: <AudioOutputDevice>[AudioOutputDevice.systemDefault, headset],
+      )..routingSucceeds = false;
+      final ProviderContainer container =
+          containerFor(service, InMemoryPlaybackPreferences());
+      await container.read(audioOutputControllerProvider.future);
+      await container
+          .read(audioOutputControllerProvider.notifier)
+          .select(headset);
+
+      service.routingSucceeds = true;
+      await container
+          .read(audioOutputControllerProvider.notifier)
+          .select(headset);
+
+      expect(service.routed, <AudioOutputDevice>[headset]);
+      expect(
+        container.read(audioOutputControllerProvider).requireValue.selected,
+        headset,
+      );
+    });
+
+    test('a failed enumeration keeps a session-only selection', () async {
+      final _FakeService service = _FakeService(
+        devices: <AudioOutputDevice>[AudioOutputDevice.systemDefault, unstable],
+      );
+      final ProviderContainer container =
+          containerFor(service, InMemoryPlaybackPreferences());
+      await container.read(audioOutputControllerProvider.future);
+      await container
+          .read(audioOutputControllerProvider.notifier)
+          .select(unstable);
+
+      // The backend goes quiet for one refresh, then comes back.
+      service.available = <AudioOutputDevice>[];
+      await container.read(audioOutputControllerProvider.notifier).refresh();
+
+      final AudioOutputSettingsState duringOutage =
+          container.read(audioOutputControllerProvider).requireValue;
+      expect(duringOutage.devices, isEmpty);
+      expect(duringOutage.selected, unstable);
+
+      service.available = <AudioOutputDevice>[
+        AudioOutputDevice.systemDefault,
+        unstable,
+      ];
+      await container.read(audioOutputControllerProvider.notifier).refresh();
+
+      // The outage must not have routed the listener away from their device.
+      expect(
+        container.read(audioOutputControllerProvider).requireValue.selected,
+        unstable,
+      );
+      expect(service.routed, <AudioOutputDevice>[unstable]);
+    });
+
+    test('two quick choices leave playback on the later one', () async {
+      final _FakeService service = _FakeService(
+        devices: <AudioOutputDevice>[
+          AudioOutputDevice.systemDefault,
+          builtIn,
+          headset,
+        ],
+      );
+      final InMemoryPlaybackPreferences preferences =
+          InMemoryPlaybackPreferences();
+      final ProviderContainer container = containerFor(service, preferences);
+      await container.read(audioOutputControllerProvider.future);
+      final AudioOutputController controller =
+          container.read(audioOutputControllerProvider.notifier);
+
+      service.holdRouting = true;
+      final Future<void> first = controller.select(builtIn);
+      final Future<void> second = controller.select(headset);
+
+      // Release the first route only once both gestures are in flight, and let
+      // it finish last if the calls were not serialized.
+      await Future<void>.delayed(Duration.zero);
+      expect(service.pendingRoutes, hasLength(1),
+          reason: 'the second choice must wait for the first');
+      service.holdRouting = false;
+      service.pendingRoutes.single.complete();
+      await Future.wait(<Future<void>>[first, second]);
+
+      expect(service.routed, <AudioOutputDevice>[builtIn, headset]);
+      expect(await preferences.audioOutputDeviceId(), headset.id);
+      expect(
+        container.read(audioOutputControllerProvider).requireValue.selected,
+        headset,
+      );
     });
   });
 }

--- a/test/features/settings/playback/audio_output_settings_section_test.dart
+++ b/test/features/settings/playback/audio_output_settings_section_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/audio_output_device.dart';
+import 'package:linthra/core/services/audio_output_device_service.dart';
+import 'package:linthra/data/repositories/audio_output_device_service_provider.dart';
+import 'package:linthra/data/repositories/in_memory_playback_preferences.dart';
+import 'package:linthra/data/repositories/playback_preferences_provider.dart';
+import 'package:linthra/features/settings/playback/audio_output_settings_section.dart';
+
+class _FakeService implements AudioOutputDeviceService {
+  _FakeService({this.isSupported = true, List<AudioOutputDevice>? devices})
+      : available = devices ?? <AudioOutputDevice>[];
+
+  @override
+  final bool isSupported;
+
+  final List<AudioOutputDevice> available;
+  final List<AudioOutputDevice> routed = <AudioOutputDevice>[];
+
+  @override
+  Future<List<AudioOutputDevice>> devices() async => available;
+
+  @override
+  Future<void> select(AudioOutputDevice device) async => routed.add(device);
+}
+
+void main() {
+  const AudioOutputDevice headset = AudioOutputDevice(
+    id: 'pipewire/alsa_output.usb-headset',
+    label: 'USB Headset',
+  );
+  const AudioOutputDevice unstable = AudioOutputDevice(
+    id: 'alsa/hw:2,0',
+    label: 'Second card',
+  );
+
+  Future<InMemoryPlaybackPreferences> pump(
+    WidgetTester tester,
+    _FakeService service, {
+    String? savedDeviceId,
+  }) async {
+    final InMemoryPlaybackPreferences preferences =
+        InMemoryPlaybackPreferences(audioOutputDeviceId: savedDeviceId);
+    final ProviderContainer container = ProviderContainer(
+      overrides: <Override>[
+        audioOutputDeviceServiceProvider.overrideWithValue(service),
+        playbackPreferencesProvider.overrideWithValue(preferences),
+      ],
+    );
+    addTearDown(container.dispose);
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(body: AudioOutputSettingsSection()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return preferences;
+  }
+
+  testWidgets('renders nothing where the system owns output routing',
+      (WidgetTester tester) async {
+    await pump(tester, _FakeService(isSupported: false));
+
+    expect(find.text('Audio output'), findsNothing);
+    expect(find.byType(Card), findsNothing);
+  });
+
+  testWidgets('lists the host outputs once the page is opened',
+      (WidgetTester tester) async {
+    final _FakeService service = _FakeService(
+      devices: <AudioOutputDevice>[AudioOutputDevice.systemDefault, headset],
+    );
+
+    await pump(tester, service);
+
+    expect(find.text('Audio output'), findsOneWidget);
+    // The dropdown renders its selected item, so "System default" is on screen.
+    expect(find.text('System default'), findsWidgets);
+    expect(find.byType(DropdownButton<String>), findsOneWidget);
+  });
+
+  testWidgets('choosing a device routes playback and stores it',
+      (WidgetTester tester) async {
+    final _FakeService service = _FakeService(
+      devices: <AudioOutputDevice>[AudioOutputDevice.systemDefault, headset],
+    );
+    final InMemoryPlaybackPreferences preferences = await pump(tester, service);
+
+    await tester.tap(find.byType(DropdownButton<String>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('USB Headset').last);
+    await tester.pumpAndSettle();
+
+    expect(service.routed, <AudioOutputDevice>[headset]);
+    expect(await preferences.audioOutputDeviceId(), headset.id);
+  });
+
+  testWidgets('says so when a device cannot be remembered',
+      (WidgetTester tester) async {
+    final _FakeService service = _FakeService(
+      devices: <AudioOutputDevice>[AudioOutputDevice.systemDefault, unstable],
+    );
+    await pump(tester, service);
+
+    await tester.tap(find.byType(DropdownButton<String>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Second card').last);
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('this session'), findsOneWidget);
+  });
+
+  testWidgets('warns when the saved device is not available',
+      (WidgetTester tester) async {
+    final _FakeService service = _FakeService(
+      devices: <AudioOutputDevice>[AudioOutputDevice.systemDefault],
+    );
+
+    await pump(tester, service, savedDeviceId: headset.id);
+
+    expect(
+      find.textContaining('saved output is not available'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('is honest when the backend reports no outputs',
+      (WidgetTester tester) async {
+    await pump(tester, _FakeService());
+
+    expect(find.textContaining('No outputs were reported'), findsOneWidget);
+    expect(find.byType(DropdownButton<String>), findsNothing);
+  });
+}

--- a/test/features/settings/playback/audio_output_settings_section_test.dart
+++ b/test/features/settings/playback/audio_output_settings_section_test.dart
@@ -17,12 +17,17 @@ class _FakeService implements AudioOutputDeviceService {
 
   final List<AudioOutputDevice> available;
   final List<AudioOutputDevice> routed = <AudioOutputDevice>[];
+  bool routingSucceeds = true;
 
   @override
   Future<List<AudioOutputDevice>> devices() async => available;
 
   @override
-  Future<void> select(AudioOutputDevice device) async => routed.add(device);
+  Future<bool> select(AudioOutputDevice device) async {
+    if (!routingSucceeds) return false;
+    routed.add(device);
+    return true;
+  }
 }
 
 void main() {
@@ -134,5 +139,21 @@ void main() {
 
     expect(find.textContaining('No outputs were reported'), findsOneWidget);
     expect(find.byType(DropdownButton<String>), findsNothing);
+  });
+
+  testWidgets('says so when the backend refuses the switch',
+      (WidgetTester tester) async {
+    final _FakeService service = _FakeService(
+      devices: <AudioOutputDevice>[AudioOutputDevice.systemDefault, headset],
+    )..routingSucceeds = false;
+    final InMemoryPlaybackPreferences preferences = await pump(tester, service);
+
+    await tester.tap(find.byType(DropdownButton<String>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('USB Headset').last);
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('could not be used'), findsOneWidget);
+    expect(await preferences.audioOutputDeviceId(), isNull);
   });
 }

--- a/third_party/just_audio_media_kit/PATCHES.md
+++ b/third_party/just_audio_media_kit/PATCHES.md
@@ -1,9 +1,11 @@
 # Vendored `just_audio_media_kit`
 
-Linthra vendors this package for one reason: upstream has no public hook for
-setting extra libmpv options at player creation, and Linthra needs one on two
-paths — production playback and the headless audio smoke test. Everything here
-is upstream source except the two hunks in [`upstream.patch`](upstream.patch).
+Linthra vendors this package for one reason: upstream keeps libmpv entirely to
+itself. It has no public hook for setting extra options at player creation, and
+no way at all to reach the `Player` it built — and Linthra needs both, on three
+paths: production playback, the headless audio smoke test, and Linux audio
+output device selection. Everything here is upstream source except the hunks in
+[`upstream.patch`](upstream.patch).
 
 ## Provenance
 
@@ -30,49 +32,83 @@ this package resolves deterministically.
 
 ## The patch
 
-Two hunks, ten added lines, no deletions:
+Two additions, in two files, no deletions.
 
-1. `lib/just_audio_media_kit.dart` — adds `JustAudioMediaKit.mpvProperties`, an
-   optional `Map<String, String>` that defaults to empty.
-2. `lib/mediakit_player.dart` — applies each entry with the package's existing
-   `setProperty` helper right after `Player()` construction, next to the
-   identical `prefetch-playlist` call upstream already makes.
+**1. `mpvProperties` — extra libmpv options at player creation.**
+
+- `lib/just_audio_media_kit.dart` adds `JustAudioMediaKit.mpvProperties`, an
+  optional `Map<String, String>` that defaults to empty.
+- `lib/mediakit_player.dart` applies each entry with the package's existing
+  `setProperty` helper right after `Player()` construction, next to the
+  identical `prefetch-playlist` call upstream already makes.
+
+**2. `livePlayers` — a registry of the players that currently exist.**
+
+- `lib/just_audio_media_kit.dart` adds `JustAudioMediaKit.livePlayers`, a
+  `Map<String, Player>` keyed by the just_audio player id.
+- `lib/mediakit_player.dart` adds its player to that map right after
+  construction and removes it in `release()`, so the map only ever holds
+  players that are alive.
 
 Nothing else changes: no new dependency, no new I/O, no new process or library
-loading. With the map left empty the generated libmpv calls are byte-for-byte
-what upstream makes; Linthra does not leave it empty (see below), so the
-difference from upstream is exactly the properties it sets and nothing more.
+loading, and no call into libmpv that upstream does not already make. With the
+map left empty and the registry unread, the generated libmpv calls are
+byte-for-byte what upstream makes; Linthra does not leave them unused (see
+below), so the difference from upstream is exactly what it does with them.
 
 ### Why
 
-Headless Linux CI has no PipeWire/Pulse device. libmpv autoselects PipeWire on
-Ubuntu and fails to open the WAV even when `ALSA_CONFIG_PATH` points the default
-PCM at the null plugin, so the native audio lifecycle smoke test needs `ao=alsa`
-set on each libmpv instance before playback starts. Upstream exposes
-`setProperty` internally but has no public hook for extra mpv options at player
-creation (unlike `prefetchPlaylist`).
+**`mpvProperties`.** Headless Linux CI has no PipeWire/Pulse device. libmpv
+autoselects PipeWire on Ubuntu and fails to open the WAV even when
+`ALSA_CONFIG_PATH` points the default PCM at the null plugin, so the native
+audio lifecycle smoke test needs `ao=alsa` set on each libmpv instance before
+playback starts. Production needs the same hook for `cache-on-disk=no`.
+Upstream exposes `setProperty` internally but has no public hook for extra mpv
+options at player creation (unlike `prefetchPlaylist`).
 
-### Who sets it
+**`livePlayers`.** just_audio's platform interface has no concept of an audio
+*output device*: nothing in `AudioPlayerPlatform` lists the sinks the host
+offers or moves playback onto one. libmpv models both (`audio-device-list` and
+`audio-device`), and media_kit exposes both on `Player` — but that `Player` is
+private to `MediaKitPlayer`, so there is no way to reach it from the app. The
+registry is the smallest thing that fixes that: the app looks up the live
+player, reads the device list from it, and calls media_kit's own
+`setAudioDevice` on it, so audio that is *already playing* moves to the chosen
+output ([#402](https://github.com/thezupzup/linthra/issues/402)).
 
-**Two callers, and production is one of them.** This hook is *not* CI-only —
+### Who sets `mpvProperties`
+
+**Three callers, and two of them are production.** This hook is *not* CI-only —
 removing it breaks shipped playback behaviour, not just a test.
 
 | Caller | Sets | Why |
 | --- | --- | --- |
 | `lib/core/services/linux_playback_controller.dart` (`linuxMpvProperties`) | `cache-on-disk=no` | media_kit turns mpv's on-disk demuxer cache on for every player; Linthra streams audio and manages its own offline cache, and mpv logs `[lavf] Failed to create file cache.` on every stream where it cannot write the temporary file ([#405](https://github.com/thezupzup/linthra/issues/405)). |
 | `tool/linux_audio_backend_smoke.dart` | `ao=alsa` | The headless CI case described above. |
+| `lib/core/services/linux_audio_output_device_service.dart` | `audio-device=<chosen device>` | The user's chosen audio output, so a player created *after* the choice starts on it. Only set once the listener picks a device; never written on a default install. |
 
 The smoke target layers its value on top of the production defaults rather than
 replacing them (`resolveLinuxMpvProperties` merges), so CI exercises the same
-cache configuration production uses, with only the output device swapped.
+cache configuration production uses, with only the output device swapped. The
+output-device service merges too, for the same reason: an output change must not
+drop `cache-on-disk=no`.
+
+### Who reads `livePlayers`
+
+One caller: `lib/core/services/linux_audio_output_device_service.dart`. It reads
+a live player to enumerate `audio-device-list` and calls `setAudioDevice` on
+every entry when the listener picks an output. When the map is empty (nothing is
+playing) it builds its own short-lived `Player` for enumeration instead and
+disposes it, so the registry is never a requirement for listing outputs — only
+for moving audio that is already playing.
 
 ## Auditing this directory
 
 `./scripts/check_vendored_packages.sh` verifies the whole claim above **offline**
 (no downloads): it reverse-applies `upstream.patch` onto a copy of the vendored
-tree and checks the result against `upstream.sha256`. If the two hunks are the
-only local change, the restored files hash to upstream's; any other edit — or a
-patch that no longer describes the tree — fails the check.
+tree and checks the result against `upstream.sha256`. If the recorded hunks are
+the only local change, the restored files hash to upstream's; any other edit —
+or a patch that no longer describes the tree — fails the check.
 
 The same script analyzes the package from its own directory with the
 repository's pinned Flutter toolchain, because the root `analysis_options.yaml`
@@ -84,13 +120,15 @@ set). CI runs it on every PR.
 1. Download the new archive and verify its `sha256` against pub.dev.
 2. Replace every file listed in `upstream.sha256` with the new upstream copy and
    regenerate that manifest from the pristine tree.
-3. Re-apply the two hunks (`git apply upstream.patch`, or by hand if they moved)
-   and regenerate `upstream.patch` from the pristine-vs-vendored diff. **Do not
-   drop them because upstream gained something similar** without checking both
-   callers in *Who sets it* first: production playback depends on this hook, so
-   losing it is a silent behaviour change, not a test-only regression.
-4. Update the table above, refresh `pubspec.lock`, and run
+3. Re-apply the hunks (`git apply upstream.patch`, or by hand if they moved) and
+   regenerate `upstream.patch` from the pristine-vs-vendored diff. **Do not drop
+   them because upstream gained something similar** without checking every
+   caller in *Who sets `mpvProperties`* and *Who reads `livePlayers`* first:
+   shipped playback and output-device selection both depend on these, so losing
+   one is a silent behaviour change, not a test-only regression.
+4. Update the tables above, refresh `pubspec.lock`, and run
    `./scripts/check_vendored_packages.sh`.
-5. If upstream ever adds its own public hook for player-creation properties,
-   move both callers onto it and drop the patch — that is the outcome this
-   vendoring exists to make unnecessary.
+5. If upstream ever adds its own public hooks — player-creation properties, or
+   any access to the underlying `Player` — move the callers onto them and drop
+   the matching hunk. That is the outcome this vendoring exists to make
+   unnecessary.

--- a/third_party/just_audio_media_kit/lib/just_audio_media_kit.dart
+++ b/third_party/just_audio_media_kit/lib/just_audio_media_kit.dart
@@ -54,6 +54,16 @@ class JustAudioMediaKit extends JustAudioPlatform {
   /// headless audio smoke layers `ao=alsa` on top for an ALSA null device.
   static Map<String, String> mpvProperties = const {};
 
+  /// The live media_kit [Player]s, keyed by the just_audio player id.
+  ///
+  /// just_audio's platform interface models no audio *output device*, so there
+  /// is no way through it to read libmpv's `audio-device-list` or to move a
+  /// playing track onto another sink. Linthra reads this map to do both (see
+  /// `LinuxAudioOutputDeviceService`). An entry appears as soon as the player
+  /// is created and is removed when it is released, so a stale [Player] is
+  /// never handed out.
+  static final Map<String, Player> livePlayers = <String, Player>{};
+
   static final _logger = Logger('JustAudioMediaKit');
   final _players = HashMap<String, MediaKitPlayer>();
 

--- a/third_party/just_audio_media_kit/lib/mediakit_player.dart
+++ b/third_party/just_audio_media_kit/lib/mediakit_player.dart
@@ -65,6 +65,8 @@ class MediaKitPlayer extends AudioPlayerPlatform {
       setProperty(_player, entry.key, entry.value);
     }
 
+    JustAudioMediaKit.livePlayers[id] = _player;
+
     if (JustAudioMediaKit.prefetchPlaylist) {
       setProperty(_player, 'prefetch-playlist', 'yes');
     }
@@ -394,6 +396,7 @@ class MediaKitPlayer extends AudioPlayerPlatform {
   /// Release the resources used by this player.
   Future<void> release() async {
     _logger.info('releasing player resources');
+    JustAudioMediaKit.livePlayers.remove(id);
     _mediaOpened = false;
     await _player.dispose();
     // cancel all stream subscriptions

--- a/third_party/just_audio_media_kit/upstream.patch
+++ b/third_party/just_audio_media_kit/upstream.patch
@@ -1,6 +1,6 @@
 --- a/lib/just_audio_media_kit.dart
 +++ b/lib/just_audio_media_kit.dart
-@@ -48,6 +48,12 @@
+@@ -48,6 +48,22 @@
    /// [the related issue](https://github.com/Pato05/just_audio_media_kit/issues/11) for more information
    static bool prefetchPlaylist = false;
  
@@ -10,12 +10,22 @@
 +  /// headless audio smoke layers `ao=alsa` on top for an ALSA null device.
 +  static Map<String, String> mpvProperties = const {};
 +
++  /// The live media_kit [Player]s, keyed by the just_audio player id.
++  ///
++  /// just_audio's platform interface models no audio *output device*, so there
++  /// is no way through it to read libmpv's `audio-device-list` or to move a
++  /// playing track onto another sink. Linthra reads this map to do both (see
++  /// `LinuxAudioOutputDeviceService`). An entry appears as soon as the player
++  /// is created and is removed when it is released, so a stale [Player] is
++  /// never handed out.
++  static final Map<String, Player> livePlayers = <String, Player>{};
++
    static final _logger = Logger('JustAudioMediaKit');
    final _players = HashMap<String, MediaKitPlayer>();
  
 --- a/lib/mediakit_player.dart
 +++ b/lib/mediakit_player.dart
-@@ -61,6 +61,10 @@
+@@ -61,6 +61,12 @@
        ready: () => _readyCompleter.complete(),
      ));
  
@@ -23,6 +33,16 @@
 +      setProperty(_player, entry.key, entry.value);
 +    }
 +
++    JustAudioMediaKit.livePlayers[id] = _player;
++
      if (JustAudioMediaKit.prefetchPlaylist) {
        setProperty(_player, 'prefetch-playlist', 'yes');
      }
+@@ -390,6 +396,7 @@
+   /// Release the resources used by this player.
+   Future<void> release() async {
+     _logger.info('releasing player resources');
++    JustAudioMediaKit.livePlayers.remove(id);
+     _mediaOpened = false;
+     await _player.dispose();
+     // cancel all stream subscriptions


### PR DESCRIPTION
Closes #402.

Settings → Music & playback gets an "Audio output" card on Linux: it lists the outputs the host offers (speakers, headset, HDMI, a USB DAC) and moves playback onto the one you pick.

## Going through the backend, not around it

The list *is* libmpv's `audio-device-list` and the choice *is* its `audio-device`, both through media_kit. The problem is reaching them: just_audio's platform interface has no notion of an output device, and media_kit's `Player` is private to `MediaKitPlayer`.

So the vendored `just_audio_media_kit` gains a second small addition next to `mpvProperties`: `livePlayers`, a map of the media_kit players that currently exist. `PATCHES.md` and `upstream.patch` record it the same way as the first one, and `scripts/check_vendored_packages.sh` still proves the tree is upstream plus that patch.

A choice is applied in two places on purpose:

- every live player, through media_kit's own `setAudioDevice`, so audio that is already playing moves rather than waiting for the next track
- `JustAudioMediaKit.mpvProperties`, so a player the engine creates afterwards (stop/start, a suspend/resume reload, a source switch) starts on it too

Live players are routed first and the property is committed only once they all succeeded, so a device that vanished mid-switch never leaves a rejected id where the next player would read it.

`media_kit` is now a direct dependency. It was already in the tree transitively via the vendored backend; nothing new ships, it is just declared where it is used.

## Behaviour

- A saved device is re-applied at launch, and launch waits for it (bounded by a 1500ms deadline, shorter than the enumeration timeout beneath it). media_kit builds its player when the first track loads and reads the chosen output at construction, so an unawaited restore would let the opening seconds play on the wrong speakers. Past the deadline launch continues and the restore still lands.
- A saved device that is no longer on the machine (unplugged headset, another machine, a renamed sink) falls back to the system default, is forgotten rather than pushed at libmpv, and the card says so.
- "Did not answer" is never read as "device gone". A backend that cannot be enumerated — including one that does not publish `audio-device-list` before the probe times out — clears nothing, re-routes nothing, and keeps the live selection.
- A refused switch is not recorded as done. Routing reports whether it took effect; on a refusal nothing is stored, playback is shown where it actually is, the card says the switch did not happen, and the next attempt is a real attempt rather than a no-op.
- Only stable ids are remembered. PipeWire/PulseAudio node names and ALSA `CARD=` names survive a reboot. Numbers do not: ALSA's `alsa/hw:1,0` handles are card *indexes* that renumber on hotplug, and a bare numeric target (`pipewire/42`) is a runtime object id the daemon reuses for a different sink. Both are applied for the session only, and the card explains that.
- Choices are serialized, so two quick picks queue rather than racing and the later gesture is the one that ends up playing and stored.
- Launch never probes for nothing: enumeration happens when the card is opened, or at launch only when there is a saved device to restore. With nothing playing there is no player to ask, so it builds a short-lived libmpv handle and disposes it — listing outputs never opens an output or makes a sound.

Android is untouched. Output routing there belongs to the system (output picker, Bluetooth, Android Auto), so the seam reports itself unsupported and the card is not rendered at all, the same shape as "Share Linthra".

## Where things live

| Piece | File |
| --- | --- |
| The seam | `lib/core/services/audio_output_device_service.dart` |
| Linux implementation | `lib/core/services/linux_audio_output_device_service.dart` |
| Platform split | `lib/core/services/platform_audio_output_device_service.dart` |
| Policy (restore, fallback, what is remembered) | `lib/features/settings/playback/audio_output_controller.dart` |
| The card | `lib/features/settings/playback/audio_output_settings_section.dart` |

## Commits

Three, and the two follow-ups are worth reading separately — they are fixes for real defects Codex found in the first, not polish:

- `101b1ae` the feature
- `a06c3e7` a probe timeout was deleting the saved preference permanently; failed routing was recorded as applied; an enumeration failure discarded a session-only choice; overlapping selections could race
- `e42d0e5` numeric ids were persisted; the startup restore was unawaited; `mpvProperties` was committed before routing succeeded

## Tests

44 tests across the mapping, the id-stability rule, the platform split, the controller policy and the card: startup restore, fallback when the saved device is gone, "backend silent is not device gone", refused switches, session-only ids, refresh picking up a hotplug, and serialization of overlapping picks. Full suite passes (4395), `flutter analyze` clean, `dart format` clean, `scripts/check_vendored_packages.sh` passes.

What tests can't cover is libmpv itself, since `flutter test` runs on the Dart VM without the native bundle — `_applyThroughMediaKit` and `_probeThroughMediaKit` are the untested seams. There's a manual matrix for that in `docs/linux-desktop.md` (switch while playing, switch then stop then play, hotplug + refresh, unplug + relaunch, replug + relaunch).

## Docs

- `docs/linux-desktop.md`: new "Audio output device" section including the guarantees above, the vendoring note updated for the second hunk, a row in the limitations table, and the manual matrix.
- `third_party/just_audio_media_kit/PATCHES.md`: what `livePlayers` is, why it exists, and who reads it.
- `docs/dependency-license-audit.md`: `media_kit` row (MIT) and the direct/transitive counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aXk7Bd8eKHgKG3nh29P2A