### PR TITLE
feat(linux): choose what closing the window does (#401)

### DIFF
--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -251,7 +251,8 @@ undeclared network access to an isolated `flatpak-builder` build.
 | **Audio playback** | Supported | media_kit/libmpv through `LinuxPlaybackController`; local files and resolved Jellyfin, Navidrome/Subsonic, and Plex HTTP(S) streams share one backend. |
 | **Suspend / resume** | Supported (app side); real device/sink timing varies | Lifecycle `paused`→`resumed` arms a bounded Linux-only reload of an actively playing track after a short backoff ([issue #466](https://github.com/TheZupZup/Linthra/issues/466)). See [Suspend / resume (manual matrix)](#suspend--resume-manual-matrix). |
 | **Light/Dark/System theme** | Supported (app side); the native brightness bridge itself is Flutter's, not independently verified here | Settings → Appearance's System/Light/Dark choice ([issue #459](https://github.com/TheZupZup/Linthra/issues/459)) is the same shared `ThemeModePreference`/`ThemeModeController` Android uses, mapped onto `MaterialApp`'s own `themeMode` — no `gsettings`/D-Bus/GNOME/KDE-specific code in Linthra itself, and no separate Linux theme path (`test/app/theme_mode_test.dart` proves that). *Supplying* System's brightness on Linux is Flutter's GTK embedder (via the XDG desktop portal or a GNOME GSettings fallback); that native bridge is outside Linthra's code and isn't exercised by `flutter test`, which runs on the Dart VM and injects brightness straight into Flutter's test `PlatformDispatcher`. Reproducing the real bridge deterministically in CI would need a running portal daemon or GNOME schemas — exactly the DE-specific setup this app avoids adding — so it stays untested here and is a known gap, not a claimed guarantee. |
-| Media session / MPRIS | Supported | `PlatformMediaSessionBinding` routes Linux to `MprisMediaSessionBinding`, which exports `/org/mpris/MediaPlayer2` and owns `org.mpris.MediaPlayer2.linthra` ([issue #397](https://github.com/TheZupZup/Linthra/issues/397)). Shells get PlaybackStatus, Metadata, Position and the transport methods; media keys work through the same interface. `audio_service` is still never initialised on Linux — it stays the Android delegate. A machine with no session bus simply gets no desktop controls. |
+| Media session / MPRIS | Supported | `PlatformMediaSessionBinding` routes Linux to `MprisMediaSessionBinding`, which exports `/org/mpris/MediaPlayer2` and owns `org.mpris.MediaPlayer2.linthra` ([issue #397](https://github.com/TheZupZup/Linthra/issues/397)). Shells get PlaybackStatus, Metadata, Position and the transport methods; media keys work through the same interface. `Raise` and `Quit` are answered too, so a listener whose window is hidden by background mode can bring Linthra back or shut it down from the shell's media widget (#401). `audio_service` is still never initialised on Linux — it stays the Android delegate. A machine with no session bus simply gets no desktop controls. |
+| Close-window behaviour | Supported | Settings → Music & playback → Desktop window chooses between quitting and keeping playback running ([issue #401](https://github.com/TheZupZup/Linthra/issues/401)). The runner answers the close, Dart decides what the answer should be, and background mode only ever starts while audio is actually playing. See [Closing the window](#closing-the-window). |
 | Android Auto | Android-only, by design | It is an Android platform integration, not a Linthra feature. |
 | Media notification + `POST_NOTIFICATIONS` | Android-only, by design | There is no equivalent gate on Linux; desktop controls come from MPRIS instead. Standalone track-change notifications are [issue #400](https://github.com/TheZupZup/Linthra/issues/400). |
 | Android audio focus | Android-only, by design | `JustAudioPlaybackController` already scopes its focus handling to Android/iOS. |
@@ -351,8 +352,10 @@ right on one monitor fails.
   identity (`APPLICATION_ID` = Android's `applicationId`, `BINARY_NAME` =
   the package name, window title = `AppInfo.name`), it still makes the four
   desktop-identity calls below in the places where GTK honours them, the window
-  metrics are sane, the offline SQLite seam is wired, and nothing under `linux/`
-  hardcodes an absolute host path.
+  metrics are sane, the offline SQLite seam is wired, the folder-picker and
+  window-lifecycle channels still agree with their Dart halves, the application
+  is still registered single-instance, and nothing under `linux/` hardcodes an
+  absolute host path.
   Tests: `test/tooling/check_linux_runner_test.py`.
 * `scripts/flatpak_launch_smoke.sh` — launches the packaged Flatpak twice and
   reads `WM_CLASS` and `_NET_WM_ICON` back off the real window each time, so a
@@ -431,6 +434,77 @@ before a Linux milestone release:
 | Sleep with **network** offline | Playing remote | Bounded recovery; Retry works when connectivity returns |
 | Minimize only (no sleep) | Playing | App stays responsive; no crash; ideally continues without a full reload |
 | Repeat sleep/wake **3×** | Playing | Still one coherent queue/position; no growing listener/service leak; UI stays usable |
+
+## Closing the window
+
+By default, closing the window quits Linthra, which is what it has always done.
+Settings → Music & playback → **Desktop window** offers the other choice:
+keep playing in the background, where a close hides the window and leaves
+playback and the desktop media controls running.
+
+The decision is split across the two halves on purpose:
+
+* **Dart decides.** `DesktopClosePolicy` combines the stored preference with
+  the live playback state, and `DesktopWindowLifecycleService` pushes the one
+  resulting boolean to the runner whenever either changes.
+* **The runner applies.** A GTK `delete-event` has to be answered
+  synchronously, so `linux/runner/window_lifecycle_channel.cc` cannot ask
+  anything: it already holds the answer, and either hides the window or lets
+  GTK destroy it.
+
+What that buys, in the order the requirements ask for it:
+
+* **No hidden zombie process.** Background mode only takes effect while audio
+  is playing (or loading, buffering, reconnecting). Close it while paused,
+  stopped or idle and Linthra quits, whatever the preference says.
+* **Nothing extra is started for it.** Hiding the window starts no background
+  service and no second process: it is the same running app with its window
+  away, so the audio engine, the queue and the MPRIS export carry on and the
+  window simply stops drawing. Linux has no foreground-service concept to hold
+  the way Android does.
+* **A hidden Linthra ends itself.** When the queue runs out, the app quits on
+  its own rather than sitting invisibly in the process list. A *pause* keeps it
+  alive, because with no window on screen a shell's media widget is the only
+  way back to playing.
+* **A clear way to fully quit.** "Quit Linthra now" sits in the same settings
+  card, and MPRIS `Quit` does the same thing from the desktop's media controls.
+  Both run the app's graceful shutdown (stop playback, release the audio
+  engine, give back the MPRIS bus name, close the database) *before* the
+  process ends, rather than leaving it to whatever time the engine gets on the
+  way down.
+* **No duplicate instance.** The runner is single-instance, so launching
+  Linthra while it is already running (from the launcher, a terminal, or a
+  desktop file) reaches the running process as an activation and presents the
+  window it already has, hidden or not. Two processes would mean two audio
+  engines, two MPRIS names and two connections to the same SQLite catalog.
+  `scripts/check_linux_runner.py` fails if the runner goes back to
+  `G_APPLICATION_NON_UNIQUE`.
+
+One deliberate interaction with [suspend / resume](#suspend--resume-manual-matrix):
+while the window is hidden, Linthra does **not** arm the post-suspend reload.
+A hide looks exactly like a system suspend from the lifecycle observer's side,
+and reloading a track the listener never stopped would be an audible skip. The
+trade is that a real machine suspend taken while the window is hidden is not
+recovered from either; it is recovered the next time the window comes back.
+
+Automated coverage: `test/core/lifecycle/desktop_close_policy_test.dart`,
+`test/core/services/desktop_window_lifecycle_service_test.dart`,
+`test/core/services/method_channel_linux_window_test.dart`,
+`test/features/settings/desktop/desktop_window_section_test.dart`, and the
+runner contract in `test/tooling/check_linux_runner_test.py`. What only a real
+desktop can answer, to re-check before a Linux milestone release:
+
+| Scenario | Setting | Expect |
+| --- | --- | --- |
+| Close the window while a track plays | Keep playing | Window disappears, audio continues, media controls still work |
+| Click the launcher again while hidden | Keep playing | The same window comes back; one process, one entry in the media controls |
+| Raise from the shell's media widget | Keep playing | Same as above |
+| Let the queue finish while hidden | Keep playing | Linthra exits on its own; the MPRIS entry disappears from the shell |
+| Pause from the media widget while hidden, then play | Keep playing | Still there, resumes the same track |
+| Close the window while paused | Keep playing | Linthra quits; nothing is left running |
+| Close the window while a track plays | Quit | Linthra quits, audio stops |
+| Quit from the media widget, or "Quit Linthra now" | Either | Playback stops, the window goes, the MPRIS name is released |
+| Reopen after any quit | Either | Normal cold start; the crash-safe session restores paused, as it always did |
 
 ## Crash-safe playback restore
 

--- a/lib/app/application_container.dart
+++ b/lib/app/application_container.dart
@@ -5,6 +5,8 @@ import '../core/platform/host_platform.dart';
 import '../data/repositories/app_icon_variant_store_provider.dart';
 import '../data/repositories/audiobookshelf_session_store_provider.dart';
 import '../data/repositories/default_provider_store_provider.dart';
+import '../data/repositories/desktop_window_controller_provider.dart';
+import '../data/repositories/desktop_window_preferences_provider.dart';
 import '../data/repositories/download_repository_provider.dart';
 import '../data/repositories/favorites_repository_provider.dart';
 import '../data/repositories/jellyfin_auto_sync_store_provider.dart';
@@ -56,8 +58,15 @@ List<Override> productionApplicationOverrides({
     sharedPreferencesDownloadStoreOverride,
     sharedPreferencesDownloadPreferencesOverride,
     sharedPreferencesPlaybackPreferencesOverride,
-    if (resolvedHost == HostPlatform.linux)
+    sharedPreferencesDesktopWindowPreferencesOverride,
+    if (resolvedHost == HostPlatform.linux) ...<Override>[
       sharedPreferencesPlaybackSessionStoreOverride,
+      // The window-lifecycle channel is Linthra's own GTK runner (#401), so
+      // only the Linux build ever opens it. Everywhere else the app keeps the
+      // no-op window controller and closing a window means whatever the host
+      // already made it mean.
+      linuxDesktopWindowControllerOverride,
+    ],
     fileSystemOfflineFileStoreOverride,
     remoteTrackDownloaderOverride,
     playbackCandidateSourceOverride,

--- a/lib/app/application_lifecycle.dart
+++ b/lib/app/application_lifecycle.dart
@@ -4,9 +4,11 @@ import 'dart:io';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../core/lifecycle/async_disposal_registry.dart';
+import '../core/models/desktop_close_behavior.dart';
 import '../core/models/plex_session.dart';
 import '../core/models/subsonic_session.dart';
 import '../core/services/artwork_disk_cache.dart';
+import '../core/services/desktop_window_lifecycle_service.dart';
 import '../core/services/media_session_binding.dart';
 import '../core/services/playback_session_persistence.dart';
 import '../core/sources/plex/plex_artwork.dart';
@@ -20,6 +22,8 @@ import '../data/repositories/remote_cache_index_provider.dart';
 import '../features/player/media_artwork_providers.dart';
 import '../features/player/player_providers.dart';
 import '../features/settings/audiobookshelf/audiobookshelf_settings_controller.dart';
+import '../features/settings/desktop/close_behavior_controller.dart';
+import '../features/settings/desktop/desktop_window_providers.dart';
 import '../features/settings/jellyfin/jellyfin_settings_controller.dart';
 import '../features/settings/playback/normalize_volume_controller.dart';
 import '../features/settings/plex/plex_settings_controller.dart';
@@ -183,6 +187,35 @@ Future<ApplicationHandle> bootstrapApplication(
 }) async {
   final ApplicationHandle handle = ApplicationHandle(container: container);
   try {
+    // The desktop window lifecycle (#401): what a window close does, and the
+    // explicit quit. Started before the media session so MPRIS can offer the
+    // same Raise/Quit the window itself does, and handed the graceful shutdown
+    // so an explicit quit releases audio, the bus name and the database before
+    // the process ends rather than racing the engine on the way down.
+    //
+    // Inert off the desktop: the window controller is then the no-op one, so
+    // nothing is pushed anywhere and nothing is ever hidden.
+    final DesktopWindowLifecycleService desktopWindow =
+        container.read(desktopWindowLifecycleServiceProvider);
+    desktopWindow.installShutdown(handle.shutdown);
+    desktopWindow.start();
+
+    // Mirror the user's close-behaviour choice onto the runner, seeding the
+    // persisted value now and pushing every later change. The runner has to
+    // answer a GTK delete-event synchronously, so it is told the answer ahead
+    // of time rather than asked for one.
+    handle.ownSubscription(
+      container.listen<AsyncValue<DesktopCloseBehavior>>(
+        desktopCloseBehaviorControllerProvider,
+        (_, AsyncValue<DesktopCloseBehavior> next) {
+          desktopWindow.setCloseBehavior(
+            next.valueOrNull ?? DesktopCloseBehavior.defaultBehavior,
+          );
+        },
+        fireImmediately: true,
+      ),
+    );
+
     // Attaching the session is best-effort and platform-routed: Android gets
     // the real `audio_service` session, Linux gets MPRIS, and every other
     // platform gets the inert binding so `audio_service` is never initialised
@@ -201,6 +234,9 @@ Future<ApplicationHandle> bootstrapApplication(
       favorites: container.read(favoritesRepositoryProvider),
       downloads: container.read(downloadRepositoryProvider),
       artwork: container.read(mediaArtworkCacheProvider),
+      // Raise and Quit for the desktop session. Off the desktop this is still
+      // the inert service, and the Android session ignores it entirely.
+      application: desktopWindow,
     );
     // Owned so shutdown gives the session back. On Android that is a no-op (the
     // session belongs to the foreground service), but on Linux it releases the

--- a/lib/app/linthra_app.dart
+++ b/lib/app/linthra_app.dart
@@ -18,6 +18,7 @@ import '../features/appearance/theme_mode_controller.dart';
 import '../features/library/remote_library_refresher.dart';
 import '../features/onboarding/onboarding_controller.dart';
 import '../features/player/player_providers.dart';
+import '../features/settings/desktop/desktop_window_providers.dart';
 import '../features/settings/jellyfin/jellyfin_availability_controller.dart';
 import '../features/support/support_actions_provider.dart';
 import '../features/support/supporter_entitlement.dart';
@@ -111,8 +112,14 @@ class _LinthraAppState extends ConsumerState<LinthraApp>
           controller.state.status.name);
       // Arm suspend recovery only on a true pause (system sleep / window
       // background). Brief `inactive` (dialogs, focus blips) must not reload.
+      //
+      // A desktop window hidden by a close (#401) is the one pause that must
+      // not arm it: playback never stopped, the audio device was never taken
+      // away, and reloading the track when the window comes back would be an
+      // audible skip in music the listener kept playing on purpose.
       if (state == AppLifecycleState.paused &&
-          controller is ActivePlaybackController) {
+          controller is ActivePlaybackController &&
+          !ref.read(desktopWindowLifecycleServiceProvider).isWindowHidden) {
         controller.onAppBackgrounded();
       }
     }

--- a/lib/core/lifecycle/desktop_close_policy.dart
+++ b/lib/core/lifecycle/desktop_close_policy.dart
@@ -1,0 +1,56 @@
+import '../models/desktop_close_behavior.dart';
+import '../models/playback_state.dart';
+
+/// The two rules behind the configurable close-window behaviour (issue #401),
+/// as pure functions of the user's choice and what playback is doing.
+///
+/// They live here, apart from the widget layer and from the GTK runner, because
+/// the interesting part of this feature is not "hide the window", it is
+/// deciding *when* hiding it is right. Both rules are exercised directly in
+/// tests, on any host, without a window or a session bus.
+abstract final class DesktopClosePolicy {
+  /// Whether closing the window should hide it and leave Linthra running.
+  ///
+  /// Two things have to be true: the user asked for it
+  /// ([DesktopCloseBehavior.keepPlaying]) *and* there is audio to keep alive.
+  /// A closed window with nothing playing simply quits, whatever the
+  /// preference says. That is the "no hidden zombie process" half of the
+  /// requirement, and it is why the preference alone does not decide.
+  static bool hidesOnClose(
+    DesktopCloseBehavior behavior,
+    PlaybackState state,
+  ) {
+    if (behavior != DesktopCloseBehavior.keepPlaying) return false;
+    return _isProducingAudio(state);
+  }
+
+  /// Whether an already-hidden Linthra still has a reason to run.
+  ///
+  /// Looser than [hidesOnClose] on purpose: once the window is away, the
+  /// desktop media controls are the only interface left, so a pause taken from
+  /// a shell's media widget has to keep the app alive for the resume that
+  /// follows. What ends a hidden session is the queue running out (or being
+  /// stopped): no current track, or a status that is not going to produce
+  /// sound again on its own.
+  static bool keepsRunningWhileHidden(PlaybackState state) {
+    if (_isProducingAudio(state)) return true;
+    return state.status == PlaybackStatus.paused && state.hasTrack;
+  }
+
+  /// Sound now, or the engine working toward it: the states in which stopping
+  /// the process would be audible to the listener.
+  static bool _isProducingAudio(PlaybackState state) {
+    switch (state.status) {
+      case PlaybackStatus.playing:
+      case PlaybackStatus.loading:
+      case PlaybackStatus.buffering:
+      case PlaybackStatus.reconnecting:
+        return true;
+      case PlaybackStatus.idle:
+      case PlaybackStatus.paused:
+      case PlaybackStatus.completed:
+      case PlaybackStatus.error:
+        return false;
+    }
+  }
+}

--- a/lib/core/models/desktop_close_behavior.dart
+++ b/lib/core/models/desktop_close_behavior.dart
@@ -1,0 +1,65 @@
+/// What closing the desktop window does (issue #401).
+///
+/// Desktop-only: on Android the window is an Activity the platform owns, and
+/// closing it never meant "quit the app" in the first place. Linthra ships
+/// [quit] as the default so the behaviour out of the box is the one it has
+/// always had (closing the window ends the app), and [keepPlaying] is an
+/// explicit opt-in, never a surprise background process.
+enum DesktopCloseBehavior {
+  /// Closing the window quits Linthra: playback stops and every resource the
+  /// app owns is released.
+  quit,
+
+  /// Closing the window hides it and leaves playback running, with the desktop
+  /// media controls (MPRIS) still live. Only takes effect while audio is
+  /// actually playing. See `DesktopClosePolicy`, which is what keeps a closed
+  /// window from leaving a silent, invisible process behind.
+  keepPlaying;
+
+  /// The behaviour a fresh install gets, and the one a missing or unreadable
+  /// stored value falls back to.
+  static const DesktopCloseBehavior defaultBehavior = DesktopCloseBehavior.quit;
+
+  /// The user-facing name of this choice, in Settings.
+  String get label {
+    switch (this) {
+      case DesktopCloseBehavior.quit:
+        return 'Quit Linthra';
+      case DesktopCloseBehavior.keepPlaying:
+        return 'Keep playing in the background';
+    }
+  }
+
+  /// A one-line description of what this choice does, shown under [label].
+  String get description {
+    switch (this) {
+      case DesktopCloseBehavior.quit:
+        return 'Playback stops and the app closes.';
+      case DesktopCloseBehavior.keepPlaying:
+        return 'The window hides while music keeps playing. Linthra quits on '
+            'its own once the queue ends.';
+    }
+  }
+
+  /// The stable string written to storage. Deliberately not `Enum.name` or the
+  /// index: renaming or reordering the enum must not silently change what a
+  /// previously stored preference means.
+  String get storageValue {
+    switch (this) {
+      case DesktopCloseBehavior.quit:
+        return 'quit';
+      case DesktopCloseBehavior.keepPlaying:
+        return 'keep_playing';
+    }
+  }
+
+  /// Reads back [storageValue]. Anything unrecognised (an older or newer
+  /// build's value, a corrupted entry) resolves to [defaultBehavior] rather
+  /// than throwing on startup.
+  static DesktopCloseBehavior fromStorage(String? value) {
+    for (final DesktopCloseBehavior behavior in DesktopCloseBehavior.values) {
+      if (behavior.storageValue == value) return behavior;
+    }
+    return defaultBehavior;
+  }
+}

--- a/lib/core/repositories/desktop_window_preferences.dart
+++ b/lib/core/repositories/desktop_window_preferences.dart
@@ -1,0 +1,16 @@
+import '../models/desktop_close_behavior.dart';
+
+/// The user's desktop window preferences (issue #401).
+///
+/// One choice today: what closing the main window does. Kept behind an
+/// interface like [PlaybackPreferences] so the lifecycle layer can read it
+/// without binding to a storage plugin, and so tests can hand it a value with
+/// no plugin registered at all.
+abstract interface class DesktopWindowPreferences {
+  /// What closing the window does. Defaults to
+  /// [DesktopCloseBehavior.defaultBehavior]: quit, the behaviour Linthra has
+  /// always had, so nothing changes until the user asks for it.
+  Future<DesktopCloseBehavior> closeBehavior();
+
+  Future<void> setCloseBehavior(DesktopCloseBehavior behavior);
+}

--- a/lib/core/services/desktop_application_actions.dart
+++ b/lib/core/services/desktop_application_actions.dart
@@ -1,0 +1,13 @@
+/// The application-level actions a desktop shell can ask Linthra to perform.
+///
+/// These are the two MPRIS root-interface methods (`Raise` and `Quit`), named
+/// as an interface of their own so `MprisPlayerObject` can offer them without
+/// knowing anything about GTK windows, and so a platform that cannot do them
+/// simply passes nothing.
+abstract interface class DesktopApplicationActions {
+  /// Brings the window back to the front, showing it again if a close hid it.
+  Future<void> raise();
+
+  /// Releases everything Linthra owns and ends the process.
+  Future<void> quit();
+}

--- a/lib/core/services/desktop_window_controller.dart
+++ b/lib/core/services/desktop_window_controller.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+
+/// Whether the desktop window is on screen or hidden in the background.
+enum DesktopWindowVisibility { shown, hidden }
+
+/// The native desktop window, as much of it as the close-behaviour feature
+/// needs (issue #401).
+///
+/// The Linux implementation talks to Linthra's own GTK runner
+/// (`linux/runner/window_lifecycle_channel.cc`); every other platform gets
+/// [NoopDesktopWindowController], so the shared lifecycle code can be written
+/// once without asking which host it is on.
+abstract interface class DesktopWindowController {
+  /// Tells the runner what the next window close should do: hide the window
+  /// ([hideOnClose] true) or let it be destroyed, which ends the process.
+  ///
+  /// Pushed rather than asked for, because a GTK `delete-event` handler has to
+  /// answer synchronously and Dart cannot be consulted inside it.
+  Future<void> setHideOnClose(bool hideOnClose);
+
+  /// Brings a hidden window back: what MPRIS `Raise` and a second launch of
+  /// an already-running Linthra both mean.
+  Future<void> showWindow();
+
+  /// Ends the process. Called only after the app has released what it owns.
+  Future<void> quit();
+
+  /// Visibility changes reported by the runner: the window being hidden by a
+  /// close, and being presented again.
+  Stream<DesktopWindowVisibility> get visibility;
+}
+
+/// The "this platform has no window to manage" controller: Android, and any
+/// desktop whose runner does not implement the channel.
+///
+/// A real named class rather than a silent `if`, for the same reason
+/// [UnsupportedMediaSessionBinding] is one: the shared service can then be
+/// wired identically everywhere and simply do nothing off the desktop.
+class NoopDesktopWindowController implements DesktopWindowController {
+  const NoopDesktopWindowController();
+
+  @override
+  Future<void> setHideOnClose(bool hideOnClose) async {}
+
+  @override
+  Future<void> showWindow() async {}
+
+  @override
+  Future<void> quit() async {}
+
+  @override
+  Stream<DesktopWindowVisibility> get visibility =>
+      const Stream<DesktopWindowVisibility>.empty();
+}

--- a/lib/core/services/desktop_window_lifecycle_service.dart
+++ b/lib/core/services/desktop_window_lifecycle_service.dart
@@ -1,0 +1,133 @@
+import 'dart:async';
+
+import '../lifecycle/desktop_close_policy.dart';
+import '../models/desktop_close_behavior.dart';
+import '../models/playback_state.dart';
+import 'desktop_application_actions.dart';
+import 'desktop_window_controller.dart';
+import 'playback_controller.dart';
+
+/// Keeps the desktop runner's close behaviour in step with the user's choice
+/// and with what playback is doing, and owns the explicit-quit path (#401).
+///
+/// The runner cannot ask Dart anything inside a GTK `delete-event` handler,
+/// because that answer has to be synchronous, so this service *pushes* the
+/// decision ahead of time: whenever the preference or the playback state
+/// changes it recomputes [DesktopClosePolicy.hidesOnClose] and hands the runner
+/// a single boolean. Closing the window is then a local decision the runner
+/// can make instantly, and it is always the decision the app would have made.
+///
+/// It also owns the two things that keep background mode honest:
+///
+///  * A hidden Linthra whose queue has run out quits itself, so closing the
+///    window can never leave a silent process behind.
+///  * [quit] releases the app's resources *before* the process ends, rather
+///    than relying on the engine to hand out enough time on the way down.
+///
+/// Inert off the desktop: the controller is then
+/// [NoopDesktopWindowController], nothing is ever hidden, and every push is a
+/// no-op.
+class DesktopWindowLifecycleService implements DesktopApplicationActions {
+  DesktopWindowLifecycleService({
+    required DesktopWindowController window,
+    required PlaybackController playback,
+  })  : _window = window,
+        _playback = playback;
+
+  final DesktopWindowController _window;
+  final PlaybackController _playback;
+
+  StreamSubscription<PlaybackState>? _playbackSubscription;
+  StreamSubscription<DesktopWindowVisibility>? _visibilitySubscription;
+
+  DesktopCloseBehavior _behavior = DesktopCloseBehavior.defaultBehavior;
+  bool? _pushedHideOnClose;
+  bool _hidden = false;
+  bool _quitting = false;
+  Future<void> Function()? _shutdown;
+
+  /// Whether the window is currently hidden, i.e. Linthra is running in the
+  /// background with no window on screen.
+  ///
+  /// Read by the app's lifecycle observer: on Linux a hide/show cycle looks
+  /// exactly like a system suspend/resume, and the post-suspend recovery must
+  /// not reload a track that never stopped playing.
+  bool get isWindowHidden => _hidden;
+
+  /// Starts mirroring playback onto the runner. Safe to call more than once.
+  void start() {
+    _playbackSubscription ??= _playback.stateStream.listen(_onPlaybackState);
+    _visibilitySubscription ??= _window.visibility.listen(_onVisibility);
+    _sync(_playback.state);
+  }
+
+  /// Applies the user's stored choice. Called with the persisted value at
+  /// startup and again on every change.
+  void setCloseBehavior(DesktopCloseBehavior behavior) {
+    if (_behavior == behavior) return;
+    _behavior = behavior;
+    _sync(_playback.state);
+  }
+
+  /// Installs the graceful shutdown [quit] runs before the process ends.
+  ///
+  /// Handed in rather than reached for: the root [ApplicationHandle] is created
+  /// by bootstrap, and this service must not have to know how to find it.
+  void installShutdown(Future<void> Function() shutdown) {
+    _shutdown = shutdown;
+  }
+
+  @override
+  Future<void> raise() => _window.showWindow();
+
+  @override
+  Future<void> quit() async {
+    if (_quitting) return;
+    _quitting = true;
+    // Stop listening first: the shutdown below stops playback, and a state
+    // change arriving mid-teardown must not start a second quit or push a
+    // close behaviour onto a window that is going away.
+    await _cancelSubscriptions();
+    try {
+      await _shutdown?.call();
+    } catch (_) {
+      // `ApplicationHandle.shutdown` never throws, and a foreign one that does
+      // must not keep the process alive.
+    }
+    await _window.quit();
+  }
+
+  /// Releases the subscriptions. The window itself is untouched: disposing
+  /// the container is not a reason to close anything the user can see.
+  Future<void> dispose() => _cancelSubscriptions();
+
+  void _onPlaybackState(PlaybackState state) {
+    if (_quitting) return;
+    _sync(state);
+    // The anti-zombie rule: nothing left to play and no window to show for it.
+    if (_hidden && !DesktopClosePolicy.keepsRunningWhileHidden(state)) {
+      unawaited(quit());
+    }
+  }
+
+  void _onVisibility(DesktopWindowVisibility visibility) {
+    _hidden = visibility == DesktopWindowVisibility.hidden;
+  }
+
+  void _sync(PlaybackState state) {
+    final bool hideOnClose = DesktopClosePolicy.hidesOnClose(_behavior, state);
+    if (_pushedHideOnClose == hideOnClose) return;
+    _pushedHideOnClose = hideOnClose;
+    unawaited(_window.setHideOnClose(hideOnClose));
+  }
+
+  Future<void> _cancelSubscriptions() async {
+    final StreamSubscription<PlaybackState>? playback = _playbackSubscription;
+    final StreamSubscription<DesktopWindowVisibility>? visibility =
+        _visibilitySubscription;
+    _playbackSubscription = null;
+    _visibilitySubscription = null;
+    await playback?.cancel();
+    await visibility?.cancel();
+  }
+}

--- a/lib/core/services/media_session_binding.dart
+++ b/lib/core/services/media_session_binding.dart
@@ -3,6 +3,7 @@ import '../repositories/download_repository.dart';
 import '../repositories/favorites_repository.dart';
 import '../repositories/music_library_repository.dart';
 import '../repositories/playlist_repository.dart';
+import 'desktop_application_actions.dart';
 import 'linthra_audio_handler.dart';
 import 'media_artwork_source.dart';
 import 'mpris/mpris_media_session.dart';
@@ -34,6 +35,11 @@ abstract interface class MediaSessionBinding {
   /// test host with no bindings) returns null and the app carries on. The
   /// repositories are what Android Auto browses; they are ignored where there
   /// is no session.
+  ///
+  /// [application] is what the session's own Raise/Quit go to. MPRIS offers
+  /// both to the desktop shell (#401), which is how a listener with no window
+  /// on screen still has a visible way to bring Linthra back or shut it down.
+  /// Passing nothing means the session advertises neither.
   Future<MediaSession?> attach(
     PlaybackController controller,
     MusicLibraryRepository library, {
@@ -41,6 +47,7 @@ abstract interface class MediaSessionBinding {
     FavoritesRepository? favorites,
     DownloadRepository? downloads,
     MediaArtworkSource? artwork,
+    DesktopApplicationActions? application,
   });
 }
 
@@ -83,6 +90,7 @@ class AudioServiceMediaSessionBinding implements MediaSessionBinding {
     FavoritesRepository? favorites,
     DownloadRepository? downloads,
     MediaArtworkSource? artwork,
+    DesktopApplicationActions? application,
   }) async {
     final LinthraAudioHandler? handler = await connectMediaSession(
       controller,
@@ -121,6 +129,7 @@ class UnsupportedMediaSessionBinding implements MediaSessionBinding {
     FavoritesRepository? favorites,
     DownloadRepository? downloads,
     MediaArtworkSource? artwork,
+    DesktopApplicationActions? application,
   }) async =>
       null;
 }
@@ -179,6 +188,7 @@ class PlatformMediaSessionBinding implements MediaSessionBinding {
     FavoritesRepository? favorites,
     DownloadRepository? downloads,
     MediaArtworkSource? artwork,
+    DesktopApplicationActions? application,
   }) =>
       _delegate.attach(
         controller,
@@ -187,5 +197,6 @@ class PlatformMediaSessionBinding implements MediaSessionBinding {
         favorites: favorites,
         downloads: downloads,
         artwork: artwork,
+        application: application,
       );
 }

--- a/lib/core/services/method_channel_linux_window.dart
+++ b/lib/core/services/method_channel_linux_window.dart
@@ -1,0 +1,118 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+
+import '../platform/host_platform.dart';
+import 'desktop_window_controller.dart';
+
+/// The [DesktopWindowController] backed by Linthra's own Linux runner channel
+/// (`linux/runner/window_lifecycle_channel.cc`), for issue #401.
+///
+/// Two directions on one channel:
+///
+///  * Dart -> runner: what the next close should do ([setHideOnClose]), bring
+///    the window back ([showWindow]), and end the process ([quit]).
+///  * runner -> Dart: the window was hidden by a close, or presented again,
+///    including by a *second launch* of an already-running Linthra, which the
+///    single-instance runner turns into "raise the window I already have"
+///    rather than a duplicate process.
+///
+/// Every call is best-effort. A build whose runner predates the channel (or
+/// any non-Linux host) answers [MissingPluginException], which is treated as
+/// "this window cannot be managed": closing it then does what it always did,
+/// which is exactly the safe fallback.
+class MethodChannelLinuxWindow implements DesktopWindowController {
+  MethodChannelLinuxWindow({
+    HostPlatform? host,
+    MethodChannel channel = _defaultChannel,
+  })  : _host = host,
+        _channel = channel {
+    _channel.setMethodCallHandler(_handleRunnerCall);
+  }
+
+  /// Mirrors `kChannelName` in `linux/runner/window_lifecycle_channel.cc`;
+  /// `scripts/check_linux_runner.py` holds the two to the same string.
+  static const String channelName =
+      'io.github.thezupzup.linthra/linux_window_lifecycle';
+
+  /// Mirrors `kSetHideOnCloseMethod` in the runner.
+  static const String setHideOnCloseMethod = 'setHideOnClose';
+
+  /// Mirrors `kShowWindowMethod` in the runner.
+  static const String showWindowMethod = 'showWindow';
+
+  /// Mirrors `kQuitMethod` in the runner.
+  static const String quitMethod = 'quit';
+
+  /// Mirrors `kWindowHiddenMethod` in the runner, sent when a close hid the
+  /// window instead of destroying it.
+  static const String windowHiddenMethod = 'windowHidden';
+
+  /// Mirrors `kWindowShownMethod` in the runner, sent when the window is
+  /// presented again.
+  static const String windowShownMethod = 'windowShown';
+
+  /// Mirrors `kHideOnCloseArgument` in the runner.
+  static const String hideOnCloseArgument = 'hideOnClose';
+
+  static const MethodChannel _defaultChannel = MethodChannel(channelName);
+
+  final HostPlatform? _host;
+  final MethodChannel _channel;
+
+  final StreamController<DesktopWindowVisibility> _visibility =
+      StreamController<DesktopWindowVisibility>.broadcast();
+
+  bool get _isLinux => (_host ?? HostPlatform.current) == HostPlatform.linux;
+
+  @override
+  Stream<DesktopWindowVisibility> get visibility => _visibility.stream;
+
+  @override
+  Future<void> setHideOnClose(bool hideOnClose) {
+    return _invoke(
+      setHideOnCloseMethod,
+      <String, Object?>{hideOnCloseArgument: hideOnClose},
+    );
+  }
+
+  @override
+  Future<void> showWindow() => _invoke(showWindowMethod);
+
+  @override
+  Future<void> quit() => _invoke(quitMethod);
+
+  /// Stops listening to the runner. The channel itself is process-wide, so the
+  /// handler is cleared rather than left pointing at a disposed controller.
+  Future<void> dispose() async {
+    _channel.setMethodCallHandler(null);
+    await _visibility.close();
+  }
+
+  Future<void> _invoke(String method, [Object? arguments]) async {
+    if (!_isLinux) return;
+    try {
+      await _channel.invokeMethod<void>(method, arguments);
+    } on MissingPluginException {
+      // A runner without the channel. Nothing to manage, nothing to report:
+      // the window keeps its default close behaviour.
+    } on PlatformException {
+      // The runner refused (no window yet, or it is already going away).
+      // Never fatal: this only ever adjusts window behaviour.
+    }
+  }
+
+  Future<void> _handleRunnerCall(MethodCall call) async {
+    switch (call.method) {
+      case windowHiddenMethod:
+        _emit(DesktopWindowVisibility.hidden);
+      case windowShownMethod:
+        _emit(DesktopWindowVisibility.shown);
+    }
+  }
+
+  void _emit(DesktopWindowVisibility value) {
+    if (_visibility.isClosed) return;
+    _visibility.add(value);
+  }
+}

--- a/lib/core/services/mpris/mpris_media_session.dart
+++ b/lib/core/services/mpris/mpris_media_session.dart
@@ -9,6 +9,7 @@ import '../../repositories/download_repository.dart';
 import '../../repositories/favorites_repository.dart';
 import '../../repositories/music_library_repository.dart';
 import '../../repositories/playlist_repository.dart';
+import '../desktop_application_actions.dart';
 import '../media_artwork_source.dart';
 import '../media_session_binding.dart';
 import '../playback_controller.dart';
@@ -56,6 +57,7 @@ class MprisMediaSession implements MediaSession {
     MediaArtworkSource? artwork,
     DBusClientFactory clientFactory = DBusClient.session,
     int? processId,
+    DesktopApplicationActions? application,
   }) async {
     DBusClient? client;
     try {
@@ -67,8 +69,11 @@ class MprisMediaSession implements MediaSession {
       // where /org/mpris/MediaPlayer2 does not exist yet, so that introspect
       // answers UnknownObject and a shell that does not retry discovery just
       // never shows Linthra.
-      final MprisPlayerObject object =
-          MprisPlayerObject(controller, artwork: artwork);
+      final MprisPlayerObject object = MprisPlayerObject(
+        controller,
+        artwork: artwork,
+        application: application,
+      );
       await client.registerObject(object);
 
       final String? name = await _claimName(client, processId ?? pid);
@@ -112,9 +117,11 @@ class MprisMediaSession implements MediaSession {
   /// The pid is tried first because it is the spec's suggestion and it makes
   /// the name legible in `playerctl -l`, but it cannot be trusted to be unique:
   /// each Flatpak instance has its own pid namespace, so two sandboxed windows
-  /// can genuinely both be pid 2, and the runner allows several instances
-  /// (G_APPLICATION_NON_UNIQUE). Random suffixes follow, so a collision costs a
-  /// less readable name rather than a window with no media controls at all.
+  /// can genuinely both be pid 2. The runner is single-instance since #401, so
+  /// a second Linthra is rare rather than routine (a second Flatpak instance,
+  /// or a machine with no session bus to register on), but a collision must
+  /// still cost a less readable name rather than a window with no media
+  /// controls at all, which is what the random suffixes that follow are for.
   static Future<String?> _claimName(DBusClient client, int processId) async {
     final Random random = Random();
     for (final String candidate in <String>[
@@ -242,6 +249,7 @@ class MprisMediaSessionBinding implements MediaSessionBinding {
     FavoritesRepository? favorites,
     DownloadRepository? downloads,
     MediaArtworkSource? artwork,
+    DesktopApplicationActions? application,
   }) {
     // The repositories are Android Auto's browse tree. MPRIS has no browsing —
     // `HasTrackList` is false — so they are deliberately unused here.
@@ -249,6 +257,7 @@ class MprisMediaSessionBinding implements MediaSessionBinding {
       controller,
       artwork: artwork,
       clientFactory: _clientFactory,
+      application: application,
     );
   }
 }

--- a/lib/core/services/mpris/mpris_player_object.dart
+++ b/lib/core/services/mpris/mpris_player_object.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:dbus/dbus.dart';
 
 import '../../app_info.dart';
 import '../../models/playback_state.dart';
 import '../../models/repeat_mode.dart';
 import '../../models/track.dart';
+import '../desktop_application_actions.dart';
 import '../media_artwork_source.dart';
 import '../playback_controller.dart';
 
@@ -31,7 +34,9 @@ class MprisPlayerObject extends DBusObject {
   MprisPlayerObject(
     this._controller, {
     MediaArtworkSource? artwork,
+    DesktopApplicationActions? application,
   })  : _artwork = artwork,
+        _application = application,
         super(DBusObjectPath('/org/mpris/MediaPlayer2'));
 
   static const String rootInterface = 'org.mpris.MediaPlayer2';
@@ -44,6 +49,12 @@ class MprisPlayerObject extends DBusObject {
 
   final PlaybackController _controller;
   final MediaArtworkSource? _artwork;
+
+  /// The window and the process behind it, when this build has one it can act
+  /// on (#401). Null on a host that cannot raise or quit itself, and then
+  /// `CanRaise`/`CanQuit` are false and both methods do nothing, which is what
+  /// the spec asks of a player that cannot perform them.
+  final DesktopApplicationActions? _application;
 
   /// A counter behind `mpris:trackid`.
   ///
@@ -135,6 +146,17 @@ class MprisPlayerObject extends DBusObject {
     ];
   }
 
+  /// Runs one of the root interface's application actions without waiting for
+  /// it. Nothing on this object may block a D-Bus reply, least of all Quit,
+  /// whose whole job is to take the connection away.
+  void _startApplicationAction(
+    Future<void> Function(DesktopApplicationActions actions) action,
+  ) {
+    final DesktopApplicationActions? actions = _application;
+    if (actions == null) return;
+    unawaited(action(actions));
+  }
+
   static DBusIntrospectProperty _readable(String name, String signature) =>
       DBusIntrospectProperty(name, DBusSignature(signature),
           access: DBusPropertyAccess.read);
@@ -145,11 +167,20 @@ class MprisPlayerObject extends DBusObject {
   Future<DBusMethodResponse> handleMethodCall(DBusMethodCall methodCall) async {
     if (methodCall.interface == rootInterface) {
       switch (methodCall.name) {
-        // Linthra advertises CanRaise/CanQuit false, so both are accepted and
-        // ignored rather than erroring: the spec says a player that cannot do
-        // them should simply do nothing.
+        // Both are accepted whether or not this build can act on them: the
+        // spec says a player that cannot perform one should simply do
+        // nothing, which is what a null [_application] means here.
         case 'Raise':
+          // Bring the window back. In background mode (#401) this is a
+          // listener's way home from the shell's media widget when Linthra has
+          // no window on screen at all.
+          _startApplicationAction((actions) => actions.raise());
+          return DBusMethodSuccessResponse();
         case 'Quit':
+          // Not awaited on purpose: quitting releases the bus connection this
+          // very call came in on, so the reply has to be sent first. The
+          // shutdown it starts is the same one an in-app Quit runs.
+          _startApplicationAction((actions) => actions.quit());
           return DBusMethodSuccessResponse();
         default:
           return DBusMethodErrorResponse.unknownMethod();
@@ -392,8 +423,10 @@ class MprisPlayerObject extends DBusObject {
   Map<String, DBusValue> properties(String interface) {
     if (interface == rootInterface) {
       return <String, DBusValue>{
-        'CanQuit': const DBusBoolean(false),
-        'CanRaise': const DBusBoolean(false),
+        // True exactly when there is a window/process seam to act on, so a
+        // shell only offers Quit and Raise where they do something (#401).
+        'CanQuit': DBusBoolean(_application != null),
+        'CanRaise': DBusBoolean(_application != null),
         'HasTrackList': const DBusBoolean(false),
         'Identity': const DBusString(AppInfo.name),
         'DesktopEntry': const DBusString(desktopEntry),

--- a/lib/data/repositories/desktop_window_controller_provider.dart
+++ b/lib/data/repositories/desktop_window_controller_provider.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/services/desktop_window_controller.dart';
+import '../../core/services/method_channel_linux_window.dart';
+
+/// The desktop window Linthra manages its close behaviour through (#401).
+///
+/// Defaults to [NoopDesktopWindowController] so widget and unit tests stay
+/// free of platform channels and every non-desktop host ignores the feature.
+/// The running Linux app overrides this with
+/// [linuxDesktopWindowControllerOverride]. Mirrors the
+/// [launcherIconServiceProvider] seam.
+final desktopWindowControllerProvider = Provider<DesktopWindowController>(
+  (ref) => const NoopDesktopWindowController(),
+);
+
+/// Production binding for Linux: the runner's window-lifecycle channel.
+/// Applied in `main` only on Linux, so no other host ever opens the channel.
+final linuxDesktopWindowControllerOverride =
+    desktopWindowControllerProvider.overrideWith((ref) {
+  final MethodChannelLinuxWindow controller = MethodChannelLinuxWindow();
+  ref.onDispose(controller.dispose);
+  return controller;
+});

--- a/lib/data/repositories/desktop_window_preferences_provider.dart
+++ b/lib/data/repositories/desktop_window_preferences_provider.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/repositories/desktop_window_preferences.dart';
+import 'in_memory_desktop_window_preferences.dart';
+import 'shared_preferences_desktop_window_preferences.dart';
+
+/// The user's desktop window preferences (currently "when I close the
+/// window"). In-memory by default so tests and dev runs need no plugins; the
+/// app persists them via `shared_preferences` through
+/// [sharedPreferencesDesktopWindowPreferencesOverride].
+final desktopWindowPreferencesProvider =
+    Provider<DesktopWindowPreferences>((ref) {
+  return InMemoryDesktopWindowPreferences();
+});
+
+final sharedPreferencesDesktopWindowPreferencesOverride =
+    desktopWindowPreferencesProvider.overrideWithValue(
+  const SharedPreferencesDesktopWindowPreferences(),
+);

--- a/lib/data/repositories/in_memory_desktop_window_preferences.dart
+++ b/lib/data/repositories/in_memory_desktop_window_preferences.dart
@@ -1,0 +1,19 @@
+import '../../core/models/desktop_close_behavior.dart';
+import '../../core/repositories/desktop_window_preferences.dart';
+
+/// A non-persistent [DesktopWindowPreferences] for development and tests.
+class InMemoryDesktopWindowPreferences implements DesktopWindowPreferences {
+  InMemoryDesktopWindowPreferences({
+    DesktopCloseBehavior closeBehavior = DesktopCloseBehavior.defaultBehavior,
+  }) : _closeBehavior = closeBehavior;
+
+  DesktopCloseBehavior _closeBehavior;
+
+  @override
+  Future<DesktopCloseBehavior> closeBehavior() async => _closeBehavior;
+
+  @override
+  Future<void> setCloseBehavior(DesktopCloseBehavior behavior) async {
+    _closeBehavior = behavior;
+  }
+}

--- a/lib/data/repositories/shared_preferences_desktop_window_preferences.dart
+++ b/lib/data/repositories/shared_preferences_desktop_window_preferences.dart
@@ -1,0 +1,28 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/models/desktop_close_behavior.dart';
+import '../../core/repositories/desktop_window_preferences.dart';
+
+/// A [DesktopWindowPreferences] backed by `shared_preferences`. One small
+/// string, so it lives next to the other small user choices in the key/value
+/// store rather than in the SQLite catalog.
+class SharedPreferencesDesktopWindowPreferences
+    implements DesktopWindowPreferences {
+  const SharedPreferencesDesktopWindowPreferences();
+
+  static const String _closeBehaviorKey = 'desktop_close_behavior';
+
+  @override
+  Future<DesktopCloseBehavior> closeBehavior() async {
+    final prefs = await SharedPreferences.getInstance();
+    // Unset, or written by a build that knew a different value: quit, the
+    // behaviour closing the window has always had.
+    return DesktopCloseBehavior.fromStorage(prefs.getString(_closeBehaviorKey));
+  }
+
+  @override
+  Future<void> setCloseBehavior(DesktopCloseBehavior behavior) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_closeBehaviorKey, behavior.storageValue);
+  }
+}

--- a/lib/features/settings/desktop/close_behavior_controller.dart
+++ b/lib/features/settings/desktop/close_behavior_controller.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/models/desktop_close_behavior.dart';
+import '../../../data/repositories/desktop_window_preferences_provider.dart';
+
+/// Owns the "When I close the window" choice: loads the persisted value and
+/// writes changes back through [DesktopWindowPreferences].
+///
+/// Only the *stored choice* lives here. What the app does with it (whether a
+/// given close actually hides the window) is
+/// `DesktopWindowLifecycleService`'s decision, taken together with what
+/// playback is doing.
+class DesktopCloseBehaviorController
+    extends AsyncNotifier<DesktopCloseBehavior> {
+  @override
+  Future<DesktopCloseBehavior> build() {
+    return ref.read(desktopWindowPreferencesProvider).closeBehavior();
+  }
+
+  Future<void> setBehavior(DesktopCloseBehavior behavior) async {
+    await ref.read(desktopWindowPreferencesProvider).setCloseBehavior(behavior);
+    state = AsyncData<DesktopCloseBehavior>(behavior);
+  }
+}
+
+final desktopCloseBehaviorControllerProvider =
+    AsyncNotifierProvider<DesktopCloseBehaviorController, DesktopCloseBehavior>(
+  DesktopCloseBehaviorController.new,
+);

--- a/lib/features/settings/desktop/desktop_window_providers.dart
+++ b/lib/features/settings/desktop/desktop_window_providers.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/services/desktop_window_lifecycle_service.dart';
+import '../../../data/repositories/desktop_window_controller_provider.dart';
+import '../../player/player_providers.dart';
+
+/// The service that keeps the desktop runner's close behaviour in step with
+/// the user's choice and with playback, and that owns the explicit quit
+/// (issue #401).
+///
+/// Created lazily and inert off the desktop: with the default
+/// [NoopDesktopWindowController] behind it, nothing is pushed anywhere. The
+/// running app starts it from `bootstrapApplication`, which is also where it
+/// is handed the graceful shutdown it runs before the process ends.
+final desktopWindowLifecycleServiceProvider =
+    Provider<DesktopWindowLifecycleService>((ref) {
+  final DesktopWindowLifecycleService service = DesktopWindowLifecycleService(
+    window: ref.watch(desktopWindowControllerProvider),
+    playback: ref.watch(playbackControllerProvider),
+  );
+  ref.onDispose(service.dispose);
+  return service;
+});

--- a/lib/features/settings/desktop/desktop_window_section.dart
+++ b/lib/features/settings/desktop/desktop_window_section.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/models/desktop_close_behavior.dart';
+import 'close_behavior_controller.dart';
+import 'desktop_window_providers.dart';
+
+/// The "Desktop window" card on the Music & playback settings page.
+///
+/// Desktop-only (the screen decides that), because it configures something
+/// Android does not have: what closing the window does. Background playback is
+/// an opt-in, and the card says plainly what it does and when it ends, so
+/// nobody has to guess why Linthra is still in their media controls.
+class DesktopWindowSettingsSection extends ConsumerWidget {
+  const DesktopWindowSettingsSection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    final AsyncValue<DesktopCloseBehavior> behavior =
+        ref.watch(desktopCloseBehaviorControllerProvider);
+    final DesktopCloseBehavior selected =
+        behavior.valueOrNull ?? DesktopCloseBehavior.defaultBehavior;
+
+    void choose(DesktopCloseBehavior? value) {
+      // Ignore taps until the stored choice has loaded, so a fast tap cannot
+      // be overwritten by the value still on its way in from storage.
+      if (value == null || behavior.isLoading) return;
+      ref
+          .read(desktopCloseBehaviorControllerProvider.notifier)
+          .setBehavior(value);
+    }
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.md,
+          AppSpacing.md,
+          AppSpacing.md,
+          AppSpacing.sm,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.desktop_windows_outlined,
+                  color: theme.colorScheme.primary,
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                Text('Desktop window', style: theme.textTheme.titleMedium),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              'Choose what closing the window does. Keeping playback running '
+              'hides the window and leaves your desktop media controls '
+              'working, but only while something is playing: with nothing to '
+              'play, closing the window still quits.',
+              style: theme.textTheme.bodySmall?.copyWith(color: muted),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            RadioGroup<DesktopCloseBehavior>(
+              groupValue: selected,
+              onChanged: choose,
+              child: Column(
+                children: [
+                  for (final DesktopCloseBehavior option
+                      in DesktopCloseBehavior.values)
+                    RadioListTile<DesktopCloseBehavior>(
+                      contentPadding: EdgeInsets.zero,
+                      value: option,
+                      title: Text(option.label),
+                      subtitle: Text(option.description),
+                    ),
+                ],
+              ),
+            ),
+            const Divider(height: AppSpacing.lg),
+            const QuitLinthraTile(),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The way out that is always available, whatever the close behaviour is set
+/// to: it releases audio, the desktop media controls and the database, then
+/// ends the process.
+///
+/// It earns its place in background mode, where a closed window is no longer
+/// the way to quit. A desktop shell's media controls offer the same Quit over
+/// MPRIS, for when there is no window on screen at all.
+class QuitLinthraTile extends ConsumerWidget {
+  const QuitLinthraTile({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      leading: const Icon(Icons.power_settings_new_outlined),
+      title: const Text('Quit Linthra now'),
+      subtitle: const Text(
+        'Stops playback and closes the app, background playback included.',
+      ),
+      onTap: () => ref.read(desktopWindowLifecycleServiceProvider).quit(),
+    );
+  }
+}

--- a/lib/features/settings/hub/music_and_playback_screen.dart
+++ b/lib/features/settings/hub/music_and_playback_screen.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../app/dimens.dart';
+import '../../../core/platform/host_platform.dart';
+import '../../../data/repositories/host_platform_provider.dart';
+import '../desktop/desktop_window_section.dart';
 import '../playback/playback_settings_section.dart';
 import '../source/default_provider_section.dart';
 import '../source/playback_source_strategy_section.dart';
@@ -10,21 +14,31 @@ import 'settings_detail_scaffold.dart';
 ///
 /// Groups the choices about *which* copy of a song plays and *how* it sounds:
 /// the default source, the playback source strategy, and volume normalization.
-/// Each card is the existing section, unchanged — nothing here touches the
+/// Each card is the existing section, unchanged, and nothing here touches the
 /// playback engine or provider logic.
-class MusicAndPlaybackScreen extends StatelessWidget {
+///
+/// On a desktop host it also carries the close-window behaviour (#401): what
+/// closing the window does is a playback choice there, since the answer is
+/// whether the music keeps going. Android never shows it, because closing a
+/// window is not something Android does.
+class MusicAndPlaybackScreen extends ConsumerWidget {
   const MusicAndPlaybackScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return const SettingsDetailScaffold(
+  Widget build(BuildContext context, WidgetRef ref) {
+    final HostPlatform host = ref.watch(hostPlatformProvider);
+    return SettingsDetailScaffold(
       title: 'Music & playback',
       children: <Widget>[
-        DefaultProviderSettingsSection(),
-        SizedBox(height: AppSpacing.md),
-        PlaybackSourceStrategySettingsSection(),
-        SizedBox(height: AppSpacing.md),
-        PlaybackSettingsSection(),
+        const DefaultProviderSettingsSection(),
+        const SizedBox(height: AppSpacing.md),
+        const PlaybackSourceStrategySettingsSection(),
+        const SizedBox(height: AppSpacing.md),
+        const PlaybackSettingsSection(),
+        if (host.isDesktop) ...<Widget>[
+          const SizedBox(height: AppSpacing.md),
+          const DesktopWindowSettingsSection(),
+        ],
       ],
     );
   }

--- a/linux/runner/CMakeLists.txt
+++ b/linux/runner/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(${BINARY_NAME}
   "main.cc"
   "my_application.cc"
   "folder_picker_channel.cc"
+  "window_lifecycle_channel.cc"
   "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
 )
 

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -7,6 +7,7 @@
 
 #include "flutter/generated_plugin_registrant.h"
 #include "folder_picker_channel.h"
+#include "window_lifecycle_channel.h"
 
 // The user-visible application name. Kept as one constant so the header bar,
 // the fallback title bar, and anything added later can never drift apart — and
@@ -32,6 +33,10 @@ struct _MyApplication {
   // here because it needs the application's own window as the dialog parent,
   // which a plugin registrant does not have.
   FolderPickerChannel* folder_picker;
+  // What closing the window does (#401), and the only thing that knows whether
+  // a window still exists. Owned here for the same reason: it is the
+  // application's own window it manages.
+  WindowLifecycleChannel* window_lifecycle;
 };
 
 G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
@@ -44,6 +49,17 @@ static void first_frame_cb(MyApplication* self, FlView* view) {
 // Implements GApplication::activate.
 static void my_application_activate(GApplication* application) {
   MyApplication* self = MY_APPLICATION(application);
+
+  // Already running: present the window we have instead of building a second
+  // one. This is the path a launcher click takes while Linthra is playing in
+  // the background with its window hidden (#401) - the runner is
+  // single-instance, so GTK hands that click to this process as an
+  // activation, and the answer to it is "here is your window back", never a
+  // duplicate app.
+  if (window_lifecycle_channel_present(self->window_lifecycle)) {
+    return;
+  }
+
   GtkWindow* window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
 
@@ -113,6 +129,11 @@ static void my_application_activate(GApplication* application) {
   // zenity/kdialog, which the sandbox does not contain. See
   // folder_picker_channel.h.
   self->folder_picker = folder_picker_channel_new(view, window);
+
+  // Registered on the same engine, and for the same reason: closing this
+  // window is the application's own decision to make, and only the runner can
+  // answer a GTK delete-event in time. See window_lifecycle_channel.h.
+  self->window_lifecycle = window_lifecycle_channel_new(view, window);
 
   gtk_widget_grab_focus(GTK_WIDGET(view));
 }
@@ -205,6 +226,7 @@ static void my_application_dispose(GObject* object) {
   MyApplication* self = MY_APPLICATION(object);
   g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
   g_clear_pointer(&self->folder_picker, folder_picker_channel_free);
+  g_clear_pointer(&self->window_lifecycle, window_lifecycle_channel_free);
   G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
 }
 
@@ -236,7 +258,20 @@ MyApplication* my_application_new() {
   // because GDK reads the program name there.
   g_set_prgname(APPLICATION_ID);
 
+  // Single instance, deliberately (#401). Launching Linthra while it is
+  // already running has to reach the window that exists rather than start a
+  // second process: two of them would mean two audio engines, two MPRIS names
+  // and two connections to the same SQLite catalog. GTK forwards the second
+  // launch to this one as an activation, and my_application_activate() answers
+  // it by presenting the window - including when a close had hidden it and
+  // there is nothing else on screen to click.
+  //
+  // The flags value is spelled as a cast rather than named: G_APPLICATION_NONE
+  // is deprecated from GLib 2.74 (which -Werror turns into a build failure) and
+  // its replacement G_APPLICATION_DEFAULT_FLAGS does not exist before it, so
+  // neither name builds everywhere Linthra is built.
   return MY_APPLICATION(g_object_new(my_application_get_type(),
                                      "application-id", APPLICATION_ID, "flags",
-                                     G_APPLICATION_NON_UNIQUE, nullptr));
+                                     static_cast<GApplicationFlags>(0),
+                                     nullptr));
 }

--- a/linux/runner/window_lifecycle_channel.cc
+++ b/linux/runner/window_lifecycle_channel.cc
@@ -1,0 +1,214 @@
+#include "window_lifecycle_channel.h"
+
+// The channel and method names Dart's MethodChannelLinuxWindow uses.
+// scripts/check_linux_runner.py holds the two sides to the same strings, so a
+// rename on one side fails a check instead of silently leaving every window
+// close doing whatever it did before the preference existed.
+static constexpr const char* kChannelName =
+    "io.github.thezupzup.linthra/linux_window_lifecycle";
+static constexpr const char* kSetHideOnCloseMethod = "setHideOnClose";
+static constexpr const char* kShowWindowMethod = "showWindow";
+static constexpr const char* kQuitMethod = "quit";
+static constexpr const char* kWindowHiddenMethod = "windowHidden";
+static constexpr const char* kWindowShownMethod = "windowShown";
+static constexpr const char* kHideOnCloseArgument = "hideOnClose";
+
+// Sent back when `setHideOnClose` arrives without the boolean it is named
+// after. Dart never does that; a build whose two halves disagree would, and it
+// should say so rather than quietly keeping the old behaviour.
+static constexpr const char* kInvalidArgumentsError = "invalid_arguments";
+// There is no window to act on: it has already been destroyed, or the app is
+// on its way out.
+static constexpr const char* kNoWindowError = "no_window";
+
+struct _WindowLifecycleChannel {
+  FlMethodChannel* channel;
+  // The application window. Cleared when GTK destroys it, so nothing here can
+  // reach a window that is already gone.
+  GtkWindow* window;
+  // What the next close does. FALSE (quit) until Dart says otherwise, which is
+  // deliberate: a runner that has not heard from the app behaves exactly like
+  // the one that shipped before this feature.
+  gboolean hide_on_close;
+  gulong delete_event_handler;
+  gulong destroy_handler;
+  // A pending `quit`, so it can be cancelled if the app goes away first.
+  guint quit_source;
+};
+
+// Tells Dart the window is now hidden / visible again. Fire-and-forget: this
+// is a notification, and there is nothing useful to do about a failure to
+// deliver one.
+static void notify_visibility(WindowLifecycleChannel* self,
+                              const char* method) {
+  g_autoptr(FlValue) args = fl_value_new_null();
+  fl_method_channel_invoke_method(self->channel, method, args, nullptr, nullptr,
+                                  nullptr);
+}
+
+static void respond_error(FlMethodCall* method_call, const char* code,
+                          const char* message) {
+  g_autoptr(FlMethodResponse) response =
+      FL_METHOD_RESPONSE(fl_method_error_response_new(code, message, nullptr));
+  g_autoptr(GError) error = nullptr;
+  if (!fl_method_call_respond(method_call, response, &error)) {
+    g_warning("Failed to send window lifecycle error: %s", error->message);
+  }
+}
+
+static void respond_success(FlMethodCall* method_call) {
+  g_autoptr(FlValue) result = fl_value_new_null();
+  g_autoptr(GError) error = nullptr;
+  if (!fl_method_call_respond_success(method_call, result, &error)) {
+    g_warning("Failed to send window lifecycle result: %s", error->message);
+  }
+}
+
+// The close button, the window menu, Alt+F4 and a compositor's close request
+// all arrive here.
+static gboolean window_delete_event_cb(GtkWidget* widget, GdkEvent* event,
+                                       gpointer user_data) {
+  WindowLifecycleChannel* self =
+      static_cast<WindowLifecycleChannel*>(user_data);
+  if (!self->hide_on_close) {
+    // Let GTK destroy the window. That takes the engine down with it, which is
+    // where Dart's own graceful shutdown runs.
+    return FALSE;
+  }
+
+  // Hidden, not destroyed: the window stays a GtkApplication window, so the
+  // application keeps running, the audio engine is untouched, and the MPRIS
+  // name stays on the bus.
+  gtk_widget_hide(widget);
+  notify_visibility(self, kWindowHiddenMethod);
+  return TRUE;
+}
+
+static void window_destroy_cb(GtkWidget* widget, gpointer user_data) {
+  WindowLifecycleChannel* self =
+      static_cast<WindowLifecycleChannel*>(user_data);
+  self->window = nullptr;
+  self->delete_event_handler = 0;
+  self->destroy_handler = 0;
+}
+
+// Destroying the window ends the process, so it happens after the reply to
+// `quit` has been sent rather than inside the call that asked for it.
+static gboolean quit_in_idle_cb(gpointer user_data) {
+  WindowLifecycleChannel* self =
+      static_cast<WindowLifecycleChannel*>(user_data);
+  self->quit_source = 0;
+  if (self->window == nullptr) return G_SOURCE_REMOVE;
+  // Past this point a close must never be turned into a hide.
+  self->hide_on_close = FALSE;
+  gtk_widget_destroy(GTK_WIDGET(self->window));
+  return G_SOURCE_REMOVE;
+}
+
+static void handle_set_hide_on_close(WindowLifecycleChannel* self,
+                                     FlMethodCall* method_call) {
+  FlValue* args = fl_method_call_get_args(method_call);
+  if (args == nullptr || fl_value_get_type(args) != FL_VALUE_TYPE_MAP) {
+    respond_error(method_call, kInvalidArgumentsError,
+                  "setHideOnClose expects a map argument.");
+    return;
+  }
+  FlValue* value = fl_value_lookup_string(args, kHideOnCloseArgument);
+  if (value == nullptr || fl_value_get_type(value) != FL_VALUE_TYPE_BOOL) {
+    respond_error(method_call, kInvalidArgumentsError,
+                  "setHideOnClose expects a bool hideOnClose.");
+    return;
+  }
+  self->hide_on_close = fl_value_get_bool(value) ? TRUE : FALSE;
+  respond_success(method_call);
+}
+
+static void window_lifecycle_method_call_cb(FlMethodChannel* channel,
+                                            FlMethodCall* method_call,
+                                            gpointer user_data) {
+  WindowLifecycleChannel* self =
+      static_cast<WindowLifecycleChannel*>(user_data);
+  const gchar* name = fl_method_call_get_name(method_call);
+
+  if (g_strcmp0(name, kSetHideOnCloseMethod) == 0) {
+    handle_set_hide_on_close(self, method_call);
+    return;
+  }
+
+  if (g_strcmp0(name, kShowWindowMethod) == 0) {
+    if (!window_lifecycle_channel_present(self)) {
+      respond_error(method_call, kNoWindowError,
+                    "There is no window to show.");
+      return;
+    }
+    respond_success(method_call);
+    return;
+  }
+
+  if (g_strcmp0(name, kQuitMethod) == 0) {
+    if (self->window == nullptr) {
+      respond_error(method_call, kNoWindowError,
+                    "There is no window to close.");
+      return;
+    }
+    if (self->quit_source == 0) {
+      self->quit_source = g_idle_add(quit_in_idle_cb, self);
+    }
+    respond_success(method_call);
+    return;
+  }
+
+  g_autoptr(FlMethodResponse) response =
+      FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
+  g_autoptr(GError) error = nullptr;
+  if (!fl_method_call_respond(method_call, response, &error)) {
+    g_warning("Failed to respond to window lifecycle call: %s", error->message);
+  }
+}
+
+WindowLifecycleChannel* window_lifecycle_channel_new(FlView* view,
+                                                     GtkWindow* window) {
+  WindowLifecycleChannel* self = g_new0(WindowLifecycleChannel, 1);
+  self->window = window;
+  self->hide_on_close = FALSE;
+
+  g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
+  FlEngine* engine = fl_view_get_engine(view);
+  self->channel = fl_method_channel_new(fl_engine_get_binary_messenger(engine),
+                                        kChannelName, FL_METHOD_CODEC(codec));
+  fl_method_channel_set_method_call_handler(
+      self->channel, window_lifecycle_method_call_cb, self, nullptr);
+
+  self->delete_event_handler =
+      g_signal_connect(window, "delete-event",
+                       G_CALLBACK(window_delete_event_cb), self);
+  self->destroy_handler =
+      g_signal_connect(window, "destroy", G_CALLBACK(window_destroy_cb), self);
+  return self;
+}
+
+gboolean window_lifecycle_channel_present(WindowLifecycleChannel* self) {
+  if (self == nullptr || self->window == nullptr) return FALSE;
+  gtk_window_present(self->window);
+  notify_visibility(self, kWindowShownMethod);
+  return TRUE;
+}
+
+void window_lifecycle_channel_free(WindowLifecycleChannel* self) {
+  if (self == nullptr) return;
+  if (self->quit_source != 0) {
+    g_source_remove(self->quit_source);
+    self->quit_source = 0;
+  }
+  if (self->window != nullptr) {
+    if (self->delete_event_handler != 0) {
+      g_signal_handler_disconnect(self->window, self->delete_event_handler);
+    }
+    if (self->destroy_handler != 0) {
+      g_signal_handler_disconnect(self->window, self->destroy_handler);
+    }
+    self->window = nullptr;
+  }
+  g_clear_object(&self->channel);
+  g_free(self);
+}

--- a/linux/runner/window_lifecycle_channel.h
+++ b/linux/runner/window_lifecycle_channel.h
@@ -1,0 +1,44 @@
+#ifndef RUNNER_WINDOW_LIFECYCLE_CHANNEL_H_
+#define RUNNER_WINDOW_LIFECYCLE_CHANNEL_H_
+
+#include <flutter_linux/flutter_linux.h>
+#include <gtk/gtk.h>
+
+G_BEGIN_DECLS
+
+// The native half of Linthra's configurable close-window behaviour (#401).
+//
+// A GTK `delete-event` handler has to answer *now*: there is no way to ask
+// Dart what to do and keep the window alive while the answer travels. So the
+// decision is pushed the other way round. Dart's
+// `DesktopWindowLifecycleService` recomputes "should the next close hide the
+// window?" whenever the user's preference or playback changes and sends it
+// here, and this channel then answers each close locally and instantly, with
+// the answer the app would have given.
+//
+// The channel carries three calls in (`setHideOnClose`, `showWindow`, `quit`)
+// and two out (`windowHidden`, `windowShown`), so Dart knows when it is
+// running with no window on screen. That is what lets it quit itself once the
+// queue ends instead of leaving an invisible process behind.
+typedef struct _WindowLifecycleChannel WindowLifecycleChannel;
+
+// Registers the window-lifecycle channel on `view`'s engine and takes over
+// `window`'s close handling. Never returns NULL.
+WindowLifecycleChannel* window_lifecycle_channel_new(FlView* view,
+                                                     GtkWindow* window);
+
+// Brings the window back and tells Dart it is visible again. Returns FALSE if
+// there is no window left to present, which is the caller's cue to build one.
+//
+// This is what a *second launch* of an already-running Linthra ends up in: the
+// runner is single-instance, so GTK forwards the launch to the running process
+// as an activation instead of starting a duplicate.
+gboolean window_lifecycle_channel_present(WindowLifecycleChannel* self);
+
+// Tears the channel down: drops the signal handlers it installed and cancels a
+// quit it had not got round to yet.
+void window_lifecycle_channel_free(WindowLifecycleChannel* self);
+
+G_END_DECLS
+
+#endif  // RUNNER_WINDOW_LIFECYCLE_CHANNEL_H_

--- a/scripts/check_linux_runner.py
+++ b/scripts/check_linux_runner.py
@@ -102,6 +102,12 @@ FOLDER_PICKER_CHANNEL_SOURCE = Path("linux") / "runner" / "folder_picker_channel
 FOLDER_PICKER_DART = (
     Path("lib") / "core" / "services" / "method_channel_linux_folder_picker.dart"
 )
+WINDOW_LIFECYCLE_CHANNEL_SOURCE = (
+    Path("linux") / "runner" / "window_lifecycle_channel.cc"
+)
+WINDOW_LIFECYCLE_DART = (
+    Path("lib") / "core" / "services" / "method_channel_linux_window.dart"
+)
 PUBSPEC = Path("pubspec.yaml")
 APP_INFO = Path("lib") / "core" / "app_info.dart"
 BUILD_GRADLE = Path("android") / "app" / "build.gradle"
@@ -218,6 +224,30 @@ FOLDER_PICKER_NATIVE_CHANNEL = r'kChannelName\s*=\s*\n?\s*"([^"]+)"'
 FOLDER_PICKER_NATIVE_METHOD = r'kPickFolderMethod\s*=\s*"([^"]+)"'
 FOLDER_PICKER_DART_CHANNEL = r"String channelName\s*=\s*\n?\s*'([^']+)'"
 FOLDER_PICKER_DART_METHOD = r"String pickFolderMethod\s*=\s*'([^']+)'"
+
+# The window-lifecycle channel (#401), checked the same way and for the same
+# reason. This one is worse when it drifts than the folder picker: nothing
+# fails, no dialog is missing, the app simply goes back to quitting on every
+# close while Settings still offers a choice that no longer does anything. Each
+# name below is one string on each side of the same wire.
+WINDOW_LIFECYCLE_NAMES = (
+    ("channel name", "kChannelName", "channelName"),
+    ("setHideOnClose method", "kSetHideOnCloseMethod", "setHideOnCloseMethod"),
+    ("showWindow method", "kShowWindowMethod", "showWindowMethod"),
+    ("quit method", "kQuitMethod", "quitMethod"),
+    ("windowHidden method", "kWindowHiddenMethod", "windowHiddenMethod"),
+    ("windowShown method", "kWindowShownMethod", "windowShownMethod"),
+    ("hideOnClose argument", "kHideOnCloseArgument", "hideOnCloseArgument"),
+)
+
+# GApplication's uniqueness, which the close behaviour depends on (#401). The
+# Flutter template runner is NON_UNIQUE, so a `flutter create` regeneration
+# would restore it, and the failure would be silent in the worst way: launching
+# Linthra while it is playing in the background with a hidden window would
+# start a *second* process, with a second audio engine, a second MPRIS name and
+# a second connection to the same SQLite catalog, instead of showing the window
+# that already exists.
+NON_UNIQUE_FLAG = "G_APPLICATION_NON_UNIQUE"
 
 # === Window identity (#554) ===
 #
@@ -761,6 +791,72 @@ def folder_picker_problems(root: Path) -> list[str]:
     return problems
 
 
+def window_lifecycle_problems(root: Path) -> list[str]:
+    """Disagreements between the runner's window-lifecycle channel and Dart's.
+
+    The channel is how the configurable close behaviour (#401) reaches the one
+    place that can act on it: a GTK `delete-event` has to be answered
+    synchronously, so Dart pushes the answer ahead of time and the runner
+    applies it. A mismatched name still compiles and still runs; the runner
+    just never hears what to do, every close destroys the window as before, and
+    the preference in Settings quietly stops meaning anything.
+    """
+    problems: list[str] = []
+
+    runner_cmakelists = _read(root, RUNNER_CMAKELISTS)
+    if WINDOW_LIFECYCLE_CHANNEL_SOURCE.name not in runner_cmakelists:
+        problems.append(
+            f"{RUNNER_CMAKELISTS} does not compile "
+            f"{WINDOW_LIFECYCLE_CHANNEL_SOURCE.name}, so the runner registers "
+            "no window-lifecycle channel"
+        )
+
+    native = _read(root, WINDOW_LIFECYCLE_CHANNEL_SOURCE)
+    dart = _read(root, WINDOW_LIFECYCLE_DART)
+    for what, native_constant, dart_constant in WINDOW_LIFECYCLE_NAMES:
+        native_value = _extract(
+            native,
+            rf'{native_constant}\s*=\s*\n?\s*"([^"]+)"',
+            f"the window lifecycle {what}",
+            WINDOW_LIFECYCLE_CHANNEL_SOURCE,
+        )
+        dart_value = _extract(
+            dart,
+            rf"String {dart_constant}\s*=\s*\n?\s*'([^']+)'",
+            f"the window lifecycle {what}",
+            WINDOW_LIFECYCLE_DART,
+        )
+        if native_value != dart_value:
+            problems.append(
+                f"window lifecycle {what} is {native_value!r} in "
+                f"{WINDOW_LIFECYCLE_CHANNEL_SOURCE} but {dart_value!r} in "
+                f"{WINDOW_LIFECYCLE_DART}"
+            )
+
+    my_application = _read(root, MY_APPLICATION)
+    if "window_lifecycle_channel_new" not in my_application:
+        problems.append(
+            f"{MY_APPLICATION} never calls window_lifecycle_channel_new(), so "
+            "the window-lifecycle channel is never registered on the engine"
+        )
+    # Presenting the existing window is what makes a second launch reach the
+    # first instance instead of building another window on top of it.
+    if "window_lifecycle_channel_present" not in my_application:
+        problems.append(
+            f"{MY_APPLICATION} never calls window_lifecycle_channel_present(), "
+            "so activating a running Linthra builds a second window instead of "
+            "showing the one it already has"
+        )
+    if NON_UNIQUE_FLAG in _blank(my_application):
+        problems.append(
+            f"{MY_APPLICATION} registers the application as "
+            f"{NON_UNIQUE_FLAG}, so launching Linthra while it is already "
+            "running starts a duplicate process instead of presenting the "
+            "window it already has (see #401)"
+        )
+    return problems
+
+
 def _blank(source: str, *, comments: bool = True, strings: bool = False) -> str:
     """Return `source` with comments and/or string literals replaced by spaces.
 
@@ -962,6 +1058,10 @@ def check(root: Path) -> list[str]:
     # The folder-picker channel (#438): two strings that have to agree, and a
     # source file that has to be compiled and registered.
     problems.extend(folder_picker_problems(root))
+
+    # The window-lifecycle channel (#401): the same shape of contract, plus the
+    # single-instance registration the close behaviour depends on.
+    problems.extend(window_lifecycle_problems(root))
 
     # The window identity (#554): the GTK/GDK calls that make the *running*
     # window answer to the same id as everything installed above, in the places

--- a/test/core/lifecycle/desktop_close_policy_test.dart
+++ b/test/core/lifecycle/desktop_close_policy_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/lifecycle/desktop_close_policy.dart';
+import 'package:linthra/core/models/desktop_close_behavior.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+
+const Track _track = Track(id: 't1', title: 'A Song', uri: '/music/a.flac');
+
+PlaybackState _state(PlaybackStatus status, {bool withTrack = true}) {
+  return PlaybackState(
+    status: status,
+    currentTrack: withTrack ? _track : null,
+  );
+}
+
+void main() {
+  group('hidesOnClose', () {
+    test('quit never hides the window, whatever playback is doing', () {
+      for (final PlaybackStatus status in PlaybackStatus.values) {
+        expect(
+          DesktopClosePolicy.hidesOnClose(
+            DesktopCloseBehavior.quit,
+            _state(status),
+          ),
+          isFalse,
+          reason: 'status $status',
+        );
+      }
+    });
+
+    test('keep playing hides the window while audio is on its way out', () {
+      for (final PlaybackStatus status in <PlaybackStatus>[
+        PlaybackStatus.playing,
+        PlaybackStatus.loading,
+        PlaybackStatus.buffering,
+        PlaybackStatus.reconnecting,
+      ]) {
+        expect(
+          DesktopClosePolicy.hidesOnClose(
+            DesktopCloseBehavior.keepPlaying,
+            _state(status),
+          ),
+          isTrue,
+          reason: 'status $status',
+        );
+      }
+    });
+
+    test('keep playing still quits when there is nothing to keep playing', () {
+      // The "no hidden zombie process" rule: the preference alone never hides
+      // a window. Pausing counts as nothing to keep alive, because a paused
+      // player the listener just closed is not background playback.
+      for (final PlaybackStatus status in <PlaybackStatus>[
+        PlaybackStatus.idle,
+        PlaybackStatus.paused,
+        PlaybackStatus.completed,
+        PlaybackStatus.error,
+      ]) {
+        expect(
+          DesktopClosePolicy.hidesOnClose(
+            DesktopCloseBehavior.keepPlaying,
+            _state(status),
+          ),
+          isFalse,
+          reason: 'status $status',
+        );
+      }
+    });
+  });
+
+  group('keepsRunningWhileHidden', () {
+    test('playing, buffering and reconnecting all keep the app alive', () {
+      for (final PlaybackStatus status in <PlaybackStatus>[
+        PlaybackStatus.playing,
+        PlaybackStatus.loading,
+        PlaybackStatus.buffering,
+        PlaybackStatus.reconnecting,
+      ]) {
+        expect(
+          DesktopClosePolicy.keepsRunningWhileHidden(_state(status)),
+          isTrue,
+          reason: 'status $status',
+        );
+      }
+    });
+
+    test('a pause taken from the media controls keeps the app alive', () {
+      // With no window on screen, the shell's media widget is the only
+      // interface left: a pause there has to survive long enough to be resumed
+      // from the same widget.
+      expect(
+        DesktopClosePolicy.keepsRunningWhileHidden(
+          _state(PlaybackStatus.paused),
+        ),
+        isTrue,
+      );
+    });
+
+    test('the queue running out ends a hidden session', () {
+      for (final PlaybackState state in <PlaybackState>[
+        _state(PlaybackStatus.completed),
+        _state(PlaybackStatus.idle, withTrack: false),
+        _state(PlaybackStatus.paused, withTrack: false),
+        _state(PlaybackStatus.error, withTrack: false),
+      ]) {
+        expect(
+          DesktopClosePolicy.keepsRunningWhileHidden(state),
+          isFalse,
+          reason: 'status ${state.status}',
+        );
+      }
+    });
+  });
+}

--- a/test/core/models/desktop_close_behavior_test.dart
+++ b/test/core/models/desktop_close_behavior_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/desktop_close_behavior.dart';
+
+void main() {
+  test('quit is what a fresh install gets', () {
+    expect(DesktopCloseBehavior.defaultBehavior, DesktopCloseBehavior.quit);
+  });
+
+  test('every value survives a round trip through storage', () {
+    for (final DesktopCloseBehavior behavior in DesktopCloseBehavior.values) {
+      expect(
+        DesktopCloseBehavior.fromStorage(behavior.storageValue),
+        behavior,
+      );
+    }
+  });
+
+  test('an unknown or missing stored value reads as quit', () {
+    // A value written by a newer build, or a corrupted entry: the app has to
+    // start, and the behaviour it starts with is the conservative one.
+    expect(DesktopCloseBehavior.fromStorage(null), DesktopCloseBehavior.quit);
+    expect(DesktopCloseBehavior.fromStorage(''), DesktopCloseBehavior.quit);
+    expect(
+      DesktopCloseBehavior.fromStorage('minimise_to_tray'),
+      DesktopCloseBehavior.quit,
+    );
+  });
+
+  test('stored values are stable strings, not enum names or indexes', () {
+    // Renaming or reordering the enum must not change what an installed copy
+    // of Linthra reads back out of storage.
+    expect(DesktopCloseBehavior.quit.storageValue, 'quit');
+    expect(DesktopCloseBehavior.keepPlaying.storageValue, 'keep_playing');
+  });
+}

--- a/test/core/services/desktop_window_lifecycle_service_test.dart
+++ b/test/core/services/desktop_window_lifecycle_service_test.dart
@@ -1,0 +1,214 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/desktop_close_behavior.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/desktop_window_controller.dart';
+import 'package:linthra/core/services/desktop_window_lifecycle_service.dart';
+
+import '../../features/player/fake_playback_controller.dart';
+
+/// A [DesktopWindowController] that records what the app asked the window to
+/// do, and lets a test play the runner's side of the conversation.
+class _RecordingWindow implements DesktopWindowController {
+  final List<bool> hideOnClose = <bool>[];
+  int showCount = 0;
+  int quitCount = 0;
+
+  final StreamController<DesktopWindowVisibility> _visibility =
+      StreamController<DesktopWindowVisibility>.broadcast();
+
+  @override
+  Stream<DesktopWindowVisibility> get visibility => _visibility.stream;
+
+  /// The runner reporting a close that hid the window, or a window presented
+  /// again.
+  Future<void> report(DesktopWindowVisibility value) async {
+    _visibility.add(value);
+    await pumpEventQueue();
+  }
+
+  @override
+  Future<void> setHideOnClose(bool value) async => hideOnClose.add(value);
+
+  @override
+  Future<void> showWindow() async => showCount++;
+
+  @override
+  Future<void> quit() async => quitCount++;
+
+  Future<void> dispose() => _visibility.close();
+}
+
+const Track _track = Track(id: 't1', title: 'A Song', uri: '/music/a.flac');
+
+PlaybackState _playing() => const PlaybackState(
+      status: PlaybackStatus.playing,
+      currentTrack: _track,
+    );
+
+void main() {
+  late FakePlaybackController playback;
+  late _RecordingWindow window;
+  late DesktopWindowLifecycleService service;
+
+  setUp(() {
+    playback = FakePlaybackController();
+    window = _RecordingWindow();
+    service = DesktopWindowLifecycleService(
+      window: window,
+      playback: playback,
+    );
+  });
+
+  tearDown(() async {
+    await service.dispose();
+    await window.dispose();
+    await playback.dispose();
+  });
+
+  test('tells the runner to quit on close until the user asks otherwise', () {
+    service.start();
+
+    expect(window.hideOnClose, <bool>[false]);
+  });
+
+  test('hides on close only once both the choice and the audio are there',
+      () async {
+    service.start();
+    window.hideOnClose.clear();
+
+    // The preference alone changes nothing: there is nothing playing yet.
+    service.setCloseBehavior(DesktopCloseBehavior.keepPlaying);
+    expect(window.hideOnClose, isEmpty);
+
+    playback.emit(_playing());
+    await pumpEventQueue();
+    expect(window.hideOnClose, <bool>[true]);
+
+    // And it is taken back the moment the music stops, so a close after the
+    // queue ends quits instead of hiding a silent window.
+    playback.emit(const PlaybackState(status: PlaybackStatus.completed));
+    await pumpEventQueue();
+    expect(window.hideOnClose, <bool>[true, false]);
+  });
+
+  test('pushes each answer once rather than on every position tick', () async {
+    service.start();
+    service.setCloseBehavior(DesktopCloseBehavior.keepPlaying);
+    window.hideOnClose.clear();
+
+    playback.emit(_playing());
+    await pumpEventQueue();
+    playback.emit(const PlaybackState(
+      status: PlaybackStatus.playing,
+      currentTrack: _track,
+      position: Duration(seconds: 3),
+    ));
+    await pumpEventQueue();
+
+    expect(window.hideOnClose, <bool>[true]);
+  });
+
+  test('a hidden Linthra quits itself when the queue runs out', () async {
+    final List<String> order = <String>[];
+    service.installShutdown(() async => order.add('shutdown'));
+    service.start();
+    service.setCloseBehavior(DesktopCloseBehavior.keepPlaying);
+    playback.emit(_playing());
+    await pumpEventQueue();
+
+    await window.report(DesktopWindowVisibility.hidden);
+    expect(window.quitCount, 0);
+
+    playback.emit(const PlaybackState(status: PlaybackStatus.completed));
+    await pumpEventQueue();
+
+    expect(order, <String>['shutdown']);
+    expect(window.quitCount, 1);
+  });
+
+  test('a pause with the window hidden keeps the app running', () async {
+    service.start();
+    service.setCloseBehavior(DesktopCloseBehavior.keepPlaying);
+    playback.emit(_playing());
+    await pumpEventQueue();
+    await window.report(DesktopWindowVisibility.hidden);
+
+    playback.emit(const PlaybackState(
+      status: PlaybackStatus.paused,
+      currentTrack: _track,
+    ));
+    await pumpEventQueue();
+
+    expect(window.quitCount, 0);
+  });
+
+  test('a visible Linthra never quits itself when playback ends', () async {
+    service.start();
+    service.setCloseBehavior(DesktopCloseBehavior.keepPlaying);
+    playback.emit(_playing());
+    await pumpEventQueue();
+    playback.emit(PlaybackState.idle);
+    await pumpEventQueue();
+
+    expect(window.quitCount, 0);
+  });
+
+  test('quit releases the app before the window goes away', () async {
+    final List<String> order = <String>[];
+    service.installShutdown(() async {
+      await Future<void>.delayed(Duration.zero);
+      order.add('shutdown');
+    });
+    service.start();
+
+    await service.quit();
+
+    expect(order, <String>['shutdown']);
+    expect(window.quitCount, 1);
+  });
+
+  test('quit runs once, however many times it is asked for', () async {
+    int shutdowns = 0;
+    service.installShutdown(() async => shutdowns++);
+    service.start();
+
+    await service.quit();
+    await service.quit();
+
+    expect(shutdowns, 1);
+    expect(window.quitCount, 1);
+  });
+
+  test('a shutdown that throws still ends the process', () async {
+    service.installShutdown(() async => throw StateError('teardown failed'));
+    service.start();
+
+    await service.quit();
+
+    expect(window.quitCount, 1);
+  });
+
+  test('raise asks the runner to show the window', () async {
+    service.start();
+
+    await service.raise();
+
+    expect(window.showCount, 1);
+  });
+
+  test('the window is left alone when the container is disposed', () async {
+    service.start();
+
+    await service.dispose();
+
+    expect(window.quitCount, 0);
+    // And a late playback state cannot reach a torn-down container.
+    window.hideOnClose.clear();
+    playback.emit(_playing());
+    await pumpEventQueue();
+    expect(window.hideOnClose, isEmpty);
+  });
+}

--- a/test/core/services/media_session_binding_test.dart
+++ b/test/core/services/media_session_binding_test.dart
@@ -4,6 +4,7 @@ import 'package:linthra/core/repositories/download_repository.dart';
 import 'package:linthra/core/repositories/favorites_repository.dart';
 import 'package:linthra/core/repositories/music_library_repository.dart';
 import 'package:linthra/core/repositories/playlist_repository.dart';
+import 'package:linthra/core/services/desktop_application_actions.dart';
 import 'package:linthra/core/services/media_artwork_source.dart';
 import 'package:linthra/core/services/media_session_binding.dart';
 import 'package:linthra/core/services/playback_controller.dart';
@@ -33,6 +34,7 @@ class _RecordingBinding implements MediaSessionBinding {
     FavoritesRepository? favorites,
     DownloadRepository? downloads,
     MediaArtworkSource? artwork,
+    DesktopApplicationActions? application,
   }) async {
     attachCalls++;
     return result ? const InertMediaSession() : null;

--- a/test/core/services/method_channel_linux_window_test.dart
+++ b/test/core/services/method_channel_linux_window_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/core/services/desktop_window_controller.dart';
+import 'package:linthra/core/services/method_channel_linux_window.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const MethodChannel channel =
+      MethodChannel(MethodChannelLinuxWindow.channelName);
+  const StandardMethodCodec codec = StandardMethodCodec();
+
+  /// Installs a handler for the runner's channel and records what Dart sent.
+  List<MethodCall> handleWith(Future<Object?> Function(MethodCall) handler) {
+    final List<MethodCall> calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall call) async {
+      calls.add(call);
+      return handler(call);
+    });
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+    return calls;
+  }
+
+  MethodChannelLinuxWindow window({HostPlatform host = HostPlatform.linux}) {
+    final MethodChannelLinuxWindow controller =
+        MethodChannelLinuxWindow(host: host);
+    addTearDown(controller.dispose);
+    return controller;
+  }
+
+  /// Delivers a call *from* the runner, the way the engine would.
+  Future<void> sendFromRunner(String method) {
+    return TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(
+      MethodChannelLinuxWindow.channelName,
+      codec.encodeMethodCall(MethodCall(method)),
+      (_) {},
+    );
+  }
+
+  group('MethodChannelLinuxWindow', () {
+    test('sends the close behaviour the runner has to act on', () async {
+      final List<MethodCall> calls = handleWith((_) async => null);
+
+      await window().setHideOnClose(true);
+
+      expect(
+          calls.single.method, MethodChannelLinuxWindow.setHideOnCloseMethod);
+      expect(
+        calls.single.arguments,
+        <String, Object?>{MethodChannelLinuxWindow.hideOnCloseArgument: true},
+      );
+    });
+
+    test('asks the runner to show the window and to quit', () async {
+      final List<MethodCall> calls = handleWith((_) async => null);
+      final MethodChannelLinuxWindow controller = window();
+
+      await controller.showWindow();
+      await controller.quit();
+
+      expect(
+        calls.map((MethodCall call) => call.method),
+        <String>[
+          MethodChannelLinuxWindow.showWindowMethod,
+          MethodChannelLinuxWindow.quitMethod,
+        ],
+      );
+    });
+
+    test('reports the window being hidden and shown again', () async {
+      handleWith((_) async => null);
+      final MethodChannelLinuxWindow controller = window();
+      final List<DesktopWindowVisibility> seen = <DesktopWindowVisibility>[];
+      final sub = controller.visibility.listen(seen.add);
+      addTearDown(sub.cancel);
+
+      await sendFromRunner(MethodChannelLinuxWindow.windowHiddenMethod);
+      await sendFromRunner(MethodChannelLinuxWindow.windowShownMethod);
+
+      expect(seen, <DesktopWindowVisibility>[
+        DesktopWindowVisibility.hidden,
+        DesktopWindowVisibility.shown,
+      ]);
+    });
+
+    test('never opens the channel off Linux', () async {
+      final List<MethodCall> calls = handleWith((_) async => null);
+
+      await window(host: HostPlatform.android).setHideOnClose(true);
+
+      expect(calls, isEmpty);
+    });
+
+    test('a runner without the channel is not an error', () async {
+      // An older build, or one whose runner was regenerated from the Flutter
+      // template: closing the window then does what it always did.
+      final MethodChannelLinuxWindow controller = window();
+
+      await expectLater(controller.setHideOnClose(true), completes);
+      await expectLater(controller.quit(), completes);
+    });
+
+    test('a refusal from the runner is not an error either', () async {
+      handleWith((_) async => throw PlatformException(code: 'no_window'));
+      final MethodChannelLinuxWindow controller = window();
+
+      await expectLater(controller.showWindow(), completes);
+    });
+  });
+}

--- a/test/core/services/mpris/mpris_player_object_test.dart
+++ b/test/core/services/mpris/mpris_player_object_test.dart
@@ -3,10 +3,23 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/models/repeat_mode.dart';
 import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/desktop_application_actions.dart';
 import 'package:linthra/core/services/media_artwork_source.dart';
 import 'package:linthra/core/services/mpris/mpris_player_object.dart';
 
 import '../../../features/player/fake_playback_controller.dart';
+
+/// The window and process behind the root interface's Raise and Quit (#401).
+class _RecordingApplication implements DesktopApplicationActions {
+  int raiseCount = 0;
+  int quitCount = 0;
+
+  @override
+  Future<void> raise() async => raiseCount++;
+
+  @override
+  Future<void> quit() async => quitCount++;
+}
 
 /// A cache that has exactly one cover ready, for the artwork-filter tests.
 class _Artwork implements MediaArtworkSource {
@@ -103,7 +116,16 @@ void main() {
       );
     });
 
-    test('Raise and Quit are accepted and do nothing', () async {
+    test('Raise and Quit are accepted and do nothing without a window',
+        () async {
+      // No application seam (Android, or a desktop whose runner cannot do
+      // this): the spec says a player that cannot perform them should simply
+      // do nothing, and say so through CanRaise/CanQuit.
+      final Map<String, DBusValue> root =
+          object.properties(MprisPlayerObject.rootInterface);
+      expect(root['CanQuit'], const DBusBoolean(false));
+      expect(root['CanRaise'], const DBusBoolean(false));
+
       expect(
         await call('Raise', interface: MprisPlayerObject.rootInterface),
         isA<DBusMethodSuccessResponse>(),
@@ -113,6 +135,41 @@ void main() {
         isA<DBusMethodSuccessResponse>(),
       );
       expect(controller.stopCount, 0);
+    });
+
+    test('offers Raise and Quit to the shell when there is a window (#401)',
+        () async {
+      final _RecordingApplication application = _RecordingApplication();
+      final MprisPlayerObject windowed =
+          MprisPlayerObject(controller, application: application);
+
+      final Map<String, DBusValue> root =
+          windowed.properties(MprisPlayerObject.rootInterface);
+      expect(root['CanQuit'], const DBusBoolean(true));
+      expect(root['CanRaise'], const DBusBoolean(true));
+
+      // Both answer immediately: Quit takes away the very connection the call
+      // arrived on, so the reply cannot wait for it.
+      expect(
+        await windowed.handleMethodCall(const DBusMethodCall(
+          sender: ':1.42',
+          interface: MprisPlayerObject.rootInterface,
+          name: 'Raise',
+        )),
+        isA<DBusMethodSuccessResponse>(),
+      );
+      expect(
+        await windowed.handleMethodCall(const DBusMethodCall(
+          sender: ':1.42',
+          interface: MprisPlayerObject.rootInterface,
+          name: 'Quit',
+        )),
+        isA<DBusMethodSuccessResponse>(),
+      );
+      await pumpEventQueue();
+
+      expect(application.raiseCount, 1);
+      expect(application.quitCount, 1);
     });
   });
 

--- a/test/features/settings/desktop/desktop_window_section_test.dart
+++ b/test/features/settings/desktop/desktop_window_section_test.dart
@@ -1,0 +1,140 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/desktop_close_behavior.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/core/services/desktop_window_controller.dart';
+import 'package:linthra/data/repositories/desktop_window_controller_provider.dart';
+import 'package:linthra/data/repositories/desktop_window_preferences_provider.dart';
+import 'package:linthra/data/repositories/host_platform_provider.dart';
+import 'package:linthra/data/repositories/in_memory_desktop_window_preferences.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/settings/desktop/desktop_window_section.dart';
+import 'package:linthra/features/settings/hub/music_and_playback_screen.dart';
+
+import '../../player/fake_playback_controller.dart';
+
+/// Records what the card asked the window to do.
+class _RecordingWindow implements DesktopWindowController {
+  int quitCount = 0;
+
+  @override
+  Future<void> setHideOnClose(bool hideOnClose) async {}
+
+  @override
+  Future<void> showWindow() async {}
+
+  @override
+  Future<void> quit() async => quitCount++;
+
+  @override
+  Stream<DesktopWindowVisibility> get visibility =>
+      const Stream<DesktopWindowVisibility>.empty();
+}
+
+void main() {
+  group('DesktopWindowSettingsSection', () {
+    late InMemoryDesktopWindowPreferences preferences;
+    late _RecordingWindow window;
+
+    Future<ProviderContainer> pump(
+      WidgetTester tester, {
+      DesktopCloseBehavior stored = DesktopCloseBehavior.quit,
+      Widget child = const DesktopWindowSettingsSection(),
+      HostPlatform host = HostPlatform.linux,
+    }) async {
+      preferences = InMemoryDesktopWindowPreferences(closeBehavior: stored);
+      window = _RecordingWindow();
+      final FakePlaybackController playback = FakePlaybackController();
+      addTearDown(playback.dispose);
+      final container = ProviderContainer(
+        overrides: [
+          desktopWindowPreferencesProvider.overrideWithValue(preferences),
+          desktopWindowControllerProvider.overrideWithValue(window),
+          hostPlatformProvider.overrideWithValue(host),
+          // The quit path reaches the playback controller; the real one on
+          // Linux opens libmpv.
+          playbackControllerProvider.overrideWithValue(playback),
+        ],
+      );
+      addTearDown(container.dispose);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(home: Scaffold(body: child)),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return container;
+    }
+
+    testWidgets('offers both close behaviours and a way out', (tester) async {
+      await pump(tester);
+
+      expect(find.text('Desktop window'), findsOneWidget);
+      expect(find.text('Quit Linthra'), findsOneWidget);
+      expect(find.text('Keep playing in the background'), findsOneWidget);
+      expect(find.text('Quit Linthra now'), findsOneWidget);
+    });
+
+    testWidgets('starts on the stored choice', (tester) async {
+      await pump(tester, stored: DesktopCloseBehavior.keepPlaying);
+
+      final RadioGroup<DesktopCloseBehavior> group =
+          tester.widget(find.byType(RadioGroup<DesktopCloseBehavior>));
+      expect(group.groupValue, DesktopCloseBehavior.keepPlaying);
+    });
+
+    testWidgets('choosing background playback persists it', (tester) async {
+      await pump(tester);
+      expect(await preferences.closeBehavior(), DesktopCloseBehavior.quit);
+
+      await tester.tap(find.text('Keep playing in the background'));
+      await tester.pumpAndSettle();
+
+      expect(
+        await preferences.closeBehavior(),
+        DesktopCloseBehavior.keepPlaying,
+      );
+    });
+
+    testWidgets('Quit now ends the app', (tester) async {
+      await pump(tester);
+
+      await tester.tap(find.text('Quit Linthra now'));
+      await tester.pumpAndSettle();
+
+      expect(window.quitCount, 1);
+    });
+
+    testWidgets('the Music & playback page shows the card on a desktop',
+        (tester) async {
+      // Tall enough for the whole page: the card is the last one on it, and a
+      // ListView does not build what it cannot show.
+      tester.view.physicalSize = const Size(1200, 3000);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      await pump(tester, child: const MusicAndPlaybackScreen());
+
+      expect(find.byType(DesktopWindowSettingsSection), findsOneWidget);
+    });
+
+    testWidgets('Android never sees it: there is no window to close there',
+        (tester) async {
+      tester.view.physicalSize = const Size(1200, 3000);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      await pump(
+        tester,
+        child: const MusicAndPlaybackScreen(),
+        host: HostPlatform.android,
+      );
+
+      expect(find.byType(DesktopWindowSettingsSection), findsNothing);
+    });
+  });
+}

--- a/test/support/recording_media_session.dart
+++ b/test/support/recording_media_session.dart
@@ -2,6 +2,7 @@ import 'package:linthra/core/repositories/download_repository.dart';
 import 'package:linthra/core/repositories/favorites_repository.dart';
 import 'package:linthra/core/repositories/music_library_repository.dart';
 import 'package:linthra/core/repositories/playlist_repository.dart';
+import 'package:linthra/core/services/desktop_application_actions.dart';
 import 'package:linthra/core/services/media_artwork_source.dart';
 import 'package:linthra/core/services/media_session_binding.dart';
 import 'package:linthra/core/services/playback_controller.dart';
@@ -37,6 +38,7 @@ class RecordingMediaSessionBinding implements MediaSessionBinding {
     FavoritesRepository? favorites,
     DownloadRepository? downloads,
     MediaArtworkSource? artwork,
+    DesktopApplicationActions? application,
   }) async {
     attachCount++;
     return session;

--- a/test/tooling/check_linux_runner_test.py
+++ b/test/tooling/check_linux_runner_test.py
@@ -91,6 +91,7 @@ MY_APPLICATION = """\
 #include "my_application.h"
 
 #include "folder_picker_channel.h"
+#include "window_lifecycle_channel.h"
 
 static constexpr const char* kApplicationName = "{display_name}";
 static constexpr int kDefaultWindowWidth = 1180;
@@ -99,7 +100,11 @@ static constexpr int kMinimumWindowWidth = 420;
 static constexpr int kMinimumWindowHeight = 600;
 
 static void activate() {{
+  if (window_lifecycle_channel_present(self->window_lifecycle)) {{
+    return;
+  }}
   self->folder_picker = folder_picker_channel_new(view, window);
+  self->window_lifecycle = window_lifecycle_channel_new(view, window);
 }}
 
 static void my_application_startup(GApplication* application) {{
@@ -114,7 +119,9 @@ MyApplication* my_application_new() {{
   g_set_prgname(APPLICATION_ID);
 
   return MY_APPLICATION(g_object_new(my_application_get_type(),
-                                     "application-id", APPLICATION_ID, nullptr));
+                                     "application-id", APPLICATION_ID, "flags",
+                                     static_cast<GApplicationFlags>(0),
+                                     nullptr));
 }}
 """
 
@@ -125,6 +132,7 @@ add_executable(${{BINARY_NAME}}
   "main.cc"
   "my_application.cc"
   "folder_picker_channel.cc"
+  "window_lifecycle_channel.cc"
 )
 """
 
@@ -148,6 +156,37 @@ class MethodChannelLinuxFolderPicker implements FolderPickerService {{
 
 FOLDER_PICKER_CHANNEL_NAME = f"{APP_ID}/linux_folder_picker"
 FOLDER_PICKER_METHOD_NAME = "pickFolder"
+
+# The two halves of the window-lifecycle channel (#401). Drift here is quieter
+# than the folder picker's: the app still runs, every close still destroys the
+# window, and the close-behaviour preference in Settings simply stops meaning
+# anything.
+WINDOW_LIFECYCLE_CHANNEL = """\
+static constexpr const char* kChannelName =
+    "{channel}";
+static constexpr const char* kSetHideOnCloseMethod = "{set_hide_on_close}";
+static constexpr const char* kShowWindowMethod = "showWindow";
+static constexpr const char* kQuitMethod = "quit";
+static constexpr const char* kWindowHiddenMethod = "windowHidden";
+static constexpr const char* kWindowShownMethod = "windowShown";
+static constexpr const char* kHideOnCloseArgument = "hideOnClose";
+"""
+
+WINDOW_LIFECYCLE_DART = """\
+class MethodChannelLinuxWindow implements DesktopWindowController {{
+  static const String channelName =
+      '{channel}';
+  static const String setHideOnCloseMethod = '{set_hide_on_close}';
+  static const String showWindowMethod = 'showWindow';
+  static const String quitMethod = 'quit';
+  static const String windowHiddenMethod = 'windowHidden';
+  static const String windowShownMethod = 'windowShown';
+  static const String hideOnCloseArgument = 'hideOnClose';
+}}
+"""
+
+WINDOW_LIFECYCLE_CHANNEL_NAME = f"{APP_ID}/linux_window_lifecycle"
+WINDOW_LIFECYCLE_SET_METHOD = "setHideOnClose"
 
 BUILD_GRADLE = """\
 android {{
@@ -293,6 +332,8 @@ def build_checkout(
     runner_cmakelists: str | None = None,
     folder_picker_channel: str | None = None,
     folder_picker_dart: str | None = None,
+    window_lifecycle_channel: str | None = None,
+    window_lifecycle_dart: str | None = None,
 ) -> Path:
     """Write a minimal, internally consistent checkout the checker can read."""
     (directory / "linux" / "runner").mkdir(parents=True, exist_ok=True)
@@ -339,6 +380,26 @@ def build_checkout(
         if folder_picker_dart is not None
         else FOLDER_PICKER_DART.format(
             channel=FOLDER_PICKER_CHANNEL_NAME, method=FOLDER_PICKER_METHOD_NAME
+        ),
+        encoding="utf-8",
+    )
+    (runner / "window_lifecycle_channel.cc").write_text(
+        window_lifecycle_channel
+        if window_lifecycle_channel is not None
+        else WINDOW_LIFECYCLE_CHANNEL.format(
+            channel=WINDOW_LIFECYCLE_CHANNEL_NAME,
+            set_hide_on_close=WINDOW_LIFECYCLE_SET_METHOD,
+        ),
+        encoding="utf-8",
+    )
+    (
+        directory / "lib" / "core" / "services" / "method_channel_linux_window.dart"
+    ).write_text(
+        window_lifecycle_dart
+        if window_lifecycle_dart is not None
+        else WINDOW_LIFECYCLE_DART.format(
+            channel=WINDOW_LIFECYCLE_CHANNEL_NAME,
+            set_hide_on_close=WINDOW_LIFECYCLE_SET_METHOD,
         ),
         encoding="utf-8",
     )
@@ -1292,6 +1353,102 @@ class FolderPickerChannelTest(CheckoutCase):
         problems = checker.check(self.root)
         self.assertEqual(len(problems), 1)
         self.assertIn("folder_picker_channel_new", problems[0])
+
+
+class WindowLifecycleChannelTest(CheckoutCase):
+    """The runner<->Dart close-behaviour contract (#401).
+
+    The close behaviour is decided in Dart and applied in the runner, so the
+    two halves only meet as strings. When they stop matching, nothing fails:
+    the runner never hears what to do, every close destroys the window as it
+    did before the preference existed, and Settings keeps offering a choice
+    that no longer changes anything.
+    """
+
+    def test_a_renamed_channel_on_the_dart_side_is_caught(self) -> None:
+        build_checkout(
+            self.root,
+            window_lifecycle_dart=WINDOW_LIFECYCLE_DART.format(
+                channel="io.example.app/renamed",
+                set_hide_on_close=WINDOW_LIFECYCLE_SET_METHOD,
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("channel name", problems[0])
+        self.assertIn("io.example.app/renamed", problems[0])
+
+    def test_a_renamed_method_on_the_native_side_is_caught(self) -> None:
+        build_checkout(
+            self.root,
+            window_lifecycle_channel=WINDOW_LIFECYCLE_CHANNEL.format(
+                channel=WINDOW_LIFECYCLE_CHANNEL_NAME,
+                set_hide_on_close="setCloseBehaviour",
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("setHideOnClose method", problems[0])
+        self.assertIn("setCloseBehaviour", problems[0])
+
+    def test_dropping_the_source_from_the_runner_build_is_caught(self) -> None:
+        build_checkout(
+            self.root,
+            runner_cmakelists=RUNNER_CMAKELISTS.replace(
+                '  "window_lifecycle_channel.cc"\n', ""
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("window_lifecycle_channel.cc", problems[0])
+
+    def test_never_registering_the_channel_is_caught(self) -> None:
+        build_checkout(
+            self.root,
+            my_application=MY_APPLICATION.format(display_name=DISPLAY_NAME).replace(
+                "  self->window_lifecycle = window_lifecycle_channel_new(view, window);\n",
+                "",
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("window_lifecycle_channel_new", problems[0])
+
+    def test_never_presenting_the_existing_window_is_caught(self) -> None:
+        # Without this, activating a running Linthra builds a second window on
+        # top of the one it already has instead of showing it.
+        runner = MY_APPLICATION.format(display_name=DISPLAY_NAME).replace(
+            """  if (window_lifecycle_channel_present(self->window_lifecycle)) {
+    return;
+  }
+""",
+            "",
+        )
+        build_checkout(self.root, my_application=runner)
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("window_lifecycle_channel_present", problems[0])
+
+    def test_a_non_unique_application_is_caught(self) -> None:
+        # What a `flutter create` regeneration restores. A second launch would
+        # then start a second process, with a second audio engine and a second
+        # connection to the same catalog, instead of showing the hidden window.
+        runner = MY_APPLICATION.format(display_name=DISPLAY_NAME).replace(
+            "static_cast<GApplicationFlags>(0)", "G_APPLICATION_NON_UNIQUE"
+        )
+        build_checkout(self.root, my_application=runner)
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("G_APPLICATION_NON_UNIQUE", problems[0])
+
+    def test_the_flag_named_only_in_a_comment_does_not_count(self) -> None:
+        runner = MY_APPLICATION.format(display_name=DISPLAY_NAME).replace(
+            "  g_set_prgname(APPLICATION_ID);",
+            "  // Deliberately not G_APPLICATION_NON_UNIQUE.\n"
+            "  g_set_prgname(APPLICATION_ID);",
+        )
+        build_checkout(self.root, my_application=runner)
+        self.assertEqual(checker.check(self.root), [])
 
 
 class OfflineBuildSeamTest(CheckoutCase):


### PR DESCRIPTION
Closes #401.

Adds the desktop close-window preference: Settings → Music & playback → **Desktop window**, with two choices. Quit Linthra (the default, and what closing the window has always done) or keep playing in the background, where the window hides and playback plus the MPRIS controls carry on.

## How it works

The decision is split in two, because a GTK `delete-event` has to be answered synchronously and there is no way to ask Dart inside it:

- **Dart decides.** `DesktopClosePolicy` combines the stored preference with the live playback state, and `DesktopWindowLifecycleService` pushes the single resulting boolean to the runner whenever either changes.
- **The runner applies.** `linux/runner/window_lifecycle_channel.cc` already holds the answer, so it either hides the window or lets GTK destroy it, instantly and locally.

## What keeps background mode honest

- Background mode only takes effect while audio is actually playing (or loading/buffering/reconnecting). Close with nothing to play and Linthra quits, whatever the preference says, so there is no invisible process left behind.
- A hidden Linthra quits itself when the queue runs out. A pause keeps it alive, since with no window on screen the shell's media widget is the only way back to playing.
- "Quit Linthra now" in the same settings card, and MPRIS `Quit`, both run the app's graceful shutdown (stop playback, release the audio engine, give the bus name back, close the database) before the process ends, rather than racing the engine on the way down.
- The runner is now single-instance. Launching Linthra while it is already running presents the window it has instead of starting a second process with a second audio engine, a second MPRIS name and a second connection to the same SQLite catalog.
- MPRIS advertises `CanRaise`/`CanQuit` only where there is a window to act on, which is what gives a hidden Linthra a visible way home and a way out.

One deliberate interaction: while the window is hidden the post-suspend reload is not armed. A hide looks exactly like a system suspend from the lifecycle observer's side, and reloading a track that never stopped playing would be an audible skip. The trade is documented in `docs/linux-desktop.md`.

Android is untouched. The settings card is desktop-only, and the service is inert behind the no-op window controller everywhere else.

## Tests

- `test/core/lifecycle/desktop_close_policy_test.dart` covers both rules across every playback status.
- `test/core/services/desktop_window_lifecycle_service_test.dart` covers the pushes, the self-quit when the queue ends, and that the graceful shutdown runs before the window goes.
- `test/core/services/method_channel_linux_window_test.dart` covers the channel in both directions, including a runner that does not have it.
- `test/features/settings/desktop/desktop_window_section_test.dart` covers the card, persistence, and that Android never sees it.
- `test/core/services/mpris/mpris_player_object_test.dart` covers Raise/Quit with and without a window.
- `scripts/check_linux_runner.py` gains the same channel-name contract the folder picker has, plus a guard against the runner going back to `G_APPLICATION_NON_UNIQUE`; `test/tooling/check_linux_runner_test.py` covers it.

`flutter analyze`, `dart format --set-exit-if-changed`, the full `flutter test` suite (4385 tests), the runner check and its Python tests all pass locally. `flutter build linux` could not run in the environment this was written in (the SQLite fetch host was blocked), so the native side was verified there by compiling both runner sources with the real GTK and flutter_linux headers under `-Wall -Werror` and checking the symbols resolve. CI has since built the Linux desktop target and the Flatpak, including the launch smoke test, green.

Manual checks (a real desktop is the only thing that can answer these) are listed in the new "Closing the window" section of `docs/linux-desktop.md`.
