### PR TITLE
feat(desktop): add volume and mute controls (#394)

### DIFF
--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -200,6 +200,33 @@ The same resolved URI path handles regular filesystem files and direct or
 transcoded Jellyfin, Navidrome/Subsonic, and supported Plex HTTP(S) URLs. No
 source-specific player exists and credentials remain in the existing resolver.
 
+### Volume
+
+Desktop needs its own volume control: there are no hardware volume keys bound to
+the app the way a phone has, and turning the whole system down to quieten one
+player is not the same thing. Now Playing (beside the action row) and the wide
+mini-player bar carry a mute button and a slider, with scroll-wheel and arrow-key
+adjustment; both are hidden on mobile, on windows too narrow to hold them, and
+while casting, where the receiver's own level is the Cast sheet's control.
+
+The level lives on the playback seam, not in a widget: `PlaybackController`
+gained `setVolume` / `setMuted`, and `PlaybackState` carries `volume` and
+`muted`. So every way of changing it — either control, a shell's MPRIS slider,
+the level restored at startup — moves the others, and nothing in the UI talks to
+libmpv directly.
+
+What the engine is actually set to is the listener's level *times* the current
+track's ReplayGain (when normalization is on) *times* the audio-focus duck
+factor, in `JustAudioPlaybackController.engineVolumeFor`. Automatic attenuation
+therefore never moves the slider, and the slider never cancels a duck. Mute
+keeps the level it was at, so unmute returns to exactly it.
+
+The volume (never the mute) is persisted per install through
+`PlaybackVolumePersistence` and restored at startup, sanitized to 0.0–1.0 on
+both the way in and the way out — an out-of-range or non-finite stored value can
+never reach the engine, and a launch is never silent for a reason nothing on
+screen explains.
+
 ### Vendored `just_audio_media_kit`
 
 `just_audio_media_kit` is vendored under `third_party/just_audio_media_kit`
@@ -251,7 +278,7 @@ undeclared network access to an isolated `flatpak-builder` build.
 | **Audio playback** | Supported | media_kit/libmpv through `LinuxPlaybackController`; local files and resolved Jellyfin, Navidrome/Subsonic, and Plex HTTP(S) streams share one backend. |
 | **Suspend / resume** | Supported (app side); real device/sink timing varies | Lifecycle `paused`→`resumed` arms a bounded Linux-only reload of an actively playing track after a short backoff ([issue #466](https://github.com/TheZupZup/Linthra/issues/466)). See [Suspend / resume (manual matrix)](#suspend--resume-manual-matrix). |
 | **Light/Dark/System theme** | Supported (app side); the native brightness bridge itself is Flutter's, not independently verified here | Settings → Appearance's System/Light/Dark choice ([issue #459](https://github.com/TheZupZup/Linthra/issues/459)) is the same shared `ThemeModePreference`/`ThemeModeController` Android uses, mapped onto `MaterialApp`'s own `themeMode` — no `gsettings`/D-Bus/GNOME/KDE-specific code in Linthra itself, and no separate Linux theme path (`test/app/theme_mode_test.dart` proves that). *Supplying* System's brightness on Linux is Flutter's GTK embedder (via the XDG desktop portal or a GNOME GSettings fallback); that native bridge is outside Linthra's code and isn't exercised by `flutter test`, which runs on the Dart VM and injects brightness straight into Flutter's test `PlatformDispatcher`. Reproducing the real bridge deterministically in CI would need a running portal daemon or GNOME schemas — exactly the DE-specific setup this app avoids adding — so it stays untested here and is a known gap, not a claimed guarantee. |
-| Media session / MPRIS | Supported | `PlatformMediaSessionBinding` routes Linux to `MprisMediaSessionBinding`, which exports `/org/mpris/MediaPlayer2` and owns `org.mpris.MediaPlayer2.linthra` ([issue #397](https://github.com/TheZupZup/Linthra/issues/397)). Shells get PlaybackStatus, Metadata, Position and the transport methods; media keys work through the same interface. `audio_service` is still never initialised on Linux — it stays the Android delegate. A machine with no session bus simply gets no desktop controls. |
+| Media session / MPRIS | Supported | `PlatformMediaSessionBinding` routes Linux to `MprisMediaSessionBinding`, which exports `/org/mpris/MediaPlayer2` and owns `org.mpris.MediaPlayer2.linthra` ([issue #397](https://github.com/TheZupZup/Linthra/issues/397)). Shells get PlaybackStatus, Metadata, Position and the transport methods; media keys work through the same interface. `Volume` is read/write, so a shell's own volume slider drives Linthra's level (and reads zero while muted); `Rate` stays honestly read-only. `audio_service` is still never initialised on Linux — it stays the Android delegate. A machine with no session bus simply gets no desktop controls. |
 | Android Auto | Android-only, by design | It is an Android platform integration, not a Linthra feature. |
 | Media notification + `POST_NOTIFICATIONS` | Android-only, by design | There is no equivalent gate on Linux; desktop controls come from MPRIS instead. Standalone track-change notifications are [issue #400](https://github.com/TheZupZup/Linthra/issues/400). |
 | Android audio focus | Android-only, by design | `JustAudioPlaybackController` already scopes its focus handling to Android/iOS. |
@@ -262,6 +289,7 @@ undeclared network access to an isolated `flatpak-builder` build.
 | Local embedded artwork | Unsupported | Tags are read without pulling cover images out of every file during a scan. Extracting and caching embedded art on desktop is [issue #408](https://github.com/TheZupZup/Linthra/issues/408); tracks keep the placeholder until then. |
 | Chromecast | Android/iOS only | Already gated in `cast_providers.dart`; Linux keeps the honest "cast unavailable" service. |
 | Share sheet, launcher-icon switching | Android-only, by design | No desktop equivalent; the UI simply omits them. |
+| Volume control | Supported | A mute and a slider on Now Playing and the wide mini-player bar, plus MPRIS `Volume`, driven through `PlaybackController` and remembered across launches ([issue #394](https://github.com/TheZupZup/Linthra/issues/394)). See [Volume](#volume). |
 | Desktop layout, keyboard shortcuts | Not started | The existing layout renders in the window and is usable for development. The desktop UX pass is later work in #376. |
 
 Nothing in that table is faked. Each one is an explicit implementation behind an

--- a/lib/app/application_lifecycle.dart
+++ b/lib/app/application_lifecycle.dart
@@ -9,11 +9,13 @@ import '../core/models/subsonic_session.dart';
 import '../core/services/artwork_disk_cache.dart';
 import '../core/services/media_session_binding.dart';
 import '../core/services/playback_session_persistence.dart';
+import '../core/services/playback_volume_persistence.dart';
 import '../core/sources/plex/plex_artwork.dart';
 import '../core/sources/subsonic/subsonic_artwork.dart';
 import '../data/repositories/download_repository_provider.dart';
 import '../data/repositories/favorites_repository_provider.dart';
 import '../data/repositories/music_library_repository_provider.dart';
+import '../data/repositories/playback_preferences_provider.dart';
 import '../data/repositories/playback_session_store_provider.dart';
 import '../data/repositories/playlist_repository_provider.dart';
 import '../data/repositories/remote_cache_index_provider.dart';
@@ -306,6 +308,12 @@ Future<ApplicationHandle> bootstrapApplication(
     // without touching anything the next container owns.
     unawaited(container.read(favoritesRepositoryProvider).refreshFromRemote());
     unawaited(container.read(playlistRepositoryProvider).refreshFromRemote());
+
+    // Desktop volume: come back at the level the listener left, before anything
+    // can play. Never blocks launch, and never restores a mute.
+    final PlaybackVolumePersistence? volumePersistence =
+        container.read(playbackVolumePersistenceProvider);
+    if (volumePersistence != null) await volumePersistence.restore();
 
     // Linux crash-safe restore: rehydrate any persisted logical queue as a
     // paused/resumable state. Never autoplay, and never block launch on a bad

--- a/lib/core/models/playback_state.dart
+++ b/lib/core/models/playback_state.dart
@@ -40,6 +40,8 @@ class PlaybackState {
     this.source,
     this.shuffleEnabled = false,
     this.repeatMode = RepeatMode.off,
+    this.volume = 1.0,
+    this.muted = false,
     this.interruptedByTransientFocus = false,
     this.errorMessage,
   });
@@ -83,6 +85,23 @@ class PlaybackState {
   /// button from; the controller consults it when a track finishes.
   final RepeatMode repeatMode;
 
+  /// The listener's own playback volume, 0.0 (silent) to 1.0 (full).
+  ///
+  /// A controller-owned mode like [shuffleEnabled] and [repeatMode], and the
+  /// *user's* level — not the engine's. What the engine is actually set to also
+  /// folds in ReplayGain normalization and any audio-focus duck, so the two are
+  /// deliberately not the same number: those are automatic attenuations the
+  /// listener never asked for and must not see their slider move for.
+  ///
+  /// Kept out of range by nothing: every writer goes through
+  /// [PlaybackState.sanitizeVolume], so a stored, remote (MPRIS), or arithmetic
+  /// value can never land here out of range or as NaN.
+  final double volume;
+
+  /// Whether playback is muted. Independent of [volume], which keeps the level
+  /// to come back to — so unmute restores exactly what was playing before.
+  final bool muted;
+
   /// Whether playback is paused *only* because another app is holding a
   /// transient audio focus (a call, a navigation prompt, a voice interaction)
   /// and Linthra intends to resume the moment focus comes back.
@@ -105,6 +124,11 @@ class PlaybackState {
   /// only on a freshly built error state and clears on the next state change, so
   /// a stale message can never ride along onto a later playing/paused state.
   final String? errorMessage;
+
+  /// The level actually heard: zero while muted, [volume] otherwise. What a
+  /// volume UI (and MPRIS' `Volume`) should show, so muted always reads as
+  /// silent without losing the level unmute restores.
+  double get effectiveVolume => muted ? 0.0 : volume;
 
   bool get isPlaying => status == PlaybackStatus.playing;
   bool get hasTrack => currentTrack != null;
@@ -138,6 +162,8 @@ class PlaybackState {
     PlaybackSource? source,
     bool? shuffleEnabled,
     RepeatMode? repeatMode,
+    double? volume,
+    bool? muted,
     bool? interruptedByTransientFocus,
   }) {
     return PlaybackState(
@@ -151,6 +177,8 @@ class PlaybackState {
       source: source ?? this.source,
       shuffleEnabled: shuffleEnabled ?? this.shuffleEnabled,
       repeatMode: repeatMode ?? this.repeatMode,
+      volume: volume ?? this.volume,
+      muted: muted ?? this.muted,
       interruptedByTransientFocus:
           interruptedByTransientFocus ?? this.interruptedByTransientFocus,
     );
@@ -175,10 +203,50 @@ class PlaybackState {
       source: source,
       shuffleEnabled: shuffleEnabled,
       repeatMode: repeatMode,
+      volume: volume,
+      muted: muted,
       interruptedByTransientFocus: value,
       errorMessage: errorMessage,
     );
   }
+
+  /// Returns this state carrying [volume] and [muted].
+  ///
+  /// Like [withTransientFocusInterruption] this re-stamps a state the
+  /// controller has already built, so [errorMessage] survives: the volume is
+  /// orthogonal to why playback stopped. Controllers stamp every emission
+  /// through here, so no emit path can publish a stale level — including the
+  /// paths that build a fresh state rather than copying the last one.
+  PlaybackState withVolume({required double volume, required bool muted}) {
+    if (volume == this.volume && muted == this.muted) return this;
+    return PlaybackState(
+      status: status,
+      currentTrack: currentTrack,
+      upNext: upNext,
+      previous: previous,
+      hasPrevious: hasPrevious,
+      position: position,
+      duration: duration,
+      source: source,
+      shuffleEnabled: shuffleEnabled,
+      repeatMode: repeatMode,
+      volume: volume,
+      muted: muted,
+      interruptedByTransientFocus: interruptedByTransientFocus,
+      errorMessage: errorMessage,
+    );
+  }
+
+  /// Forces [value] into the only range a volume may ever hold: 0.0–1.0.
+  ///
+  /// Every path that can produce a volume from outside the app — a persisted
+  /// preference, an MPRIS client, a scroll/keyboard step's arithmetic — goes
+  /// through here, so an out-of-range or non-finite value is corrected at the
+  /// edge instead of reaching the audio engine. A non-finite value has no
+  /// sensible clamp, so it falls back to full volume: the level the app plays
+  /// at with no preference at all.
+  static double sanitizeVolume(double value) =>
+      value.isFinite ? value.clamp(0.0, 1.0) : 1.0;
 
   @override
   bool operator ==(Object other) =>
@@ -194,6 +262,8 @@ class PlaybackState {
           other.source == source &&
           other.shuffleEnabled == shuffleEnabled &&
           other.repeatMode == repeatMode &&
+          other.volume == volume &&
+          other.muted == muted &&
           other.interruptedByTransientFocus == interruptedByTransientFocus &&
           other.errorMessage == errorMessage);
 
@@ -210,6 +280,8 @@ class PlaybackState {
       source,
       shuffleEnabled,
       repeatMode,
+      volume,
+      muted,
       interruptedByTransientFocus,
       errorMessage,
     );

--- a/lib/core/repositories/playback_preferences.dart
+++ b/lib/core/repositories/playback_preferences.dart
@@ -6,10 +6,23 @@
 ///  - "Normalize volume": when on, playback applies a track's ReplayGain so
 ///    songs play at a more even loudness. Off by default — the safe choice, so
 ///    audio is never altered unless the listener opts in.
+///  - The playback volume the desktop controls set, so a window that is closed
+///    and reopened comes back at the level it was left at.
 abstract interface class PlaybackPreferences {
   /// Whether volume normalization (ReplayGain) is applied during playback.
   /// Defaults to `false`, so audio plays untouched out of the box.
   Future<bool> normalizeVolume();
 
   Future<void> setNormalizeVolume(bool value);
+
+  /// The listener's persisted playback volume, 0.0–1.0. Defaults to `1.0` (full
+  /// volume) when nothing has been stored yet.
+  ///
+  /// Implementations sanitize what they read: a missing, out-of-range, or
+  /// otherwise unusable stored value comes back as the default rather than
+  /// reaching the audio engine.
+  Future<double> volume();
+
+  /// Stores [value] as the playback volume, sanitized to 0.0–1.0.
+  Future<void> setVolume(double value);
 }

--- a/lib/core/services/active_playback_controller.dart
+++ b/lib/core/services/active_playback_controller.dart
@@ -236,6 +236,19 @@ class ActivePlaybackController implements PlaybackController {
   @override
   Future<void> stop() => _local.stop();
 
+  // Volume is this *device's* level, so it always goes to the local engine —
+  // even while casting, where it is retained and applied again when the engine
+  // resumes. A receiver's own volume is a different control with a different
+  // scale, owned by the cast sheet (`CastVolumeControls`) through
+  // [CastService]; routing the device slider onto it would leave the phone or
+  // desktop permanently at whatever level the last cast session ended on.
+
+  @override
+  void setVolume(double volume) => _local.setVolume(volume);
+
+  @override
+  void setMuted(bool muted) => _local.setMuted(muted);
+
   // --- Queue commands always go to the local controller (the queue owner) --
   // While casting it is suspended, so these update the current track/up-next
   // without local audio; the cast service mirrors the change onto the receiver.

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -290,6 +290,15 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   // volume whenever a track loads (and immediately when toggled).
   bool _normalizeVolume = false;
 
+  // The listener's own volume and mute, owned here like shuffle and repeat: they
+  // are session-wide modes, not properties of the loaded source, so they survive
+  // track changes, a cast handoff, and a post-suspend reload. They are kept
+  // apart from the engine's level on purpose — normalization and ducking
+  // attenuate what is heard without ever moving the listener's slider — and are
+  // folded together with those in [_engineVolume].
+  double _volume = 1.0;
+  bool _muted = false;
+
   // How many times the current track has been retried after a mid-stream
   // failure. Reset when a fresh track loads and when playback reaches `playing`,
   // so each track (and each successful stretch) gets its own one-retry budget.
@@ -599,9 +608,7 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   /// wins — Linthra can never be left stuck ducked.
   void _enqueueFocusVolume() {
     if (_suspended) return;
-    final double base =
-        volumeFor(_queue.current, normalizeVolume: _normalizeVolume);
-    final double target = _ducked ? base * _duckVolumeFactor : base;
+    final double target = _engineVolume();
     _focusChain = _focusChain.then((_) async {
       try {
         await _player.setVolume(target);
@@ -1069,8 +1076,11 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   void _emit(PlaybackState next, {bool force = false}) {
     // Stamp the foreground focus hold on from one place, so no emit path can
     // publish a state that disagrees with the current hold.
-    final PlaybackState stamped =
-        next.withTransientFocusInterruption(_foregroundHeldForFocus);
+    final PlaybackState stamped = next
+        .withTransientFocusInterruption(_foregroundHeldForFocus)
+        // Stamped from one place like the focus hold, so the paths that build a
+        // fresh state (an error, a restore) can never publish a stale level.
+        .withVolume(volume: _volume, muted: _muted);
     // [force] bypasses the equality guard for a state that differs only in a way
     // PlaybackState == can't see — namely a same-bare-id provider swap, where
     // Track == compares only the bare id (jellyfin:101 == subsonic:101), so the
@@ -1239,6 +1249,36 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     unawaited(_applyVolume());
   }
 
+  @override
+  void setVolume(double volume) {
+    final double next = PlaybackState.sanitizeVolume(volume);
+    // Turning the level up is an unmute: a slider dragged off zero that stayed
+    // silent because a mute flag nobody can see is still set would look broken.
+    final bool nextMuted = _muted && next <= 0.0;
+    if (next == _volume && nextMuted == _muted) return;
+    _volume = next;
+    _muted = nextMuted;
+    _publishVolume();
+  }
+
+  @override
+  void setMuted(bool muted) {
+    if (muted == _muted) return;
+    _muted = muted;
+    // [_volume] is deliberately untouched, so unmute comes back to exactly the
+    // level that was playing.
+    _publishVolume();
+  }
+
+  /// Pushes a volume/mute change to the engine and re-stamps the state so the
+  /// UI (and MPRIS) follow immediately.
+  void _publishVolume() {
+    // Best-effort and silent, like the normalization toggle: a volume tweak must
+    // never surface as a playback error or interrupt audio.
+    unawaited(_applyVolume());
+    _emit(_state);
+  }
+
   /// The engine volume (0.0–1.0) to use for [track] given whether normalization
   /// is on. With it off, or no track loaded, returns 1.0 (full, untouched).
   /// With it on, returns the track's safe ReplayGain multiplier — attenuation
@@ -1249,16 +1289,50 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     return track.replayGain.linearVolume();
   }
 
+  /// What the engine should actually be set to right now: the listener's level
+  /// (zero while muted), attenuated by the current track's ReplayGain when
+  /// normalization is on, and again by the duck factor while another app holds
+  /// a duckable transient focus.
+  ///
+  /// One definition, read by both the load path and the focus chain, so a duck
+  /// landing mid-track and a track loading mid-duck agree on the answer.
+  double _engineVolume() => engineVolumeFor(
+        _queue.current,
+        normalizeVolume: _normalizeVolume,
+        volume: _volume,
+        muted: _muted,
+        ducked: _ducked,
+      );
+
+  /// How the three attenuations compose, as a pure function so the order can be
+  /// asserted without an engine: the track's ReplayGain (when normalization is
+  /// on), the listener's own level (zero while muted), and the duck factor while
+  /// another app holds a duckable transient focus.
+  ///
+  /// They multiply rather than override each other — halving the volume of an
+  /// already-normalized track means half of *that* — and every factor is at
+  /// most 1.0, so the result can never exceed full volume or amplify anything.
+  @visibleForTesting
+  static double engineVolumeFor(
+    Track? track, {
+    required bool normalizeVolume,
+    required double volume,
+    required bool muted,
+    required bool ducked,
+  }) {
+    double level = volumeFor(track, normalizeVolume: normalizeVolume);
+    level *= muted ? 0.0 : volume;
+    // [_restoreDuckedVolume] clears the duck and re-applies the listener's level
+    // on the unduck/regain, so the engine is never left attenuated.
+    if (ducked) level *= _duckVolumeFactor;
+    return level;
+  }
+
   /// Pushes the target volume for the current track onto the engine. A cast
   /// receiver owns its own volume while suspended, so this is a no-op then.
   Future<void> _applyVolume() async {
     if (_suspended) return;
-    double volume =
-        volumeFor(_queue.current, normalizeVolume: _normalizeVolume);
-    // While another app holds a duckable transient focus, attenuate (but keep
-    // playing). [_restoreDuckedVolume] clears the flag and re-applies full
-    // volume on the unduck/regain, so the engine is never left ducked.
-    if (_ducked) volume *= _duckVolumeFactor;
+    final double volume = _engineVolume();
     try {
       await _player.setVolume(volume);
     } catch (_) {

--- a/lib/core/services/mpris/mpris_player_object.dart
+++ b/lib/core/services/mpris/mpris_player_object.dart
@@ -120,7 +120,8 @@ class MprisPlayerObject extends DBusObject {
           DBusIntrospectProperty('Shuffle', DBusSignature('b'),
               access: DBusPropertyAccess.readwrite),
           _readable('Metadata', 'a{sv}'),
-          _readable('Volume', 'd'),
+          DBusIntrospectProperty('Volume', DBusSignature('d'),
+              access: DBusPropertyAccess.readwrite),
           _readable('Position', 'x'),
           _readable('MinimumRate', 'd'),
           _readable('MaximumRate', 'd'),
@@ -373,12 +374,20 @@ class MprisPlayerObject extends DBusObject {
         }
         _controller.setShuffleEnabled((value as DBusBoolean).value);
         return DBusMethodSuccessResponse();
-      case 'Rate':
       case 'Volume':
-        // Both are read/write in the spec and read-only here: Linthra's
-        // playback seam exposes neither a rate nor a volume (desktop volume
-        // control is #394). Saying so is better than accepting a value and
-        // silently not applying it.
+        if (value.signature != DBusSignature('d')) {
+          return DBusMethodErrorResponse.invalidArgs();
+        }
+        // The spec's own advice for a value outside 0.0–1.0 is to clamp it, and
+        // a shell's slider can hand over a hair above 1.0 through floating
+        // point alone. Setting it above zero unmutes, the same as dragging
+        // Linthra's own slider up.
+        _controller.setVolume((value as DBusDouble).value);
+        return DBusMethodSuccessResponse();
+      case 'Rate':
+        // Read/write in the spec and read-only here: Linthra's playback seam
+        // exposes no playback rate. Saying so is better than accepting a value
+        // and silently not applying it.
         return DBusMethodErrorResponse.propertyReadOnly();
       default:
         return DBusMethodErrorResponse.unknownProperty();
@@ -412,7 +421,9 @@ class MprisPlayerObject extends DBusObject {
       'Rate': const DBusDouble(1.0),
       'Shuffle': DBusBoolean(state.shuffleEnabled),
       'Metadata': DBusDict.stringVariant(metadata()),
-      'Volume': const DBusDouble(1.0),
+      // The level actually heard, so a mute in Linthra reads as zero on the bus
+      // rather than as an unchanged slider in the shell.
+      'Volume': DBusDouble(state.effectiveVolume),
       'Position': DBusInt64(state.position.inMicroseconds),
       'MinimumRate': const DBusDouble(1.0),
       'MaximumRate': const DBusDouble(1.0),

--- a/lib/core/services/playback_controller.dart
+++ b/lib/core/services/playback_controller.dart
@@ -74,6 +74,23 @@ abstract interface class PlaybackController {
   /// track finishes; the new mode is reflected in [PlaybackState.repeatMode].
   void setRepeatMode(RepeatMode mode);
 
+  /// Sets the listener's playback volume, 0.0 (silent) to 1.0 (full).
+  ///
+  /// Out-of-range and non-finite values are corrected rather than rejected (see
+  /// [PlaybackState.sanitizeVolume]), so a scroll step's arithmetic or a remote
+  /// control's value can never reach the audio engine unbounded. Raising the
+  /// volume above zero also unmutes, which is what dragging a muted slider up
+  /// obviously means. The new level is reflected in [PlaybackState.volume].
+  ///
+  /// This is the *user's* level, applied on top of whatever the engine is doing
+  /// automatically (ReplayGain normalization, an audio-focus duck) — so those
+  /// never move the slider, and this never undoes them.
+  void setVolume(double volume);
+
+  /// Mutes or unmutes playback, leaving [PlaybackState.volume] untouched so
+  /// unmuting restores exactly the level that was playing before.
+  void setMuted(bool muted);
+
   Future<void> play();
   Future<void> pause();
   Future<void> stop();

--- a/lib/core/services/playback_session_persistence.dart
+++ b/lib/core/services/playback_session_persistence.dart
@@ -119,6 +119,11 @@ class PlaybackSessionPersistence {
     } else {
       _positionTimer?.cancel();
       _positionTimer = null;
+      // Paused, and nothing the *document* holds has moved. A state can change
+      // for reasons this document has no field for — a volume step or a mute,
+      // which emit as fast as a slider drags — and rewriting an identical
+      // session for each of those is a disk write per pointer move.
+      if (_lastPersisted!.position == state.position) return;
       unawaited(_persist(state));
     }
   }

--- a/lib/core/services/playback_volume_persistence.dart
+++ b/lib/core/services/playback_volume_persistence.dart
@@ -41,6 +41,11 @@ class PlaybackVolumePersistence {
   double? _lastSeen;
   bool _disposed = false;
 
+  /// The writes, one after another. Every save joins this chain, so two of them
+  /// can never overlap (and land out of order), and [dispose] has one thing to
+  /// await to know the last level actually reached disk.
+  Future<void> _writes = Future<void>.value();
+
   /// Loads the stored volume and applies it to the controller.
   ///
   /// Best-effort: a store that throws leaves playback at full volume rather
@@ -72,16 +77,20 @@ class PlaybackVolumePersistence {
     });
   }
 
-  Future<void> _persist(double volume) async {
-    try {
-      await _preferences.setVolume(volume);
-    } catch (_) {
-      // Ignore: failing to remember a volume must never break playback.
-    }
+  Future<void> _persist(double volume) {
+    _writes = _writes.then((_) async {
+      try {
+        await _preferences.setVolume(volume);
+      } catch (_) {
+        // Ignore: failing to remember a volume must never break playback.
+      }
+    });
+    return _writes;
   }
 
-  /// Stops listening and flushes a pending save, so a level changed just before
-  /// shutdown is still remembered.
+  /// Stops listening, flushes a pending save, and waits for any write already
+  /// in flight — so a level changed just before shutdown is on disk by the time
+  /// the app is allowed to exit, whether its debounce had fired yet or not.
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;
@@ -91,6 +100,7 @@ class PlaybackVolumePersistence {
     await _subscription?.cancel();
     _subscription = null;
     final double? pending = _lastSeen;
-    if (savePending && pending != null) await _persist(pending);
+    if (savePending && pending != null) unawaited(_persist(pending));
+    await _writes;
   }
 }

--- a/lib/core/services/playback_volume_persistence.dart
+++ b/lib/core/services/playback_volume_persistence.dart
@@ -1,0 +1,96 @@
+import 'dart:async';
+
+import '../models/playback_state.dart';
+import '../repositories/playback_preferences.dart';
+import 'playback_controller.dart';
+
+/// Remembers the desktop volume across launches.
+///
+/// The engine is the source of truth while the app runs (the slider, MPRIS, and
+/// a mute all go through [PlaybackController]), so this listens to the state
+/// stream rather than being written to from the UI: whatever changes the level,
+/// the same value is what gets stored.
+///
+/// Restore is deliberately one-way and sanitized. [PlaybackPreferences] hands
+/// back a level clamped to 0.0–1.0, and this applies it once at startup before
+/// anything can play — so a corrupt or out-of-range stored value can never
+/// reach the audio engine, and a level restored from disk never surprises the
+/// listener mid-track.
+///
+/// Mute is intentionally *not* persisted: coming back to a player that is
+/// silent for a reason nothing on screen explains is the worst version of this
+/// feature. A new launch always starts unmuted at the stored level.
+class PlaybackVolumePersistence {
+  PlaybackVolumePersistence({
+    required PlaybackPreferences preferences,
+    required PlaybackController controller,
+    required Stream<PlaybackState> playbackStates,
+    Duration saveDebounce = const Duration(milliseconds: 500),
+  })  : _preferences = preferences,
+        _controller = controller,
+        _saveDebounce = saveDebounce {
+    _subscription = playbackStates.listen(_onPlaybackState);
+  }
+
+  final PlaybackPreferences _preferences;
+  final PlaybackController _controller;
+  final Duration _saveDebounce;
+
+  StreamSubscription<PlaybackState>? _subscription;
+  Timer? _saveTimer;
+  double? _lastSeen;
+  bool _disposed = false;
+
+  /// Loads the stored volume and applies it to the controller.
+  ///
+  /// Best-effort: a store that throws leaves playback at full volume rather
+  /// than blocking startup.
+  Future<void> restore() async {
+    if (_disposed) return;
+    try {
+      final double stored =
+          PlaybackState.sanitizeVolume(await _preferences.volume());
+      if (_disposed) return;
+      _lastSeen = stored;
+      _controller.setVolume(stored);
+    } catch (_) {
+      // Ignore: a failed restore must never stop the app from launching.
+    }
+  }
+
+  void _onPlaybackState(PlaybackState state) {
+    if (_disposed) return;
+    final double volume = state.volume;
+    if (volume == _lastSeen) return;
+    _lastSeen = volume;
+    // Debounced: a drag emits a state per pointer move, and each write is a
+    // disk touch. The last value in a burst is the one worth keeping.
+    _saveTimer?.cancel();
+    _saveTimer = Timer(_saveDebounce, () {
+      _saveTimer = null;
+      unawaited(_persist(volume));
+    });
+  }
+
+  Future<void> _persist(double volume) async {
+    try {
+      await _preferences.setVolume(volume);
+    } catch (_) {
+      // Ignore: failing to remember a volume must never break playback.
+    }
+  }
+
+  /// Stops listening and flushes a pending save, so a level changed just before
+  /// shutdown is still remembered.
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    final bool savePending = _saveTimer != null;
+    _saveTimer?.cancel();
+    _saveTimer = null;
+    await _subscription?.cancel();
+    _subscription = null;
+    final double? pending = _lastSeen;
+    if (savePending && pending != null) await _persist(pending);
+  }
+}

--- a/lib/core/services/unsupported_playback_controller.dart
+++ b/lib/core/services/unsupported_playback_controller.dart
@@ -39,6 +39,8 @@ class UnsupportedPlaybackController implements LocalPlaybackController {
       StreamController<PlaybackState>.broadcast();
 
   PlaybackState _state = PlaybackState.idle;
+  double _volume = 1.0;
+  bool _muted = false;
   bool _disposed = false;
 
   @override
@@ -64,8 +66,14 @@ class UnsupportedPlaybackController implements LocalPlaybackController {
 
   void _emit(PlaybackState next) {
     if (_disposed) return;
-    _state = next;
-    _states.add(next);
+    // Stamped from one place, like the real engine's emit, so every path here
+    // (including the refusals, which build a state from scratch) publishes the
+    // listener's current level.
+    final PlaybackState stamped =
+        next.withVolume(volume: _volume, muted: _muted);
+    if (identical(stamped, _state)) return;
+    _state = stamped;
+    _states.add(stamped);
   }
 
   @override
@@ -131,6 +139,28 @@ class UnsupportedPlaybackController implements LocalPlaybackController {
       shuffleEnabled: _state.shuffleEnabled,
       repeatMode: mode,
     ));
+  }
+
+  // The listener's volume is real state even here: there is no engine to apply
+  // it to, but remembering it (and reflecting it in the emitted state) keeps the
+  // contract honest and means a host that later grows an engine starts at the
+  // level the user chose rather than at full volume.
+
+  @override
+  void setVolume(double volume) {
+    final double next = PlaybackState.sanitizeVolume(volume);
+    final bool nextMuted = _muted && next <= 0.0;
+    if (next == _volume && nextMuted == _muted) return;
+    _volume = next;
+    _muted = nextMuted;
+    _emit(_state);
+  }
+
+  @override
+  void setMuted(bool muted) {
+    if (muted == _muted) return;
+    _muted = muted;
+    _emit(_state);
   }
 
   @override

--- a/lib/data/repositories/in_memory_playback_preferences.dart
+++ b/lib/data/repositories/in_memory_playback_preferences.dart
@@ -1,11 +1,15 @@
+import '../../core/models/playback_state.dart';
 import '../../core/repositories/playback_preferences.dart';
 
 /// A non-persistent [PlaybackPreferences] for development and tests.
 class InMemoryPlaybackPreferences implements PlaybackPreferences {
-  InMemoryPlaybackPreferences({bool normalizeVolume = false})
-      : _normalizeVolume = normalizeVolume;
+  InMemoryPlaybackPreferences(
+      {bool normalizeVolume = false, double volume = 1.0})
+      : _normalizeVolume = normalizeVolume,
+        _volume = PlaybackState.sanitizeVolume(volume);
 
   bool _normalizeVolume;
+  double _volume;
 
   @override
   Future<bool> normalizeVolume() async => _normalizeVolume;
@@ -13,5 +17,13 @@ class InMemoryPlaybackPreferences implements PlaybackPreferences {
   @override
   Future<void> setNormalizeVolume(bool value) async {
     _normalizeVolume = value;
+  }
+
+  @override
+  Future<double> volume() async => _volume;
+
+  @override
+  Future<void> setVolume(double value) async {
+    _volume = PlaybackState.sanitizeVolume(value);
   }
 }

--- a/lib/data/repositories/playback_preferences_provider.dart
+++ b/lib/data/repositories/playback_preferences_provider.dart
@@ -1,12 +1,17 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/lifecycle/async_disposal_registry.dart';
 import '../../core/repositories/playback_preferences.dart';
+import '../../core/services/playback_volume_persistence.dart';
+import '../../features/player/player_providers.dart';
+import 'host_platform_provider.dart';
 import 'in_memory_playback_preferences.dart';
 import 'shared_preferences_playback_preferences.dart';
 
-/// The user's playback preferences (currently "Normalize volume"). In-memory by
-/// default so tests and dev runs need no plugins; the app persists them via
-/// `shared_preferences` through [sharedPreferencesPlaybackPreferencesOverride].
+/// The user's playback preferences ("Normalize volume" and the desktop playback
+/// volume). In-memory by default so tests and dev runs need no plugins; the app
+/// persists them via `shared_preferences` through
+/// [sharedPreferencesPlaybackPreferencesOverride].
 final playbackPreferencesProvider = Provider<PlaybackPreferences>((ref) {
   return InMemoryPlaybackPreferences();
 });
@@ -15,3 +20,25 @@ final sharedPreferencesPlaybackPreferencesOverride =
     playbackPreferencesProvider.overrideWithValue(
   const SharedPreferencesPlaybackPreferences(),
 );
+
+/// Remembers the playback volume across launches, and restores it at startup.
+///
+/// Desktop only, because the volume controls are: a phone's volume is the
+/// system's, set with its hardware keys, so Android and iOS keep playing at the
+/// engine's full level exactly as before. Returns `null` elsewhere.
+/// Side-effect only; `main` instantiates it once and awaits
+/// [PlaybackVolumePersistence.restore].
+final playbackVolumePersistenceProvider =
+    Provider<PlaybackVolumePersistence?>((ref) {
+  if (!ref.watch(hostPlatformProvider).isDesktop) return null;
+
+  final PlaybackVolumePersistence service = PlaybackVolumePersistence(
+    preferences: ref.watch(playbackPreferencesProvider),
+    // The routing controller, so a level set while casting is still stored and
+    // restored — it is the device's own volume either way.
+    controller: ref.read(playbackControllerProvider),
+    playbackStates: ref.read(playbackControllerProvider).stateStream,
+  );
+  ref.onDisposeAsync(service.dispose);
+  return service;
+});

--- a/lib/data/repositories/shared_preferences_playback_preferences.dart
+++ b/lib/data/repositories/shared_preferences_playback_preferences.dart
@@ -1,14 +1,16 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../core/models/playback_state.dart';
 import '../../core/repositories/playback_preferences.dart';
 
-/// A [PlaybackPreferences] backed by `shared_preferences`. The single choice is
-/// a small bool, so it lives next to the other small user choices in the
+/// A [PlaybackPreferences] backed by `shared_preferences`. Both choices are
+/// small scalars, so they live next to the other small user choices in the
 /// key/value store rather than in the SQLite catalog.
 class SharedPreferencesPlaybackPreferences implements PlaybackPreferences {
   const SharedPreferencesPlaybackPreferences();
 
   static const String _normalizeVolumeKey = 'playback_normalize_volume';
+  static const String _volumeKey = 'playback_volume';
 
   @override
   Future<bool> normalizeVolume() async {
@@ -21,5 +23,22 @@ class SharedPreferencesPlaybackPreferences implements PlaybackPreferences {
   Future<void> setNormalizeVolume(bool value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_normalizeVolumeKey, value);
+  }
+
+  @override
+  Future<double> volume() async {
+    final prefs = await SharedPreferences.getInstance();
+    // Sanitized on the way out, not trusted: the store is a plain file a user
+    // (or a future bug) can leave a 7.5, a -1, or a NaN in, and an unbounded
+    // value must never reach the audio engine. Nothing stored means full
+    // volume, the level the app has always played at.
+    final double? stored = prefs.getDouble(_volumeKey);
+    return stored == null ? 1.0 : PlaybackState.sanitizeVolume(stored);
+  }
+
+  @override
+  Future<void> setVolume(double value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(_volumeKey, PlaybackState.sanitizeVolume(value));
   }
 }

--- a/lib/features/player/mini_player.dart
+++ b/lib/features/player/mini_player.dart
@@ -11,12 +11,14 @@ import '../../core/models/playback_state.dart';
 import '../../core/models/track.dart';
 import '../../core/services/playback_source_label.dart';
 import '../../data/repositories/favorites_repository_provider.dart';
+import '../../data/repositories/host_platform_provider.dart';
 import '../../shared/widgets/wavy_progress_indicator.dart';
 import 'cast/cast_providers.dart';
 import 'favorites_providers.dart';
 import 'player_providers.dart';
 import 'widgets/album_artwork.dart';
 import 'widgets/queue_sheet.dart';
+import 'widgets/volume_controls.dart';
 
 /// A compact, persistent now-playing bar shown above the bottom navigation on
 /// every main screen (Library / Folders / Playlists / Downloads / Settings).
@@ -49,6 +51,10 @@ class MiniPlayer extends ConsumerWidget {
   /// can give up the space the previous/next buttons and the queue button need.
   static const double _transportBreakpoint = 600;
 
+  /// The volume control asks for another ~140px beside the queue button, so it
+  /// waits for a bar wide enough to give it without squeezing the title.
+  static const double _volumeBreakpoint = 840;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     // Watch only the current track (id-distinct) and its resolved source, so the
@@ -76,6 +82,7 @@ class MiniPlayer extends ConsumerWidget {
     final bool isCasting = ref.watch(
       castStateProvider.select((s) => s.valueOrNull?.isConnected ?? false),
     );
+    final bool isDesktop = ref.watch(hostPlatformProvider).isDesktop;
     final subtitle = _subtitle(track);
     // The copy actually playing (Navidrome / Jellyfin / Local music / Cache),
     // shown as a faint tag beside the metadata. Hidden while casting, where the
@@ -113,6 +120,15 @@ class MiniPlayer extends ConsumerWidget {
                         isCasting: isCasting,
                       );
 
+                      // Desktop bars wide enough for the full transport also
+                      // get the volume control, where a desktop listener looks
+                      // for it first. Hidden while casting: the level that
+                      // matters then is the receiver's, which the cast sheet
+                      // owns.
+                      final bool showVolume = isDesktop &&
+                          !isCasting &&
+                          constraints.maxWidth >= _volumeBreakpoint;
+
                       if (constraints.maxWidth >= _transportBreakpoint) {
                         // Two equally weighted side columns, so the transport
                         // sits on the window's centre line rather than
@@ -125,10 +141,17 @@ class MiniPlayer extends ConsumerWidget {
                               showFavorite: true,
                               showSkip: true,
                             ),
-                            const Expanded(
+                            Expanded(
                               child: Align(
                                 alignment: AlignmentDirectional.centerEnd,
-                                child: _QueueButton(),
+                                child: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: <Widget>[
+                                    if (showVolume)
+                                      const VolumeControls(),
+                                    const _QueueButton(),
+                                  ],
+                                ),
                               ),
                             ),
                           ],

--- a/lib/features/player/mini_player.dart
+++ b/lib/features/player/mini_player.dart
@@ -147,8 +147,7 @@ class MiniPlayer extends ConsumerWidget {
                                 child: Row(
                                   mainAxisSize: MainAxisSize.min,
                                   children: <Widget>[
-                                    if (showVolume)
-                                      const VolumeControls(),
+                                    if (showVolume) const VolumeControls(),
                                     const _QueueButton(),
                                   ],
                                 ),

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../app/dimens.dart';
 import '../../core/models/playback_state.dart';
 import '../../core/models/track.dart';
+import '../../data/repositories/host_platform_provider.dart';
 import '../../shared/layout/adaptive_layout.dart';
 import '../../shared/widgets/empty_state.dart';
 import 'cast/cast_button.dart';
@@ -19,6 +20,7 @@ import 'widgets/now_playing_background.dart';
 import 'widgets/playback_controls.dart';
 import 'widgets/playback_progress_bar.dart';
 import 'widgets/track_metadata.dart';
+import 'widgets/volume_controls.dart';
 
 /// Full-screen now-playing view. Renders from [playbackStateProvider] and drives
 /// playback through the [PlaybackController]; it never touches the audio engine,
@@ -201,7 +203,7 @@ class _NowPlayingState extends State<_NowPlaying> {
                   const SizedBox(height: AppSpacing.lg),
                   const _LiveControls(),
                   const SizedBox(height: AppSpacing.md),
-                  NowPlayingActions(
+                  _ActionsBar(
                     track: track,
                     lyricsVisible: _showLyrics,
                     onToggleLyrics: _toggleLyrics,
@@ -252,12 +254,70 @@ class _NowPlayingState extends State<_NowPlaying> {
         // never further away for reading lyrics.
         const _LiveControls(),
         const SizedBox(height: AppSpacing.md),
-        NowPlayingActions(
+        _ActionsBar(
           track: track,
           lyricsVisible: _showLyrics,
           onToggleLyrics: _toggleLyrics,
         ),
       ],
+    );
+  }
+}
+
+/// The action row, plus the desktop volume control beside it.
+///
+/// They share one band on purpose: volume is a secondary control here (the
+/// transport above it is what the screen is for), and giving it a row of its own
+/// would take height from the artwork and the lyrics — which a short window at a
+/// large text scale does not have to spare.
+///
+/// The control is desktop-only: a phone's volume is the system's, set with its
+/// hardware keys, so mobile keeps exactly the row it had. It also steps aside
+/// while casting, where the level that matters belongs to the receiver and the
+/// cast sheet already owns it, and on a desktop window too narrow to hold both
+/// it and the five actions — a slider squeezing the queue button off the edge
+/// is worse than no slider.
+class _ActionsBar extends ConsumerWidget {
+  /// The narrowest band that holds the five actions and the volume control
+  /// without squeezing either. Measured against the band itself, not the
+  /// window: in the two-column layout this row lives in the narrower half.
+  static const double _volumeBandMinWidth = 460;
+
+  const _ActionsBar({
+    required this.track,
+    required this.lyricsVisible,
+    required this.onToggleLyrics,
+  });
+
+  final Track track;
+  final bool lyricsVisible;
+  final VoidCallback onToggleLyrics;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final Widget actions = NowPlayingActions(
+      track: track,
+      lyricsVisible: lyricsVisible,
+      onToggleLyrics: onToggleLyrics,
+    );
+    // Falls back to the service's own state until the first stream event, the
+    // same way the source/casting line does.
+    final bool casting = ref.watch(
+          castStateProvider.select((s) => s.valueOrNull?.isConnected),
+        ) ??
+        ref.watch(castServiceProvider).state.isConnected;
+    if (casting || !ref.watch(hostPlatformProvider).isDesktop) return actions;
+
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        if (constraints.maxWidth < _volumeBandMinWidth) return actions;
+        return Row(
+          children: <Widget>[
+            Expanded(child: actions),
+            const VolumeControls(),
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/features/player/widgets/volume_controls.dart
+++ b/lib/features/player/widgets/volume_controls.dart
@@ -114,16 +114,24 @@ class _VolumeControlsState extends ConsumerState<VolumeControls> {
             // Wide enough to aim at a level, narrow enough to share a row with
             // the controls it sits beside.
             width: 120,
-            child: Slider(
-              value: sliderValue,
-              onChanged: _onChanged,
-              onChangeEnd: _onChangeEnd,
-              // Names the slider for anyone who lands on it directly.
-              // Semantics only: the value indicator `label` can also drive is
-              // shown `onlyForDiscrete`, and this slider is continuous.
-              label: 'Volume',
-              semanticFormatterCallback: (double value) =>
-                  '${(value * 100).round()}%',
+            // Merged, not just wrapped: a `Semantics` label alone sits on its
+            // own node above the slider's, so a screen reader landing on the
+            // slider hears "70%" with nothing saying of what — next to a
+            // position slider on the same screen, that is unusable. Merging
+            // puts the name on the same node as the value and the
+            // increase/decrease actions. (`Slider.label` is not this: it drives
+            // the visual value indicator, and only for discrete sliders.)
+            child: MergeSemantics(
+              child: Semantics(
+                label: 'Volume',
+                child: Slider(
+                  value: sliderValue,
+                  onChanged: _onChanged,
+                  onChangeEnd: _onChangeEnd,
+                  semanticFormatterCallback: (double value) =>
+                      '${(value * 100).round()}%',
+                ),
+              ),
             ),
           ),
         ],

--- a/lib/features/player/widgets/volume_controls.dart
+++ b/lib/features/player/widgets/volume_controls.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/models/playback_state.dart';
+import '../../../core/services/playback_controller.dart';
+import '../player_providers.dart';
+
+/// How far one scroll notch moves the level. Small enough to fine-tune, large
+/// enough that a few notches cross the range — the step desktop mixers settle
+/// on. (Arrow keys are the Slider's own 10% step, not this one.)
+const double volumeStep = 0.05;
+
+/// The desktop volume control: mute/unmute plus a slider, driven entirely
+/// through the [PlaybackController].
+///
+/// It reads the level from [PlaybackState] rather than keeping its own, so the
+/// UI can never drift from what is actually playing: a change made anywhere
+/// else — the other copy of this widget, a shell's MPRIS slider, a restored
+/// preference at startup — moves this slider too. The only local state is the
+/// in-progress drag, so a state event mid-gesture doesn't fight the pointer.
+///
+/// Desktop only by placement, not by check: the phone layouts don't build it,
+/// because a phone's volume is the system's and belongs to its hardware keys.
+/// It sizes itself to sit in a row of icon buttons — the Now Playing action row
+/// and the mini-player bar both host it that way — so callers add their own
+/// spacing rather than working around padding baked in here.
+class VolumeControls extends ConsumerStatefulWidget {
+  const VolumeControls({super.key});
+
+  @override
+  ConsumerState<VolumeControls> createState() => _VolumeControlsState();
+}
+
+class _VolumeControlsState extends ConsumerState<VolumeControls> {
+  /// The level being dragged right now, or null when the pointer is not down.
+  double? _dragValue;
+
+  PlaybackController get _controller => ref.read(playbackControllerProvider);
+
+  void _onChanged(double value) {
+    // Applied live rather than on release: a volume slider that only takes
+    // effect when you let go gives no feedback while you are choosing a level.
+    // (It is also what makes arrow-key adjustment work — the Slider's keyboard
+    // actions call onChanged and never onChangeEnd.)
+    setState(() => _dragValue = value);
+    _controller.setVolume(value);
+  }
+
+  void _onChangeEnd(double value) {
+    _controller.setVolume(value);
+    setState(() => _dragValue = null);
+  }
+
+  /// Scroll wheel over the control: up is louder, down is quieter.
+  void _onPointerSignal(
+    PointerSignalEvent event, {
+    required double volume,
+    required bool muted,
+  }) {
+    if (event is! PointerScrollEvent) return;
+    // Both axes count: a horizontal wheel or a trackpad's sideways flick over a
+    // horizontal slider means the same thing as a vertical one.
+    final double delta = event.scrollDelta.dy != 0
+        ? -event.scrollDelta.dy
+        : -event.scrollDelta.dx;
+    if (delta == 0) return;
+    final bool louder = delta > 0;
+    // Scrolling down while muted is already what it asks for. Ignoring it keeps
+    // the level mute has to come back to, instead of quietly grinding it to
+    // zero behind a muted icon.
+    if (muted && !louder) return;
+    // Muted, scrolling up: step off the silence rather than off the remembered
+    // level, so one notch is one notch of what you can hear.
+    final double current = muted ? 0.0 : volume;
+    _controller.setVolume(current + (louder ? volumeStep : -volumeStep));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final PlaybackController controller = ref.watch(playbackControllerProvider);
+    final ({double volume, bool muted}) level = ref.watch(
+      playbackStateProvider.select((AsyncValue<PlaybackState> async) {
+        final PlaybackState state = async.valueOrNull ?? controller.state;
+        return (volume: state.volume, muted: state.muted);
+      }),
+    );
+
+    final double effective = level.muted ? 0.0 : level.volume;
+    final double sliderValue = _dragValue ?? effective;
+    final bool silent = effective <= 0.0;
+
+    return Listener(
+      onPointerSignal: (PointerSignalEvent event) => _onPointerSignal(
+        event,
+        volume: level.volume,
+        muted: level.muted,
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          IconButton(
+            onPressed: () => controller.setMuted(!level.muted),
+            icon: Icon(_iconFor(silent: silent, volume: effective)),
+            // Selected while muted, so mute reads as the toggle it is rather
+            // than as two buttons that swap places.
+            isSelected: level.muted,
+            iconSize: 22,
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+            tooltip: level.muted ? 'Unmute' : 'Mute',
+          ),
+          SizedBox(
+            // Wide enough to aim at a level, narrow enough to share a row with
+            // the controls it sits beside.
+            width: 120,
+            child: Slider(
+              value: sliderValue,
+              onChanged: _onChanged,
+              onChangeEnd: _onChangeEnd,
+              // Names the slider for anyone who lands on it directly.
+              // Semantics only: the value indicator `label` can also drive is
+              // shown `onlyForDiscrete`, and this slider is continuous.
+              label: 'Volume',
+              semanticFormatterCallback: (double value) =>
+                  '${(value * 100).round()}%',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// The glyph for the current level: an explicit "off" while silent (muted or
+  /// dragged to zero, which sound the same), and a quieter speaker below
+  /// halfway so the icon carries the level as well as the state.
+  static IconData _iconFor({required bool silent, required double volume}) {
+    if (silent) return Icons.volume_off;
+    if (volume < 0.5) return Icons.volume_down;
+    return Icons.volume_up;
+  }
+}

--- a/test/core/services/active_playback_controller_test.dart
+++ b/test/core/services/active_playback_controller_test.dart
@@ -485,4 +485,50 @@ void main() {
       expect(controller.state.currentTrack, _trackB);
     });
   });
+
+  group('volume', () {
+    test('goes to the device engine and shows up in the merged state',
+        () async {
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      controller.setVolume(0.35);
+      await _waitFor(controller, (PlaybackState s) => s.volume == 0.35);
+
+      expect(local.state.volume, 0.35);
+      expect(controller.state.volume, 0.35);
+    });
+
+    test('a mute is the device\'s, and unmute restores the level', () async {
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      controller.setVolume(0.5);
+      controller.setMuted(true);
+      await _waitFor(controller, (PlaybackState s) => s.muted);
+      expect(controller.state.effectiveVolume, 0.0);
+
+      controller.setMuted(false);
+      await _waitFor(controller, (PlaybackState s) => !s.muted);
+      expect(controller.state.effectiveVolume, 0.5);
+    });
+
+    test('while casting it still sets the device level, not the receiver\'s',
+        () async {
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      cast.emit(_casting());
+      await _waitFor(controller,
+          (_) => controller.activeOutput == ActivePlaybackOutput.cast);
+
+      controller.setVolume(0.2);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      // The engine keeps the level for when it takes over again; the receiver's
+      // own volume is the cast sheet's control, not this one.
+      expect(local.state.volume, 0.2);
+      expect(controller.state.volume, 0.2);
+    });
+  });
 }

--- a/test/core/services/mpris/mpris_player_object_test.dart
+++ b/test/core/services/mpris/mpris_player_object_test.dart
@@ -491,19 +491,75 @@ void main() {
       expect(controller.state.repeatMode, RepeatMode.off);
     });
 
-    test('Volume and Rate say they are read-only rather than lying', () async {
-      // Linthra's playback seam has neither, so accepting a value and not
-      // applying it would leave a shell's volume slider permanently wrong.
-      expect(
-        await object.setProperty(
-            MprisPlayerObject.playerInterface, 'Volume', const DBusDouble(0.5)),
-        isA<DBusMethodErrorResponse>(),
-      );
+    test('Rate says it is read-only rather than lying', () async {
+      // Linthra's playback seam has no playback rate, so accepting a value and
+      // not applying it would leave a shell's control permanently wrong.
       expect(
         await object.setProperty(
             MprisPlayerObject.playerInterface, 'Rate', const DBusDouble(2)),
         isA<DBusMethodErrorResponse>(),
       );
+    });
+
+    test('Volume reports the level actually heard', () {
+      expect(property('Volume'), const DBusDouble(1.0));
+
+      controller.setVolume(0.4);
+      expect(property('Volume'), const DBusDouble(0.4));
+
+      // Muted reads as silent on the bus, without losing the stored level.
+      controller.setMuted(true);
+      expect(property('Volume'), const DBusDouble(0.0));
+
+      controller.setMuted(false);
+      expect(property('Volume'), const DBusDouble(0.4));
+    });
+
+    test('setting Volume from the bus changes playback', () async {
+      expect(
+        await object.setProperty(MprisPlayerObject.playerInterface, 'Volume',
+            const DBusDouble(0.25)),
+        isA<DBusMethodSuccessResponse>(),
+      );
+
+      expect(controller.state.volume, 0.25);
+      expect(property('Volume'), const DBusDouble(0.25));
+    });
+
+    test('a Volume outside the spec range is clamped, not refused', () async {
+      expect(
+        await object.setProperty(
+            MprisPlayerObject.playerInterface, 'Volume', const DBusDouble(1.4)),
+        isA<DBusMethodSuccessResponse>(),
+      );
+      expect(controller.state.volume, 1.0);
+
+      expect(
+        await object.setProperty(
+            MprisPlayerObject.playerInterface, 'Volume', const DBusDouble(-2)),
+        isA<DBusMethodSuccessResponse>(),
+      );
+      expect(controller.state.volume, 0.0);
+    });
+
+    test('setting Volume above zero unmutes', () async {
+      controller.setVolume(0.6);
+      controller.setMuted(true);
+
+      await object.setProperty(
+          MprisPlayerObject.playerInterface, 'Volume', const DBusDouble(0.3));
+
+      expect(controller.state.muted, isFalse);
+      expect(controller.state.volume, 0.3);
+    });
+
+    test('a Volume of the wrong type is refused', () async {
+      expect(
+        await object.setProperty(MprisPlayerObject.playerInterface, 'Volume',
+            const DBusString('loud')),
+        isA<DBusMethodErrorResponse>(),
+      );
+      expect(controller.state.volume, 1.0);
     });
   });
 

--- a/test/core/services/playback_controller_volume_test.dart
+++ b/test/core/services/playback_controller_volume_test.dart
@@ -1,9 +1,44 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/models/replay_gain.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/services/just_audio_playback_controller.dart';
 
+/// A channel-free engine that records the volumes the controller pushes, so the
+/// listener's level can be checked where it actually lands.
+class _RecordingPlayer extends Fake implements AudioPlayer {
+  final List<double> volumes = <double>[];
+
+  @override
+  Stream<PlayerState> get playerStateStream =>
+      const Stream<PlayerState>.empty();
+  @override
+  Stream<Duration> get positionStream => const Stream<Duration>.empty();
+  @override
+  Stream<Duration?> get durationStream => const Stream<Duration?>.empty();
+  @override
+  Stream<PlaybackEvent> get playbackEventStream =>
+      const Stream<PlaybackEvent>.empty();
+
+  @override
+  Future<void> setVolume(double volume) async => volumes.add(volume);
+  @override
+  Future<void> play() async {}
+  @override
+  Future<void> pause() async {}
+  @override
+  Future<void> stop() async {}
+  @override
+  Future<void> dispose() async {}
+}
+
+/// Flushes the unawaited `setVolume` the controller fires.
+Future<void> _settle() => Future<void>.delayed(Duration.zero);
+
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   Track track({ReplayGain gain = ReplayGain.none}) =>
       Track(id: 't', title: 'T', uri: 'file:///t.flac', replayGain: gain);
 
@@ -44,6 +79,209 @@ void main() {
         JustAudioPlaybackController.volumeFor(quiet, normalizeVolume: true),
         1.0,
       );
+    });
+  });
+
+  group('JustAudioPlaybackController volume and mute', () {
+    ({JustAudioPlaybackController controller, _RecordingPlayer player})
+        build() {
+      final _RecordingPlayer player = _RecordingPlayer();
+      final JustAudioPlaybackController controller =
+          JustAudioPlaybackController(player: player);
+      addTearDown(controller.dispose);
+      return (controller: controller, player: player);
+    }
+
+    test('starts at full volume, unmuted', () {
+      final built = build();
+
+      expect(built.controller.state.volume, 1.0);
+      expect(built.controller.state.muted, isFalse);
+      expect(built.controller.state.effectiveVolume, 1.0);
+    });
+
+    test('setVolume reaches the engine and the emitted state', () async {
+      final built = build();
+
+      final List<double> emitted = <double>[];
+      final sub =
+          built.controller.stateStream.listen((s) => emitted.add(s.volume));
+
+      built.controller.setVolume(0.25);
+      await _settle();
+
+      expect(built.controller.state.volume, 0.25);
+      expect(built.player.volumes.last, 0.25);
+      expect(emitted, contains(0.25));
+      await sub.cancel();
+    });
+
+    test('a volume outside 0-1 is clamped, never passed on', () async {
+      final built = build();
+
+      // From half volume, so a clamped value is a real change the engine sees.
+      built.controller.setVolume(0.5);
+      await _settle();
+
+      built.controller.setVolume(4.2);
+      await _settle();
+      expect(built.controller.state.volume, 1.0);
+      expect(built.player.volumes.last, 1.0);
+
+      built.controller.setVolume(-3);
+      await _settle();
+      expect(built.controller.state.volume, 0.0);
+      expect(built.player.volumes.last, 0.0);
+    });
+
+    test(
+        'a non-finite volume falls back to full rather than reaching the '
+        'engine', () async {
+      final built = build();
+
+      built.controller.setVolume(double.nan);
+      await _settle();
+
+      expect(built.controller.state.volume, 1.0);
+      expect(built.player.volumes, everyElement(isNot(isNaN)));
+    });
+
+    test('a redundant setVolume does not emit', () async {
+      final built = build();
+
+      var emissions = 0;
+      final sub = built.controller.stateStream.listen((_) => emissions++);
+
+      built.controller.setVolume(1.0); // already full
+      await _settle();
+
+      expect(emissions, 0);
+      await sub.cancel();
+    });
+
+    test('mute silences the engine and unmute restores the same level',
+        () async {
+      final built = build();
+
+      built.controller.setVolume(0.4);
+      await _settle();
+
+      built.controller.setMuted(true);
+      await _settle();
+      expect(built.player.volumes.last, 0.0);
+      expect(built.controller.state.muted, isTrue);
+      // The level is kept, not overwritten by the mute.
+      expect(built.controller.state.volume, 0.4);
+      expect(built.controller.state.effectiveVolume, 0.0);
+
+      built.controller.setMuted(false);
+      await _settle();
+      expect(built.player.volumes.last, 0.4);
+      expect(built.controller.state.effectiveVolume, 0.4);
+    });
+
+    test('raising the volume while muted unmutes', () async {
+      final built = build();
+
+      built.controller.setVolume(0.8);
+      built.controller.setMuted(true);
+      await _settle();
+
+      built.controller.setVolume(0.3);
+      await _settle();
+
+      expect(built.controller.state.muted, isFalse);
+      expect(built.player.volumes.last, 0.3);
+    });
+
+    test('setting the volume to zero leaves the mute flag alone', () async {
+      final built = build();
+
+      built.controller.setMuted(true);
+      built.controller.setVolume(0);
+      await _settle();
+
+      expect(built.controller.state.muted, isTrue,
+          reason: 'zero is already silent; it is not an unmute');
+    });
+
+    test('the listener level reaches the engine on its own', () async {
+      final built = build();
+
+      built.controller.setVolume(0.5);
+      await _settle();
+
+      expect(built.player.volumes.last, 0.5);
+    });
+  });
+
+  group('JustAudioPlaybackController.engineVolumeFor', () {
+    double engine(
+      Track? t, {
+      bool normalizeVolume = false,
+      double volume = 1.0,
+      bool muted = false,
+      bool ducked = false,
+    }) =>
+        JustAudioPlaybackController.engineVolumeFor(
+          t,
+          normalizeVolume: normalizeVolume,
+          volume: volume,
+          muted: muted,
+          ducked: ducked,
+        );
+
+    test('full volume with nothing attenuating', () {
+      expect(engine(track()), 1.0);
+    });
+
+    test('the listener level and ReplayGain multiply', () {
+      final loud = track(gain: const ReplayGain(trackGainDb: -6.0));
+      final double normalized =
+          JustAudioPlaybackController.volumeFor(loud, normalizeVolume: true);
+
+      expect(
+        engine(loud, normalizeVolume: true, volume: 0.5),
+        closeTo(normalized * 0.5, 0.0001),
+      );
+    });
+
+    test('mute silences whatever else is applied', () {
+      final loud = track(gain: const ReplayGain(trackGainDb: -6.0));
+
+      expect(
+          engine(loud, normalizeVolume: true, volume: 0.8, muted: true), 0.0);
+    });
+
+    test('a duck attenuates the listener level without replacing it', () {
+      final double ducked = engine(track(), volume: 0.6, ducked: true);
+
+      expect(ducked, lessThan(0.6),
+          reason: 'a duck lowers whatever the listener chose');
+      expect(ducked, greaterThan(0.0),
+          reason: 'ducking stays audible, it never silences');
+    });
+
+    test('never exceeds full volume', () {
+      final quiet = track(gain: const ReplayGain(trackGainDb: 6.0));
+
+      expect(engine(quiet, normalizeVolume: true), lessThanOrEqualTo(1.0));
+    });
+  });
+
+  group('PlaybackState.sanitizeVolume', () {
+    test('passes an in-range level through', () {
+      expect(PlaybackState.sanitizeVolume(0.35), 0.35);
+    });
+
+    test('clamps out-of-range levels', () {
+      expect(PlaybackState.sanitizeVolume(1.5), 1.0);
+      expect(PlaybackState.sanitizeVolume(-0.5), 0.0);
+    });
+
+    test('falls back to full volume for a non-finite level', () {
+      expect(PlaybackState.sanitizeVolume(double.nan), 1.0);
+      expect(PlaybackState.sanitizeVolume(double.infinity), 1.0);
     });
   });
 }

--- a/test/core/services/playback_session_persistence_test.dart
+++ b/test/core/services/playback_session_persistence_test.dart
@@ -188,11 +188,69 @@ void main() {
       await persistence.dispose();
       await controller.dispose();
     });
+    test('a volume-only change on a paused track writes nothing', () async {
+      // The session document has no volume or mute field, so re-saving it for
+      // a slider step would be a disk write per pointer move.
+      final _CountingStore store = _CountingStore();
+      final FakePlaybackController controller = FakePlaybackController();
+      final PlaybackSessionPersistence persistence = PlaybackSessionPersistence(
+        store: store,
+        controller: controller,
+        playbackStates: controller.stateStream,
+        localFileExists: (_) => true,
+        positionSaveInterval: Duration.zero,
+      );
+      addTearDown(persistence.dispose);
+      addTearDown(controller.dispose);
+
+      controller.emit(const PlaybackState(
+        status: PlaybackStatus.paused,
+        currentTrack: remote,
+        position: Duration(seconds: 12),
+        duration: Duration(minutes: 3),
+      ));
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+      final int afterFirst = store.saves;
+      expect(afterFirst, greaterThan(0));
+
+      controller.setVolume(0.6);
+      controller.setVolume(0.5);
+      controller.setMuted(true);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(store.saves, afterFirst);
+
+      // A real move still persists.
+      controller.emit(const PlaybackState(
+        status: PlaybackStatus.paused,
+        currentTrack: remote,
+        position: Duration(seconds: 40),
+        duration: Duration(minutes: 3),
+      ));
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(store.saves, greaterThan(afterFirst));
+    });
   });
 }
 
 /// Local engine that throws from [restoreSession] so startup-safety can be
 /// asserted without a real audio backend.
+/// Counts saves, so a test can prove a state change wrote nothing rather than
+/// only that the last document still looks right.
+class _CountingStore extends InMemoryPlaybackSessionStore {
+  int saves = 0;
+
+  @override
+  Future<void> save(PersistedPlaybackSession session) async {
+    saves++;
+    await super.save(session);
+  }
+}
+
 class _ThrowingRestoreController extends FakePlaybackController {
   @override
   Future<void> restoreSession({

--- a/test/core/services/playback_volume_persistence_test.dart
+++ b/test/core/services/playback_volume_persistence_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/repositories/playback_preferences.dart';
@@ -15,6 +17,10 @@ class _RawPreferences implements PlaybackPreferences {
   final List<double> writes = <double>[];
   bool throwOnRead = false;
 
+  /// When set, a write parks here until the test completes it — so a test can
+  /// hold a save in flight and prove shutdown waits for it.
+  Completer<void>? writeGate;
+
   @override
   Future<bool> normalizeVolume() async => false;
 
@@ -29,6 +35,8 @@ class _RawPreferences implements PlaybackPreferences {
 
   @override
   Future<void> setVolume(double value) async {
+    final Completer<void>? gate = writeGate;
+    if (gate != null) await gate.future;
     stored = value;
     writes.add(value);
   }
@@ -150,6 +158,34 @@ void main() {
     await persistence.dispose();
 
     expect(preferences.stored, 0.2);
+  });
+
+  test('dispose waits for a write already in flight', () async {
+    final controller = FakePlaybackController();
+    addTearDown(controller.dispose);
+    final preferences = _RawPreferences(1.0);
+    final persistence = attach(preferences, controller);
+
+    // Hold the write open, then let the debounce fire so a save is genuinely
+    // in flight with no timer left pending.
+    preferences.writeGate = Completer<void>();
+    controller.setVolume(0.3);
+    await pastDebounce();
+    expect(preferences.writes, isEmpty, reason: 'the write is parked');
+
+    bool disposed = false;
+    final Future<void> shutdown =
+        persistence.dispose().then((_) => disposed = true);
+    await Future<void>.delayed(Duration.zero);
+    expect(disposed, isFalse,
+        reason: 'shutdown must not finish while the level is still being '
+            'written');
+
+    preferences.writeGate!.complete();
+    await shutdown;
+
+    expect(disposed, isTrue);
+    expect(preferences.stored, 0.3);
   });
 
   test('stops listening once disposed', () async {

--- a/test/core/services/playback_volume_persistence_test.dart
+++ b/test/core/services/playback_volume_persistence_test.dart
@@ -1,0 +1,195 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/repositories/playback_preferences.dart';
+import 'package:linthra/core/services/playback_volume_persistence.dart';
+import 'package:linthra/data/repositories/in_memory_playback_preferences.dart';
+
+import '../../features/player/fake_playback_controller.dart';
+
+/// Preferences that hand back exactly what a test put in the store, including
+/// the values a healthy app would never write — that is the point.
+class _RawPreferences implements PlaybackPreferences {
+  _RawPreferences(this.stored);
+
+  double stored;
+  final List<double> writes = <double>[];
+  bool throwOnRead = false;
+
+  @override
+  Future<bool> normalizeVolume() async => false;
+
+  @override
+  Future<void> setNormalizeVolume(bool value) async {}
+
+  @override
+  Future<double> volume() async {
+    if (throwOnRead) throw StateError('unreadable');
+    return stored;
+  }
+
+  @override
+  Future<void> setVolume(double value) async {
+    stored = value;
+    writes.add(value);
+  }
+}
+
+void main() {
+  const Duration debounce = Duration(milliseconds: 10);
+  Future<void> pastDebounce() =>
+      Future<void>.delayed(const Duration(milliseconds: 40));
+
+  PlaybackVolumePersistence attach(
+    PlaybackPreferences preferences,
+    FakePlaybackController controller,
+  ) {
+    final PlaybackVolumePersistence persistence = PlaybackVolumePersistence(
+      preferences: preferences,
+      controller: controller,
+      playbackStates: controller.stateStream,
+      saveDebounce: debounce,
+    );
+    addTearDown(persistence.dispose);
+    return persistence;
+  }
+
+  test('restores the stored level onto the controller', () async {
+    final controller = FakePlaybackController();
+    addTearDown(controller.dispose);
+    final persistence =
+        attach(InMemoryPlaybackPreferences(volume: 0.3), controller);
+
+    await persistence.restore();
+
+    expect(controller.state.volume, 0.3);
+  });
+
+  test('an out-of-range stored level is corrected, never applied raw',
+      () async {
+    final controller = FakePlaybackController();
+    addTearDown(controller.dispose);
+    final preferences = _RawPreferences(9.5);
+    final persistence = attach(preferences, controller);
+
+    await persistence.restore();
+
+    expect(controller.state.volume, 1.0);
+  });
+
+  test('a non-finite stored level falls back to full volume', () async {
+    final controller = FakePlaybackController();
+    addTearDown(controller.dispose);
+    final persistence = attach(_RawPreferences(double.nan), controller);
+
+    await persistence.restore();
+
+    expect(controller.state.volume, 1.0);
+  });
+
+  test('a store that throws leaves playback at full volume', () async {
+    final controller = FakePlaybackController();
+    addTearDown(controller.dispose);
+    final preferences = _RawPreferences(0.5)..throwOnRead = true;
+    final persistence = attach(preferences, controller);
+
+    await persistence.restore();
+
+    expect(controller.state.volume, 1.0);
+  });
+
+  test('never restores a mute', () async {
+    final controller = FakePlaybackController();
+    addTearDown(controller.dispose);
+    final persistence =
+        attach(InMemoryPlaybackPreferences(volume: 0.4), controller);
+
+    await persistence.restore();
+
+    expect(controller.state.muted, isFalse);
+  });
+
+  test('a level change is persisted once the burst settles', () async {
+    final controller = FakePlaybackController();
+    addTearDown(controller.dispose);
+    final preferences = _RawPreferences(1.0);
+    attach(preferences, controller);
+
+    // A drag: several states in quick succession, one write.
+    controller.setVolume(0.9);
+    controller.setVolume(0.7);
+    controller.setVolume(0.6);
+    await pastDebounce();
+
+    expect(preferences.writes, <double>[0.6]);
+  });
+
+  test('muting does not overwrite the stored level', () async {
+    final controller = FakePlaybackController();
+    addTearDown(controller.dispose);
+    final preferences = _RawPreferences(1.0);
+    attach(preferences, controller);
+
+    controller.setVolume(0.5);
+    await pastDebounce();
+    controller.setMuted(true);
+    await pastDebounce();
+
+    expect(preferences.stored, 0.5);
+  });
+
+  test('dispose flushes a level changed just before shutdown', () async {
+    final controller = FakePlaybackController();
+    addTearDown(controller.dispose);
+    final preferences = _RawPreferences(1.0);
+    final persistence = attach(preferences, controller);
+
+    controller.setVolume(0.2);
+    // Long enough for the state to arrive, not long enough for the debounce:
+    // the write is still pending when shutdown starts.
+    await Future<void>.delayed(Duration.zero);
+    await persistence.dispose();
+
+    expect(preferences.stored, 0.2);
+  });
+
+  test('stops listening once disposed', () async {
+    final controller = FakePlaybackController();
+    addTearDown(controller.dispose);
+    final preferences = _RawPreferences(1.0);
+    final persistence = attach(preferences, controller);
+
+    await persistence.dispose();
+    final int writesAtShutdown = preferences.writes.length;
+    controller.setVolume(0.1);
+    await pastDebounce();
+
+    expect(preferences.writes.length, writesAtShutdown);
+  });
+
+  test('the shared state model is what both sides agree on', () {
+    // A guard on the contract the two halves share: the persisted number and
+    // the state field are the same sanitized level.
+    expect(PlaybackState.sanitizeVolume(0.42), 0.42);
+  });
+
+  test('the in-memory preferences sanitize what they are given', () async {
+    final preferences = InMemoryPlaybackPreferences(volume: 3);
+    expect(await preferences.volume(), 1.0);
+
+    await preferences.setVolume(-1);
+    expect(await preferences.volume(), 0.0);
+  });
+
+  test('a restore does not immediately write the value back', () async {
+    final controller = FakePlaybackController();
+    addTearDown(controller.dispose);
+    final preferences = _RawPreferences(0.35);
+    final persistence = attach(preferences, controller);
+
+    await persistence.restore();
+    await pastDebounce();
+
+    expect(preferences.writes, isEmpty,
+        reason: 'restoring is not a change worth writing back');
+  });
+}

--- a/test/features/player/fake_playback_controller.dart
+++ b/test/features/player/fake_playback_controller.dart
@@ -52,10 +52,11 @@ class FakePlaybackController implements LocalPlaybackController {
   bool disposed = false;
   final List<Duration> seeks = <Duration>[];
 
-  /// Pushes [next] to listeners and updates the synchronous [state].
+  /// Pushes [next] to listeners and updates the synchronous [state], stamping
+  /// the current volume/mute onto it exactly as the real controller does.
   void emit(PlaybackState next) {
-    _state = next;
-    _states.add(next);
+    _state = next.withVolume(volume: _volume, muted: _muted);
+    _states.add(_state);
   }
 
   @override
@@ -320,6 +321,29 @@ class FakePlaybackController implements LocalPlaybackController {
     restartQueueCount++;
     _queue = _queue.restarted();
     _playCurrent();
+  }
+
+  /// The listener's volume and mute, mirrored from production: the level is
+  /// kept across a mute so unmute restores it, and every emitted state carries
+  /// both so widget tests read them the same way the UI does.
+  double _volume = 1.0;
+  bool _muted = false;
+
+  @override
+  void setVolume(double volume) {
+    final double next = PlaybackState.sanitizeVolume(volume);
+    final bool nextMuted = _muted && next <= 0.0;
+    if (next == _volume && nextMuted == _muted) return;
+    _volume = next;
+    _muted = nextMuted;
+    emit(_state);
+  }
+
+  @override
+  void setMuted(bool muted) {
+    if (muted == _muted) return;
+    _muted = muted;
+    emit(_state);
   }
 
   @override

--- a/test/features/player/volume_controls_test.dart
+++ b/test/features/player/volume_controls_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -218,6 +219,26 @@ void main() {
       await tester.dragFrom(box.center, const Offset(-2000, 0));
       await tester.pumpAndSettle();
       expect(controller.state.volume, 0.0);
+    });
+
+    testWidgets('announces itself as the volume, not a bare percentage',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      final controller = await _pumpControls(tester);
+      controller.setVolume(0.7);
+      await tester.pumpAndSettle();
+
+      // One node carrying both the name and the value: a screen reader landing
+      // on the slider has to hear which slider it is, since Now Playing also
+      // has a position one.
+      final SemanticsData data =
+          tester.getSemantics(find.byType(Slider)).getSemanticsData();
+      expect(data.label, 'Volume');
+      expect(data.value, '70%');
+      expect(data.flagsCollection.isSlider, isTrue);
+      expect(data.hasAction(SemanticsAction.increase), isTrue);
+
+      handle.dispose();
     });
 
     testWidgets('follows a level set somewhere else', (tester) async {

--- a/test/features/player/volume_controls_test.dart
+++ b/test/features/player/volume_controls_test.dart
@@ -1,0 +1,300 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/cast_state.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/data/repositories/host_platform_provider.dart';
+import 'package:linthra/features/player/cast/cast_providers.dart';
+import 'package:linthra/features/player/mini_player.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/player_screen.dart';
+import 'package:linthra/features/player/widgets/volume_controls.dart';
+
+import 'cast/fake_cast_service.dart';
+import 'fake_playback_controller.dart';
+
+const Track _track = Track(
+  id: '1',
+  title: 'Song One',
+  uri: '/music/song1.mp3',
+  artistName: 'Artist A',
+);
+
+const CastDevice _device = CastDevice(id: 'd1', name: 'Living Room');
+
+PlaybackState _playing() => const PlaybackState(
+      status: PlaybackStatus.playing,
+      currentTrack: _track,
+    );
+
+/// Pumps the volume control on its own, so the assertions are about the widget
+/// rather than the screen that hosts it.
+Future<FakePlaybackController> _pumpControls(
+  WidgetTester tester, {
+  PlaybackState? initial,
+}) async {
+  final FakePlaybackController controller =
+      FakePlaybackController(initial: initial ?? _playing());
+  addTearDown(controller.dispose);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        playbackControllerProvider.overrideWithValue(controller),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(body: Center(child: VolumeControls())),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return controller;
+}
+
+Future<void> _pumpPlayer(
+  WidgetTester tester, {
+  required HostPlatform host,
+  FakeCastService? cast,
+  Size size = const Size(1400, 1000),
+}) async {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = size;
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        hostPlatformProvider.overrideWithValue(host),
+        playbackControllerProvider
+            .overrideWithValue(FakePlaybackController(initial: _playing())),
+        if (cast != null) castServiceProvider.overrideWithValue(cast),
+      ],
+      child: const MaterialApp(home: PlayerScreen()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// Pumps the mini-player bar at [width], the way the shell hosts it.
+Future<void> _pumpBar(
+  WidgetTester tester, {
+  required HostPlatform host,
+  required double width,
+}) async {
+  tester.view.devicePixelRatio = 1;
+  tester.view.physicalSize = Size(width, 800);
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        hostPlatformProvider.overrideWithValue(host),
+        playbackControllerProvider
+            .overrideWithValue(FakePlaybackController(initial: _playing())),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(
+          body: SizedBox.expand(),
+          bottomNavigationBar: MiniPlayer(),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('VolumeControls', () {
+    testWidgets('drives the controller as the slider moves', (tester) async {
+      final controller = await _pumpControls(tester);
+
+      final Finder slider = find.byType(Slider);
+      final Rect box = tester.getRect(slider);
+      // Drag to roughly a quarter of the track.
+      await tester.dragFrom(
+        box.centerLeft + const Offset(4, 0),
+        Offset(box.width * 0.25, 0),
+      );
+      await tester.pumpAndSettle();
+
+      expect(controller.state.volume, greaterThan(0.0));
+      expect(controller.state.volume, lessThan(1.0));
+    });
+
+    testWidgets('the mute button mutes and unmutes', (tester) async {
+      final controller = await _pumpControls(tester);
+
+      await tester.tap(find.byTooltip('Mute'));
+      await tester.pumpAndSettle();
+      expect(controller.state.muted, isTrue);
+      expect(find.byIcon(Icons.volume_off), findsOneWidget);
+
+      await tester.tap(find.byTooltip('Unmute'));
+      await tester.pumpAndSettle();
+      expect(controller.state.muted, isFalse);
+    });
+
+    testWidgets('unmuting comes back to the level that was playing',
+        (tester) async {
+      final controller = await _pumpControls(tester);
+      controller.setVolume(0.4);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Mute'));
+      await tester.pumpAndSettle();
+      expect(controller.state.effectiveVolume, 0.0);
+
+      await tester.tap(find.byTooltip('Unmute'));
+      await tester.pumpAndSettle();
+      expect(controller.state.effectiveVolume, 0.4);
+    });
+
+    testWidgets('the scroll wheel steps the level up and down', (tester) async {
+      final controller = await _pumpControls(tester);
+      controller.setVolume(0.5);
+      await tester.pumpAndSettle();
+
+      final Offset over = tester.getCenter(find.byType(Slider));
+      final TestPointer pointer = TestPointer(1, PointerDeviceKind.mouse);
+      pointer.hover(over);
+      await tester.sendEventToBinding(
+        pointer.scroll(const Offset(0, -20)),
+      );
+      await tester.pumpAndSettle();
+      expect(controller.state.volume, closeTo(0.5 + volumeStep, 0.0001));
+
+      await tester.sendEventToBinding(pointer.scroll(const Offset(0, 20)));
+      await tester.pumpAndSettle();
+      expect(controller.state.volume, closeTo(0.5, 0.0001));
+    });
+
+    testWidgets('scrolling down while muted keeps the level to come back to',
+        (tester) async {
+      final controller = await _pumpControls(tester);
+      controller.setVolume(0.6);
+      controller.setMuted(true);
+      await tester.pumpAndSettle();
+
+      final Offset over = tester.getCenter(find.byType(Slider));
+      final TestPointer pointer = TestPointer(1, PointerDeviceKind.mouse);
+      pointer.hover(over);
+      await tester.sendEventToBinding(pointer.scroll(const Offset(0, 20)));
+      await tester.pumpAndSettle();
+
+      expect(controller.state.volume, 0.6);
+      expect(controller.state.muted, isTrue);
+    });
+
+    testWidgets('the keyboard adjusts the focused slider', (tester) async {
+      final controller = await _pumpControls(tester);
+      controller.setVolume(0.5);
+      await tester.pumpAndSettle();
+
+      // Tab to the slider (the mute button is the first stop on the way there),
+      // then step it down with an arrow key.
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pumpAndSettle();
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pumpAndSettle();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pumpAndSettle();
+
+      expect(controller.state.volume, lessThan(0.5));
+    });
+
+    testWidgets('never leaves the 0-1 range however far it is dragged',
+        (tester) async {
+      final controller = await _pumpControls(tester);
+
+      final Rect box = tester.getRect(find.byType(Slider));
+      await tester.dragFrom(box.center, const Offset(2000, 0));
+      await tester.pumpAndSettle();
+      expect(controller.state.volume, 1.0);
+
+      await tester.dragFrom(box.center, const Offset(-2000, 0));
+      await tester.pumpAndSettle();
+      expect(controller.state.volume, 0.0);
+    });
+
+    testWidgets('follows a level set somewhere else', (tester) async {
+      final controller = await _pumpControls(tester);
+
+      // Stands in for MPRIS, or the other copy of this control.
+      controller.setVolume(0.2);
+      await tester.pumpAndSettle();
+
+      final Slider slider = tester.widget<Slider>(find.byType(Slider));
+      expect(slider.value, closeTo(0.2, 0.0001));
+    });
+  });
+
+  group('Now Playing placement', () {
+    testWidgets('desktop shows the volume control', (tester) async {
+      await _pumpPlayer(tester, host: HostPlatform.linux);
+
+      expect(find.byType(VolumeControls), findsOneWidget);
+    });
+
+    testWidgets('mobile playback UI is unchanged', (tester) async {
+      await _pumpPlayer(tester, host: HostPlatform.android);
+
+      expect(find.byType(VolumeControls), findsNothing);
+    });
+
+    testWidgets('a narrow desktop window keeps the actions it had',
+        (tester) async {
+      // The five actions and a slider do not both fit; the slider is the one
+      // that gives way.
+      await _pumpPlayer(
+        tester,
+        host: HostPlatform.linux,
+        size: const Size(420, 900),
+      );
+
+      expect(find.byType(VolumeControls), findsNothing);
+    });
+
+    testWidgets('hidden while casting, where the receiver owns the level',
+        (tester) async {
+      final FakeCastService cast = FakeCastService(
+        initial: const CastState(
+          availability: CastAvailability.connected,
+          devices: <CastDevice>[_device],
+          connectedDevice: _device,
+          isCasting: true,
+        ),
+      );
+      addTearDown(cast.dispose);
+
+      await _pumpPlayer(tester, host: HostPlatform.linux, cast: cast);
+
+      expect(find.byType(VolumeControls), findsNothing);
+    });
+  });
+
+  group('mini-player placement', () {
+    testWidgets('a wide desktop bar carries the volume control',
+        (tester) async {
+      await _pumpBar(tester, host: HostPlatform.linux, width: 1200);
+
+      expect(find.byType(VolumeControls), findsOneWidget);
+    });
+
+    testWidgets('a narrow bar leaves it out rather than squeezing the title',
+        (tester) async {
+      await _pumpBar(tester, host: HostPlatform.linux, width: 700);
+
+      expect(find.byType(VolumeControls), findsNothing);
+    });
+
+    testWidgets('the phone bar is unchanged', (tester) async {
+      await _pumpBar(tester, host: HostPlatform.android, width: 1200);
+
+      expect(find.byType(VolumeControls), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
Closes #394.

Desktop has no hardware volume keys bound to the app, so until now the only way to quieten Linthra on Linux was to turn the whole system down. This adds a proper volume control, on the playback seam rather than in a widget.

## What changed

**Playback seam**

- `PlaybackController` gains `setVolume` / `setMuted`; `PlaybackState` carries `volume` and `muted`. Both are stamped onto every emission from one place (next to the focus-hold stamp), so the paths that build a fresh state (an error, a session restore) can't publish a stale level.
- What the engine is actually set to is the listener's level times the current track's ReplayGain (when normalization is on) times the audio-focus duck factor, in `JustAudioPlaybackController.engineVolumeFor`. Automatic attenuation never moves the slider, and the slider never cancels a duck.
- Mute leaves the level alone, so unmute returns to exactly what was playing. Raising the volume above zero unmutes, since that is obviously what dragging a muted slider up means.
- Every value goes through `PlaybackState.sanitizeVolume` (clamped to 0.0-1.0, non-finite falls back to full), so a scroll step's arithmetic, a stored preference, or an MPRIS client can never hand the engine something out of range.
- `ActivePlaybackController` routes volume to the local engine even while casting: it is this device's level either way. The receiver's own volume stays the Cast sheet's control, on its own scale.

**UI**

- A new `VolumeControls` widget: mute button plus slider, with scroll-wheel steps (5%) and the Slider's own arrow-key adjustment. It reads the level from `PlaybackState`, so every copy of it, MPRIS, and the restored preference all stay in sync; the only local state is the in-progress drag.
- Placed on Now Playing, sharing the action row's band rather than adding one, so the artwork and lyrics keep their height (the short-window-at-2x-text-scale layout test was what caught this), and on the wide mini-player bar next to the queue button.
- Hidden on mobile, on windows too narrow to hold it without squeezing the other controls, and while casting.

**MPRIS**

- `Volume` is now read/write and reports the level actually heard (zero while muted), so a shell's own slider drives playback. Out-of-range values are clamped per the spec rather than refused. `Rate` stays honestly read-only.

**Persistence**

- `PlaybackVolumePersistence` listens to the state stream and stores the volume (debounced, flushed on shutdown), restoring it at startup on desktop. The mute is deliberately not persisted: coming back to a silent player with nothing on screen explaining it is the worst version of this feature.

Android and iOS are untouched: no volume UI is built there, and with no persistence provider the engine level stays exactly where it was.

## Tests

- Controller: bounds and clamping, non-finite input, redundant sets don't emit, mute/unmute round trip, and the pure composition of listener level, ReplayGain and duck.
- Persistence: restore, sanitizing on the way in, a throwing store, debounced writes, the shutdown flush, and that a mute is never stored.
- MPRIS: reading the effective level, setting it from the bus, clamping, unmuting, and refusing the wrong type.
- Widgets: drag, mute button, wheel (including scrolling down while muted), keyboard, following a level set elsewhere, and placement on Now Playing and the mini-player across platform, width and casting.

`dart format`, `flutter analyze` and the full `flutter test` suite (4403 tests) pass locally.

## Docs

`docs/linux-desktop.md` gets a Volume section under Audio playback, a row in the Linux support table, and the MPRIS row now mentions the writable `Volume`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xSxQ78SeVBzFTPgLiBD6U

---
_Generated by [Claude Code](https://claude.ai/code/session_017xSxQ78SeVBzFTPgLiBD6U)_