### PR TITLE
perf(battery): stop the work playback does for nothing (#344)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,7 +36,7 @@ The full index of Linthra's docs. New to the project? Start with the
 | Playlists & safe removal | [playlists-and-delete.md](./playlists-and-delete.md) |
 | Smart mixes (automatic playlists) | [smart-mixes.md](./smart-mixes.md) |
 | Backup & restore (file format) | [backup-restore-format.md](./backup-restore-format.md) |
-| Battery usage | [battery.md](./battery.md) |
+| Battery usage | [battery.md](./battery.md) · [playback audit](./battery-playback-audit.md) |
 | App icon & branding (in-app + real Android launcher icon) | [app-icon-branding.md](./app-icon-branding.md) |
 
 ## Quality & releases

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,8 +94,9 @@ lib/
   network. Each source carries a `SourceAvailability`
   (`notConfigured` / `checking` / `available` / `unreachable` /
   `authenticationError`), established by a cheap session probe on startup, on app
-  resume, on a background poll, and from what the playback path already
-  discovered. `selectAvailableTracks` then narrows the stored catalog to the
+  resume, on a periodic re-probe while the app is on screen (it stands down
+  while hidden — see [battery.md](battery.md)), and from what the playback path
+  already discovered. `selectAvailableTracks` then narrows the stored catalog to the
   *active library* before de-duplication, so an unreachable server's streamed
   tracks drop out of every browse surface at once — while its downloaded copies
   stay playable and local music is untouched. It is a **view, never a removal**:

--- a/docs/battery-playback-audit.md
+++ b/docs/battery-playback-audit.md
@@ -1,0 +1,278 @@
+# Audit — battery use during normal playback
+
+This is the report for issue #344 ("Investigate high battery drain during normal
+playback"). It is a read-through of everything that runs while music is playing,
+checked against what [docs/battery.md](./battery.md) claims, plus the focused
+fixes the read-through justified and the measurements behind them.
+
+**Scope:** the work the app does *around* the audio, in both listening shapes
+the issue asks about — screen off with the app backgrounded, and Now Playing
+left open. Audio quality, gapless, background playback, Android Auto and
+streaming behaviour are untouched by everything here; nothing was disabled to
+make a number look better.
+
+> **Bottom line.** Most of what `docs/battery.md` describes is real and holds up:
+> the foreground service and wake locks follow playback, the position flush is
+> coalesced and self-cancelling and the UI surfaces are properly isolated from
+> it. Two things did not match the document, and both ran for the *whole* length
+> of a screen-off session:
+>
+> 1. **A configured Jellyfin server was re-probed every 45 s regardless of
+>    whether the app was on screen** — about **80 network round-trips an hour**
+>    with the screen off, against a document that says "no background polling",
+>    and radio wake-ups on mobile data.
+> 2. **Several services rebuilt work per position tick** (~4 Hz) that they then
+>    threw away — fingerprint strings over the whole up-next list, and a
+>    re-materialized media-session queue window. Measured on a 5000-track
+>    up-next: **~292 ms of CPU per five minutes of playback**, all of it
+>    discarded.
+>
+> Both are fixed here. A third, Linux-only finding (the crash-safe session
+> rewriting its whole document every 2 s) is fixed too. The refresh-rate and
+> Now Playing findings are documented rather than changed, with reasons.
+
+---
+
+## How this was audited
+
+- Read the playback path end to end: `just_audio_playback_controller.dart`,
+  `active_playback_controller.dart`, `linthra_audio_handler.dart`, and every
+  service that subscribes to the unified `PlaybackState` stream
+  (`smart_precache_service.dart`, `remote_prebuffer_service.dart`,
+  `media_artwork_prewarm_service.dart`, `playback_reporting_service.dart`,
+  `playback_session_persistence.dart`, the MPRIS session).
+- Swept the Dart sources for everything that can fire without the user:
+  `Timer`, `Timer.periodic`, `Stream.periodic`, `AnimationController`,
+  `.repeat(`, and every `.listen(` on the playback stream.
+- Read the Android side for the refresh-rate and lifecycle behaviour
+  (`MainActivity.kt`, `DisplayRefreshRate.kt`).
+- Checked each claim in `docs/battery.md` against the code, which is what turned
+  up findings 1 and 2 — the document was describing an intent the code had
+  drifted from.
+- Measured the per-tick cost with a new harness,
+  `test/benchmarks/playback_tick_cost_bench.dart`, before and after each change,
+  on the same machine in the same session.
+
+**What this audit could not do:** run `batterystats` on a real phone. No device
+was available, so there is no "X% per hour before / Y% after" figure here. The
+measurements below are counted work — requests per hour, writes per hour, CPU
+microseconds per tick — which is what the fixes actually remove. An on-device
+`dumpsys batterystats --charged` comparison across a 30–60 minute session is
+still worth doing, and the checklist for it is at the end.
+
+---
+
+## 1. The availability probe polled with the screen off
+
+**Verdict: real, and the biggest single wake-up source. Fixed.**
+
+`JellyfinAvailabilityController` re-probes a configured server on a timer so
+that walking back onto the home network restores the library on its own. In
+production that interval is 45 s. The timer was started whenever a server was
+configured and cancelled only when the provider was disposed — and the provider
+is watched by the active library, so in practice it never was.
+
+That is the opposite of what the app is built to do everywhere else, and it is
+worst exactly where it hurts: `audio_service` deliberately keeps the process and
+the Flutter isolate alive during screen-off playback (see the foreground-service
+section of `docs/battery.md`), so this timer kept firing for the entire session.
+**About 80 authenticated round-trips an hour, refreshing a library nobody could
+see** — and on mobile data, 80 chances an hour to pull the radio out of idle.
+`docs/battery.md` claimed "No background polling, heartbeats, or keep-alives".
+
+**Fix.** The poll now follows app visibility. `AppVisibility`
+(`lib/core/lifecycle/app_visibility.dart`) is a small signal published by the
+root widget's lifecycle observer; the controller starts the timer when the UI is
+shown and cancels it when it is hidden. Nothing else changes: the resume path
+already re-probes immediately when you come back, the playback path still
+reports what it learns through `noteReachability` whether the UI is up or not,
+and a hide/show flip deliberately does not re-run the notifier's `build` — that
+would reset a settled answer to `checking` and blink the library.
+
+| | Before | After |
+| --- | --- | --- |
+| Probes/hour, app on screen | ~80 | ~80 (unchanged) |
+| Probes/hour, screen off while playing | ~80 | **0** |
+| Time to recover the library on return | ≤ 45 s | immediate (resume probe) |
+
+Covered by `test/features/settings/jellyfin/jellyfin_availability_controller_test.dart`
+("the poll follows app visibility") and the wiring test in
+`test/app/playback_lifecycle_test.dart`.
+
+## 2. Per-tick work that was thrown away
+
+**Verdict: real. Fixed.**
+
+The engine's position stream is coalesced to a steady ~4 Hz flush (that part
+works as documented). Every one of those ticks is delivered to each service
+listening on the unified state stream, and each service starts by deciding
+whether anything it cares about changed. The *deciding* was the problem:
+
+- `SmartPrecacheService` built a fingerprint **string over the entire up-next
+  list** — on every tick. Selecting "play all" on a large library means that
+  string is the whole queue, rebuilt four times a second, for the whole session.
+- `RemotePrebufferService` did the same over the head of the queue, and
+  `MediaArtworkPrewarmService` over its look-ahead: smaller, same shape.
+- `LinthraAudioHandler._broadcast` re-materialized the published queue window
+  (up to 250 tracks) and rebuilt a `MediaItem` on every tick, only to compare
+  them and conclude nothing had changed.
+
+None of it was *wrong* — the comparisons all reached the right answer, which is
+why no test caught it — it was just work done to discover that there was no work
+to do.
+
+**Fix.** One shared, allocation-free test replaces the fingerprint strings:
+`samePlaybackLookahead` (`lib/core/services/playback_lookahead.dart`) compares
+the current track, shuffle/repeat, and only the head of up-next each service can
+actually warm, short-circuiting on object identity — `PlaybackState.copyWith`
+passes the queue lists straight through, so an unchanged queue is provably
+unchanged in constant time. The media-session bridge got the same treatment: a
+tick whose queue objects, track, and duration are identical to the last
+broadcast skips straight to the playback-state push (which still follows the
+position and re-syncs on drift, as before). A cover finishing its warm forces a
+re-publish, since artwork resolves outside `PlaybackState`.
+
+Measured with `test/benchmarks/playback_tick_cost_bench.dart`, 1200 ticks
+(≈ 5 minutes of playback), median of 3 runs, same machine:
+
+| Case | Before | After |
+| --- | --- | --- |
+| Stream only (the floor: building + delivering the states) | 14.7 ms | 14.4 ms |
+| Media-session bridge, 20 000-track queue | 34.3 ms | 25.7 ms |
+| Look-ahead services, 5000-track up-next | 306.6 ms | 23.8 ms |
+
+Net of the floor, that is **~19 ms → ~11 ms** for the media-session bridge and
+**~291 ms → ~9 ms** for the look-ahead services per five minutes of playback —
+about a 30× reduction on the latter. Per hour of screen-off listening, roughly
+3.5 s of pure-waste CPU becomes about 0.1 s. On its own that is not a battery
+meter moving; it is the constant background hum that makes the CPU harder to
+keep parked, and it scales with the user's queue size, which is exactly the
+"few songs and I'm reaching for a charger" shape the issue describes.
+
+Behaviour is unchanged and locked in by
+`test/core/services/playback_lookahead_test.dart` plus two new cases in
+`linthra_audio_handler_test.dart` (a rebuilt-but-equal queue is still not
+re-published; a duration arriving for the same track still updates the item).
+
+## 3. The Linux crash-safe session rewrote itself every 2 seconds
+
+**Verdict: real, Linux only. Fixed.**
+
+`PlaybackSessionPersistence` (constructed on Linux only — Android has no
+equivalent) persisted the logical queue so an unexpected restart can restore it.
+Structural changes wrote immediately, which is right; position ticks were
+debounced to **2 s**, which is not. Every one of those writes re-encodes the
+*whole* document and rewrites the store's single key.
+
+Measured: a 200-track queue encodes to **28.8 KB in ~0.57 ms**. At a 2 s
+debounce that is **~1800 encodes and 1800 rewrites an hour** — around a second
+of CPU per hour spent serialising, plus the disk traffic, for a record only a
+crash ever reads.
+
+There was a second, quieter bug in it: the debounced save wrote the state that
+*armed* the timer, not the freshest one, so the record was already stale when it
+landed.
+
+**Fix.** The debounce is now 10 s and writes the freshest position seen, and
+`dispose()` flushes a pending position so a clean quit records exactly where
+playback was. Everything meaningful still persists immediately — track change,
+queue edit, pause, stop, shutdown — so what the longer interval bounds is only
+what an unexpected kill *mid-playback* can lose: up to 10 s of position instead
+of up to 4 s. Writes drop from ~1800/hour to ~360/hour.
+
+Covered by the "position saves are coalesced (battery)" group in
+`test/core/services/playback_session_persistence_test.dart`.
+
+## 4. Now Playing, artwork and the blur
+
+**Verdict: matches the document. No change.**
+
+Checked because the issue asks specifically about the open Now Playing screen:
+
+- The full-screen blurred backdrop sits on its own `RepaintBoundary` and is
+  keyed by the artwork URI, so the live progress bar and the equalizer painting
+  above it never re-rasterize the 40px gaussian blur.
+- The wavy progress bar really has no perpetual animation — one ~420 ms swell
+  per play/pause flip, skipped under reduced motion, then no scheduled frames.
+- Track rows, the queue sheet, and the synced-lyrics viewport all select
+  position-*independent* slices, so a tick doesn't rebuild them.
+- Only the slim `_LiveControls` column follows the position on the now-playing
+  screen; the artwork and metadata around it do not.
+
+Nothing here needed changing. These are already covered by the throttle tests
+listed in `docs/battery.md`.
+
+## 5. Refresh rate while the app is open
+
+**Verdict: correct as designed, with a real cost worth naming. Documented, not
+changed.**
+
+`DisplayRefreshRate` picks the highest refresh mode *at the current resolution*,
+never lowers resolution, leaves a 60 Hz panel alone, and releases the pin
+entirely under battery saver (re-evaluating on the OS broadcast). That is all as
+documented.
+
+The cost the document doesn't name: `preferredDisplayModeId` is a *pin*, so
+while the app is foregrounded the panel is held at that mode even when nothing
+is moving — a static Now Playing screen at 120 Hz that the system would
+otherwise have dropped to an idle rate. It is only paid while the app is on
+screen (a screen-off session is unaffected, which is the case the issue is
+mostly about), and releasing the pin when nothing is animating risks a stutter
+on the first flick of a scroll. Left alone deliberately; recorded under "possible
+future work" in `docs/battery.md` so the next person measuring has the context.
+
+## 6. Server playback reports
+
+**Verdict: correct and bounded. Documented more honestly.**
+
+A *streamed* track sends start / pause / resume / stop, plus a progress ping at
+most every 10 s while playing — the standard reporting a Jellyfin / Plex /
+Subsonic server needs to show Linthra as an active player. It is off the
+playback path, throttled by `PlaybackReportingService.progressInterval`, and a
+local or cached track sends nothing at all. It also rides a radio the stream is
+already keeping busy, so its marginal cost is small.
+
+`docs/battery.md` said "no extra network calls per tick", which is true but
+skipped past this; it now names the 10 s report explicitly. No code change:
+lengthening the interval risks servers timing the session out, which is a
+correctness regression for a feature people use.
+
+## What was checked and found already correct
+
+Short version, so a future audit doesn't have to re-derive it:
+
+- Foreground service / wake locks follow real playback, with the deliberate
+  transient-focus hold, and a re-buffer or track transition never demotes it.
+- The ~4 Hz position flush stops itself when nothing new arrives and restarts on
+  the next event.
+- Media-session pushes are gated on what the session renders plus a ~1 s
+  position drift; `audio_service` interpolates the rest.
+- The cast status poll and cast position ticker run only while casting *and*
+  playing.
+- Smart pre-cache reacts to what-to-cache changes only, honours the mobile-data
+  policy, stays quiet under repeat-one, and runs one fetch at a time.
+- Local scans are user-triggered only; cover art is extracted once at scan time;
+  cache eviction is event-driven.
+- Diagnostics are `kDebugMode`-gated for logging and otherwise write only to a
+  bounded in-memory ring buffer — nothing per tick, nothing to disk.
+- The Jellyfin remote-control keep-alive exists only while remote control is
+  actually on, and replies on the interval the server asks for.
+
+## Still worth doing on a real device
+
+This audit removed measurable work but could not close the loop on a phone. The
+run that would:
+
+1. Charge to 100 %, `adb shell dumpsys batterystats --reset`.
+2. 30–60 minutes of playback, screen off, app backgrounded — once from a
+   streamed source, once from downloaded/offline tracks.
+3. The same again with Now Playing left open, screen on, untouched.
+4. `adb shell dumpsys batterystats --charged <package>` for each, through
+   [Battery Historian](https://github.com/google/battery-historian): wake locks,
+   mobile-radio active time, wake-up counts, and CPU time attributed to the app.
+5. Compare against the same runs on the commit before this change.
+
+The specific predictions to check: **zero** availability requests in the
+screen-off runs, unchanged wake-lock behaviour (the foreground service must
+still hold across playback exactly as before), and lower app CPU time in the
+runs with a long queue.

--- a/docs/battery.md
+++ b/docs/battery.md
@@ -63,6 +63,28 @@ The only periodic timers in the app are tightly scoped and self-cancelling:
   receiver is actually playing**, and stop the moment it pauses. See
   `chromecast_cast_transport.dart` and `ActivePlaybackController._syncTicker`.
 
+### The services under playback ignore position ticks
+
+A position tick is the most frequent thing the app produces, and several
+services listen to the same state stream. Each of them decides *first* whether
+anything it cares about actually moved, and the check itself is written to cost
+nothing:
+
+- **The media-session bridge** re-publishes the now-playing item and the car's
+  "Up Next" window only when the track, the queue, or the duration changes. A
+  position tick is recognised by object identity — the state stream hands the
+  same queue objects through — so a tick never rebuilds the published window,
+  whatever the queue's size. See `LinthraAudioHandler._broadcast`.
+- **Smart pre-cache, the remote stream prebuffer, and the media-session artwork
+  prewarm** share one allocation-free test for "is this the same look-ahead
+  work?" (`samePlaybackLookahead`), which compares the current track, the modes,
+  and only the head of up-next that each service can actually warm. See
+  `lib/core/services/playback_lookahead.dart`.
+- **The Linux crash-safe session** (Android has no equivalent) rewrites its
+  document on every real change — a track change, a queue edit, pause, stop, and
+  a clean shutdown — and coalesces the position in between, so a session that is
+  simply playing costs a handful of writes a minute rather than hundreds.
+
 ### UI rebuilds follow real changes, not the clock
 
 A music player's UI is driven by a position that updates several times a second.
@@ -133,17 +155,38 @@ deliberately conservative about power:
 See `DisplayRefreshRate` (`android/app/src/main/kotlin/.../DisplayRefreshRate.kt`),
 driven from `MainActivity`'s resume/pause.
 
-### Network: event-driven, never polled
+### Network: event-driven, and never polled in the background
 
-- **No background polling, heartbeats, or keep-alives** for Jellyfin or
-  Navidrome/Subsonic. The HTTP clients are request/response only.
+- **Nothing polls, heartbeats, or keeps a connection alive while the app is off
+  screen.** The Jellyfin / Navidrome / Subsonic HTTP clients are request /
+  response only.
+- **The one recurring request is the server availability probe, and it runs only
+  while the app is on screen.** A configured Jellyfin server is re-probed about
+  once a minute so walking back onto the home network restores the library on
+  its own, with no reconnect and no rescan. That probe is gated on app
+  visibility: the moment the screen goes off (or the app is backgrounded) the
+  timer is cancelled, and it comes back — with an immediate probe — when you
+  return to the app. This matters because playback deliberately keeps the
+  process alive: an ungated once-a-minute probe would keep waking the CPU and
+  the radio for a whole listening session, refreshing a library nobody is
+  looking at. See `JellyfinAvailabilityController` and `AppVisibility`
+  (`lib/core/lifecycle/app_visibility.dart`).
 - **Library sync runs on an explicit "Sync library" action**, with a one-time
   auto-sync on first connecting an account. There is no recurring sync loop.
 - **Connectivity is observed, not polled** — Linthra reacts to OS connectivity
   events rather than waking up to test the network.
-- **During playback there are no extra network calls per tick** — lyrics are
+- **During playback there are no network calls per position tick** — lyrics are
   fetched once per track (keyed by id, auto-disposed when no longer current), and
-  artwork URLs are stable.
+  artwork URLs are stable. What a *streamed* track does send is the standard
+  playback report your server needs to show Linthra as an active player
+  (start / pause / resume / stop, plus a progress ping at most every 10 s while
+  playing). It is bounded and off the playback path, it rides a radio the stream
+  is already using, and a local or cached track sends nothing at all. See
+  `PlaybackReportingService`.
+- **Remote control, when you turn it on, is a socket rather than a poll.** The
+  Jellyfin control socket answers the server's own `ForceKeepAlive` on the
+  interval the server asks for; nothing keeps it open when remote control is
+  off.
 
 ### Scans, cache, and artwork: once, on demand
 
@@ -232,6 +275,18 @@ Battery work is only safe if it's measurable. Useful levers:
   `test/features/player/queue_sheet_throttle_test.dart`,
   `test/shared/widgets/now_playing_indicator_test.dart`) so a regression that
   reintroduces per-tick rebuilds fails CI.
+- **The tick-cost benchmark** measures the non-UI half: how much work the
+  services hanging off the playback state stream do for a run of position
+  ticks. It is a harness, not a CI gate, so run it explicitly and compare two
+  revisions on the same machine:
+
+  ```bash
+  flutter test test/benchmarks/playback_tick_cost_bench.dart
+  ```
+
+The most recent read-through of the whole playback path, with the numbers it
+produced and what was changed as a result, is in
+[docs/battery-playback-audit.md](./battery-playback-audit.md).
 
 ## Possible future work (not done here)
 
@@ -247,3 +302,12 @@ avoid risky changes:
   under the OS battery-saver or when unplugged below a threshold. This needs a
   battery-state signal and a user-facing setting, so it's deferred rather than
   guessed.
+- **Visibility-aware refresh rate.** The high-refresh preference is pinned for
+  as long as the app is foregrounded, which also stops the system dropping to a
+  lower idle rate while a static Now Playing screen sits on screen. Releasing
+  the pin while nothing is animating would hand that back, but it needs care not
+  to make scrolling stutter on the first flick, so it is measured-and-deferred
+  rather than guessed at. See the audit for the reasoning.
+- **Per-provider availability probes.** Only Jellyfin probes today. If Subsonic
+  or Plex adopt the same probe, they should adopt the same visibility gate with
+  it rather than each adding a timer of their own.

--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -142,6 +142,11 @@ check in §4 #14b):
 - ☐ **Paused ≥ 30 min** (Bluetooth connected, screen off): Linthra's background CPU
   is **negligible** — confirming the position flush stopped on pause and nothing
   polls while idle. This is the key "no unnecessary polling/wake-ups" check.
+- ☐ **Screen-off playback with a Jellyfin server configured**: on the server's
+  own access log (or a proxy log), Linthra makes **no** availability probes
+  while the app is off screen — only the playback reports for a streamed track.
+  Returning to the app probes once, immediately, and the library is intact
+  either way. This is the visibility gate from issue #344.
 
 ## 3b. Server playback reporting (Now Playing on your server)
 

--- a/lib/app/linthra_app.dart
+++ b/lib/app/linthra_app.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../core/app_info.dart';
+import '../core/lifecycle/app_visibility.dart';
 import '../core/lifecycle/platform_shutdown_policy.dart';
 import '../core/platform/host_platform.dart';
 import '../core/services/active_playback_controller.dart';
@@ -106,6 +107,12 @@ class _LinthraAppState extends ConsumerState<LinthraApp>
     if (state == AppLifecycleState.paused ||
         state == AppLifecycleState.hidden ||
         state == AppLifecycleState.inactive) {
+      if (state != AppLifecycleState.inactive) {
+        // The UI is off screen. Background work that only serves the visible UI
+        // stands down here — with playback keeping the isolate alive, a poll
+        // nobody can see is a pure wake-up. Playback itself is untouched.
+        ref.read(appVisibilityProvider.notifier).onHidden();
+      }
       final controller = ref.read(playbackControllerProvider);
       StabilityDiagnostics.backgroundPlaybackState(
           controller.state.status.name);
@@ -117,6 +124,7 @@ class _LinthraAppState extends ConsumerState<LinthraApp>
       }
     }
     if (state == AppLifecycleState.resumed) {
+      ref.read(appVisibilityProvider.notifier).onShown();
       final controller = ref.read(playbackControllerProvider);
       if (controller is ActivePlaybackController) {
         controller.onAppResumed();

--- a/lib/core/lifecycle/app_visibility.dart
+++ b/lib/core/lifecycle/app_visibility.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Whether the app's UI is on screen right now.
+///
+/// This exists for battery, not for UI: while music plays with the screen off,
+/// `audio_service` deliberately keeps the process (and the Flutter isolate)
+/// alive, so a timer that only refreshes something *nobody can see* keeps
+/// firing for the whole session — waking the CPU, and on a poll like the server
+/// availability probe the cellular radio too. Background work that exists to
+/// keep the visible UI honest gates on this and stands down while hidden; the
+/// app-resume path re-runs it the moment the user comes back. See
+/// `docs/battery.md`.
+///
+/// It says nothing about playback: audio keeps playing exactly as before while
+/// this is `false`. Nothing that affects sound, the media session, or a
+/// download may read it.
+///
+/// Defaults to visible, so a host that never reports a lifecycle transition
+/// (tests, a platform without the observer) behaves exactly as it did before
+/// this existed.
+class AppVisibility extends Notifier<bool> {
+  @override
+  bool build() => true;
+
+  /// The app became visible (`resumed`).
+  void onShown() => _set(true);
+
+  /// The app is no longer on screen (`paused` / `hidden`). A brief `inactive`
+  /// — a permission dialog, a notification shade pull — is deliberately *not*
+  /// hidden: it is over in a moment, and standing down for it would cost more
+  /// than it saves.
+  void onHidden() => _set(false);
+
+  void _set(bool visible) {
+    if (state != visible) state = visible;
+  }
+}
+
+/// The live "is the UI on screen?" signal, published by the root app widget's
+/// lifecycle observer.
+final appVisibilityProvider = NotifierProvider<AppVisibility, bool>(
+  AppVisibility.new,
+);

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -120,6 +120,26 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   int _lastQueueStart = 0;
   bool _seeded = false;
 
+  // The exact queue/track/duration inputs the metadata half of the last
+  // broadcast was derived from, kept by *reference* so a position tick can be
+  // recognised for what it is before any work is done for it.
+  //
+  // A steady playing state emits ~4 times a second, and every one of those
+  // emissions carries the same `previous` / `upNext` list objects and the same
+  // current track: [PlaybackState.copyWith] passes the lists straight through,
+  // so a tick that only advances the position cannot have changed a single row.
+  // Without this guard each of those ticks re-materialized the published window
+  // (up to [maxPublishedQueueItems] tracks) and rebuilt a [audio.MediaItem],
+  // only for the comparisons below to conclude nothing changed — several
+  // thousand list writes a minute, for the whole length of a screen-off
+  // session. Identity is a conservative test: a genuinely new list (a queue
+  // edit, a skip, a shuffle) is a different object and falls through to the
+  // full comparison, so nothing a session renders can be missed by it.
+  List<Track>? _lastBroadcastPrevious;
+  List<Track>? _lastBroadcastUpNext;
+  Track? _lastBroadcastTrack;
+  Duration? _lastBroadcastDuration;
+
   /// The most rows the platform session's queue ever carries.
   ///
   /// The published queue is delivered to every media controller — Android Auto
@@ -295,7 +315,22 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
 
   // ------------------------------------------------------------------------
 
-  void _broadcast(PlaybackState state) {
+  /// Mirrors [state] onto the platform session.
+  ///
+  /// [force] re-derives the media item and queue window even when the state's
+  /// own inputs are unchanged. That is what a cover finishing its warm needs:
+  /// the artwork is looked up outside [PlaybackState] (see [_sessionArtUri]),
+  /// so the same track can genuinely publish a different item.
+  void _broadcast(PlaybackState state, {bool force = false}) {
+    // A pure position tick carries the same queue objects, the same track, and
+    // the same duration as the last broadcast, so nothing the notification, the
+    // lock screen, or the car's "Up Next" renders can have moved. Reuse what
+    // was published instead of rebuilding it several times a second — the
+    // playback state below still follows the position and re-syncs on drift.
+    if (!force && _isPublishedMetadataUnchanged(state)) {
+      _pushPlaybackState(state, start: _lastQueueStart);
+      return;
+    }
     final Track? track = state.currentTrack;
     final audio.MediaItem? item = track == null
         ? null
@@ -331,6 +366,32 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
         for (final Track t in window) _trackMediaItem(t, id: t.id),
       ]);
     }
+    _lastBroadcastPrevious = state.previous;
+    _lastBroadcastUpNext = state.upNext;
+    _lastBroadcastTrack = state.currentTrack;
+    _lastBroadcastDuration = state.duration;
+    _pushPlaybackState(state, start: start);
+  }
+
+  /// Whether [state] would publish exactly the media item and queue window the
+  /// last broadcast already did, judged by object identity so the check itself
+  /// costs nothing on the ~4 Hz position path.
+  ///
+  /// Deliberately conservative: two equal-but-rebuilt lists answer `false` and
+  /// take the full comparison below, so this can only ever skip work that was
+  /// provably redundant.
+  bool _isPublishedMetadataUnchanged(PlaybackState state) {
+    return _seeded &&
+        identical(state.previous, _lastBroadcastPrevious) &&
+        identical(state.upNext, _lastBroadcastUpNext) &&
+        identical(state.currentTrack, _lastBroadcastTrack) &&
+        state.duration == _lastBroadcastDuration;
+  }
+
+  /// Pushes the platform playback state for [state] when something it renders
+  /// changed. [start] is the absolute queue index the published window begins
+  /// at, so the highlighted row stays numbered within what was published.
+  void _pushPlaybackState(PlaybackState state, {required int start}) {
     // The active row, numbered within the published window so the car
     // highlights the right one — a window-relative index, matching the ids
     // `audio_service` assigns the rows it published.
@@ -377,7 +438,10 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
       // report shows the rebroadcast is off the playback path — [_broadcast]
       // mirrors the controller's *current* state and issues no transport command.
       StabilityDiagnostics.mediaItemRebroadcast('artwork');
-      _broadcast(_controller.state);
+      // Forced: the state itself hasn't changed (same track, same queue), only
+      // the cover the item resolves to, so the position-tick fast path must not
+      // short-circuit this one.
+      _broadcast(_controller.state, force: true);
     }
   }
 

--- a/lib/core/services/media_artwork_prewarm_service.dart
+++ b/lib/core/services/media_artwork_prewarm_service.dart
@@ -4,6 +4,7 @@ import 'dart:developer' as developer;
 import '../models/playback_state.dart';
 import '../models/track.dart';
 import 'media_artwork_source.dart';
+import 'playback_lookahead.dart';
 
 /// Secret-free diagnostic tag for the media-session artwork warm path. View with
 /// `adb logcat | grep Linthra.MediaArtwork`. Logs only structural outcomes
@@ -57,14 +58,14 @@ class MediaArtworkPrewarmService {
   final Set<Uri> _requested = <Uri>{};
   final List<Uri> _queue = <Uri>[];
   bool _running = false;
-  String? _lastKey;
+  PlaybackState? _lastInputs;
 
   void _onState(PlaybackState state) {
-    final String key = _keyFor(state);
     // Only react when the now-playing + look-ahead set changes — not on every
-    // position tick (which re-emits the same key).
-    if (key == _lastKey) return;
-    _lastKey = key;
+    // position tick, which changes neither. The check allocates nothing and
+    // short-circuits on an unchanged queue (see [samePlaybackLookahead]).
+    if (samePlaybackLookahead(state, _lastInputs, ahead: _lookahead)) return;
+    _lastInputs = state;
     // Prioritise the now-playing cover (front of the queue) so it warms before
     // the look-ahead — its delay is the one visible on the now-playing card.
     _enqueue(state.currentTrack?.artworkUri, front: true);
@@ -87,17 +88,6 @@ class MediaArtworkPrewarmService {
     } else {
       _queue.add(art);
     }
-  }
-
-  /// A fingerprint of the now-playing + look-ahead track uris, so warming reacts
-  /// to queue/track changes but not to position/status ticks (same key). Keyed by
-  /// uri (not the bare id) so switching between two providers' same-id copies
-  /// still triggers a warm.
-  String _keyFor(PlaybackState state) {
-    final String current = state.currentTrack?.uri ?? '-';
-    final String ahead =
-        state.upNext.take(_lookahead).map((Track t) => t.uri).join(',');
-    return '$current|$ahead';
   }
 
   Future<void> _drain() async {

--- a/lib/core/services/playback_lookahead.dart
+++ b/lib/core/services/playback_lookahead.dart
@@ -1,0 +1,57 @@
+import '../models/playback_state.dart';
+import '../models/track.dart';
+
+/// Whether two playback states describe the same *look-ahead work*: the same
+/// track playing, the same modes, and the same first [ahead] entries of
+/// up-next.
+///
+/// Every service that warms something ahead of playback — the smart pre-cache,
+/// the remote stream prebuffer, the media-session artwork prewarm — listens to
+/// the same unified [PlaybackState] stream, which emits several times a second
+/// while playing. Only a handful of those emissions change what there is to
+/// warm; the rest are position ticks. This is the shared "did anything I care
+/// about actually move?" test they gate on.
+///
+/// Two properties matter for battery, and both are deliberate:
+///
+///  * **It allocates nothing.** These services used to fingerprint a state by
+///    building a string out of the up-next uris on *every* emission — several
+///    times a second, for the whole length of a screen-off session, over a
+///    queue that can hold the user's entire library. The comparison below walks
+///    at most [ahead] entries and, on the overwhelmingly common position tick,
+///    stops at the first `identical` check: [PlaybackState.copyWith] hands the
+///    same list objects to the new state, so an unchanged queue is provably
+///    unchanged in constant time.
+///  * **It stops at [ahead].** A change further down a long queue cannot affect
+///    what these services warm (they only ever look at the head of up-next), so
+///    reacting to it would be pure work for no benefit.
+///
+/// A null state never matches, so a service's first emission always runs.
+bool samePlaybackLookahead(
+  PlaybackState? a,
+  PlaybackState? b, {
+  required int ahead,
+}) {
+  if (a == null || b == null) return false;
+  if (identical(a, b)) return true;
+  // Compared by uri, not by [Track] equality (bare id): a fallback that swaps
+  // `jellyfin:101` for `subsonic:101` keeps the id but is a different copy to
+  // warm.
+  if (a.currentTrack?.uri != b.currentTrack?.uri) return false;
+  if (a.shuffleEnabled != b.shuffleEnabled) return false;
+  if (a.repeatMode != b.repeatMode) return false;
+  return _sameHead(a.upNext, b.upNext, ahead);
+}
+
+/// Whether the first [ahead] entries of [a] and [b] are the same tracks in the
+/// same order (a shorter list must match in full).
+bool _sameHead(List<Track> a, List<Track> b, int ahead) {
+  if (identical(a, b)) return true;
+  final int countA = a.length < ahead ? a.length : ahead;
+  final int countB = b.length < ahead ? b.length : ahead;
+  if (countA != countB) return false;
+  for (int i = 0; i < countA; i++) {
+    if (a[i].uri != b[i].uri) return false;
+  }
+  return true;
+}

--- a/lib/core/services/playback_session_persistence.dart
+++ b/lib/core/services/playback_session_persistence.dart
@@ -23,7 +23,7 @@ class PlaybackSessionPersistence {
     required Stream<PlaybackState> playbackStates,
     bool Function(MusicProvider provider)? isRemoteProviderAvailable,
     bool Function(String localUri)? localFileExists,
-    Duration positionSaveInterval = const Duration(seconds: 2),
+    Duration positionSaveInterval = const Duration(seconds: 10),
   })  : _store = store,
         _controller = controller,
         _isRemoteProviderAvailable = isRemoteProviderAvailable,
@@ -36,11 +36,29 @@ class PlaybackSessionPersistence {
   final LocalPlaybackController _controller;
   final bool Function(MusicProvider provider)? _isRemoteProviderAvailable;
   final bool Function(String localUri) _localFileExists;
+
+  /// How long a run of pure position ticks is coalesced before the session is
+  /// rewritten.
+  ///
+  /// Every save re-encodes the whole logical queue and rewrites the store's one
+  /// document, so this interval is the cost of the feature: at a couple of
+  /// seconds it was hundreds of encodes and disk writes an hour for a session
+  /// nobody was reading — real CPU and I/O on a laptop running on battery, for
+  /// a record only a crash ever consumes. Every *meaningful* moment still
+  /// persists immediately (a track change, a queue edit, pause/stop, and a
+  /// clean shutdown via [dispose]), so what this interval bounds is the
+  /// position an unexpected kill mid-playback can lose.
   final Duration _positionSaveInterval;
 
   StreamSubscription<PlaybackState>? _subscription;
   Timer? _positionTimer;
   PlaybackState? _lastPersisted;
+
+  /// The freshest state seen while a position save is pending. The debounced
+  /// save writes *this*, not the state that happened to arm the timer, so a
+  /// longer interval costs fewer writes without ever persisting a staler
+  /// position than the moment it fires.
+  PlaybackState? _pendingPositionState;
   bool _restoring = false;
   bool _disposed = false;
 
@@ -89,6 +107,7 @@ class PlaybackSessionPersistence {
     if (state.currentTrack == null) {
       _positionTimer?.cancel();
       _positionTimer = null;
+      _pendingPositionState = null;
       _lastPersisted = null;
       unawaited(_clearQuietly());
       return;
@@ -107,20 +126,29 @@ class PlaybackSessionPersistence {
     if (structuralChange) {
       _positionTimer?.cancel();
       _positionTimer = null;
+      _pendingPositionState = null;
       unawaited(_persist(state));
       return;
     }
 
     if (state.status == PlaybackStatus.playing) {
-      _positionTimer ??= Timer(_positionSaveInterval, () {
-        _positionTimer = null;
-        unawaited(_persist(state));
-      });
+      _pendingPositionState = state;
+      _positionTimer ??= Timer(_positionSaveInterval, _flushPosition);
     } else {
       _positionTimer?.cancel();
       _positionTimer = null;
+      _pendingPositionState = null;
       unawaited(_persist(state));
     }
+  }
+
+  /// Writes the freshest position seen since the debounce started.
+  void _flushPosition() {
+    _positionTimer = null;
+    final PlaybackState? state = _pendingPositionState;
+    _pendingPositionState = null;
+    if (state == null || _disposed) return;
+    unawaited(_persist(state));
   }
 
   Future<void> _persist(PlaybackState state) async {
@@ -191,12 +219,20 @@ class PlaybackSessionPersistence {
     return true;
   }
 
-  /// Stops listening. Safe to call more than once.
+  /// Stops listening, persisting any position still waiting on the debounce so
+  /// a clean shutdown records exactly where playback was. Safe to call more
+  /// than once.
   Future<void> dispose() async {
     if (_disposed) return;
+    // Marked disposed up front, so a second (or concurrent) dispose can't run
+    // the flush again — [_persist] itself deliberately doesn't check the flag,
+    // which is what lets this last write through.
     _disposed = true;
     _positionTimer?.cancel();
     _positionTimer = null;
+    final PlaybackState? pending = _pendingPositionState;
+    _pendingPositionState = null;
+    if (pending != null) await _persist(pending);
     await _subscription?.cancel();
     _subscription = null;
   }

--- a/lib/core/services/remote_prebuffer_service.dart
+++ b/lib/core/services/remote_prebuffer_service.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import '../models/playback_state.dart';
 import '../models/repeat_mode.dart';
 import '../models/track.dart';
+import 'playback_lookahead.dart';
 import 'remote_cache/remote_stream_prebufferer.dart';
 
 /// Drives the [RemoteStreamPrebufferer] from live playback: as the queue moves,
@@ -42,38 +43,20 @@ class RemotePrebufferService {
 
   /// The last set of inputs we prepared against, so pure position/status ticks
   /// don't re-trigger a pass.
-  String? _lastKey;
+  PlaybackState? _lastInputs;
   PlaybackState? _pending;
   bool _running = false;
 
   void _onState(PlaybackState state) {
-    final String key = _keyFor(state);
-    if (key == _lastKey) return;
-    _lastKey = key;
+    // Only the inputs that decide what to prepare count: the playing track,
+    // shuffle, repeat, and the head of up-next this service warms. A position
+    // tick moves none of them and costs a few reference checks here (see
+    // [samePlaybackLookahead]).
+    if (samePlaybackLookahead(state, _lastInputs, ahead: _ahead)) return;
+    _lastInputs = state;
     if (state.currentTrack == null) return;
     _pending = state;
     unawaited(_drain());
-  }
-
-  /// A fingerprint of the inputs that decide what to prepare: the playing track,
-  /// shuffle, repeat, and the head of up-next we warm. Excludes
-  /// position/duration/status so listening doesn't thrash on playback ticks.
-  String _keyFor(PlaybackState state) {
-    final StringBuffer buffer = StringBuffer()
-      ..write(state.currentTrack?.uri ?? '-')
-      ..write('|')
-      ..write(state.shuffleEnabled)
-      ..write('|')
-      ..write(state.repeatMode.name)
-      ..write('|');
-    final int count =
-        _ahead < state.upNext.length ? _ahead : state.upNext.length;
-    for (int i = 0; i < count; i++) {
-      buffer
-        ..write(state.upNext[i].uri)
-        ..write(',');
-    }
-    return buffer.toString();
   }
 
   Future<void> _drain() async {

--- a/lib/core/services/smart_precache_service.dart
+++ b/lib/core/services/smart_precache_service.dart
@@ -4,6 +4,7 @@ import '../models/playback_state.dart';
 import '../models/repeat_mode.dart';
 import '../models/track.dart';
 import '../repositories/download_preferences.dart';
+import 'playback_lookahead.dart';
 import 'stability_diagnostics.dart';
 import 'track_prefetcher.dart';
 
@@ -55,40 +56,25 @@ class SmartPrecacheService {
 
   /// The last set of inputs we pre-cached against, so pure position/status
   /// ticks (which don't change what to cache) don't re-trigger a pass.
-  String? _lastKey;
+  PlaybackState? _lastInputs;
   PlaybackState? _pendingState;
   bool _running = false;
 
   void _onState(PlaybackState state) {
-    final String key = _keyFor(state);
     // React only when something that affects *what to cache* changed — the
-    // playing track, the up-next list, shuffle, or repeat — not on every
-    // position tick (which re-emits the same key).
-    if (key == _lastKey) return;
-    _lastKey = key;
+    // playing track, the head of up-next, shuffle, or repeat — not on every
+    // position tick, which changes none of them. The comparison itself is
+    // allocation-free and short-circuits on an unchanged queue, so a tick costs
+    // a handful of reference checks (see [samePlaybackLookahead]).
+    if (samePlaybackLookahead(state, _lastInputs, ahead: kMaxPrecacheCount)) {
+      return;
+    }
+    _lastInputs = state;
     if (state.currentTrack == null) return;
     // Remember the freshest state and drain; a pass already running picks this
     // up when it finishes, so the latest queue always wins.
     _pendingState = state;
     unawaited(_drain());
-  }
-
-  /// A cheap fingerprint of the inputs that decide what to pre-cache. Excludes
-  /// position/duration/status so listening doesn't thrash on playback ticks.
-  static String _keyFor(PlaybackState state) {
-    final StringBuffer buffer = StringBuffer()
-      ..write(state.currentTrack?.uri ?? '-')
-      ..write('|')
-      ..write(state.shuffleEnabled)
-      ..write('|')
-      ..write(state.repeatMode.name)
-      ..write('|');
-    for (final Track track in state.upNext) {
-      buffer
-        ..write(track.uri)
-        ..write(',');
-    }
-    return buffer.toString();
   }
 
   Future<void> _drain() async {

--- a/lib/features/settings/jellyfin/jellyfin_availability_controller.dart
+++ b/lib/features/settings/jellyfin/jellyfin_availability_controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/lifecycle/app_visibility.dart';
 import '../../../core/models/jellyfin_session.dart';
 import '../../../core/services/reachability.dart';
 import '../../../core/sources/jellyfin/jellyfin_availability.dart';
@@ -20,13 +21,23 @@ import 'jellyfin_settings_providers.dart';
 final jellyfinAvailabilityPollIntervalProvider =
     Provider<Duration?>((ref) => null);
 
-/// Production binding: re-probe a configured server periodically.
+/// Production binding: re-probe a configured server periodically *while the
+/// app is on screen*.
 ///
 /// Short enough that walking back onto the home network restores the library on
 /// its own, with no reconnect and no rescan, and long enough that an absent
 /// server costs one cheap, already-authenticated request a minute rather than a
 /// battery drain. App resume and the playback path cover the rest, so this is a
 /// backstop, not the primary signal.
+///
+/// The poll runs only while the UI is visible ([appVisibilityProvider]). With
+/// the screen off, `audio_service` keeps this isolate alive for playback, so
+/// this timer would otherwise keep firing for the whole session — a network
+/// round-trip (and on mobile data, a radio wake-up) every interval, refreshing
+/// a library nobody is looking at. Nothing is lost by standing down: coming
+/// back to the app re-probes immediately (see `LinthraApp`'s resume path), and
+/// the playback path reports what it learns through [noteReachability] whether
+/// the UI is up or not.
 final jellyfinAvailabilityPollOverride =
     jellyfinAvailabilityPollIntervalProvider.overrideWithValue(
   const Duration(seconds: 45),
@@ -53,6 +64,14 @@ class JellyfinAvailabilityController extends Notifier<SourceAvailabilityState> {
   Timer? _poll;
   bool _disposed = false;
 
+  /// How often to re-probe while the app is on screen, or null for no polling
+  /// at all. Read once per build from [jellyfinAvailabilityPollIntervalProvider].
+  Duration? _interval;
+
+  /// Whether a configured session exists, so a visibility change can restart
+  /// the poll without re-reading the settings controller.
+  bool _configured = false;
+
   /// Guards against a slow probe from a previous session/server landing on top
   /// of a newer answer. Every probe takes a ticket; only the newest one may
   /// write. Kept across `build()` re-runs (Riverpod reuses the notifier), which
@@ -76,17 +95,23 @@ class JellyfinAvailabilityController extends Notifier<SourceAvailabilityState> {
       _poll = null;
     });
 
+    _configured = configured;
     if (!configured) {
       // Nothing configured: no probe, no timer, and nothing hidden.
       _generation++;
       return const SourceAvailabilityState.notConfigured();
     }
 
-    final Duration? interval =
-        ref.read(jellyfinAvailabilityPollIntervalProvider);
-    if (interval != null && interval > Duration.zero) {
-      _poll = Timer.periodic(interval, (_) => unawaited(refresh()));
-    }
+    _interval = ref.read(jellyfinAvailabilityPollIntervalProvider);
+    // Listened to rather than watched: a visibility flip must start or stop the
+    // timer without re-running this build, which would reset a settled
+    // availability back to `checking` (blinking the library) and fire a fresh
+    // probe every time the user pockets the phone.
+    ref.listen<bool>(
+      appVisibilityProvider,
+      (bool? previous, bool visible) => _syncPoll(visible: visible),
+    );
+    _syncPoll(visible: ref.read(appVisibilityProvider));
     // Probe off the build so the notifier never writes state while building.
     // Until it lands the state is `checking`, which hides nothing (see
     // [SourceAvailability.hidesTracks]) — a library must not blink out while we
@@ -95,6 +120,25 @@ class JellyfinAvailabilityController extends Notifier<SourceAvailabilityState> {
       if (!_disposed) unawaited(refresh());
     });
     return const SourceAvailabilityState.checking();
+  }
+
+  /// Starts or stops the background poll for the current visibility.
+  ///
+  /// Only ever touches the timer: it never probes and never writes state, so a
+  /// pocketed phone (or a returning one) can't move the library on its own.
+  void _syncPoll({required bool visible}) {
+    final Duration? interval = _interval;
+    final bool shouldPoll = !_disposed &&
+        _configured &&
+        visible &&
+        interval != null &&
+        interval > Duration.zero;
+    if (!shouldPoll) {
+      _poll?.cancel();
+      _poll = null;
+      return;
+    }
+    _poll ??= Timer.periodic(interval, (_) => unawaited(refresh()));
   }
 
   /// Re-probes the configured server now. Safe to call from anywhere and at any

--- a/test/app/playback_lifecycle_test.dart
+++ b/test/app/playback_lifecycle_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/app/linthra_app.dart';
+import 'package:linthra/core/lifecycle/app_visibility.dart';
 import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/services/notification_permission.dart';
@@ -187,6 +188,32 @@ void main() {
     // background boundary is captured (here, playing) for the bug report.
     expect(StabilityDiagnostics.playbackStateAtBackground, 'playing');
     expect(StabilityDiagnostics.lastLifecycleState, 'paused');
+  });
+
+  testWidgets(
+      'app visibility follows the lifecycle, so hidden work can stand '
+      'down', (tester) async {
+    await _pumpApp(tester);
+    final ProviderContainer container =
+        ProviderScope.containerOf(tester.element(find.byType(LinthraApp)));
+
+    expect(container.read(appVisibilityProvider), isTrue);
+
+    // A brief inactive (a dialog, the notification shade) is not "hidden": it
+    // is over in a moment, and standing down for it would cost more than it
+    // saves.
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+    await tester.pump();
+    expect(container.read(appVisibilityProvider), isTrue);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    await tester.pump();
+    expect(container.read(appVisibilityProvider), isFalse,
+        reason: 'screen off: background work that only serves the UI stops');
+
+    await _foreground(tester);
+    expect(container.read(appVisibilityProvider), isTrue);
   });
 
   testWidgets(

--- a/test/benchmarks/playback_tick_cost_bench.dart
+++ b/test/benchmarks/playback_tick_cost_bench.dart
@@ -1,0 +1,179 @@
+// A measurement harness, not a regression test.
+//
+// It times the work that the services hanging off the playback state stream do
+// for a run of *position ticks* — the ~4 Hz emissions that make up the
+// overwhelming majority of what a playing session produces, and the one cost
+// that runs for the whole length of a screen-off listening session. See
+// docs/battery-playback-audit.md for what it was written for and the numbers it
+// produced.
+//
+// Deliberately named `_bench.dart`, not `_test.dart`, so `flutter test` does
+// not pick it up: the numbers are machine- and load-dependent and would make a
+// flaky CI gate. The invariants it inspired *are* covered by real tests
+// (`test/core/services/playback_lookahead_test.dart`, the "session updates are
+// not flooded by position ticks" group in `linthra_audio_handler_test.dart`).
+//
+// Run it explicitly, and compare two revisions on the same machine:
+//
+//     flutter test test/benchmarks/playback_tick_cost_bench.dart
+//
+// Every case emits [_ticks] position-only states, which is about five minutes
+// of playback. The "stream only" case is the floor: building and delivering
+// those states with nothing listening. Subtract it to read a service's own
+// cost.
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/persisted_playback_session.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/repeat_mode.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/linthra_audio_handler.dart';
+import 'package:linthra/core/services/media_artwork_prewarm_service.dart';
+import 'package:linthra/core/services/media_browser_tree.dart';
+import 'package:linthra/core/services/smart_precache_service.dart';
+import 'package:linthra/core/services/track_prefetcher.dart';
+import 'package:linthra/data/repositories/in_memory_download_preferences.dart';
+
+import '../features/library/fake_music_library_repository.dart';
+import '../features/player/fake_playback_controller.dart';
+
+/// Warms nothing: the benchmark measures the *deciding*, not the fetching.
+class _NoopPrefetcher implements TrackPrefetcher {
+  @override
+  Future<void> prefetch(Track track) async {}
+}
+
+Track _t(int i) => Track(
+      id: '$i',
+      title: 'Track $i',
+      uri: 'jellyfin:$i',
+      albumName: 'Album ${i % 500}',
+      artistName: 'Artist ${i % 200}',
+      duration: const Duration(minutes: 3),
+      // A credential-free reference, so the artwork prewarm has real work to
+      // consider rather than skipping every cover as platform-loadable.
+      artworkUri: Uri.parse('subsonic-cover:$i'),
+    );
+
+/// About five minutes of playback at the ~4 Hz position flush.
+const int _ticks = 1200;
+
+/// A big-but-real library selection: "play all songs" on a large collection.
+const int _queueLength = 20000;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('BENCH stream only (the floor)', () async {
+    final List<Track> upNext = <Track>[for (int i = 0; i < 5000; i++) _t(i)];
+    final StreamController<PlaybackState> states =
+        StreamController<PlaybackState>.broadcast();
+    states.stream.listen((_) {});
+    PlaybackState state = PlaybackState(
+      status: PlaybackStatus.playing,
+      currentTrack: _t(99999),
+      upNext: upNext,
+    );
+    states.add(state);
+    await Future<void>.delayed(Duration.zero);
+
+    final Stopwatch sw = Stopwatch()..start();
+    for (int i = 0; i < _ticks; i++) {
+      state = state.copyWith(position: Duration(milliseconds: i * 250));
+      states.add(state);
+    }
+    await Future<void>.delayed(Duration.zero);
+    sw.stop();
+    // ignore: avoid_print
+    print('BENCH stream only, $_ticks ticks: ${sw.elapsedMicroseconds}us');
+    await states.close();
+  });
+
+  test('BENCH media-session bridge', () async {
+    final List<Track> queue = <Track>[
+      for (int i = 0; i < _queueLength; i++) _t(i),
+    ];
+    final FakePlaybackController controller = FakePlaybackController();
+    final LinthraAudioHandler handler = LinthraAudioHandler(
+      controller,
+      MediaBrowserTree(FakeMusicLibraryRepository()),
+    );
+    await controller.playTracks(queue, startIndex: _queueLength ~/ 2);
+    await Future<void>.delayed(Duration.zero);
+
+    final Stopwatch sw = Stopwatch()..start();
+    for (int i = 0; i < _ticks; i++) {
+      controller.emit(
+        controller.state.copyWith(position: Duration(milliseconds: i * 250)),
+      );
+    }
+    await Future<void>.delayed(Duration.zero);
+    sw.stop();
+    // ignore: avoid_print
+    print('BENCH media-session bridge, $_queueLength-track queue, $_ticks '
+        'ticks: ${sw.elapsedMicroseconds}us');
+    await handler.dispose();
+    await controller.dispose();
+  });
+
+  test('BENCH look-ahead services', () async {
+    final List<Track> upNext = <Track>[for (int i = 0; i < 5000; i++) _t(i)];
+    final StreamController<PlaybackState> states =
+        StreamController<PlaybackState>.broadcast();
+    SmartPrecacheService(
+      playbackStates: states.stream,
+      prefetcher: _NoopPrefetcher(),
+      preferences: InMemoryDownloadPreferences(),
+    );
+    MediaArtworkPrewarmService(
+      playbackStates: states.stream,
+      warm: (Uri _) async => null,
+    );
+
+    PlaybackState state = PlaybackState(
+      status: PlaybackStatus.playing,
+      currentTrack: _t(99999),
+      upNext: upNext,
+    );
+    states.add(state);
+    await Future<void>.delayed(Duration.zero);
+
+    final Stopwatch sw = Stopwatch()..start();
+    for (int i = 0; i < _ticks; i++) {
+      state = state.copyWith(position: Duration(milliseconds: i * 250));
+      states.add(state);
+    }
+    await Future<void>.delayed(Duration.zero);
+    sw.stop();
+    // ignore: avoid_print
+    print('BENCH look-ahead services, 5000-track up-next, $_ticks ticks: '
+        '${sw.elapsedMicroseconds}us');
+    await states.close();
+  });
+
+  test('BENCH session document encode (Linux crash-safe session)', () async {
+    // What one debounced position save costs before it ever reaches the disk.
+    final List<Track> tracks = <Track>[for (int i = 0; i < 200; i++) _t(i)];
+    final PersistedPlaybackSession? session =
+        PersistedPlaybackSession.fromPlayback(
+      previous: tracks.sublist(0, 50),
+      current: tracks[50],
+      upNext: tracks.sublist(51),
+      position: const Duration(seconds: 30),
+      shuffleEnabled: false,
+      repeatMode: RepeatMode.off,
+    );
+    const int rounds = 100;
+    final Stopwatch sw = Stopwatch()..start();
+    int bytes = 0;
+    for (int i = 0; i < rounds; i++) {
+      bytes = jsonEncode(session!.toJson()).length;
+    }
+    sw.stop();
+    // ignore: avoid_print
+    print('BENCH session encode, 200-track queue: ${bytes}B, '
+        '${(sw.elapsedMicroseconds / rounds).toStringAsFixed(0)}us/encode');
+  });
+}

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -259,6 +259,64 @@ void main() {
         expect(pushed.length, greaterThan(baseline));
       });
 
+      test('a rebuilt but identical queue is still not re-published', () async {
+        // The position-tick fast path recognises unchanged inputs by object
+        // identity. A state that rebuilt its lists for unrelated reasons must
+        // fall through to the full comparison and still not thrash the car's
+        // Up Next list.
+        await controller.playTracks(<Track>[_track('a'), _track('b')]);
+        await _settle();
+
+        final List<List<audio.MediaItem>> pushes = <List<audio.MediaItem>>[];
+        final List<audio.MediaItem?> items = <audio.MediaItem?>[];
+        final subs = <StreamSubscription<void>>[
+          handler.queue.listen(pushes.add),
+          handler.mediaItem.listen(items.add),
+        ];
+        addTearDown(() {
+          for (final StreamSubscription<void> sub in subs) {
+            sub.cancel();
+          }
+        });
+        await _settle();
+        final int queueBaseline = pushes.length;
+        final int itemBaseline = items.length;
+
+        final PlaybackState current = controller.state;
+        controller.emit(current.copyWith(
+          upNext: List<Track>.of(current.upNext),
+          previous: List<Track>.of(current.previous),
+          position: const Duration(milliseconds: 300),
+        ));
+        await _settle();
+
+        expect(pushes.length, queueBaseline);
+        expect(items.length, itemBaseline);
+      });
+
+      test('a duration arriving for the same track still updates the item',
+          () async {
+        // Duration is part of what the session renders, and it lands *after*
+        // the track is already current — the one metadata change a
+        // "nothing but the position moved" shortcut could swallow.
+        await controller.playTracks(<Track>[_track('a')]);
+        await _settle();
+
+        final List<audio.MediaItem?> items = <audio.MediaItem?>[];
+        final sub = handler.mediaItem.listen(items.add);
+        addTearDown(sub.cancel);
+        await _settle();
+        final int baseline = items.length;
+
+        controller.emit(
+          controller.state.copyWith(duration: const Duration(minutes: 4)),
+        );
+        await _settle();
+
+        expect(items.length, greaterThan(baseline));
+        expect(items.last?.duration, const Duration(minutes: 4));
+      });
+
       test('a pause is pushed even when the position is steady', () async {
         await controller.playTracks(<Track>[_track('a')]);
         await _settle();

--- a/test/core/services/playback_lookahead_test.dart
+++ b/test/core/services/playback_lookahead_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/repeat_mode.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/playback_lookahead.dart';
+
+Track _t(String id, {String provider = 'jellyfin'}) =>
+    Track(id: id, title: id, uri: '$provider:$id');
+
+PlaybackState _state(
+  Track? current,
+  List<Track> upNext, {
+  Duration position = Duration.zero,
+  bool shuffle = false,
+  RepeatMode repeat = RepeatMode.off,
+  PlaybackStatus status = PlaybackStatus.playing,
+}) =>
+    PlaybackState(
+      status: status,
+      currentTrack: current,
+      upNext: upNext,
+      position: position,
+      shuffleEnabled: shuffle,
+      repeatMode: repeat,
+    );
+
+void main() {
+  group('samePlaybackLookahead', () {
+    test('a position tick is the same work', () {
+      final List<Track> upNext = <Track>[_t('2'), _t('3')];
+      final PlaybackState first = _state(_t('1'), upNext);
+      // Exactly how the controller emits a tick: the queue objects are handed
+      // through untouched, only the position moves.
+      final PlaybackState tick =
+          first.copyWith(position: const Duration(seconds: 7));
+
+      expect(samePlaybackLookahead(first, tick, ahead: 3), isTrue);
+    });
+
+    test('a status change alone is the same work', () {
+      final PlaybackState playing = _state(_t('1'), <Track>[_t('2')]);
+      final PlaybackState paused =
+          playing.copyWith(status: PlaybackStatus.paused);
+
+      expect(samePlaybackLookahead(playing, paused, ahead: 3), isTrue);
+    });
+
+    test('a null state never matches, so the first emission always runs', () {
+      final PlaybackState state = _state(_t('1'), <Track>[_t('2')]);
+
+      expect(samePlaybackLookahead(state, null, ahead: 3), isFalse);
+      expect(samePlaybackLookahead(null, state, ahead: 3), isFalse);
+    });
+
+    test('a track change is different work', () {
+      final List<Track> upNext = <Track>[_t('2')];
+
+      expect(
+        samePlaybackLookahead(
+          _state(_t('1'), upNext),
+          _state(_t('9'), upNext),
+          ahead: 3,
+        ),
+        isFalse,
+      );
+    });
+
+    test('a same-id copy from another provider is different work', () {
+      // The fallback that swaps jellyfin:101 for subsonic:101 keeps the bare id
+      // but is a different copy to warm.
+      expect(
+        samePlaybackLookahead(
+          _state(_t('101'), const <Track>[]),
+          _state(_t('101', provider: 'subsonic'), const <Track>[]),
+          ahead: 3,
+        ),
+        isFalse,
+      );
+    });
+
+    test('shuffle and repeat changes are different work', () {
+      final Track current = _t('1');
+      final List<Track> upNext = <Track>[_t('2')];
+
+      expect(
+        samePlaybackLookahead(
+          _state(current, upNext),
+          _state(current, upNext, shuffle: true),
+          ahead: 3,
+        ),
+        isFalse,
+      );
+      expect(
+        samePlaybackLookahead(
+          _state(current, upNext),
+          _state(current, upNext, repeat: RepeatMode.one),
+          ahead: 3,
+        ),
+        isFalse,
+      );
+    });
+
+    test('a rebuilt but equal queue still compares as the same work', () {
+      // Identity is only the fast path; equal contents must still match, or a
+      // queue rebuilt for unrelated reasons would re-trigger a warm.
+      expect(
+        samePlaybackLookahead(
+          _state(_t('1'), <Track>[_t('2'), _t('3')]),
+          _state(_t('1'), <Track>[_t('2'), _t('3')]),
+          ahead: 3,
+        ),
+        isTrue,
+      );
+    });
+
+    test('a change inside the look-ahead is different work', () {
+      expect(
+        samePlaybackLookahead(
+          _state(_t('1'), <Track>[_t('2'), _t('3')]),
+          _state(_t('1'), <Track>[_t('2'), _t('4')]),
+          ahead: 3,
+        ),
+        isFalse,
+      );
+    });
+
+    test('a change past the look-ahead is not work at all', () {
+      // Only the head of up-next is ever warmed, so a queue edit 50 tracks out
+      // must not wake anything up.
+      final List<Track> head = <Track>[_t('2'), _t('3')];
+      expect(
+        samePlaybackLookahead(
+          _state(_t('1'), <Track>[...head, _t('50')]),
+          _state(_t('1'), <Track>[...head, _t('51')]),
+          ahead: 2,
+        ),
+        isTrue,
+      );
+    });
+
+    test('a shorter queue is different work even past the look-ahead', () {
+      // Reaching the end of the queue matters: there is nothing left to warm.
+      expect(
+        samePlaybackLookahead(
+          _state(_t('1'), <Track>[_t('2'), _t('3')]),
+          _state(_t('1'), <Track>[_t('2')]),
+          ahead: 5,
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/core/services/playback_session_persistence_test.dart
+++ b/test/core/services/playback_session_persistence_test.dart
@@ -166,6 +166,89 @@ void main() {
       await controller.dispose();
     });
 
+    group('position saves are coalesced (battery)', () {
+      // Every save re-encodes the whole logical queue and rewrites the store's
+      // single document. A run of position ticks — several a second while
+      // playing — must therefore cost exactly one write, and that write must
+      // carry the position at the moment it happens rather than the older one
+      // that armed the timer.
+      test('a run of ticks costs one save, carrying the freshest position',
+          () async {
+        final _CountingStore store = _CountingStore();
+        final FakePlaybackController controller = FakePlaybackController();
+        final PlaybackSessionPersistence persistence =
+            PlaybackSessionPersistence(
+          store: store,
+          controller: controller,
+          playbackStates: controller.stateStream,
+          localFileExists: (_) => true,
+          positionSaveInterval: const Duration(milliseconds: 40),
+        );
+
+        controller.emit(const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: remote,
+          position: Duration(seconds: 1),
+        ));
+        await Future<void>.delayed(Duration.zero);
+        // The first emission is a structural change (a new track): it persists
+        // straight away, and only the ticks after it are debounced.
+        final int structuralSaves = store.saves;
+        expect(structuralSaves, 1);
+
+        for (int second = 2; second <= 6; second++) {
+          controller.emit(PlaybackState(
+            status: PlaybackStatus.playing,
+            currentTrack: remote,
+            position: Duration(seconds: second),
+          ));
+          await Future<void>.delayed(Duration.zero);
+        }
+        expect(store.saves, structuralSaves,
+            reason: 'ticks inside the interval must not each write');
+
+        await Future<void>.delayed(const Duration(milliseconds: 80));
+        expect(store.saves, structuralSaves + 1);
+        expect((await store.load())!.position, const Duration(seconds: 6));
+
+        await persistence.dispose();
+        await controller.dispose();
+      });
+
+      test('a clean shutdown persists the position still waiting', () async {
+        final _CountingStore store = _CountingStore();
+        final FakePlaybackController controller = FakePlaybackController();
+        final PlaybackSessionPersistence persistence =
+            PlaybackSessionPersistence(
+          store: store,
+          controller: controller,
+          playbackStates: controller.stateStream,
+          localFileExists: (_) => true,
+          positionSaveInterval: const Duration(minutes: 1),
+        );
+
+        controller.emit(const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: remote,
+          position: Duration(seconds: 1),
+        ));
+        await Future<void>.delayed(Duration.zero);
+        controller.emit(const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: remote,
+          position: Duration(seconds: 42),
+        ));
+        await Future<void>.delayed(Duration.zero);
+
+        // Quitting the app mustn't throw away where playback actually was just
+        // because the debounce hadn't elapsed.
+        await persistence.dispose();
+        expect((await store.load())!.position, const Duration(seconds: 42));
+
+        await controller.dispose();
+      });
+    });
+
     test('restore failure clears the store and never throws', () async {
       final InMemoryPlaybackSessionStore store = InMemoryPlaybackSessionStore(
         const PersistedPlaybackSession(
@@ -189,6 +272,18 @@ void main() {
       await controller.dispose();
     });
   });
+}
+
+/// A store that counts writes, so a test can assert how often the session
+/// document is actually rewritten (the cost the debounce exists to bound).
+class _CountingStore extends InMemoryPlaybackSessionStore {
+  int saves = 0;
+
+  @override
+  Future<void> save(PersistedPlaybackSession session) async {
+    saves++;
+    await super.save(session);
+  }
 }
 
 /// Local engine that throws from [restoreSession] so startup-safety can be

--- a/test/features/settings/jellyfin/jellyfin_availability_controller_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_availability_controller_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/lifecycle/app_visibility.dart';
 import 'package:linthra/core/models/jellyfin_session.dart';
 import 'package:linthra/core/services/reachability.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_exception.dart';
@@ -185,6 +186,73 @@ void main() {
     expect(container.read(jellyfinAvailabilityProvider).status,
         SourceAvailability.available);
     expect(client.verifyCount, greaterThan(1));
+  });
+
+  group('the poll follows app visibility (battery)', () {
+    test('stops while the app is off screen, without probing on the way out',
+        () async {
+      final client = FakeJellyfinClient();
+      final container = _container(
+        saved: _session,
+        client: client,
+        poll: const Duration(milliseconds: 20),
+      );
+      await _settle();
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+      await _settle();
+      final int whileVisible = client.verifyCount;
+      expect(whileVisible, greaterThan(1), reason: 'polling while on screen');
+
+      // Screen off: playback keeps this isolate alive, so an ungated timer
+      // would keep probing the server for the whole session.
+      container.read(appVisibilityProvider.notifier).onHidden();
+      await _settle();
+      expect(client.verifyCount, whileVisible,
+          reason: 'going off screen must not itself probe');
+
+      await Future<void>.delayed(const Duration(milliseconds: 80));
+      await _settle();
+      expect(client.verifyCount, whileVisible,
+          reason: 'no background probes while the UI is hidden');
+
+      // And nothing was hidden by standing down: the last answer still stands.
+      expect(container.read(jellyfinAvailabilityProvider).status,
+          SourceAvailability.available);
+    });
+
+    test('resumes polling when the app comes back', () async {
+      final client = FakeJellyfinClient();
+      final container = _container(
+        saved: _session,
+        client: client,
+        poll: const Duration(milliseconds: 20),
+      );
+      await _settle();
+      container.read(appVisibilityProvider.notifier).onHidden();
+      await _settle();
+      final int whileHidden = client.verifyCount;
+
+      container.read(appVisibilityProvider.notifier).onShown();
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+      await _settle();
+      expect(client.verifyCount, greaterThan(whileHidden));
+    });
+
+    test('a visibility flip never blinks the library back to checking',
+        () async {
+      final client = FakeJellyfinClient();
+      final container = _container(saved: _session, client: client);
+      await _settle();
+      expect(container.read(jellyfinAvailabilityProvider).status,
+          SourceAvailability.available);
+
+      container.read(appVisibilityProvider.notifier).onHidden();
+      container.read(appVisibilityProvider.notifier).onShown();
+      await _settle();
+
+      expect(container.read(jellyfinAvailabilityProvider).status,
+          SourceAvailability.available);
+    });
   });
 }
 


### PR DESCRIPTION
Closes #344 (investigation part; anything further can be split out).

I read through everything that runs while music is playing and checked it against what `docs/battery.md` claims. Most of the document holds up: the foreground service and wake locks follow real playback, the ~4 Hz position flush is coalesced and self-cancelling, and the Now Playing surfaces really are isolated from position ticks (blur on its own RepaintBoundary, no perpetual wave animation, lyrics/queue/rows selecting position-independent slices).

Two things did not match, and both ran for the whole length of a screen-off session.

## 1. The availability probe polled with the screen off

A configured Jellyfin server was re-probed every 45s whenever one was configured. Since `audio_service` deliberately keeps the isolate alive during playback, that timer kept firing for the entire session: roughly **80 authenticated round-trips an hour** (and as many chances to pull the radio out of idle) to refresh a library nobody could see. The document says "no background polling, heartbeats, or keep-alives", so this was drift, not a decision.

The poll now follows a small `AppVisibility` signal published by the root lifecycle observer: it runs while the UI is on screen and stands down while hidden. Nothing is lost, because the resume path already re-probes immediately and the playback path still reports what it learns through `noteReachability` either way. A visibility flip deliberately does not re-run the notifier's `build` — that would reset a settled answer to `checking` and blink the library.

Screen-off probes go from ~80/hour to **0**.

## 2. Services rebuilt per-tick work they then threw away

Every position tick reaches several services, and each one starts by deciding whether anything it cares about changed. The deciding was the problem:

- smart pre-cache fingerprinted the **entire up-next list** into a string, four times a second
- the remote prebuffer and the media-session artwork prewarm did the same over their look-ahead
- the media-session bridge re-materialized the published queue window (up to 250 tracks) and rebuilt a `MediaItem` every tick, only to compare them and conclude nothing had changed

All of it reached the right answer, which is why no test caught it. `samePlaybackLookahead` replaces the fingerprint strings with one allocation-free comparison that short-circuits on list identity (`copyWith` passes the queue lists straight through, so an unchanged queue is provably unchanged in constant time), and the bridge now skips straight to the playback-state push when the queue objects, track and duration are unchanged. A cover finishing its warm forces a re-publish, since artwork resolves outside `PlaybackState`.

Measured with the new harness (`test/benchmarks/playback_tick_cost_bench.dart`), 1200 ticks ≈ 5 minutes of playback, median of 3 runs on the same machine:

| Case | Before | After |
| --- | --- | --- |
| Stream only (the floor) | 14.7 ms | 14.4 ms |
| Media-session bridge, 20 000-track queue | 34.3 ms | 25.7 ms |
| Look-ahead services, 5000-track up-next | 306.6 ms | 23.8 ms |

Net of the floor that is ~19 ms → ~11 ms and ~291 ms → ~9 ms, so about 3.5 s of pure-waste CPU an hour becomes about 0.1 s. It scales with queue size, which is exactly the "play all, then reach for a charger" shape the issue describes.

## 3. Linux crash-safe session (bonus finding)

`PlaybackSessionPersistence` (Linux only) rewrote its whole encoded queue every 2s — ~1800 encodes and disk writes an hour, 28.8 KB for a 200-track queue — and the debounced save wrote the state that *armed* the timer rather than the freshest one. Now 10s, writing the newest position, with a flush on `dispose()` so a clean quit records exactly where playback was. Everything meaningful (track change, queue edit, pause, stop, shutdown) still persists immediately, so what the longer interval bounds is only what an unexpected kill mid-playback can lose.

## Checked and deliberately left alone

- **Refresh rate.** `DisplayRefreshRate` behaves as documented (highest mode at the current resolution, never lowers resolution, releases the pin under battery saver). The cost the doc didn't name is that a pin also stops the system dropping to an idle rate while a static Now Playing sits on screen. Releasing it when nothing animates risks a stutter on the first flick, so it is written down as future work rather than guessed at.
- **Server progress reports.** A streamed track sends start/pause/resume/stop plus a progress ping at most every 10s. That is what makes your server show Linthra as an active player, it rides a radio the stream is already using, and lengthening it risks servers timing the session out. Documented explicitly instead of changed.

Nothing here touches audio quality, gapless, background playback, Android Auto, or streaming behaviour, and nothing was disabled to make a number look better.

## What still needs a real phone

I could not run `batterystats` (no device), so there is no "X%/hour before, Y% after" figure. The measurements above are counted work: requests per hour, writes per hour, CPU per tick. `docs/battery-playback-audit.md` ends with the exact on-device run worth doing and the three predictions to check (zero availability requests screen-off, unchanged wake-lock behaviour, lower app CPU on long queues). I also added the screen-off probe check to the manual QA checklist.

## Tests

- `test/core/services/playback_lookahead_test.dart` — new, covers the shared comparison including the identity fast path and the "a change past the look-ahead is not work" case
- two new cases in `linthra_audio_handler_test.dart`: a rebuilt-but-equal queue is still not re-published, and a duration arriving for the same track still updates the item
- "position saves are coalesced (battery)" group in `playback_session_persistence_test.dart`
- "the poll follows app visibility (battery)" group in `jellyfin_availability_controller_test.dart`, plus the lifecycle wiring test in `test/app/playback_lifecycle_test.dart`

Full suite green locally (4369 tests), `dart format` and `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWfxW4ToxEAVYWJbgSfrKb

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWfxW4ToxEAVYWJbgSfrKb)_