### PR TITLE
Desktop polish: Now Playing bar/view, panes, window state, density, hover, context menus, multi-select (#380-#387)

### DIFF
--- a/.github/workflows/cpp-desktop-window.yml
+++ b/.github/workflows/cpp-desktop-window.yml
@@ -1,0 +1,37 @@
+name: C++ desktop window state
+
+on:
+  pull_request:
+    paths:
+      - 'native/linthra_desktop/**'
+      - '.github/workflows/cpp-desktop-window.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'native/linthra_desktop/**'
+      - '.github/workflows/cpp-desktop-window.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  desktop-window:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Release, Debug]
+    name: desktop-window (${{ matrix.build_type }})
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Configure
+        run: >-
+          cmake -S native/linthra_desktop -B build/linthra_desktop
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+
+      - name: Build
+        run: cmake --build build/linthra_desktop --parallel
+
+      - name: Run tests
+        run: ctest --test-dir build/linthra_desktop --output-on-failure

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -380,7 +380,9 @@ undeclared network access to an isolated `flatpak-builder` build.
 | Chromecast | Android/iOS only | Already gated in `cast_providers.dart`; Linux keeps the honest "cast unavailable" service. |
 | Share sheet, launcher-icon switching | Android-only, by design | No desktop equivalent; the UI simply omits them. |
 | Volume control | Supported | A mute and a slider on Now Playing and the wide mini-player bar, plus MPRIS `Volume`, driven through `PlaybackController` and remembered across launches ([issue #394](https://github.com/TheZupZup/Linthra/issues/394)). See [Volume](#volume). |
-| Desktop layout | Supported | The shell swaps its bottom bar for a navigation rail at 900 px, and feature screens adapt on the width they are given — see [How the desktop layout adapts](#how-the-desktop-layout-adapts). |
+| Desktop layout | Supported | The shell swaps its bottom bar for a navigation rail at 900 px, and feature screens adapt on the width they are given — including a third pane for the Library grids and for Now Playing's queue. See [How the desktop layout adapts](#how-the-desktop-layout-adapts). |
+| Window geometry | Supported | Size and maximized state survive a restart; position too, on X11. A saved position is re-checked against the monitors attached now. See [Window state](#window-state). |
+| Pointer affordances | Supported | Compact content density, visible hover feedback, right-click context menus with a keyboard equivalent, and Ctrl/Shift multi-select in track lists — all keyed on the input rather than the window width. See [Pointer, not width](#pointer-not-width). |
 | Keyboard shortcuts | Partial | Quick search is bound to **Ctrl+K** / **Ctrl+F** ([issue #393](https://github.com/TheZupZup/Linthra/issues/393)) — see [Quick search](#quick-search-ctrlk). The volume control takes the wheel and arrow keys when focused; global transport and volume shortcuts are still later work in #376. |
 
 Nothing in that table is faked. Each one is an explicit implementation behind an
@@ -436,6 +438,14 @@ the phone layout rather than a cramped desktop one.
 | `AdaptiveLayoutBuilder` | resolves the class from the widget's own `BoxConstraints` — inside the desktop shell a screen is narrower than the window by the navigation rail, and a pane is narrower still |
 | `AdaptiveContentWidth` | caps and centres a single column (`maxContentWidth`, or `maxFormWidth` for settings), a no-op below the cap |
 
+`lib/shared/layout/pane_layout.dart` holds the compositions built out of those:
+
+| Piece | What it does |
+| --- | --- |
+| `SplitPanes` | two panes with a hairline between them, one at a fixed width and one taking the rest, capped and centred — the shape a header pane beside a scrolling list and a grid beside a detail both want, written once |
+| `ListDetailPanes` | a list or grid that gains a detail pane once its own box is wide enough, and tells the list which mode it is in so a tap can select into the pane or push a route |
+| `DetailPanePlaceholder` | the calm "nothing picked yet" state, so the pane holds its width instead of making the grid reflow on every click |
+
 What it buys, per surface:
 
 * **Album grid** — cards stay between 200 and 260 logical px and the grid adds
@@ -448,13 +458,74 @@ What it buys, per surface:
 * **Album and artist detail** — at `expanded` and up, a persistent left pane
   (cover/portrait, counts, Play and Shuffle) beside the scrolling track list.
   Selection mode falls back to the single column.
+* **Albums and Artists, three panes** — past `listDetailMinWidth` the grid keeps
+  its place and the album (or artist) opens *beside* it, so browsing a shelf is
+  a click each rather than a click and a trip back. With the shell's navigation
+  rail that is navigation · content · detail. Below the split width the same
+  screen is pushed as a route, exactly as before. The selection lives on the
+  Library screen rather than in the pane, so dragging a window across the
+  threshold moves the detail between a pane and a page without resetting it.
 * **Now Playing** — at `expanded` and up, the cover sits beside the metadata
   and transport, and lyrics open *next to* the cover instead of replacing it.
-  Same `_showLyrics` state and same playback state as the stacked layout.
+  Same `_showLyrics` state and same playback state as the stacked layout. Wider
+  still, the queue joins them as a third column instead of a sheet over the top,
+  so lyrics and up-next are readable at once; the action row's queue button
+  becomes the pane toggle, and narrower windows keep the sheet.
+* **The now-playing bar** — on a desktop host the progress line along its top
+  edge is a seek control, not a readout: the same `PlaybackProgressBar` the full
+  player uses, at its compact density and without the time caption. Width alone
+  does not promote it — a tablet in landscape is as wide as a desktop window and
+  still driven by a thumb.
 
 Both breakpoints in the app agree by construction: the shell swaps its bottom
 bar for the navigation rail at 900 px of window, and a feature screen inside it
 only reaches `expanded` once the space left over is 1000 px wide.
+
+### Pointer, not width
+
+Three things adapt on the **input** rather than on the window, because that is
+what they are actually about. A tablet in landscape is as wide as a desktop
+window and is still driven by a thumb.
+
+* **Content density** — the theme uses `VisualDensity.adaptivePlatformDensity`,
+  Material's own adaptive value: compact on Linux/macOS/Windows, standard
+  everywhere touch-first. The two places that sized rows with a hard-coded
+  number follow it rather than ignoring it — the songs list's fixed row extent
+  (which the A–Z index measures its scroll offsets in) and the artist grid's
+  cell floor — and both only give back padding, never room the words need.
+* **Hover** — `hoverColor` carries enough weight to be seen on a black-first
+  theme, and every ink surface picks it up at once: list rows, buttons, grid
+  cards, rail destinations, menu items. It is neutral rather than brand-tinted,
+  because the violet tint is what *selected* means.
+  `HoverHighlight`/`HoverArtworkVeil` in `shared/widgets` cover the one case ink
+  cannot: an album cover hides the overlay painted on the Material behind it.
+* **Right-click and modifier-click** — `ContextMenuRegion` opens a surface's
+  existing menu on secondary click and on the keyboard's menu key (or
+  Shift+F10), and `TrackSelection` reads Ctrl/Cmd and Shift off the hardware
+  keyboard at tap time. Nothing is gated on a platform, so a keyboard case on a
+  tablet gets both for free and a bare touch tap is unchanged.
+
+### Context menus and multi-select
+
+Right-clicking a row opens the list that surface already had, built at open time
+so it reflects the state as it is then. Track rows share one list and one
+dispatcher with their 3-dot button, so a right-click cannot offer an action a
+tap cannot; they also gain **Show album** and **Show artist**, routed through the
+same derived ids the grids use and offered only where the tags give somewhere to
+go. Albums and artists get **Play · Shuffle · Play next · Add to queue · Add to
+playlist**, each a command their detail pages already call. Playlists reuse
+their rename/delete pair.
+
+Multi-select follows the rules every desktop list has. Ctrl-click (Cmd on macOS)
+picks one row out and starts a selection when there is none; Shift-click takes
+everything between. `TrackSelection` (`lib/features/library/track_selection.dart`)
+owns both, keyed by the provider-namespaced uri so two providers' same-id copies
+can never be selected together, and it resolves a bulk action against the list
+*as shown* — so a row that a search or a removal has taken off screen can never
+be acted on. A range is computed over the list the clicked row is in, which for
+the songs tab is the A–Z view's own sorted order rather than whatever the screen
+handed it. Starting a selection hands the screen the keyboard, so Escape leaves
+it. Long-press still does what it always did, so nothing about a phone changes.
 
 ### Quick search (Ctrl+K)
 

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -16,6 +16,8 @@ what works today, and what deliberately does not yet.
 * The window carries Linthra's real identity: application id
   `io.github.thezupzup.linthra` (the same reverse-DNS id as the Android build),
   window title `Linthra`, a 1180×780 default size and a 420×600 minimum.
+* The window remembers its size, maximized state and (on X11) its position
+  across restarts — see [Window state](#window-state).
 * Every shared layer is the same code Android runs: domain models, providers,
   repositories, routing, theming, the local scanner, and the Jellyfin /
   Navidrome / Subsonic / Plex integrations.
@@ -477,6 +479,41 @@ Tests: `test/shared/layout/adaptive_layout_test.dart`,
 `test/features/player/player_desktop_layout_test.dart` — each covers the phone
 width alongside 1280, 1920, 2560 and ultrawide, so a change that only looks
 right on one monitor fails.
+
+## Window state
+
+The window opens where you left it. `linux/runner/window_state_store.cc` writes
+`$XDG_CONFIG_HOME/io.github.thezupzup.linthra/window-state` on shutdown and
+reads it back before the window is shown, so a restored window is drawn at its
+remembered size on the first frame rather than resizing in front of you.
+
+Three things about it are worth knowing:
+
+* **The size saved is the unmaximized one.** GTK 3 will not tell you that after
+  the fact — `gtk_window_get_size()` on a maximized window returns the maximized
+  size — so the store tracks the last size the window had while it was an
+  ordinary window, and saves that alongside the maximized flag. Un-maximizing
+  after a restart lands back where you left it.
+* **Position is X11-only.** Wayland gives a client neither its own position nor
+  a way to set one. Under Wayland the file holds a size and no position, and the
+  compositor places the window, which is what Wayland users expect rather than
+  something to work around.
+* **A saved position is re-checked against the monitors that exist now.** Unplug
+  the monitor a window was on and the position is dropped rather than restored
+  off-screen; so is one whose title bar would land above the work area, where no
+  mouse could reach it. The *size* survives either way — losing a monitor should
+  not also lose the window's shape.
+
+The rules behind all of that — what a saved geometry means, when it is too
+damaged to trust, whether a position is still reachable — live in
+[`native/linthra_desktop`](../native/linthra_desktop), which is pure C++ with no
+GTK, no GDK and no filesystem in it. The runner links those sources directly and
+does the toolkit half; the same sources build and test on their own, without a
+display server or a second monitor to unplug, in
+[`cpp-desktop-window.yml`](../.github/workflows/cpp-desktop-window.yml).
+
+A damaged or missing file is never fatal: it falls back to the 1180×780 default,
+clamped to the 420×600 minimum. Deleting the file resets the window.
 
 ## Guardrails
 

--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -106,6 +106,16 @@ abstract final class AppTheme {
       // about what is pointing at the row, and an Android tablet in landscape
       // is as wide as a desktop window and still driven by a thumb.
       visualDensity: VisualDensity.adaptivePlatformDensity,
+      // Hover feedback (#385). Material's default is a 4% white/black veil,
+      // which on a black-first theme is close to invisible — so a mouse user
+      // could not tell a row apart from the page it sits on.
+      //
+      // Deliberately neutral rather than brand-tinted: the violet tint is what
+      // *selected* means (see listTileTheme below), and hover has to stay
+      // distinct from selection, from focus and from pressed. One value here
+      // reaches every ink surface at once: list rows, buttons, grid cards, the
+      // navigation rail's destinations and popup-menu items.
+      hoverColor: onSurface.withValues(alpha: 0.07),
       extensions: <ThemeExtension<dynamic>>[
         LinthraAccents(
           accentBright: palette.accentBright,

--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -96,6 +96,16 @@ abstract final class AppTheme {
       useMaterial3: true,
       brightness: brightness,
       colorScheme: colorScheme,
+      // Desktop content density (#384). Material's own adaptive value: compact
+      // on Linux/macOS/Windows, standard everywhere touch-first, so a Linux
+      // window fits materially more of a library per screen while a phone's
+      // rows and tap targets do not move a pixel.
+      //
+      // It reads `defaultTargetPlatform`, the same signal the shell's
+      // navigation rail keys off, rather than shrinking on width: density is
+      // about what is pointing at the row, and an Android tablet in landscape
+      // is as wide as a desktop window and still driven by a thumb.
+      visualDensity: VisualDensity.adaptivePlatformDensity,
       extensions: <ThemeExtension<dynamic>>[
         LinthraAccents(
           accentBright: palette.accentBright,

--- a/lib/features/library/album_detail_screen.dart
+++ b/lib/features/library/album_detail_screen.dart
@@ -31,17 +31,34 @@ import 'widgets/track_tile.dart';
 /// Long-pressing a track starts multi-select so any subset can use that same
 /// playlist flow.
 class AlbumDetailScreen extends ConsumerStatefulWidget {
-  const AlbumDetailScreen({required this.albumId, super.key});
+  const AlbumDetailScreen({
+    required this.albumId,
+    this.selection,
+    super.key,
+  });
 
   final String albumId;
+
+  /// The selection to work in, when a host owns one.
+  ///
+  /// As a pushed route the screen keeps its own, and its lifetime is the
+  /// route's. As a detail pane it does not get to: the pane is dropped whenever
+  /// the window narrows past [listDetailMinWidth], which would reset a
+  /// selection the user is in the middle of on an ordinary resize. So the host
+  /// that holds *which* album is open holds what is picked inside it too, and
+  /// the pane can come and go without losing either.
+  final TrackSelection? selection;
 
   @override
   ConsumerState<AlbumDetailScreen> createState() => _AlbumDetailScreenState();
 }
 
 class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
+  /// The selection used when no host supplied one.
+  final TrackSelection _ownSelection = TrackSelection();
+
   /// Which songs are picked, and where a Shift-click measures from (#387).
-  final TrackSelection _selection = TrackSelection();
+  TrackSelection get _selection => widget.selection ?? _ownSelection;
 
   bool get _selecting => _selection.isActive;
 

--- a/lib/features/library/album_detail_screen.dart
+++ b/lib/features/library/album_detail_screen.dart
@@ -8,6 +8,7 @@ import '../../core/catalog/library_grouping.dart';
 import '../../core/models/album.dart';
 import '../../core/models/track.dart';
 import '../../shared/layout/adaptive_layout.dart';
+import '../../shared/layout/pane_layout.dart';
 import '../../shared/widgets/empty_state.dart';
 import '../player/player_providers.dart';
 import '../player/widgets/album_artwork.dart';
@@ -35,11 +36,6 @@ class AlbumDetailScreen extends ConsumerStatefulWidget {
   @override
   ConsumerState<AlbumDetailScreen> createState() => _AlbumDetailScreenState();
 }
-
-/// Width of the album pane in the desktop two-pane layout: enough for a
-/// comfortable cover and both transport buttons, narrow enough to leave the
-/// track list the majority of the window.
-const double _detailPaneWidth = 320;
 
 class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
   final Set<String> _selectedUris = <String>{};
@@ -167,36 +163,23 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
   /// track list. Both read the same `tracks` list and the same selection set,
   /// so nothing here duplicates state — it is the single-column body, laid out.
   Widget _twoPaneBody(Album album, List<Track> tracks) {
-    return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: maxPaneLayoutWidth),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: <Widget>[
-            SizedBox(
-              width: _detailPaneWidth,
-              child: SingleChildScrollView(
-                child: _AlbumHeader(
-                  album: album,
-                  trackCount: tracks.length,
-                  stacked: true,
-                  onPlay: () => _play(context, tracks),
-                  onShuffle: () => _shuffle(context, tracks),
-                ),
-              ),
-            ),
-            const VerticalDivider(width: 1),
-            Expanded(
-              child: ListView.builder(
-                key: const Key('album_detail_tracks'),
-                padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
-                itemCount: tracks.length,
-                itemBuilder: (BuildContext context, int index) =>
-                    _trackTile(tracks, index),
-              ),
-            ),
-          ],
+    return SplitPanes(
+      fixedWidth: sidePaneWidth,
+      fixed: SingleChildScrollView(
+        child: _AlbumHeader(
+          album: album,
+          trackCount: tracks.length,
+          stacked: true,
+          onPlay: () => _play(context, tracks),
+          onShuffle: () => _shuffle(context, tracks),
         ),
+      ),
+      flexible: ListView.builder(
+        key: const Key('album_detail_tracks'),
+        padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+        itemCount: tracks.length,
+        itemBuilder: (BuildContext context, int index) =>
+            _trackTile(tracks, index),
       ),
     );
   }

--- a/lib/features/library/album_detail_screen.dart
+++ b/lib/features/library/album_detail_screen.dart
@@ -16,6 +16,7 @@ import '../playlists/widgets/add_to_playlist_sheet.dart';
 import 'library_browse_providers.dart';
 import 'library_controller.dart';
 import 'library_state.dart';
+import 'track_selection.dart';
 import 'unified_library_providers.dart';
 import 'widgets/track_tile.dart';
 
@@ -38,9 +39,10 @@ class AlbumDetailScreen extends ConsumerStatefulWidget {
 }
 
 class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
-  final Set<String> _selectedUris = <String>{};
+  /// Which songs are picked, and where a Shift-click measures from (#387).
+  final TrackSelection _selection = TrackSelection();
 
-  bool get _selecting => _selectedUris.isNotEmpty;
+  bool get _selecting => _selection.isActive;
 
   @override
   Widget build(BuildContext context) {
@@ -83,10 +85,7 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
     // Bound after the null check so the layout closures below see a non-null
     // album; a promoted local can't be captured by one.
     final Album resolved = album;
-    final List<Track> selected = <Track>[
-      for (final Track track in tracks)
-        if (_selectedUris.contains(track.uri)) track,
-    ];
+    final List<Track> selected = _selection.resolve(tracks);
 
     final Widget scaffold = Scaffold(
       appBar: _selecting
@@ -191,9 +190,10 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
       index: index,
       selectable: true,
       selectionActive: _selecting,
-      selected: _selectedUris.contains(track.uri),
+      selected: _selection.contains(track.uri),
       onSelectStart: () => _enterSelection(track),
       onSelectToggle: () => _toggle(track),
+      onSelectRange: _extendSelection,
     );
   }
 
@@ -217,23 +217,23 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
   }
 
   void _enterSelection(Track track) {
-    setState(() {
-      _selectedUris
-        ..clear()
-        ..add(track.uri);
-    });
+    setState(() => _selection.start(track));
+  }
+
+  /// Shift-click: everything between the anchor and the clicked row, over the
+  /// list that row is actually in.
+  void _extendSelection(List<Track> tracks, int index) {
+    setState(() => _selection.extendTo(tracks, index));
   }
 
   void _toggle(Track track) {
     setState(() {
-      if (!_selectedUris.add(track.uri)) {
-        _selectedUris.remove(track.uri);
-      }
+      _selection.toggle(track);
     });
   }
 
   void _exitSelection() {
-    setState(_selectedUris.clear);
+    setState(_selection.clear);
   }
 
   Future<void> _addSelectedToPlaylist(List<Track> selected) async {

--- a/lib/features/library/album_detail_screen.dart
+++ b/lib/features/library/album_detail_screen.dart
@@ -256,13 +256,21 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
     });
   }
 
+  /// Leaves the selection.
+  ///
+  /// The clear is not guarded by [mounted], only the rebuild is: a host-owned
+  /// selection outlives this screen on purpose (see [AlbumDetailScreen.selection]), so
+  /// an action that finishes after a resize took the pane away still has to end
+  /// the mode it belongs to. Otherwise widening the window brings back a
+  /// selection whose work is already done.
   void _exitSelection() {
-    setState(_selection.clear);
+    _selection.clear();
+    if (mounted) setState(() {});
   }
 
   Future<void> _addSelectedToPlaylist(List<Track> selected) async {
     await showAddToPlaylistSheet(context, selected);
-    if (mounted) _exitSelection();
+    _exitSelection();
   }
 
   void _play(BuildContext context, List<Track> tracks) {

--- a/lib/features/library/album_detail_screen.dart
+++ b/lib/features/library/album_detail_screen.dart
@@ -18,6 +18,7 @@ import 'library_controller.dart';
 import 'library_state.dart';
 import 'track_selection.dart';
 import 'unified_library_providers.dart';
+import 'widgets/selection_escape_scope.dart';
 import 'widgets/track_tile.dart';
 
 /// One album's tracks, in album order, with Play / Shuffle and tap-to-play.
@@ -126,12 +127,18 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
     );
 
     if (!_selecting) return scaffold;
+    // Back leaves the selection on a phone; Escape is the desktop's Back, and
+    // the rows here take Ctrl and Shift clicks just like the songs list does.
     return PopScope(
       canPop: false,
       onPopInvokedWithResult: (bool didPop, _) {
         if (!didPop) _exitSelection();
       },
-      child: scaffold,
+      child: SelectionEscapeScope(
+        selecting: _selecting,
+        onEscape: _exitSelection,
+        child: scaffold,
+      ),
     );
   }
 

--- a/lib/features/library/artist_detail_screen.dart
+++ b/lib/features/library/artist_detail_screen.dart
@@ -20,6 +20,7 @@ import 'library_state.dart';
 import 'track_selection.dart';
 import 'unified_library_providers.dart';
 import 'widgets/album_tile.dart';
+import 'widgets/selection_escape_scope.dart';
 import 'widgets/track_tile.dart';
 
 /// One artist's catalog: their albums (each opening its album detail) and all
@@ -121,12 +122,18 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
     );
 
     if (!_selecting) return scaffold;
+    // Back leaves the selection on a phone; Escape is the desktop's Back, and
+    // the rows here take Ctrl and Shift clicks just like the songs list does.
     return PopScope(
       canPop: false,
       onPopInvokedWithResult: (bool didPop, _) {
         if (!didPop) _exitSelection();
       },
-      child: scaffold,
+      child: SelectionEscapeScope(
+        selecting: _selecting,
+        onEscape: _exitSelection,
+        child: scaffold,
+      ),
     );
   }
 

--- a/lib/features/library/artist_detail_screen.dart
+++ b/lib/features/library/artist_detail_screen.dart
@@ -26,17 +26,29 @@ import 'widgets/track_tile.dart';
 /// One artist's catalog: their albums (each opening its album detail) and all
 /// their tracks, with Play all / Shuffle all.
 class ArtistDetailScreen extends ConsumerStatefulWidget {
-  const ArtistDetailScreen({required this.artistId, super.key});
+  const ArtistDetailScreen({
+    required this.artistId,
+    this.selection,
+    super.key,
+  });
 
   final String artistId;
+
+  /// The selection to work in, when a host owns one. See
+  /// [AlbumDetailScreen.selection]: as a detail pane the screen is unmounted by
+  /// an ordinary resize, so what is picked has to outlive it.
+  final TrackSelection? selection;
 
   @override
   ConsumerState<ArtistDetailScreen> createState() => _ArtistDetailScreenState();
 }
 
 class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
+  /// The selection used when no host supplied one.
+  final TrackSelection _ownSelection = TrackSelection();
+
   /// Which songs are picked, and where a Shift-click measures from (#387).
-  final TrackSelection _selection = TrackSelection();
+  TrackSelection get _selection => widget.selection ?? _ownSelection;
 
   bool get _selecting => _selection.isActive;
 

--- a/lib/features/library/artist_detail_screen.dart
+++ b/lib/features/library/artist_detail_screen.dart
@@ -9,6 +9,7 @@ import '../../core/models/album.dart';
 import '../../core/models/artist.dart';
 import '../../core/models/track.dart';
 import '../../shared/layout/adaptive_layout.dart';
+import '../../shared/layout/pane_layout.dart';
 import '../../shared/widgets/artwork_image.dart';
 import '../../shared/widgets/empty_state.dart';
 import '../player/player_providers.dart';
@@ -30,8 +31,6 @@ class ArtistDetailScreen extends ConsumerStatefulWidget {
   @override
   ConsumerState<ArtistDetailScreen> createState() => _ArtistDetailScreenState();
 }
-
-const double _detailPaneWidth = 320;
 
 class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
   final Set<String> _selectedUris = <String>{};
@@ -100,30 +99,19 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
           WindowSizeClass sizeClass,
         ) {
           if (!_selecting && sizeClass.isAtLeast(WindowSizeClass.expanded)) {
-            return Center(
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: maxPaneLayoutWidth),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: <Widget>[
-                    SizedBox(
-                      width: _detailPaneWidth,
-                      child: SingleChildScrollView(
-                        child: _ArtistHeader(
-                          artist: resolved,
-                          albumCount: albums.length,
-                          trackCount: tracks.length,
-                          stacked: true,
-                          onPlay: () => _play(context, tracks),
-                          onShuffle: () => _shuffle(context, tracks),
-                        ),
-                      ),
-                    ),
-                    const VerticalDivider(width: 1),
-                    Expanded(child: _catalogList(albums, tracks)),
-                  ],
+            return SplitPanes(
+              fixedWidth: sidePaneWidth,
+              fixed: SingleChildScrollView(
+                child: _ArtistHeader(
+                  artist: resolved,
+                  albumCount: albums.length,
+                  trackCount: tracks.length,
+                  stacked: true,
+                  onPlay: () => _play(context, tracks),
+                  onShuffle: () => _shuffle(context, tracks),
                 ),
               ),
+              flexible: _catalogList(albums, tracks),
             );
           }
           return AdaptiveContentWidth(

--- a/lib/features/library/artist_detail_screen.dart
+++ b/lib/features/library/artist_detail_screen.dart
@@ -250,13 +250,21 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
     });
   }
 
+  /// Leaves the selection.
+  ///
+  /// The clear is not guarded by [mounted], only the rebuild is: a host-owned
+  /// selection outlives this screen on purpose (see [ArtistDetailScreen.selection]), so
+  /// an action that finishes after a resize took the pane away still has to end
+  /// the mode it belongs to. Otherwise widening the window brings back a
+  /// selection whose work is already done.
   void _exitSelection() {
-    setState(_selection.clear);
+    _selection.clear();
+    if (mounted) setState(() {});
   }
 
   Future<void> _addSelectedToPlaylist(List<Track> selected) async {
     await showAddToPlaylistSheet(context, selected);
-    if (mounted) _exitSelection();
+    _exitSelection();
   }
 
   void _openAlbum(BuildContext context, String albumId) {

--- a/lib/features/library/artist_detail_screen.dart
+++ b/lib/features/library/artist_detail_screen.dart
@@ -17,6 +17,7 @@ import '../playlists/widgets/add_to_playlist_sheet.dart';
 import 'library_browse_providers.dart';
 import 'library_controller.dart';
 import 'library_state.dart';
+import 'track_selection.dart';
 import 'unified_library_providers.dart';
 import 'widgets/album_tile.dart';
 import 'widgets/track_tile.dart';
@@ -33,9 +34,10 @@ class ArtistDetailScreen extends ConsumerStatefulWidget {
 }
 
 class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
-  final Set<String> _selectedUris = <String>{};
+  /// Which songs are picked, and where a Shift-click measures from (#387).
+  final TrackSelection _selection = TrackSelection();
 
-  bool get _selecting => _selectedUris.isNotEmpty;
+  bool get _selecting => _selection.isActive;
 
   @override
   Widget build(BuildContext context) {
@@ -70,10 +72,7 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
 
     final Artist resolved = artist;
     final List<Album> albums = albumsForArtist(songs, widget.artistId);
-    final List<Track> selected = <Track>[
-      for (final Track track in tracks)
-        if (_selectedUris.contains(track.uri)) track,
-    ];
+    final List<Track> selected = _selection.resolve(tracks);
 
     final Widget scaffold = Scaffold(
       appBar: _selecting
@@ -187,9 +186,10 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
             index: index,
             selectable: true,
             selectionActive: _selecting,
-            selected: _selectedUris.contains(track.uri),
+            selected: _selection.contains(track.uri),
             onSelectStart: () => _enterSelection(track),
             onSelectToggle: () => _toggle(track),
+            onSelectRange: _extendSelection,
           );
         },
       ),
@@ -216,23 +216,23 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
   }
 
   void _enterSelection(Track track) {
-    setState(() {
-      _selectedUris
-        ..clear()
-        ..add(track.uri);
-    });
+    setState(() => _selection.start(track));
+  }
+
+  /// Shift-click: everything between the anchor and the clicked row, over the
+  /// list that row is actually in.
+  void _extendSelection(List<Track> tracks, int index) {
+    setState(() => _selection.extendTo(tracks, index));
   }
 
   void _toggle(Track track) {
     setState(() {
-      if (!_selectedUris.add(track.uri)) {
-        _selectedUris.remove(track.uri);
-      }
+      _selection.toggle(track);
     });
   }
 
   void _exitSelection() {
-    setState(_selectedUris.clear);
+    setState(_selection.clear);
   }
 
   Future<void> _addSelectedToPlaylist(List<Track> selected) async {

--- a/lib/features/library/library_browse_providers.dart
+++ b/lib/features/library/library_browse_providers.dart
@@ -18,3 +18,26 @@ final libraryAlbumsProvider = Provider<List<Album>>((ref) {
 final libraryArtistsProvider = Provider<List<Artist>>((ref) {
   return groupArtists(ref.watch(libraryUnifiedTracksProvider));
 });
+
+/// The album ids the catalog can actually open a page for.
+///
+/// Not every track on screen comes from the flat catalog: the folder browser
+/// lists a server's tree on demand, so it can show a track whose album has
+/// never been synced. `AlbumDetailScreen` resolves its id against
+/// [libraryAlbumsProvider] alone, so a row like that must not offer "Show
+/// album" (#386) — the page it would open says "Album not found".
+///
+/// A set rather than a scan: the menu asks this per row, and a linear walk of
+/// every album on a large library would be an O(N) pass per open.
+final libraryAlbumIdsProvider = Provider<Set<String>>((ref) {
+  return <String>{
+    for (final Album album in ref.watch(libraryAlbumsProvider)) album.id,
+  };
+});
+
+/// The artist ids the catalog can open a page for. See [libraryAlbumIdsProvider].
+final libraryArtistIdsProvider = Provider<Set<String>>((ref) {
+  return <String>{
+    for (final Artist artist in ref.watch(libraryArtistsProvider)) artist.id,
+  };
+});

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io' show Platform;
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
@@ -35,6 +34,7 @@ import 'widgets/album_grid.dart';
 import 'widgets/alphabet_track_list.dart';
 import 'widgets/artist_grid.dart';
 import 'widgets/library_search_field.dart';
+import 'widgets/selection_escape_scope.dart';
 
 /// Browse the de-duplicated catalog across Songs, Albums and Artists.
 ///
@@ -67,11 +67,6 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   /// rather than in the rows so it survives a catalog refresh or a rebuild.
   final TrackSelection _selection = TrackSelection();
   bool _selecting = false;
-
-  /// Holds the keyboard while a selection is running, so Escape has somewhere
-  /// to land. Clicking a row does not move focus on its own.
-  final FocusNode _selectionFocus =
-      FocusNode(debugLabel: 'library selection', skipTraversal: true);
 
   /// What the Albums / Artists detail pane is showing on a window wide enough
   /// to have one. Held here rather than in the panes so it survives the pane
@@ -188,7 +183,6 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
     _tabController.removeListener(_onTabChanged);
     _tabController.dispose();
     _searchController.dispose();
-    _selectionFocus.dispose();
     super.dispose();
   }
 
@@ -273,25 +267,9 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
       onPopInvokedWithResult: (bool didPop, _) {
         if (!didPop && _selecting) _exitSelection();
       },
-      // Escape is the desktop's Back: a selection made with Ctrl and Shift has
-      // to be dismissable without reaching for the mouse again.
-      //
-      // Starting a selection hands this node the keyboard (see
-      // [_focusSelection]), because a selection is a mode and a mode with no
-      // focus has nowhere for a key to land. Kept out of the Tab order, so it
-      // is somewhere focus is *put* rather than a stop on the way through.
-      child: Focus(
-        focusNode: _selectionFocus,
-        skipTraversal: true,
-        onKeyEvent: (FocusNode node, KeyEvent event) {
-          if (!_selecting ||
-              event is! KeyDownEvent ||
-              event.logicalKey != LogicalKeyboardKey.escape) {
-            return KeyEventResult.ignored;
-          }
-          _exitSelection();
-          return KeyEventResult.handled;
-        },
+      child: SelectionEscapeScope(
+        selecting: _selecting,
+        onEscape: _exitSelection,
         child: Scaffold(
           appBar: _selecting
               ? _selectionAppBar(selected)
@@ -576,7 +554,6 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
       _selecting = true;
       _selection.start(track);
     });
-    _focusSelection();
     // Selection is only reachable from the songs list, so that is the list it
     // must show. Guarding the restore is not enough on its own: a long press
     // holds the pointer for half a second before firing, and a restore landing
@@ -595,14 +572,6 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
       _selection.toggle(track);
       if (!_selection.isActive) _selecting = false;
     });
-    _focusSelection();
-  }
-
-  /// Hands the screen the keyboard once something is picked, so Escape (and
-  /// anything else the mode binds later) reaches it. A no-op when the selection
-  /// just emptied out.
-  void _focusSelection() {
-    if (_selecting) _selectionFocus.requestFocus();
   }
 
   /// Shift-click: everything between the anchor and the clicked row, over the
@@ -613,7 +582,6 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
       _selection.extendTo(tracks, index);
       _selecting = _selection.isActive;
     });
-    _focusSelection();
   }
 
   void _exitSelection() {

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -75,6 +75,15 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   String? _paneAlbumId;
   String? _paneArtistId;
 
+  /// What is picked *inside* those panes, for the same reason: the pane is
+  /// dropped whenever the window narrows past [listDetailMinWidth], so a
+  /// selection owned by the detail screen would not survive a resize the user
+  /// did not think of as leaving it. Reset when the pane moves to another
+  /// album or artist, since a selection only means anything against the list it
+  /// was made in.
+  final TrackSelection _paneAlbumSelection = TrackSelection();
+  final TrackSelection _paneArtistSelection = TrackSelection();
+
   late final TabController _tabController;
   final TextEditingController _searchController = TextEditingController();
   String _query = '';
@@ -439,7 +448,10 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
             context.push(AppRoutes.albumDetailPath(album.id));
             return;
           }
-          setState(() => _paneAlbumId = album.id);
+          setState(() {
+            if (_paneAlbumId != album.id) _paneAlbumSelection.clear();
+            _paneAlbumId = album.id;
+          });
         },
       ),
       // A selection that is no longer in the filtered grid would leave the pane
@@ -449,7 +461,11 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
         final String? id = _paneAlbumId;
         if (id == null) return null;
         if (!filtered.any((Album album) => album.id == id)) return null;
-        return AlbumDetailScreen(key: ValueKey<String>(id), albumId: id);
+        return AlbumDetailScreen(
+          key: ValueKey<String>(id),
+          albumId: id,
+          selection: _paneAlbumSelection,
+        );
       },
       placeholderBuilder: (BuildContext context) => const DetailPanePlaceholder(
         icon: Icons.album_outlined,
@@ -478,14 +494,21 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
             context.push(AppRoutes.artistDetailPath(artist.id));
             return;
           }
-          setState(() => _paneArtistId = artist.id);
+          setState(() {
+            if (_paneArtistId != artist.id) _paneArtistSelection.clear();
+            _paneArtistId = artist.id;
+          });
         },
       ),
       detailBuilder: (BuildContext context) {
         final String? id = _paneArtistId;
         if (id == null) return null;
         if (!filtered.any((Artist artist) => artist.id == id)) return null;
-        return ArtistDetailScreen(key: ValueKey<String>(id), artistId: id);
+        return ArtistDetailScreen(
+          key: ValueKey<String>(id),
+          artistId: id,
+          selection: _paneArtistSelection,
+        );
       },
       placeholderBuilder: (BuildContext context) => const DetailPanePlaceholder(
         icon: Icons.person_outline,

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io' show Platform;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
@@ -28,6 +29,7 @@ import 'library_state.dart';
 import 'library_sync_activity.dart';
 import 'selected_folder_controller.dart';
 import 'song_actions.dart';
+import 'track_selection.dart';
 import 'unified_library_providers.dart';
 import 'widgets/album_grid.dart';
 import 'widgets/alphabet_track_list.dart';
@@ -61,8 +63,15 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   /// survives a tab being added or reordered later.
   static const List<String> _tabNames = <String>['songs', 'albums', 'artists'];
 
-  final Set<String> _selectedUris = <String>{};
+  /// Which songs are picked, and where a Shift-click measures from. Held here
+  /// rather than in the rows so it survives a catalog refresh or a rebuild.
+  final TrackSelection _selection = TrackSelection();
   bool _selecting = false;
+
+  /// Holds the keyboard while a selection is running, so Escape has somewhere
+  /// to land. Clicking a row does not move focus on its own.
+  final FocusNode _selectionFocus =
+      FocusNode(debugLabel: 'library selection', skipTraversal: true);
 
   /// What the Albums / Artists detail pane is showing on a window wide enough
   /// to have one. Held here rather than in the panes so it survives the pane
@@ -179,6 +188,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
     _tabController.removeListener(_onTabChanged);
     _tabController.dispose();
     _searchController.dispose();
+    _selectionFocus.dispose();
     super.dispose();
   }
 
@@ -244,10 +254,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
     // the count and actions stay accurate. Keyed by the provider-namespaced uri,
     // not the bare id, so two different-provider songs sharing an id can't be
     // selected (or bulk-acted on) together.
-    final List<Track> selected = <Track>[
-      for (final Track track in songs)
-        if (_selectedUris.contains(track.uri)) track,
-    ];
+    final List<Track> selected = _selection.resolve(songs);
 
     // A connected folder-capable server is browseable before (or even without)
     // a flat catalog sync, so it is enough to show the Library tabs on its own.
@@ -266,23 +273,43 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
       onPopInvokedWithResult: (bool didPop, _) {
         if (!didPop && _selecting) _exitSelection();
       },
-      child: Scaffold(
-        appBar: _selecting
-            ? _selectionAppBar(selected)
-            : AppBar(
-                title: const Text('Library'),
-                actions: <Widget>[
-                  IconButton(
-                    icon: const Icon(Icons.create_new_folder_outlined),
-                    tooltip: 'Select music folder',
-                    onPressed: _pickAndScan,
-                  ),
-                ],
-                bottom: browsing ? _tabBar() : null,
-              ),
-        body: browsing
-            ? _browseBody(songs, syncingSources)
-            : _statusBody(state, selectedFolder.valueOrNull, syncingSources),
+      // Escape is the desktop's Back: a selection made with Ctrl and Shift has
+      // to be dismissable without reaching for the mouse again.
+      //
+      // Starting a selection hands this node the keyboard (see
+      // [_focusSelection]), because a selection is a mode and a mode with no
+      // focus has nowhere for a key to land. Kept out of the Tab order, so it
+      // is somewhere focus is *put* rather than a stop on the way through.
+      child: Focus(
+        focusNode: _selectionFocus,
+        skipTraversal: true,
+        onKeyEvent: (FocusNode node, KeyEvent event) {
+          if (!_selecting ||
+              event is! KeyDownEvent ||
+              event.logicalKey != LogicalKeyboardKey.escape) {
+            return KeyEventResult.ignored;
+          }
+          _exitSelection();
+          return KeyEventResult.handled;
+        },
+        child: Scaffold(
+          appBar: _selecting
+              ? _selectionAppBar(selected)
+              : AppBar(
+                  title: const Text('Library'),
+                  actions: <Widget>[
+                    IconButton(
+                      icon: const Icon(Icons.create_new_folder_outlined),
+                      tooltip: 'Select music folder',
+                      onPressed: _pickAndScan,
+                    ),
+                  ],
+                  bottom: browsing ? _tabBar() : null,
+                ),
+          body: browsing
+              ? _browseBody(songs, syncingSources)
+              : _statusBody(state, selectedFolder.valueOrNull, syncingSources),
+        ),
       ),
     );
   }
@@ -500,9 +527,10 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
         tracks: tracks,
         selectable: true,
         selectionActive: _selecting,
-        selectedUris: _selectedUris,
+        selectedUris: _selection.uris,
         onSelectStart: _enterSelection,
         onSelectToggle: _toggle,
+        onSelectRange: _extendSelection,
       ),
     );
   }
@@ -546,10 +574,9 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   void _enterSelection(Track track) {
     setState(() {
       _selecting = true;
-      _selectedUris
-        ..clear()
-        ..add(track.uri);
+      _selection.start(track);
     });
+    _focusSelection();
     // Selection is only reachable from the songs list, so that is the list it
     // must show. Guarding the restore is not enough on its own: a long press
     // holds the pointer for half a second before firing, and a restore landing
@@ -565,17 +592,34 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
 
   void _toggle(Track track) {
     setState(() {
-      if (!_selectedUris.add(track.uri)) {
-        _selectedUris.remove(track.uri);
-      }
-      if (_selectedUris.isEmpty) _selecting = false;
+      _selection.toggle(track);
+      if (!_selection.isActive) _selecting = false;
     });
+    _focusSelection();
+  }
+
+  /// Hands the screen the keyboard once something is picked, so Escape (and
+  /// anything else the mode binds later) reaches it. A no-op when the selection
+  /// just emptied out.
+  void _focusSelection() {
+    if (_selecting) _selectionFocus.requestFocus();
+  }
+
+  /// Shift-click: everything between the anchor and the clicked row, over the
+  /// list the A–Z view actually shows — so a search or a re-sort can never make
+  /// a range span rows that are not between its two ends on screen.
+  void _extendSelection(List<Track> tracks, int index) {
+    setState(() {
+      _selection.extendTo(tracks, index);
+      _selecting = _selection.isActive;
+    });
+    _focusSelection();
   }
 
   void _exitSelection() {
     setState(() {
       _selecting = false;
-      _selectedUris.clear();
+      _selection.clear();
     });
   }
 

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -15,8 +15,11 @@ import '../../core/services/bulk_track_actions.dart';
 import '../../core/sources/local/folder_location.dart';
 import '../../data/repositories/library_tab_store_provider.dart';
 import '../../shared/layout/adaptive_layout.dart';
+import '../../shared/layout/pane_layout.dart';
 import '../../shared/widgets/empty_state.dart';
 import '../playlists/widgets/add_to_playlist_sheet.dart';
+import 'album_detail_screen.dart';
+import 'artist_detail_screen.dart';
 import 'folder_browser_providers.dart';
 import 'library_browse_providers.dart';
 import 'library_controller.dart';
@@ -60,6 +63,13 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
 
   final Set<String> _selectedUris = <String>{};
   bool _selecting = false;
+
+  /// What the Albums / Artists detail pane is showing on a window wide enough
+  /// to have one. Held here rather than in the panes so it survives the pane
+  /// coming and going with the window width — and so a narrow window's pushed
+  /// route and a wide window's pane are the same screen, opened two ways.
+  String? _paneAlbumId;
+  String? _paneArtistId;
 
   late final TabController _tabController;
   final TextEditingController _searchController = TextEditingController();
@@ -416,10 +426,30 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
         message: 'You can still browse the connected server from Folders.',
       );
     }
-    return AlbumGrid(
-      albums: filtered,
-      onOpen: (Album album) =>
-          context.push(AppRoutes.albumDetailPath(album.id)),
+    return ListDetailPanes(
+      listBuilder: (BuildContext context, bool paneVisible) => AlbumGrid(
+        albums: filtered,
+        onOpen: (Album album) {
+          if (!paneVisible) {
+            context.push(AppRoutes.albumDetailPath(album.id));
+            return;
+          }
+          setState(() => _paneAlbumId = album.id);
+        },
+      ),
+      // A selection that is no longer in the filtered grid would leave the pane
+      // showing an album the list says isn't there, so the pane follows the
+      // search rather than outliving it.
+      detailBuilder: (BuildContext context) {
+        final String? id = _paneAlbumId;
+        if (id == null) return null;
+        if (!filtered.any((Album album) => album.id == id)) return null;
+        return AlbumDetailScreen(key: ValueKey<String>(id), albumId: id);
+      },
+      placeholderBuilder: (BuildContext context) => const DetailPanePlaceholder(
+        icon: Icons.album_outlined,
+        message: 'Pick an album to see its songs here.',
+      ),
     );
   }
 
@@ -435,10 +465,27 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
         message: 'You can still browse the connected server from Folders.',
       );
     }
-    return ArtistGrid(
-      artists: filtered,
-      onOpen: (Artist artist) =>
-          context.push(AppRoutes.artistDetailPath(artist.id)),
+    return ListDetailPanes(
+      listBuilder: (BuildContext context, bool paneVisible) => ArtistGrid(
+        artists: filtered,
+        onOpen: (Artist artist) {
+          if (!paneVisible) {
+            context.push(AppRoutes.artistDetailPath(artist.id));
+            return;
+          }
+          setState(() => _paneArtistId = artist.id);
+        },
+      ),
+      detailBuilder: (BuildContext context) {
+        final String? id = _paneArtistId;
+        if (id == null) return null;
+        if (!filtered.any((Artist artist) => artist.id == id)) return null;
+        return ArtistDetailScreen(key: ValueKey<String>(id), artistId: id);
+      },
+      placeholderBuilder: (BuildContext context) => const DetailPanePlaceholder(
+        icon: Icons.person_outline,
+        message: 'Pick an artist to see their albums here.',
+      ),
     );
   }
 

--- a/lib/features/library/track_selection.dart
+++ b/lib/features/library/track_selection.dart
@@ -1,0 +1,102 @@
+import '../../core/models/track.dart';
+
+/// Which tracks a list has selected, and where a Shift-click measures from.
+///
+/// Held by the screen rather than by the rows, so it survives a rebuild of the
+/// list — a catalog refresh, a download finishing, a position tick — and so a
+/// row never has to know anything about its neighbours (#387).
+///
+/// Membership is keyed by the provider-namespaced uri, never the bare id: a
+/// local `file:///…` copy and a `jellyfin:101` copy of the same song are
+/// different rows with different actions, and two providers' same-id copies
+/// must never end up selected together.
+///
+/// Pure, so the awkward parts — an anchor for a row that has since been
+/// filtered out, a range dragged backwards, a selection that outlives the
+/// tracks it named — are unit-testable without pumping a list.
+class TrackSelection {
+  final Set<String> _uris = <String>{};
+
+  /// The row a Shift-click extends from: the last row the user picked
+  /// deliberately, which is what every desktop list means by it.
+  String? _anchorUri;
+
+  bool get isActive => _uris.isNotEmpty;
+
+  int get length => _uris.length;
+
+  bool contains(String uri) => _uris.contains(uri);
+
+  /// The selected uris, for a list that renders its own rows' checkboxes.
+  Set<String> get uris => _uris;
+
+  /// The uri a Shift-click would extend from, or null when there is none.
+  String? get anchorUri => _anchorUri;
+
+  /// Starts a fresh selection at [track] — a long-press, or a plain click on a
+  /// row while nothing is selected.
+  void start(Track track) {
+    _uris
+      ..clear()
+      ..add(track.uri);
+    _anchorUri = track.uri;
+  }
+
+  /// Adds or removes one row, the way Ctrl-click does.
+  ///
+  /// The anchor follows the click either way: after Ctrl-clicking a row, a
+  /// Shift-click extends from *there*, whether the Ctrl-click selected the row
+  /// or deselected it.
+  void toggle(Track track) {
+    if (!_uris.add(track.uri)) {
+      _uris.remove(track.uri);
+    }
+    _anchorUri = track.uri;
+    if (_uris.isEmpty) _anchorUri = null;
+  }
+
+  /// Selects everything between the anchor and [index] of [tracks], inclusive.
+  ///
+  /// [tracks] is the list the clicked row is actually in — already sorted and
+  /// filtered as the user sees it — so a range can never span rows that are not
+  /// on screen between the two ends. With no anchor, or an anchor no longer in
+  /// this list (it was filtered out, or removed), the click behaves as a plain
+  /// [start]: extending from a row that is not there would select an arbitrary
+  /// run.
+  void extendTo(List<Track> tracks, int index) {
+    if (index < 0 || index >= tracks.length) return;
+    final String? anchor = _anchorUri;
+    final int from = anchor == null
+        ? -1
+        : tracks.indexWhere((Track track) => track.uri == anchor);
+    if (from < 0) {
+      start(tracks[index]);
+      return;
+    }
+    final int lo = from < index ? from : index;
+    final int hi = from < index ? index : from;
+    for (int i = lo; i <= hi; i++) {
+      _uris.add(tracks[i].uri);
+    }
+    // The anchor stays where it was, so dragging a Shift-click back and forth
+    // grows and shrinks from the same end rather than walking away from it.
+  }
+
+  void clear() {
+    _uris.clear();
+    _anchorUri = null;
+  }
+
+  /// The selected tracks, in the order [tracks] has them.
+  ///
+  /// Filtering here rather than storing [Track]s is what keeps a bulk action
+  /// honest: rows that have since left the list (removed, or filtered out by a
+  /// search) simply are not in the result, so an action can never reach a row
+  /// the count in the app bar does not describe.
+  List<Track> resolve(List<Track> tracks) {
+    return <Track>[
+      for (final Track track in tracks)
+        if (_uris.contains(track.uri)) track,
+    ];
+  }
+}

--- a/lib/features/library/widgets/album_grid_card.dart
+++ b/lib/features/library/widgets/album_grid_card.dart
@@ -5,6 +5,7 @@ import '../../../app/dimens.dart';
 import '../../../core/catalog/library_grouping.dart';
 import '../../../core/models/album.dart';
 import '../../../core/models/track.dart';
+import '../../../shared/widgets/hover_highlight.dart';
 import '../../player/widgets/album_artwork.dart';
 import '../../playlists/widgets/add_to_playlist_sheet.dart';
 import '../unified_library_providers.dart';
@@ -64,38 +65,48 @@ class AlbumGridCard extends ConsumerWidget {
         borderRadius: const BorderRadius.all(Radius.circular(AppRadii.md)),
         onTap: onTap,
         onLongPress: () => _addAllToPlaylist(context, ref),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Flexible(
-              child: AspectRatio(
-                aspectRatio: 1,
-                child: AlbumArtwork(artworkUri: album.artworkUri),
+        // The InkWell's own hover overlay is painted on the Material behind the
+        // card, so the cover hides it and a mouse user gets feedback on the
+        // labels and none on the artwork they are pointing at. The veil is that
+        // same hover colour, drawn where it can be seen.
+        child: HoverHighlight(
+          builder: (BuildContext context, bool hovered) => Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Flexible(
+                child: AspectRatio(
+                  aspectRatio: 1,
+                  child: HoverArtworkVeil(
+                    hovered: hovered,
+                    borderRadius: BorderRadius.circular(AppRadii.md),
+                    child: AlbumArtwork(artworkUri: album.artworkUri),
+                  ),
+                ),
               ),
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            Text(
-              album.title,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-              style: theme.textTheme.titleSmall?.copyWith(
-                fontWeight: FontWeight.w600,
-                height: _lineHeight,
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                album.title,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w600,
+                  height: _lineHeight,
+                ),
               ),
-            ),
-            const SizedBox(height: AppSpacing.xs),
-            Text(
-              album.artistName?.isNotEmpty == true
-                  ? album.artistName!
-                  : kUnknownArtist,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-                height: _lineHeight,
+              const SizedBox(height: AppSpacing.xs),
+              Text(
+                album.artistName?.isNotEmpty == true
+                    ? album.artistName!
+                    : kUnknownArtist,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                  height: _lineHeight,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/library/widgets/album_grid_card.dart
+++ b/lib/features/library/widgets/album_grid_card.dart
@@ -5,10 +5,12 @@ import '../../../app/dimens.dart';
 import '../../../core/catalog/library_grouping.dart';
 import '../../../core/models/album.dart';
 import '../../../core/models/track.dart';
+import '../../../shared/widgets/context_menu_region.dart';
 import '../../../shared/widgets/hover_highlight.dart';
 import '../../player/widgets/album_artwork.dart';
 import '../../playlists/widgets/add_to_playlist_sheet.dart';
 import '../unified_library_providers.dart';
+import 'collection_menu.dart';
 
 /// One card in the Albums grid: square cover, title, artist.
 ///
@@ -61,62 +63,71 @@ class AlbumGridCard extends ConsumerWidget {
     // One semantics node per card, so a screen reader announces
     // "<title>, <artist>" as a single tappable target instead of two labels.
     return MergeSemantics(
-      child: InkWell(
-        borderRadius: const BorderRadius.all(Radius.circular(AppRadii.md)),
-        onTap: onTap,
-        onLongPress: () => _addAllToPlaylist(context, ref),
-        // The InkWell's own hover overlay is painted on the Material behind the
-        // card, so the cover hides it and a mouse user gets feedback on the
-        // labels and none on the artwork they are pointing at. The veil is that
-        // same hover colour, drawn where it can be seen.
-        child: HoverHighlight(
-          builder: (BuildContext context, bool hovered) => Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Flexible(
-                child: AspectRatio(
-                  aspectRatio: 1,
-                  child: HoverArtworkVeil(
-                    hovered: hovered,
-                    borderRadius: BorderRadius.circular(AppRadii.md),
-                    child: AlbumArtwork(artworkUri: album.artworkUri),
+      child: ContextMenuRegion<CollectionAction>(
+        itemBuilder: (BuildContext context) => collectionMenuItems(),
+        onSelected: (CollectionAction action) => runCollectionAction(
+          context,
+          ref,
+          action,
+          _tracks(ref),
+        ),
+        child: InkWell(
+          borderRadius: const BorderRadius.all(Radius.circular(AppRadii.md)),
+          onTap: onTap,
+          onLongPress: () => _addAllToPlaylist(context, ref),
+          // The InkWell's own hover overlay is painted on the Material behind the
+          // card, so the cover hides it and a mouse user gets feedback on the
+          // labels and none on the artwork they are pointing at. The veil is that
+          // same hover colour, drawn where it can be seen.
+          child: HoverHighlight(
+            builder: (BuildContext context, bool hovered) => Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Flexible(
+                  child: AspectRatio(
+                    aspectRatio: 1,
+                    child: HoverArtworkVeil(
+                      hovered: hovered,
+                      borderRadius: BorderRadius.circular(AppRadii.md),
+                      child: AlbumArtwork(artworkUri: album.artworkUri),
+                    ),
                   ),
                 ),
-              ),
-              const SizedBox(height: AppSpacing.sm),
-              Text(
-                album.title,
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-                style: theme.textTheme.titleSmall?.copyWith(
-                  fontWeight: FontWeight.w600,
-                  height: _lineHeight,
+                const SizedBox(height: AppSpacing.sm),
+                Text(
+                  album.title,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    height: _lineHeight,
+                  ),
                 ),
-              ),
-              const SizedBox(height: AppSpacing.xs),
-              Text(
-                album.artistName?.isNotEmpty == true
-                    ? album.artistName!
-                    : kUnknownArtist,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.onSurfaceVariant,
-                  height: _lineHeight,
+                const SizedBox(height: AppSpacing.xs),
+                Text(
+                  album.artistName?.isNotEmpty == true
+                      ? album.artistName!
+                      : kUnknownArtist,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                    height: _lineHeight,
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),
     );
   }
 
+  List<Track> _tracks(WidgetRef ref) =>
+      tracksForAlbum(ref.read(libraryUnifiedTracksProvider), album.id);
+
   void _addAllToPlaylist(BuildContext context, WidgetRef ref) {
-    final List<Track> tracks = tracksForAlbum(
-      ref.read(libraryUnifiedTracksProvider),
-      album.id,
-    );
+    final List<Track> tracks = _tracks(ref);
     if (tracks.isNotEmpty) {
       showAddToPlaylistSheet(context, tracks);
     }

--- a/lib/features/library/widgets/album_tile.dart
+++ b/lib/features/library/widgets/album_tile.dart
@@ -5,9 +5,11 @@ import '../../../app/dimens.dart';
 import '../../../core/catalog/library_grouping.dart';
 import '../../../core/models/album.dart';
 import '../../../core/models/track.dart';
+import '../../../shared/widgets/context_menu_region.dart';
 import '../../player/widgets/album_artwork.dart';
 import '../../playlists/widgets/add_to_playlist_sheet.dart';
 import '../unified_library_providers.dart';
+import 'collection_menu.dart';
 
 /// One row in the Albums list: cover, title, artist, and track count.
 ///
@@ -22,35 +24,43 @@ class AlbumTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final ThemeData theme = Theme.of(context);
-    return ListTile(
-      leading: SizedBox.square(
-        dimension: 48,
-        child: AlbumArtwork(
-          artworkUri: album.artworkUri,
-          borderRadius: const BorderRadius.all(Radius.circular(AppRadii.sm)),
+    return ContextMenuRegion<CollectionAction>(
+      itemBuilder: (BuildContext context) => collectionMenuItems(),
+      onSelected: (CollectionAction action) =>
+          runCollectionAction(context, ref, action, _tracks(ref)),
+      child: ListTile(
+        leading: SizedBox.square(
+          dimension: 48,
+          child: AlbumArtwork(
+            artworkUri: album.artworkUri,
+            borderRadius: const BorderRadius.all(Radius.circular(AppRadii.sm)),
+          ),
         ),
-      ),
-      title: Text(
-        album.title,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-        style: theme.textTheme.titleMedium?.copyWith(
-          fontWeight: FontWeight.w600,
+        title: Text(
+          album.title,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
         ),
-      ),
-      subtitle: Text(
-        _subtitle(album),
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-        style: theme.textTheme.bodyMedium?.copyWith(
-          color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+        subtitle: Text(
+          _subtitle(album),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+          ),
         ),
+        trailing: const Icon(Icons.chevron_right),
+        onTap: onTap,
+        onLongPress: () => _addAllToPlaylist(context, ref),
       ),
-      trailing: const Icon(Icons.chevron_right),
-      onTap: onTap,
-      onLongPress: () => _addAllToPlaylist(context, ref),
     );
   }
+
+  List<Track> _tracks(WidgetRef ref) =>
+      tracksForAlbum(ref.read(libraryUnifiedTracksProvider), album.id);
 
   void _addAllToPlaylist(BuildContext context, WidgetRef ref) {
     final List<Track> tracks = tracksForAlbum(

--- a/lib/features/library/widgets/alphabet_track_list.dart
+++ b/lib/features/library/widgets/alphabet_track_list.dart
@@ -22,6 +22,7 @@ class AlphabetTrackList extends StatefulWidget {
     this.selectedUris = const <String>{},
     this.onSelectToggle,
     this.onSelectStart,
+    this.onSelectRange,
     super.key,
   });
 
@@ -41,8 +42,13 @@ class AlphabetTrackList extends StatefulWidget {
   /// Toggles a track's selection (tap while in selection mode).
   final void Function(Track track)? onSelectToggle;
 
-  /// Starts selection with a track (long-press).
+  /// Starts selection with a track (long-press, or a Ctrl-click from nothing).
   final void Function(Track track)? onSelectStart;
+
+  /// Shift-click: extend the selection to a row, over the list *as sorted
+  /// here*. This list sorts its own rows, so the host cannot compute a range
+  /// against the tracks it handed in.
+  final void Function(List<Track> tracks, int index)? onSelectRange;
 
   @override
   State<AlphabetTrackList> createState() => _AlphabetTrackListState();
@@ -220,6 +226,7 @@ class _AlphabetTrackListState extends State<AlphabetTrackList> {
               onSelectStart: widget.onSelectStart == null
                   ? null
                   : () => widget.onSelectStart!(track),
+              onSelectRange: widget.onSelectRange,
             );
           },
         ),

--- a/lib/features/library/widgets/alphabet_track_list.dart
+++ b/lib/features/library/widgets/alphabet_track_list.dart
@@ -51,8 +51,15 @@ class AlphabetTrackList extends StatefulWidget {
 class _AlphabetTrackListState extends State<AlphabetTrackList> {
   /// Fixed extents let the index compute an exact scroll offset for any letter
   /// without measuring laid-out widgets.
+  ///
+  /// The row extent follows the theme's [VisualDensity] rather than being one
+  /// number for everyone (#384): a desktop theme is compact, and a list of song
+  /// rows is where that difference is worth the most — eight pixels a row is a
+  /// couple more songs per screen on every scroll. Touch keeps 64 exactly.
+  static const double _baseTrackExtent = 64;
   static const double _headerExtent = 36;
-  static const double _trackExtent = 64;
+
+  double _trackExtent = _baseTrackExtent;
 
   /// Width of the trailing A–Z rail. The list reserves this much right-side
   /// padding so rows (and the 3-dot overflow menu) never sit under the rail.
@@ -78,6 +85,21 @@ class _AlphabetTrackListState extends State<AlphabetTrackList> {
     super.initState();
     _rebuildIndex();
     _controller.addListener(_syncActiveLetter);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // The per-letter offsets are measured in row extents, so a density change
+    // (a theme swap, or this list being rebuilt on another platform in a test)
+    // has to re-derive them or the rail would scroll to the wrong song.
+    final double extent = (_baseTrackExtent +
+            Theme.of(context).visualDensity.baseSizeAdjustment.dy)
+        .clamp(48.0, _baseTrackExtent);
+    if (extent != _trackExtent) {
+      _trackExtent = extent;
+      _rebuildIndex();
+    }
   }
 
   @override

--- a/lib/features/library/widgets/artist_grid.dart
+++ b/lib/features/library/widgets/artist_grid.dart
@@ -62,7 +62,13 @@ class ArtistGrid extends StatelessWidget {
     final double subtitle =
         scaler.scale(theme.textTheme.bodyMedium?.fontSize ?? 14) * _lineHeight;
     final double text = title + subtitle + AppSpacing.md;
-    return text > _defaultRowExtent ? text : _defaultRowExtent;
+    // The floor follows the theme's density (#384) so a compact desktop row
+    // actually gets shorter instead of sitting in a cell sized for a touch one.
+    // The text-driven part above is untouched: density buys padding back, never
+    // room the words need.
+    final double floor = _defaultRowExtent +
+        theme.visualDensity.baseSizeAdjustment.dy.clamp(-8.0, 0.0);
+    return text > floor ? text : floor;
   }
 
   static const double _lineHeight = 1.35;

--- a/lib/features/library/widgets/artist_tile.dart
+++ b/lib/features/library/widgets/artist_tile.dart
@@ -5,8 +5,10 @@ import '../../../core/catalog/library_grouping.dart';
 import '../../../core/models/artist.dart';
 import '../../../core/models/track.dart';
 import '../../../shared/widgets/artwork_image.dart';
+import '../../../shared/widgets/context_menu_region.dart';
 import '../../playlists/widgets/add_to_playlist_sheet.dart';
 import '../unified_library_providers.dart';
+import 'collection_menu.dart';
 
 /// One row in the Artists list: avatar, name, album count, and track count.
 ///
@@ -21,35 +23,43 @@ class ArtistTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final ThemeData theme = Theme.of(context);
-    return ListTile(
-      leading: _ArtistAvatar(artworkUri: artist.artworkUri),
-      title: Text(
-        artist.name,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-        style: theme.textTheme.titleMedium?.copyWith(
-          fontWeight: FontWeight.w600,
+    // Right-click (and the keyboard's menu key) offers what an artist page's
+    // own buttons already do (#386); the long-press stays exactly the
+    // add-to-playlist shortcut a phone has always had.
+    return ContextMenuRegion<CollectionAction>(
+      itemBuilder: (BuildContext context) => collectionMenuItems(),
+      onSelected: (CollectionAction action) =>
+          runCollectionAction(context, ref, action, _tracks(ref)),
+      child: ListTile(
+        leading: _ArtistAvatar(artworkUri: artist.artworkUri),
+        title: Text(
+          artist.name,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
         ),
-      ),
-      subtitle: Text(
-        _subtitle(artist),
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-        style: theme.textTheme.bodyMedium?.copyWith(
-          color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+        subtitle: Text(
+          _subtitle(artist),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+          ),
         ),
+        trailing: const Icon(Icons.chevron_right),
+        onTap: onTap,
+        onLongPress: () => _addAllToPlaylist(context, ref),
       ),
-      trailing: const Icon(Icons.chevron_right),
-      onTap: onTap,
-      onLongPress: () => _addAllToPlaylist(context, ref),
     );
   }
 
+  List<Track> _tracks(WidgetRef ref) =>
+      tracksForArtist(ref.read(libraryUnifiedTracksProvider), artist.id);
+
   void _addAllToPlaylist(BuildContext context, WidgetRef ref) {
-    final List<Track> tracks = tracksForArtist(
-      ref.read(libraryUnifiedTracksProvider),
-      artist.id,
-    );
+    final List<Track> tracks = _tracks(ref);
     if (tracks.isNotEmpty) {
       showAddToPlaylistSheet(context, tracks);
     }

--- a/lib/features/library/widgets/collection_menu.dart
+++ b/lib/features/library/widgets/collection_menu.dart
@@ -1,0 +1,100 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../app/routes.dart';
+import '../../../core/models/track.dart';
+import '../../player/player_providers.dart';
+import '../../playlists/widgets/add_to_playlist_sheet.dart';
+
+/// What a right-click offers on something that *is* a set of songs: an album,
+/// an artist, a playlist (#386).
+///
+/// Deliberately only what the domain layer already does. Every entry maps onto
+/// a command the detail screens have used since before this menu existed —
+/// [PlaybackController.playTracks], `playNext`, `addToQueue`, and the shared
+/// add-to-playlist sheet with its duplicate and source safeguards — so the menu
+/// carries no logic of its own to drift.
+enum CollectionAction {
+  play,
+  shuffle,
+  playNext,
+  addToQueue,
+  addToPlaylist,
+}
+
+/// The entries, in the order a listener reaches for them.
+List<PopupMenuEntry<CollectionAction>> collectionMenuItems() {
+  return <PopupMenuEntry<CollectionAction>>[
+    _item(CollectionAction.play, Icons.play_arrow, 'Play'),
+    _item(CollectionAction.shuffle, Icons.shuffle, 'Shuffle'),
+    const PopupMenuDivider(),
+    _item(CollectionAction.playNext, Icons.queue_music, 'Play next'),
+    _item(CollectionAction.addToQueue, Icons.add_to_queue, 'Add to queue'),
+    _item(
+        CollectionAction.addToPlaylist, Icons.playlist_add, 'Add to playlist'),
+  ];
+}
+
+PopupMenuItem<CollectionAction> _item(
+  CollectionAction action,
+  IconData icon,
+  String label,
+) {
+  return PopupMenuItem<CollectionAction>(
+    value: action,
+    child: ListTile(
+      contentPadding: EdgeInsets.zero,
+      leading: Icon(icon),
+      title: Text(label),
+    ),
+  );
+}
+
+/// Runs [action] against [tracks].
+///
+/// [tracks] is read at the moment the action is chosen, not when the menu was
+/// built, so a catalog that changed while the menu was open cannot act on a
+/// stale list. An empty set does nothing rather than starting silence.
+Future<void> runCollectionAction(
+  BuildContext context,
+  WidgetRef ref,
+  CollectionAction action,
+  List<Track> tracks,
+) async {
+  if (tracks.isEmpty) return;
+  final controller = ref.read(playbackControllerProvider);
+  switch (action) {
+    case CollectionAction.play:
+      unawaited(controller.playTracks(tracks));
+      unawaited(context.push(AppRoutes.player));
+    case CollectionAction.shuffle:
+      controller.setShuffleEnabled(true);
+      unawaited(controller.playTracks(tracks));
+      unawaited(context.push(AppRoutes.player));
+    case CollectionAction.playNext:
+      if (controller.state.currentTrack == null) {
+        // Nothing is playing, so there is no "next" to insert before. The
+        // shared command starts the first track it is handed and queues the
+        // rest behind it, which is what "play this next" means from silence.
+        for (final Track track in tracks) {
+          controller.addToQueue(track);
+        }
+      } else {
+        // Each insert lands directly after the current track, so an album
+        // queued front-to-back would play backwards. Reversing is the one
+        // thing a set knows that a single track does not.
+        for (final Track track in tracks.reversed) {
+          controller.playNext(track);
+        }
+      }
+    case CollectionAction.addToQueue:
+      for (final Track track in tracks) {
+        controller.addToQueue(track);
+      }
+    case CollectionAction.addToPlaylist:
+      await showAddToPlaylistSheet(context, tracks);
+  }
+}

--- a/lib/features/library/widgets/selection_escape_scope.dart
+++ b/lib/features/library/widgets/selection_escape_scope.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Lets Escape leave a track selection, on every screen that has one (#387).
+///
+/// A selection is a mode, and a mode with no keyboard focus has nowhere for a
+/// key to land: clicking a row does not move focus by itself, so without this
+/// the only way out of a selection started with Ctrl or Shift is the mouse
+/// again — the app bar's close button. On a phone the system Back gesture is
+/// that way out, which is what the hosts' `PopScope` already answers; Escape is
+/// the desktop's Back.
+///
+/// So the scope takes the keyboard the moment a selection starts and hands
+/// Escape to [onEscape]. Its node is kept out of the Tab order: it is somewhere
+/// focus is *put*, not a stop on the way through, and Tab from there walks on
+/// into the page as it always did.
+class SelectionEscapeScope extends StatefulWidget {
+  const SelectionEscapeScope({
+    required this.selecting,
+    required this.onEscape,
+    required this.child,
+    super.key,
+  });
+
+  /// Whether a selection is running. The rising edge is what claims focus.
+  final bool selecting;
+
+  final VoidCallback onEscape;
+
+  final Widget child;
+
+  @override
+  State<SelectionEscapeScope> createState() => _SelectionEscapeScopeState();
+}
+
+class _SelectionEscapeScopeState extends State<SelectionEscapeScope> {
+  final FocusNode _node = FocusNode(
+    debugLabel: 'track selection',
+    skipTraversal: true,
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.selecting) _claimFocus();
+  }
+
+  @override
+  void didUpdateWidget(SelectionEscapeScope oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Only on the rising edge: re-requesting on every selection change would
+    // pull focus back from anything the user had since moved it to — a search
+    // field, the app bar's own buttons — for no reason.
+    if (widget.selecting && !oldWidget.selecting) _claimFocus();
+  }
+
+  void _claimFocus() {
+    // After the frame that turned selection on: the node is only attached once
+    // this build has been mounted.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && widget.selecting) _node.requestFocus();
+    });
+  }
+
+  @override
+  void dispose() {
+    _node.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      focusNode: _node,
+      skipTraversal: true,
+      onKeyEvent: (FocusNode node, KeyEvent event) {
+        if (!widget.selecting ||
+            event is! KeyDownEvent ||
+            event.logicalKey != LogicalKeyboardKey.escape) {
+          return KeyEventResult.ignored;
+        }
+        widget.onEscape();
+        return KeyEventResult.handled;
+      },
+      child: widget.child,
+    );
+  }
+}

--- a/lib/features/library/widgets/track_tile.dart
+++ b/lib/features/library/widgets/track_tile.dart
@@ -19,6 +19,7 @@ import '../../player/now_playing.dart';
 import '../../player/player_providers.dart';
 import '../../player/widgets/track_artwork.dart';
 import '../../playlists/widgets/add_to_playlist_sheet.dart';
+import '../library_browse_providers.dart';
 import '../song_actions.dart';
 
 /// The actions reachable from a track row's overflow menu. Which subset is
@@ -215,6 +216,8 @@ class TrackTile extends ConsumerWidget {
         isFavorite: ref.read(isFavoriteProvider(track.uri)),
         isRemote: isRemote,
         status: status,
+        hasAlbumPage: _hasAlbumPage(ref, track),
+        hasArtistPage: _hasArtistPage(ref, track),
       ),
       onSelected: (_TrackAction action) =>
           _runTrackAction(context, ref, track, action),
@@ -324,19 +327,24 @@ class _OverflowMenu extends ConsumerWidget {
       icon: const Icon(Icons.more_vert),
       tooltip: 'More actions',
       onSelected: (action) => _run(context, ref, action),
-      itemBuilder: (context) => _menuItems(isFavorite),
+      itemBuilder: (context) => _menuItems(ref, isFavorite),
     );
   }
 
   /// Context-aware action list. Offline actions are gated on [isRemote]; the
   /// rest depend on the track's [DownloadStatus]. The favourite toggle, queue,
   /// add-to-playlist, and remove-from-Linthra actions are always available.
-  List<PopupMenuEntry<_TrackAction>> _menuItems(bool isFavorite) {
+  List<PopupMenuEntry<_TrackAction>> _menuItems(
+    WidgetRef ref,
+    bool isFavorite,
+  ) {
     return _trackMenuItems(
       track: track,
       isFavorite: isFavorite,
       isRemote: isRemote,
       status: status,
+      hasAlbumPage: _hasAlbumPage(ref, track),
+      hasArtistPage: _hasArtistPage(ref, track),
     );
   }
 
@@ -347,6 +355,24 @@ class _OverflowMenu extends ConsumerWidget {
   ) =>
       _runTrackAction(context, ref, track, action);
 }
+
+/// Whether this track's album has a page to open.
+///
+/// A row is not proof the catalog knows the album: the folder browser lists a
+/// server's tree on demand, so it shows tracks that were never synced into the
+/// flat catalog. `AlbumDetailScreen` resolves ids against that catalog alone,
+/// so offering "Show album" for one of those rows lands the user on "Album not
+/// found" right after they picked a song that plays fine.
+///
+/// Read, not watched: the menu is built when it opens, so this is the answer at
+/// that moment. Both detail screens derive their ids the same way, so a hit
+/// here is the page the Albums tab would have opened.
+bool _hasAlbumPage(WidgetRef ref, Track track) =>
+    ref.read(libraryAlbumIdsProvider).contains(albumIdForTrack(track));
+
+/// Whether this track's artist has a page to open. See [_hasAlbumPage].
+bool _hasArtistPage(WidgetRef ref, Track track) =>
+    ref.read(libraryArtistIdsProvider).contains(artistIdForTrack(track));
 
 /// The row's action list, built fresh so it always reflects the current
 /// favourite and download state.
@@ -359,6 +385,8 @@ List<PopupMenuEntry<_TrackAction>> _trackMenuItems({
   required bool isFavorite,
   required bool isRemote,
   required DownloadStatus status,
+  required bool hasAlbumPage,
+  required bool hasArtistPage,
 }) {
   final items = <PopupMenuEntry<_TrackAction>>[
     _item(
@@ -391,9 +419,11 @@ List<PopupMenuEntry<_TrackAction>> _trackMenuItems({
   // rest: "where does this song live" is a different question from "do
   // something to it". Offered only where there is somewhere to go — a track
   // with no album tags has no album page to open.
-  final bool hasAlbum = (track.albumName ?? '').trim().isNotEmpty ||
-      (track.albumId ?? '').trim().isNotEmpty;
-  final bool hasArtist = (track.artistName ?? '').trim().isNotEmpty;
+  final bool hasAlbum = hasAlbumPage &&
+      ((track.albumName ?? '').trim().isNotEmpty ||
+          (track.albumId ?? '').trim().isNotEmpty);
+  final bool hasArtist =
+      hasArtistPage && (track.artistName ?? '').trim().isNotEmpty;
   if (hasAlbum || hasArtist) {
     items.add(const PopupMenuDivider());
     if (hasAlbum) {

--- a/lib/features/library/widgets/track_tile.dart
+++ b/lib/features/library/widgets/track_tile.dart
@@ -1,13 +1,17 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../app/routes.dart';
+import '../../../core/catalog/library_grouping.dart';
 import '../../../core/models/track.dart';
 import '../../../core/repositories/download_repository.dart';
 import '../../../core/repositories/download_store.dart';
 import '../../../data/repositories/download_repository_provider.dart';
 import '../../../data/repositories/favorites_repository_provider.dart';
+import '../../../shared/widgets/context_menu_region.dart';
 import '../../downloads/download_providers.dart';
 import '../../player/favorites_providers.dart';
 import '../../player/now_playing.dart';
@@ -28,6 +32,8 @@ enum _TrackAction {
   removeOffline,
   retryDownload,
   cancel,
+  showAlbum,
+  showArtist,
   removeFromLibrary,
 }
 
@@ -104,7 +110,7 @@ class TrackTile extends ConsumerWidget {
             ?.fraction
         : null;
 
-    return ListTile(
+    final Widget row = ListTile(
       selected: selectionActive && selected,
       leading: TrackArtwork(
         artworkUri: track.artworkUri,
@@ -163,6 +169,24 @@ class TrackTile extends ConsumerWidget {
         context.push(AppRoutes.player);
       },
       onLongPress: (selectable && !selectionActive) ? onSelectStart : null,
+    );
+
+    // The same menu the 3-dot button opens, on right-click and on the
+    // keyboard's menu key (#386). Built at open time, so it reflects the
+    // favourite and download state as it is then rather than as it was when the
+    // row was laid out. Withheld while selecting: the app bar is acting on the
+    // whole selection there, and a per-row menu would be acting on one row.
+    return ContextMenuRegion<_TrackAction>(
+      enabled: !selectionActive,
+      itemBuilder: (BuildContext context) => _trackMenuItems(
+        track: track,
+        isFavorite: ref.read(isFavoriteProvider(track.uri)),
+        isRemote: isRemote,
+        status: status,
+      ),
+      onSelected: (_TrackAction action) =>
+          _runTrackAction(context, ref, track, action),
+      child: row,
     );
   }
 
@@ -264,50 +288,11 @@ class _OverflowMenu extends ConsumerWidget {
   /// rest depend on the track's [DownloadStatus]. The favourite toggle, queue,
   /// add-to-playlist, and remove-from-Linthra actions are always available.
   List<PopupMenuEntry<_TrackAction>> _menuItems(bool isFavorite) {
-    final items = <PopupMenuEntry<_TrackAction>>[
-      _item(
-        _TrackAction.toggleFavorite,
-        isFavorite ? Icons.favorite : Icons.favorite_border,
-        isFavorite ? 'Remove from favorites' : 'Add to favorites',
-      ),
-      _item(_TrackAction.playNext, Icons.queue_music, 'Play next'),
-      _item(_TrackAction.addToQueue, Icons.add_to_queue, 'Add to queue'),
-      _item(_TrackAction.addToPlaylist, Icons.playlist_add, 'Add to playlist'),
-    ];
-    if (isRemote) {
-      switch (status) {
-        case DownloadStatus.notDownloaded:
-          items.add(_item(_TrackAction.download, Icons.download_outlined,
-              'Download for offline'));
-        case DownloadStatus.queued:
-        case DownloadStatus.downloading:
-          items.add(_item(_TrackAction.cancel, Icons.close, 'Cancel download'));
-        case DownloadStatus.downloaded:
-          items.add(_item(_TrackAction.removeOffline, Icons.delete_outline,
-              'Remove offline copy'));
-        case DownloadStatus.failed:
-          items.add(_item(
-              _TrackAction.retryDownload, Icons.refresh, 'Retry download'));
-          items.add(_item(_TrackAction.cancel, Icons.close, 'Cancel download'));
-      }
-    }
-    items.add(_item(_TrackAction.removeFromLibrary, Icons.remove_circle_outline,
-        'Remove from Linthra'));
-    return items;
-  }
-
-  PopupMenuItem<_TrackAction> _item(
-    _TrackAction action,
-    IconData icon,
-    String label,
-  ) {
-    return PopupMenuItem<_TrackAction>(
-      value: action,
-      child: ListTile(
-        contentPadding: EdgeInsets.zero,
-        leading: Icon(icon),
-        title: Text(label),
-      ),
+    return _trackMenuItems(
+      track: track,
+      isFavorite: isFavorite,
+      isRemote: isRemote,
+      status: status,
     );
   }
 
@@ -315,58 +300,161 @@ class _OverflowMenu extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
     _TrackAction action,
-  ) async {
-    switch (action) {
-      case _TrackAction.toggleFavorite:
-        // Like/unlike without touching playback or the queue. Re-read the
-        // current state so the toggle is correct even if the heart changed
-        // after the menu opened, and hand the real [Track] to the repository so
-        // its uri routes local/Jellyfin/Subsonic favourites (and the Subsonic
-        // sync push) correctly.
-        final bool isFavorite = ref.read(isFavoriteProvider(track.uri));
-        await ref
-            .read(favoritesRepositoryProvider)
-            .setFavorite(track, !isFavorite);
-      case _TrackAction.playNext:
-        ref.read(playbackControllerProvider).playNext(track);
-      case _TrackAction.addToQueue:
-        ref.read(playbackControllerProvider).addToQueue(track);
-      case _TrackAction.addToPlaylist:
-        await showAddToPlaylistSheet(context, <Track>[track]);
-      case _TrackAction.download:
-      case _TrackAction.retryDownload:
-        await _download(context, ref);
-      case _TrackAction.cancel:
-        // Cancelling an in-flight/queued download is not destructive to a saved
-        // copy, so it needs no confirmation.
-        await ref.read(downloadRepositoryProvider).removeDownload(track);
-      case _TrackAction.removeOffline:
-        await SongActions.removeOfflineCopies(context, ref, <Track>[track]);
-      case _TrackAction.removeFromLibrary:
-        await SongActions.removeFromLibrary(
-          context,
-          ref,
-          <Track>[track],
-          expandLogicalSources: true,
-        );
+  ) =>
+      _runTrackAction(context, ref, track, action);
+}
+
+/// The row's action list, built fresh so it always reflects the current
+/// favourite and download state.
+///
+/// Shared by the trailing 3-dot button and the row's right-click menu (#386):
+/// one list, one dispatcher, so a right-click can never offer an action a tap
+/// cannot — or run it differently.
+List<PopupMenuEntry<_TrackAction>> _trackMenuItems({
+  required Track track,
+  required bool isFavorite,
+  required bool isRemote,
+  required DownloadStatus status,
+}) {
+  final items = <PopupMenuEntry<_TrackAction>>[
+    _item(
+      _TrackAction.toggleFavorite,
+      isFavorite ? Icons.favorite : Icons.favorite_border,
+      isFavorite ? 'Remove from favorites' : 'Add to favorites',
+    ),
+    _item(_TrackAction.playNext, Icons.queue_music, 'Play next'),
+    _item(_TrackAction.addToQueue, Icons.add_to_queue, 'Add to queue'),
+    _item(_TrackAction.addToPlaylist, Icons.playlist_add, 'Add to playlist'),
+  ];
+  if (isRemote) {
+    switch (status) {
+      case DownloadStatus.notDownloaded:
+        items.add(_item(_TrackAction.download, Icons.download_outlined,
+            'Download for offline'));
+      case DownloadStatus.queued:
+      case DownloadStatus.downloading:
+        items.add(_item(_TrackAction.cancel, Icons.close, 'Cancel download'));
+      case DownloadStatus.downloaded:
+        items.add(_item(_TrackAction.removeOffline, Icons.delete_outline,
+            'Remove offline copy'));
+      case DownloadStatus.failed:
+        items.add(
+            _item(_TrackAction.retryDownload, Icons.refresh, 'Retry download'));
+        items.add(_item(_TrackAction.cancel, Icons.close, 'Cancel download'));
     }
   }
-
-  /// Starts the download, surfacing the friendly, secret-free reasons it might
-  /// not start: a full cache with nothing safe to evict, or the network policy
-  /// queueing it (mobile data not allowed, or offline). Other errors fall
-  /// through to the row's "failed" indicator (with a retry action).
-  Future<void> _download(BuildContext context, WidgetRef ref) async {
-    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
-    try {
-      final DownloadRequestOutcome outcome =
-          await ref.read(downloadRepositoryProvider).requestDownload(track);
-      final String? message = outcome.blockedMessage;
-      if (message != null) {
-        messenger.showSnackBar(SnackBar(content: Text(message)));
-      }
-    } on CacheStorageException catch (error) {
-      messenger.showSnackBar(SnackBar(content: Text(error.message)));
+  // Navigation, last before the destructive action and separated from the
+  // rest: "where does this song live" is a different question from "do
+  // something to it". Offered only where there is somewhere to go — a track
+  // with no album tags has no album page to open.
+  final bool hasAlbum = (track.albumName ?? '').trim().isNotEmpty ||
+      (track.albumId ?? '').trim().isNotEmpty;
+  final bool hasArtist = (track.artistName ?? '').trim().isNotEmpty;
+  if (hasAlbum || hasArtist) {
+    items.add(const PopupMenuDivider());
+    if (hasAlbum) {
+      items.add(
+          _item(_TrackAction.showAlbum, Icons.album_outlined, 'Show album'));
     }
+    if (hasArtist) {
+      items.add(
+          _item(_TrackAction.showArtist, Icons.person_outline, 'Show artist'));
+    }
+    items.add(const PopupMenuDivider());
+  }
+  items.add(_item(_TrackAction.removeFromLibrary, Icons.remove_circle_outline,
+      'Remove from Linthra'));
+  return items;
+}
+
+PopupMenuItem<_TrackAction> _item(
+  _TrackAction action,
+  IconData icon,
+  String label,
+) {
+  return PopupMenuItem<_TrackAction>(
+    value: action,
+    child: ListTile(
+      contentPadding: EdgeInsets.zero,
+      leading: Icon(icon),
+      title: Text(label),
+    ),
+  );
+}
+
+/// Runs one action against the shared commands — the playback controller, the
+/// favourites and download repositories, the safe remove actions — so the menu
+/// owns no business logic of its own.
+Future<void> _runTrackAction(
+  BuildContext context,
+  WidgetRef ref,
+  Track track,
+  _TrackAction action,
+) async {
+  switch (action) {
+    case _TrackAction.toggleFavorite:
+      // Like/unlike without touching playback or the queue. Re-read the
+      // current state so the toggle is correct even if the heart changed
+      // after the menu opened, and hand the real [Track] to the repository so
+      // its uri routes local/Jellyfin/Subsonic favourites (and the Subsonic
+      // sync push) correctly.
+      final bool isFavorite = ref.read(isFavoriteProvider(track.uri));
+      await ref
+          .read(favoritesRepositoryProvider)
+          .setFavorite(track, !isFavorite);
+    case _TrackAction.playNext:
+      ref.read(playbackControllerProvider).playNext(track);
+    case _TrackAction.addToQueue:
+      ref.read(playbackControllerProvider).addToQueue(track);
+    case _TrackAction.addToPlaylist:
+      await showAddToPlaylistSheet(context, <Track>[track]);
+    case _TrackAction.download:
+    case _TrackAction.retryDownload:
+      await _download(context, ref, track);
+    case _TrackAction.cancel:
+      // Cancelling an in-flight/queued download is not destructive to a saved
+      // copy, so it needs no confirmation.
+      await ref.read(downloadRepositoryProvider).removeDownload(track);
+    case _TrackAction.removeOffline:
+      await SongActions.removeOfflineCopies(context, ref, <Track>[track]);
+    case _TrackAction.showAlbum:
+      // The same derived ids the Albums and Artists grids route with, so the
+      // menu lands on exactly the page those tabs would have opened.
+      unawaited(
+        context.push(AppRoutes.albumDetailPath(albumIdForTrack(track))),
+      );
+    case _TrackAction.showArtist:
+      unawaited(
+        context.push(AppRoutes.artistDetailPath(artistIdForTrack(track))),
+      );
+    case _TrackAction.removeFromLibrary:
+      await SongActions.removeFromLibrary(
+        context,
+        ref,
+        <Track>[track],
+        expandLogicalSources: true,
+      );
+  }
+}
+
+/// Starts the download, surfacing the friendly, secret-free reasons it might
+/// not start: a full cache with nothing safe to evict, or the network policy
+/// queueing it (mobile data not allowed, or offline). Other errors fall
+/// through to the row's "failed" indicator (with a retry action).
+Future<void> _download(
+  BuildContext context,
+  WidgetRef ref,
+  Track track,
+) async {
+  final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+  try {
+    final DownloadRequestOutcome outcome =
+        await ref.read(downloadRepositoryProvider).requestDownload(track);
+    final String? message = outcome.blockedMessage;
+    if (message != null) {
+      messenger.showSnackBar(SnackBar(content: Text(message)));
+    }
+  } on CacheStorageException catch (error) {
+    messenger.showSnackBar(SnackBar(content: Text(error.message)));
   }
 }

--- a/lib/features/library/widgets/track_tile.dart
+++ b/lib/features/library/widgets/track_tile.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
@@ -53,6 +54,13 @@ enum _TrackAction {
 /// [onSelectToggle] instead of playing. Hosts that don't pass these (e.g.
 /// Favorites) keep the plain tap-to-play behaviour.
 ///
+/// With a keyboard attached the modifiers a desktop list is expected to honour
+/// work too (#387), whether or not a selection is already running: Ctrl-click
+/// (Cmd on macOS) toggles this row alone, and Shift-click extends from the last
+/// row picked to this one through [onSelectRange]. They are read off the
+/// hardware keyboard at tap time rather than gated on a platform, so a keyboard
+/// case on a tablet gets them for free and a bare touch tap is unchanged.
+///
 /// Source-awareness: offline/download actions only appear for *remote* tracks
 /// (resolved through [remoteTrackDownloaderProvider], the same seam the
 /// download repository uses). On-device tracks are already local, so showing
@@ -67,6 +75,7 @@ class TrackTile extends ConsumerWidget {
     this.selected = false,
     this.onSelectToggle,
     this.onSelectStart,
+    this.onSelectRange,
     super.key,
   });
 
@@ -85,6 +94,13 @@ class TrackTile extends ConsumerWidget {
 
   final VoidCallback? onSelectToggle;
   final VoidCallback? onSelectStart;
+
+  /// Shift-click: select everything between the host's anchor and this row.
+  ///
+  /// Handed the exact list this row is in, already sorted and filtered as the
+  /// user sees it, so a range can never span rows that are not on screen
+  /// between its two ends.
+  final void Function(List<Track> tracks, int index)? onSelectRange;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -160,6 +176,22 @@ class TrackTile extends ConsumerWidget {
               ],
             ),
       onTap: () {
+        if (selectable && _extendsSelection) {
+          onSelectRange?.call(tracks, index);
+          return;
+        }
+        // Ctrl (or Cmd) picks this row out on its own, and starts a selection
+        // when there isn't one — the whole point of it on a desktop, where
+        // holding a row down for half a second to begin is not the gesture
+        // anybody reaches for.
+        if (selectable && _togglesSelection) {
+          if (selectionActive) {
+            onSelectToggle?.call();
+          } else {
+            onSelectStart?.call();
+          }
+          return;
+        }
         if (selectionActive) {
           onSelectToggle?.call();
           return;
@@ -189,6 +221,18 @@ class TrackTile extends ConsumerWidget {
       child: row,
     );
   }
+
+  /// Whether the modifiers held right now mean "toggle just this row".
+  ///
+  /// Cmd counts alongside Ctrl so the row behaves the way a macOS list does;
+  /// Shift wins when both are down, which is what every file manager does.
+  static bool get _togglesSelection {
+    final HardwareKeyboard keyboard = HardwareKeyboard.instance;
+    return !keyboard.isShiftPressed &&
+        (keyboard.isControlPressed || keyboard.isMetaPressed);
+  }
+
+  static bool get _extendsSelection => HardwareKeyboard.instance.isShiftPressed;
 
   /// Prefer human-readable artist/album metadata; fall back to the raw
   /// uri/path when a track has no tags yet.

--- a/lib/features/player/mini_player.dart
+++ b/lib/features/player/mini_player.dart
@@ -17,8 +17,10 @@ import 'cast/cast_providers.dart';
 import 'favorites_providers.dart';
 import 'player_providers.dart';
 import 'widgets/album_artwork.dart';
+import 'widgets/playback_progress_bar.dart';
 import 'widgets/queue_sheet.dart';
 import 'widgets/volume_controls.dart';
+import 'widgets/wavy_seek_bar.dart';
 
 /// A compact, persistent now-playing bar shown above the bottom navigation on
 /// every main screen (Library / Folders / Playlists / Downloads / Settings).
@@ -36,6 +38,13 @@ import 'widgets/volume_controls.dart';
 /// the full row — favorite · previous · play/pause · next — centred between the
 /// metadata and the queue button, so skipping a track or liking one never means
 /// opening the full player first.
+///
+/// On a desktop host the progress line along the top edge is a seek control
+/// rather than a readout: a pointer is precise enough to aim at a slim line, and
+/// jumping 30 seconds back is the one thing a listener does often enough that
+/// opening the full player for it grates. On a touch host it stays exactly the
+/// decorative line it has always been — a 14 px strip is not a touch target, and
+/// it sits right where a thumb reaches for the bar itself.
 class MiniPlayer extends ConsumerWidget {
   const MiniPlayer({super.key});
 
@@ -104,7 +113,7 @@ class MiniPlayer extends ConsumerWidget {
           height: miniPlayerHeight,
           child: Column(
             children: [
-              const _MiniProgressBar(),
+              _MiniProgressBar(seekable: isDesktop),
               Expanded(
                 child: Padding(
                   padding: const EdgeInsets.symmetric(
@@ -339,17 +348,26 @@ class _MiniSubtitle extends StatelessWidget {
 /// surfaces read as one design. Sits at 0 (an empty track) when the duration is
 /// still unknown, so it never animates indeterminately or jumps.
 ///
-/// Deliberately marker-less, and pinned at the full wave rather than following
-/// the play/pause swell the full player uses: at this size the wave is texture
-/// rather than a control, and this bar is on screen on every main tab — so it
-/// stays a plain repaint per position tick and adds no animation frames
-/// anywhere in the app. Tapping the mini-player opens the full player; it is
-/// not a seek surface, so it carries no slider semantics of its own.
+/// Where a pointer is the input — [seekable], set on desktop hosts — it is the
+/// same [PlaybackProgressBar] the full player uses, at its compact density and
+/// without the elapsed/total caption there is no room for. That buys the drag
+/// preview, the optimistic hold until playback acknowledges a seek, the slider
+/// semantics and the arrow-key handling for free, and keeps the two surfaces
+/// seeking identically rather than approximately.
+///
+/// On a touch host it stays what it always was: marker-less, pinned at the full
+/// wave rather than following the play/pause swell the full player uses. At that
+/// size the wave is texture rather than a control, and this bar is on screen on
+/// every main tab — so it stays a plain repaint per position tick and adds no
+/// animation frames anywhere in the app.
 ///
 /// It watches the position/duration itself, so a position tick rebuilds only
 /// this thin line — not the artwork and text above it.
 class _MiniProgressBar extends ConsumerWidget {
-  const _MiniProgressBar();
+  const _MiniProgressBar({required this.seekable});
+
+  /// Whether the line takes clicks, drags and arrow keys as seeks.
+  final bool seekable;
 
   /// Enough room for the wave's peaks and stroke without meaningfully eating
   /// into the 64dp bar's content row.
@@ -360,6 +378,22 @@ class _MiniProgressBar extends ConsumerWidget {
     final controller = ref.watch(playbackControllerProvider);
     final state =
         ref.watch(playbackStateProvider).valueOrNull ?? controller.state;
+
+    if (seekable) {
+      return PlaybackProgressBar(
+        // Same reasoning as the full player's bar: identity is the track, so a
+        // track change disposes an optimistically held seek instead of carrying
+        // it onto the next song.
+        key: ValueKey<String?>(state.currentTrack?.uri),
+        position: state.position,
+        duration: state.duration,
+        playing: state.isPlaying,
+        density: WavySeekBarDensity.compact,
+        showTimeLabels: false,
+        onSeek: controller.seek,
+      );
+    }
+
     final theme = Theme.of(context);
     final int total = state.duration.inMilliseconds;
     final double value = total > 0

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -19,6 +19,7 @@ import 'widgets/now_playing_actions.dart';
 import 'widgets/now_playing_background.dart';
 import 'widgets/playback_controls.dart';
 import 'widgets/playback_progress_bar.dart';
+import 'widgets/queue_sheet.dart';
 import 'widgets/track_metadata.dart';
 import 'widgets/volume_controls.dart';
 
@@ -132,6 +133,17 @@ class _NowPlaying extends StatefulWidget {
 }
 
 class _NowPlayingState extends State<_NowPlaying> {
+  /// How wide a queue pane is drawn. Wide enough for a title, a duration and a
+  /// drag handle without the title truncating on most songs.
+  static const double _queuePaneWidth = 340;
+
+  /// The narrowest the screen may be and still host the queue as a third
+  /// column: the pane's own width, plus enough left over that the cover and the
+  /// controls beside it are no tighter than they are at the bottom of the
+  /// two-column layout.
+  static const double _queuePaneMinWidth =
+      expandedWindowWidth + _queuePaneWidth + AppSpacing.lg;
+
   /// Whether the stage is showing lyrics instead of the cover.
   ///
   /// Deliberately kept across track changes: someone reading along wants the
@@ -139,6 +151,13 @@ class _NowPlayingState extends State<_NowPlaying> {
   /// than a gesture, so it can't collide with the existing swipe-to-dismiss or
   /// with dragging the seek bar.
   bool _showLyrics = false;
+
+  /// Whether the queue is open as a pane beside the cover.
+  ///
+  /// Remembered even while the window is too narrow to draw it, so dragging a
+  /// window down to a phone width and back finds the queue where it was left
+  /// rather than closed.
+  bool _showQueue = false;
 
   @override
   Widget build(BuildContext context) {
@@ -153,6 +172,12 @@ class _NowPlayingState extends State<_NowPlaying> {
         // the two vertically, since the cover shrinks beside the controls
         // instead of stacking on top of them.
         final bool wide = sizeClass.isAtLeast(WindowSizeClass.expanded);
+        // A third column has to earn its place: at the low end of `expanded`
+        // the cover and the controls are already using the width, and a queue
+        // squeezed in beside them would shrink both to make room for a list
+        // that is one tap away as a sheet.
+        final bool canHostQueue =
+            wide && constraints.maxWidth >= _queuePaneMinWidth;
         return Padding(
           padding: const EdgeInsets.fromLTRB(
             AppSpacing.md,
@@ -160,7 +185,8 @@ class _NowPlayingState extends State<_NowPlaying> {
             AppSpacing.md,
             AppSpacing.lg,
           ),
-          child: wide ? _wideLayout() : _stackedLayout(),
+          child:
+              wide ? _wideLayout(canHostQueue: canHostQueue) : _stackedLayout(),
         );
       },
     );
@@ -171,11 +197,18 @@ class _NowPlayingState extends State<_NowPlaying> {
   /// cover instead of replacing it, which is the whole point of the extra
   /// width. Same widgets, same `_showLyrics`, same playback state as the
   /// stacked layout; only the arrangement differs.
-  Widget _wideLayout() {
+  ///
+  /// Wider still ([canHostQueue]) the queue joins them as a third column rather
+  /// than as a sheet over the top, so lyrics and up-next are readable at the
+  /// same time — which is the other thing the width is for. It is the same
+  /// [QueueSheet] the sheet shows, so a reorder or a jump behaves identically
+  /// whichever shape it is wearing.
+  Widget _wideLayout({required bool canHostQueue}) {
     final Track track = widget.track;
+    final bool queueOpen = canHostQueue && _showQueue;
     return Center(
       child: ConstrainedBox(
-        // Ultrawide windows stop stretching the two columns apart here.
+        // Ultrawide windows stop stretching the columns apart here.
         constraints: const BoxConstraints(maxWidth: maxPaneLayoutWidth),
         child: Row(
           children: <Widget>[
@@ -207,10 +240,25 @@ class _NowPlayingState extends State<_NowPlaying> {
                     track: track,
                     lyricsVisible: _showLyrics,
                     onToggleLyrics: _toggleLyrics,
+                    // Below the pane width the button keeps opening the sheet,
+                    // so the queue is never unreachable at any window size.
+                    queueVisible: queueOpen,
+                    onToggleQueue: canHostQueue ? _toggleQueue : null,
                   ),
                 ],
               ),
             ),
+            if (queueOpen) ...<Widget>[
+              const SizedBox(width: AppSpacing.lg),
+              // A fixed width, not a flex share: the queue is a list of song
+              // rows, and rows have a width that reads well. Letting it grow
+              // with the window would only pull each title away from its
+              // handle, and would take the space from the cover.
+              const SizedBox(
+                width: _queuePaneWidth,
+                child: QueueSheet(embedded: true),
+              ),
+            ],
           ],
         ),
       ),
@@ -218,6 +266,8 @@ class _NowPlayingState extends State<_NowPlaying> {
   }
 
   void _toggleLyrics() => setState(() => _showLyrics = !_showLyrics);
+
+  void _toggleQueue() => setState(() => _showQueue = !_showQueue);
 
   /// Phones, and any window without the width (or height) for two columns.
   ///
@@ -287,11 +337,19 @@ class _ActionsBar extends ConsumerWidget {
     required this.track,
     required this.lyricsVisible,
     required this.onToggleLyrics,
+    this.queueVisible = false,
+    this.onToggleQueue,
   });
 
   final Track track;
   final bool lyricsVisible;
   final VoidCallback onToggleLyrics;
+
+  /// Whether the screen is hosting the queue as a pane, and how to toggle it.
+  /// Null on the layouts that have no room for one, which leaves the queue
+  /// button opening its sheet.
+  final bool queueVisible;
+  final VoidCallback? onToggleQueue;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -299,6 +357,8 @@ class _ActionsBar extends ConsumerWidget {
       track: track,
       lyricsVisible: lyricsVisible,
       onToggleLyrics: onToggleLyrics,
+      queueVisible: queueVisible,
+      onToggleQueue: onToggleQueue,
     );
     // Falls back to the service's own state until the first stream event, the
     // same way the source/casting line does.

--- a/lib/features/player/widgets/now_playing_actions.dart
+++ b/lib/features/player/widgets/now_playing_actions.dart
@@ -20,12 +20,20 @@ import 'sleep_timer_sheet.dart';
 /// ones), queue opens the up-next list, lyrics switches the screen into its
 /// lyrics-focused mode, and the sleep timer (a moon that lights up while a
 /// countdown is running) opens the delay picker.
+///
+/// Queue is the one action whose *shape* depends on the host surface. A window
+/// wide enough to hold a queue beside the cover passes [onToggleQueue], and the
+/// button becomes a pane toggle that reads like the lyrics one next to it.
+/// Everywhere else it stays what it has always been: a modal sheet over the
+/// screen.
 class NowPlayingActions extends ConsumerWidget {
   const NowPlayingActions({
     super.key,
     required this.track,
     this.lyricsVisible = false,
     this.onToggleLyrics,
+    this.queueVisible = false,
+    this.onToggleQueue,
   });
 
   final Track track;
@@ -38,6 +46,15 @@ class NowPlayingActions extends ConsumerWidget {
   /// the action row without a lyrics area, which leaves the button inert rather
   /// than opening something the caller didn't ask for.
   final VoidCallback? onToggleLyrics;
+
+  /// Whether a hosted queue pane is currently open, so the button can read as
+  /// the toggle it becomes. Meaningless without [onToggleQueue].
+  final bool queueVisible;
+
+  /// Opens and closes a queue pane the host lays out itself. Null — the default
+  /// — keeps the queue a modal sheet, which is the right shape on every surface
+  /// without the width for a pane.
+  final VoidCallback? onToggleQueue;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -88,10 +105,17 @@ class NowPlayingActions extends ConsumerWidget {
         ),
         IconButton(
           iconSize: 22,
-          onPressed: () => _openQueue(context),
-          icon: const Icon(Icons.queue_music_outlined),
-          color: muted,
-          tooltip: 'Queue',
+          onPressed: onToggleQueue ?? () => _openQueue(context),
+          icon: Icon(
+            queueVisible ? Icons.queue_music : Icons.queue_music_outlined,
+          ),
+          color: queueVisible ? theme.colorScheme.primary : muted,
+          isSelected: onToggleQueue == null ? null : queueVisible,
+          tooltip: switch ((onToggleQueue != null, queueVisible)) {
+            (true, true) => 'Hide queue',
+            (true, false) => 'Show queue',
+            _ => 'Queue',
+          },
         ),
         IconButton(
           iconSize: 22,

--- a/lib/features/player/widgets/playback_progress_bar.dart
+++ b/lib/features/player/widgets/playback_progress_bar.dart
@@ -65,7 +65,9 @@ class PlaybackProgressBar extends StatefulWidget {
   /// Which renderer to use. Defaults to [defaultPlaybackProgressStyle].
   final PlaybackProgressStyle style;
 
-  /// How much room the wave renderer takes. The slider renderer has one size.
+  /// How much room the bar takes. Both renderers honour it: the mini-player
+  /// gives its 64dp bar a compact one and needs that to hold whichever
+  /// renderer [defaultPlaybackProgressStyle] currently selects.
   final WavySeekBarDensity density;
 
   /// Whether the elapsed/total caption is drawn under the bar. The now-playing
@@ -182,6 +184,11 @@ class _PlaybackProgressBarState extends State<PlaybackProgressBar> {
         _pendingSeekMs?.clamp(0, totalMs.toDouble()) ??
         posMs.toDouble();
 
+    // Both renderers answer to the density: a call site that has only a few
+    // pixels (the mini player) must not sprout a full-size control if
+    // [defaultPlaybackProgressStyle] is ever flipped back to the slider.
+    final bool compact = widget.density == WavySeekBarDensity.compact;
+
     final muted = theme.colorScheme.onSurfaceVariant;
     final labelStyle = theme.textTheme.labelSmall?.copyWith(
       color: muted,
@@ -203,9 +210,15 @@ class _PlaybackProgressBarState extends State<PlaybackProgressBar> {
             ),
           PlaybackProgressStyle.slider => SliderTheme(
               data: SliderTheme.of(context).copyWith(
-                trackHeight: 4,
-                overlayShape: const RoundSliderOverlayShape(overlayRadius: 12),
-                thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 6),
+                trackHeight: compact ? 2 : 4,
+                // The slider's height is its overlay's, so shrinking that is
+                // what keeps the fallback inside a bar sized for the wave.
+                overlayShape: RoundSliderOverlayShape(
+                  overlayRadius: compact ? 6 : 12,
+                ),
+                thumbShape: RoundSliderThumbShape(
+                  enabledThumbRadius: compact ? 3 : 6,
+                ),
                 inactiveTrackColor:
                     theme.colorScheme.onSurface.withValues(alpha: 0.15),
               ),

--- a/lib/features/player/widgets/playback_progress_bar.dart
+++ b/lib/features/player/widgets/playback_progress_bar.dart
@@ -46,6 +46,8 @@ class PlaybackProgressBar extends StatefulWidget {
     required this.onSeek,
     this.playing = false,
     this.style = defaultPlaybackProgressStyle,
+    this.density = WavySeekBarDensity.standard,
+    this.showTimeLabels = true,
     super.key,
   });
 
@@ -62,6 +64,14 @@ class PlaybackProgressBar extends StatefulWidget {
 
   /// Which renderer to use. Defaults to [defaultPlaybackProgressStyle].
   final PlaybackProgressStyle style;
+
+  /// How much room the wave renderer takes. The slider renderer has one size.
+  final WavySeekBarDensity density;
+
+  /// Whether the elapsed/total caption is drawn under the bar. The now-playing
+  /// *bar* turns it off: it has no room for it, and the full player one tap
+  /// away shows both times.
+  final bool showTimeLabels;
 
   /// How close [position] has to land to a released seek target before the bar
   /// hands the display back to it.
@@ -189,6 +199,7 @@ class _PlaybackProgressBarState extends State<PlaybackProgressBar> {
               onChangeEnd: canSeek ? _onChangeEnd : null,
               semanticFormatter: _formatMs,
               playing: widget.playing,
+              density: widget.density,
             ),
           PlaybackProgressStyle.slider => SliderTheme(
               data: SliderTheme.of(context).copyWith(
@@ -216,19 +227,20 @@ class _PlaybackProgressBarState extends State<PlaybackProgressBar> {
         },
         // Snug under the track and aligned to its ends, so the times read as a
         // caption for the bar rather than a separate, floating row.
-        Padding(
-          padding: const EdgeInsets.only(top: AppSpacing.xs),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(_formatMs(barValue), style: labelStyle),
-              Text(
-                hasDuration ? _format(widget.duration) : '--:--',
-                style: labelStyle,
-              ),
-            ],
+        if (widget.showTimeLabels)
+          Padding(
+            padding: const EdgeInsets.only(top: AppSpacing.xs),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(_formatMs(barValue), style: labelStyle),
+                Text(
+                  hasDuration ? _format(widget.duration) : '--:--',
+                  style: labelStyle,
+                ),
+              ],
+            ),
           ),
-        ),
       ],
     );
   }

--- a/lib/features/player/widgets/queue_sheet.dart
+++ b/lib/features/player/widgets/queue_sheet.dart
@@ -7,6 +7,7 @@ import '../../../app/dimens.dart';
 import '../../../core/models/playback_state.dart';
 import '../../../core/models/playlist.dart';
 import '../../../core/models/track.dart';
+import '../../../core/repositories/playlist_repository.dart';
 import '../../../data/repositories/playlist_repository_provider.dart';
 import '../../../shared/widgets/now_playing_indicator.dart';
 import '../../playlists/widgets/create_playlist_dialog.dart';
@@ -159,7 +160,12 @@ class QueueSheet extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
   ) async {
+    // Both captured before the dialog: embedded in the player's queue pane,
+    // this sheet is unmounted the moment the window narrows past the pane's
+    // minimum, and a resize while the name prompt is up would otherwise leave
+    // the save reaching through a disposed ref on submit.
     final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    final PlaylistRepository repository = ref.read(playlistRepositoryProvider);
     // Read the freshest full queue at tap time rather than capturing it in
     // build — build now selects only the queue identity (see above), and a save
     // is a one-off action, not a hot path.
@@ -174,7 +180,6 @@ class QueueSheet extends ConsumerWidget {
     final PlaylistEdit? edit = await showCreatePlaylistDialog(context);
     if (edit == null) return;
 
-    final repository = ref.read(playlistRepositoryProvider);
     final Playlist created = await repository.createPlaylist(
       edit.name,
       description: edit.description,

--- a/lib/features/player/widgets/queue_sheet.dart
+++ b/lib/features/player/widgets/queue_sheet.dart
@@ -30,6 +30,13 @@ Future<void> showQueueSheet(BuildContext context) {
 
 /// The Queue / Up Next manager.
 ///
+/// Hosted two ways. As a modal sheet ([showQueueSheet]) it keeps its own height
+/// budget and safe-area inset, the way a sheet has to. As an [embedded] pane —
+/// what a desktop-width Now Playing does with it — it fills whatever box the
+/// host gives it instead: the pane is already inside the screen's padding, and
+/// a sheet's 85%-of-the-window ceiling in a column that is the full window tall
+/// would leave a band of dead space under the list.
+///
 /// Reads the live [PlaybackState] (so it stays current while open) and shows,
 /// top to bottom: a header with Save/Clear actions, the played history, the
 /// current track, and the reorderable up-next list. Every edit goes through the
@@ -38,7 +45,10 @@ Future<void> showQueueSheet(BuildContext context) {
 /// never start a second, duplicate playback (local or cast). It only ever holds
 /// catalog [Track]s, never a resolved/authenticated stream URL.
 class QueueSheet extends ConsumerWidget {
-  const QueueSheet({super.key});
+  const QueueSheet({this.embedded = false, super.key});
+
+  /// Whether the host lays this out as a pane rather than a modal sheet.
+  final bool embedded;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -65,75 +75,77 @@ class QueueSheet extends ConsumerWidget {
     final bool canClear = upNext.isNotEmpty || history.isNotEmpty;
     final bool canSave = current != null;
 
+    final Widget body = Column(
+      mainAxisSize: embedded ? MainAxisSize.max : MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.fromLTRB(
+            AppSpacing.lg,
+            0,
+            AppSpacing.sm,
+            AppSpacing.sm,
+          ),
+          child: Row(
+            children: <Widget>[
+              Icon(Icons.queue_music, color: theme.colorScheme.primary),
+              const SizedBox(width: AppSpacing.sm),
+              Text('Queue', style: theme.textTheme.titleMedium),
+              const Spacer(),
+              IconButton(
+                onPressed: canSave ? () => _saveAsPlaylist(context, ref) : null,
+                icon: const Icon(Icons.playlist_add),
+                tooltip: 'Save queue as playlist',
+              ),
+              TextButton(
+                onPressed: canClear ? controller.clearQueue : null,
+                child: const Text('Clear'),
+              ),
+            ],
+          ),
+        ),
+        Flexible(
+          child: current == null
+              ? const _EmptyQueue()
+              : CustomScrollView(
+                  slivers: <Widget>[
+                    if (history.isNotEmpty) ...<Widget>[
+                      const _SectionLabel(label: 'Previously played'),
+                      SliverList.builder(
+                        itemCount: history.length,
+                        itemBuilder: (context, index) => _HistoryTile(
+                          track: history[index],
+                          onTap: () => ref
+                              .read(playbackControllerProvider)
+                              .playFromHistory(index),
+                        ),
+                      ),
+                    ],
+                    const _SectionLabel(label: 'Now playing'),
+                    SliverToBoxAdapter(
+                      child: _CurrentTile(track: current),
+                    ),
+                    const _SectionLabel(label: 'Up next'),
+                    if (upNext.isEmpty)
+                      const SliverToBoxAdapter(child: _NothingUpNext())
+                    else
+                      _UpNextList(tracks: upNext),
+                    const SliverToBoxAdapter(
+                      child: SizedBox(height: AppSpacing.md),
+                    ),
+                  ],
+                ),
+        ),
+      ],
+    );
+
+    if (embedded) return body;
     return SafeArea(
       child: ConstrainedBox(
         constraints: BoxConstraints(
           maxHeight: MediaQuery.sizeOf(context).height * 0.85,
         ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: <Widget>[
-            Padding(
-              padding: const EdgeInsets.fromLTRB(
-                AppSpacing.lg,
-                0,
-                AppSpacing.sm,
-                AppSpacing.sm,
-              ),
-              child: Row(
-                children: <Widget>[
-                  Icon(Icons.queue_music, color: theme.colorScheme.primary),
-                  const SizedBox(width: AppSpacing.sm),
-                  Text('Queue', style: theme.textTheme.titleMedium),
-                  const Spacer(),
-                  IconButton(
-                    onPressed:
-                        canSave ? () => _saveAsPlaylist(context, ref) : null,
-                    icon: const Icon(Icons.playlist_add),
-                    tooltip: 'Save queue as playlist',
-                  ),
-                  TextButton(
-                    onPressed: canClear ? controller.clearQueue : null,
-                    child: const Text('Clear'),
-                  ),
-                ],
-              ),
-            ),
-            Flexible(
-              child: current == null
-                  ? const _EmptyQueue()
-                  : CustomScrollView(
-                      slivers: <Widget>[
-                        if (history.isNotEmpty) ...<Widget>[
-                          const _SectionLabel(label: 'Previously played'),
-                          SliverList.builder(
-                            itemCount: history.length,
-                            itemBuilder: (context, index) => _HistoryTile(
-                              track: history[index],
-                              onTap: () => ref
-                                  .read(playbackControllerProvider)
-                                  .playFromHistory(index),
-                            ),
-                          ),
-                        ],
-                        const _SectionLabel(label: 'Now playing'),
-                        SliverToBoxAdapter(
-                          child: _CurrentTile(track: current),
-                        ),
-                        const _SectionLabel(label: 'Up next'),
-                        if (upNext.isEmpty)
-                          const SliverToBoxAdapter(child: _NothingUpNext())
-                        else
-                          _UpNextList(tracks: upNext),
-                        const SliverToBoxAdapter(
-                          child: SizedBox(height: AppSpacing.md),
-                        ),
-                      ],
-                    ),
-            ),
-          ],
-        ),
+        child: body,
       ),
     );
   }

--- a/lib/features/player/widgets/wavy_seek_bar.dart
+++ b/lib/features/player/widgets/wavy_seek_bar.dart
@@ -4,6 +4,52 @@ import 'package:flutter/services.dart';
 import '../../../app/dimens.dart';
 import '../../../shared/widgets/wavy_progress_indicator.dart';
 
+/// How much room a [WavySeekBar] is drawn to take.
+///
+/// The wave is the same shape in both; what changes is how loud it is drawn and
+/// how tall a target it offers. Grouping the five metrics behind one value keeps
+/// the call sites honest — a bar is either a screen's main control or a slim
+/// line on a bar, never an arbitrary mix of the two.
+enum WavySeekBarDensity {
+  /// The now-playing screen's bar: a comfortable, WCAG-sized target with a
+  /// visible marker.
+  standard(
+    hitHeight: 44,
+    amplitude: 3,
+    wavelength: 28,
+    strokeWidth: 3,
+    thumbRadius: 6,
+  ),
+
+  /// The now-playing *bar's* top edge: a slim line that still takes a click and
+  /// a drag. Marker-less, because at this size a marker reads as grit rather
+  /// than as a handle, and the line already sits under the pointer.
+  compact(
+    hitHeight: 14,
+    amplitude: 1.4,
+    wavelength: 26,
+    strokeWidth: 2,
+    thumbRadius: 0,
+  );
+
+  const WavySeekBarDensity({
+    required this.hitHeight,
+    required this.amplitude,
+    required this.wavelength,
+    required this.strokeWidth,
+    required this.thumbRadius,
+  });
+
+  /// Height of the hit target. The painted line is much thinner.
+  final double hitHeight;
+  final double amplitude;
+  final double wavelength;
+  final double strokeWidth;
+
+  /// Radius of the drag marker; zero draws none.
+  final double thumbRadius;
+}
+
 /// A seekable playback position control drawn as a gentle wave.
 ///
 /// The API deliberately mirrors [Slider] — [value], [max], [onChanged],
@@ -30,6 +76,7 @@ class WavySeekBar extends StatelessWidget {
     required this.onChangeEnd,
     required this.semanticFormatter,
     this.playing = false,
+    this.density = WavySeekBarDensity.standard,
     super.key,
   });
 
@@ -55,17 +102,9 @@ class WavySeekBar extends StatelessWidget {
   /// while it is, and eases down to a calmer, shallower wave when paused.
   final bool playing;
 
-  /// Height of the touch target. The painted line is much thinner; the box is
-  /// sized for a comfortable, WCAG-sized target instead.
-  static const double _hitHeight = 44.0;
-
-  static const double _amplitude = 3.0;
-
-  /// Long enough that the line reads as a slow wave rather than a tight
-  /// squiggle at phone widths (roughly a dozen crests across a full track).
-  static const double _wavelength = 28.0;
-  static const double _strokeWidth = 3.0;
-  static const double _thumbRadius = 6.0;
+  /// How tall and how loud the bar is drawn. Only the metrics change; the
+  /// gestures, the keyboard handling and the semantics are the same in both.
+  final WavySeekBarDensity density;
 
   /// One increase/decrease action moves this much of the track…
   static const double _semanticStepFraction = 0.05;
@@ -138,8 +177,8 @@ class WavySeekBar extends StatelessWidget {
         /// touches is the point the marker lands on.
         double positionAt(double dx) {
           final double inset = WavyProgressIndicator.trackInset(
-            thumbRadius: _thumbRadius,
-            strokeWidth: _strokeWidth,
+            thumbRadius: density.thumbRadius,
+            strokeWidth: density.strokeWidth,
           );
           final double trackWidth = width - inset * 2;
           if (trackWidth <= 0) return 0;
@@ -176,7 +215,7 @@ class WavySeekBar extends StatelessWidget {
           onHorizontalDragEnd:
               _enabled ? (details) => onChangeEnd?.call(value) : null,
           child: Container(
-            height: _hitHeight,
+            height: density.hitHeight,
             width: double.infinity,
             // A visible focus ring is the keyboard's equivalent of the pointer's
             // marker: without it, Tab moves through the transport with nothing
@@ -195,12 +234,12 @@ class WavySeekBar extends StatelessWidget {
               activeColor: theme.colorScheme.secondary,
               inactiveColor:
                   theme.colorScheme.onSurface.withValues(alpha: 0.15),
-              amplitude: _amplitude,
-              wavelength: _wavelength,
-              strokeWidth: _strokeWidth,
+              amplitude: density.amplitude,
+              wavelength: density.wavelength,
+              strokeWidth: density.strokeWidth,
               // With no duration there is nothing to point at, so the marker is
               // withheld rather than parked misleadingly at the start.
-              thumbRadius: max > 0 ? _thumbRadius : 0.0,
+              thumbRadius: max > 0 ? density.thumbRadius : 0.0,
               active: playing,
             ),
           ),

--- a/lib/features/playlists/playlists_screen.dart
+++ b/lib/features/playlists/playlists_screen.dart
@@ -7,6 +7,7 @@ import '../../core/models/playlist.dart';
 import '../../data/repositories/playlist_repository_provider.dart';
 import '../../shared/layout/adaptive_layout.dart';
 import '../../shared/widgets/confirm_dialog.dart';
+import '../../shared/widgets/context_menu_region.dart';
 import '../../shared/widgets/empty_state.dart';
 import '../library/remote_library_refresher.dart';
 import 'playlist_providers.dart';
@@ -124,45 +125,58 @@ class _PlaylistTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final ThemeData theme = Theme.of(context);
-    return ListTile(
-      leading: CircleAvatar(
-        backgroundColor: theme.colorScheme.primary.withValues(alpha: 0.12),
-        child: Icon(
-          playlist.isRemote ? Icons.cloud_outlined : Icons.queue_music,
-          color: theme.colorScheme.primary,
+    // The same two actions the trailing button offers, on right-click and on
+    // the keyboard's menu key (#386). Rename and delete are all the domain
+    // layer supports for a playlist from here, so that is all the menu claims.
+    return ContextMenuRegion<_PlaylistMenuAction>(
+      itemBuilder: (BuildContext context) => _menuItems(),
+      onSelected: (action) => _run(context, ref, action),
+      child: ListTile(
+        leading: CircleAvatar(
+          backgroundColor: theme.colorScheme.primary.withValues(alpha: 0.12),
+          child: Icon(
+            playlist.isRemote ? Icons.cloud_outlined : Icons.queue_music,
+            color: theme.colorScheme.primary,
+          ),
+        ),
+        title: Text(
+          playlist.name,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        subtitle: Text(_subtitle()),
+        trailing: PopupMenuButton<_PlaylistMenuAction>(
+          icon: const Icon(Icons.more_vert),
+          tooltip: 'Playlist actions',
+          onSelected: (action) => _run(context, ref, action),
+          itemBuilder: (context) => _menuItems(),
+        ),
+        onTap: () => context.push(AppRoutes.playlistDetailPath(playlist.id)),
+      ),
+    );
+  }
+
+  /// One list for both the button and the right-click menu, so they can never
+  /// offer different things.
+  List<PopupMenuEntry<_PlaylistMenuAction>> _menuItems() {
+    return const <PopupMenuEntry<_PlaylistMenuAction>>[
+      PopupMenuItem<_PlaylistMenuAction>(
+        value: _PlaylistMenuAction.rename,
+        child: ListTile(
+          contentPadding: EdgeInsets.zero,
+          leading: Icon(Icons.edit_outlined),
+          title: Text('Rename'),
         ),
       ),
-      title: Text(
-        playlist.name,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
+      PopupMenuItem<_PlaylistMenuAction>(
+        value: _PlaylistMenuAction.delete,
+        child: ListTile(
+          contentPadding: EdgeInsets.zero,
+          leading: Icon(Icons.delete_outline),
+          title: Text('Delete'),
+        ),
       ),
-      subtitle: Text(_subtitle()),
-      trailing: PopupMenuButton<_PlaylistMenuAction>(
-        icon: const Icon(Icons.more_vert),
-        tooltip: 'Playlist actions',
-        onSelected: (action) => _run(context, ref, action),
-        itemBuilder: (context) => const <PopupMenuEntry<_PlaylistMenuAction>>[
-          PopupMenuItem<_PlaylistMenuAction>(
-            value: _PlaylistMenuAction.rename,
-            child: ListTile(
-              contentPadding: EdgeInsets.zero,
-              leading: Icon(Icons.edit_outlined),
-              title: Text('Rename'),
-            ),
-          ),
-          PopupMenuItem<_PlaylistMenuAction>(
-            value: _PlaylistMenuAction.delete,
-            child: ListTile(
-              contentPadding: EdgeInsets.zero,
-              leading: Icon(Icons.delete_outline),
-              title: Text('Delete'),
-            ),
-          ),
-        ],
-      ),
-      onTap: () => context.push(AppRoutes.playlistDetailPath(playlist.id)),
-    );
+    ];
   }
 
   /// "{n} songs", with a subtle source/status suffix: "· Sync failed" when a

--- a/lib/shared/layout/pane_layout.dart
+++ b/lib/shared/layout/pane_layout.dart
@@ -40,10 +40,15 @@ const double listDetailMinWidth = detailPaneWidth + mediumWindowWidth;
 /// same rule as everywhere else in `shared/layout`.
 ///
 /// It deliberately owns no selection state. The host keeps that, which is what
-/// makes the two modes one screen rather than two: resizing across the
-/// threshold moves the detail between a pane and a pushed route, and neither
-/// the selection nor anything the detail is doing is reset by the move.
-/// [listBuilder] is told which mode it is in so a tap can open the right one.
+/// makes the two modes one screen rather than two: [listBuilder] is told which
+/// mode it is in so a tap opens the right one, and what the user picked in
+/// either survives crossing the threshold.
+///
+/// That last part is the host's job, and it is easy to get wrong: dropping the
+/// pane unmounts the detail outright, so any state the detail holds itself,
+/// including a track selection in progress, goes with it on a resize the user
+/// never thought of as leaving the screen. State that has to outlive the pane
+/// belongs to the host and is passed down (see `LibraryScreen`).
 class ListDetailPanes extends StatelessWidget {
   const ListDetailPanes({
     required this.listBuilder,

--- a/lib/shared/layout/pane_layout.dart
+++ b/lib/shared/layout/pane_layout.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+
+import '../../app/dimens.dart';
+import 'adaptive_layout.dart';
+
+/// Width of a fixed side pane that holds one thing's header: a cover, a title
+/// block and its two transport buttons.
+///
+/// Album and artist detail both draw exactly this pane, which is why the number
+/// lives here rather than once per screen.
+const double sidePaneWidth = 320;
+
+/// Width given to a detail pane beside a list or grid.
+///
+/// Enough for a cover, a title block and a column of track rows without the
+/// titles truncating; narrow enough that the grid beside it keeps several
+/// columns. It is a fixed width rather than a flex share because both halves
+/// have a natural size: the grid grows by whole cards, and the detail is a
+/// column of rows that reads badly stretched.
+const double detailPaneWidth = 460;
+
+/// The narrowest a surface may be and still split into list and detail.
+///
+/// The pane's own width plus the room a grid needs to stay a grid. Below this a
+/// split would leave two cramped columns where one comfortable one fits, so the
+/// detail goes back to being a page of its own.
+const double listDetailMinWidth = detailPaneWidth + mediumWindowWidth;
+
+/// A list (or grid) that gains a detail pane once its box is wide enough to
+/// hold one.
+///
+/// This is the composition seam for Linthra's desktop layouts: inside the shell
+/// the navigation rail is already a pane, so a screen that splits itself here
+/// makes the window read as navigation · content · detail without any screen
+/// having to know it is one of three.
+///
+/// The split is decided from the box this widget is given, not from the window
+/// or the platform, so it holds wherever the screen is hosted — inside the
+/// desktop shell, on a tablet, in a test that pumps it at a fixed size. The
+/// same rule as everywhere else in `shared/layout`.
+///
+/// It deliberately owns no selection state. The host keeps that, which is what
+/// makes the two modes one screen rather than two: resizing across the
+/// threshold moves the detail between a pane and a pushed route, and neither
+/// the selection nor anything the detail is doing is reset by the move.
+/// [listBuilder] is told which mode it is in so a tap can open the right one.
+class ListDetailPanes extends StatelessWidget {
+  const ListDetailPanes({
+    required this.listBuilder,
+    required this.detailBuilder,
+    required this.placeholderBuilder,
+    this.paneWidth = detailPaneWidth,
+    this.minWidthForPane = listDetailMinWidth,
+    super.key,
+  });
+
+  /// The list or grid. Told whether a detail pane is on screen beside it, so it
+  /// can select into the pane instead of pushing a route.
+  final Widget Function(BuildContext context, bool paneVisible) listBuilder;
+
+  /// The detail for the current selection, or null when there is none. Only
+  /// called while the pane is visible.
+  final Widget? Function(BuildContext context) detailBuilder;
+
+  /// What the pane shows with nothing selected. A pane that blinks in and out
+  /// as the selection changes would make the grid beside it reflow on every
+  /// tap, so the pane holds its width and shows this instead.
+  final WidgetBuilder placeholderBuilder;
+
+  final double paneWidth;
+  final double minWidthForPane;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final bool paneVisible = constraints.maxWidth >= minWidthForPane;
+        final Widget list = listBuilder(context, paneVisible);
+        if (!paneVisible) return list;
+
+        return SplitPanes(
+          fixed: detailBuilder(context) ?? placeholderBuilder(context),
+          fixedWidth: paneWidth,
+          flexible: list,
+          fixedFirst: false,
+          // A grid is happy at any width — it answers extra room with more
+          // cards — so this one is not capped the way a column of rows is.
+          maxWidth: double.infinity,
+        );
+      },
+    );
+  }
+}
+
+/// Two panes side by side with a hairline between them: one at a fixed width,
+/// the other taking what is left.
+///
+/// The shape every desktop composition in Linthra ends up wanting — a header
+/// pane beside a scrolling list, a grid beside a detail — written once so the
+/// divider, the cap and the stretch behaviour cannot drift apart between them.
+///
+/// Content is capped at [maxWidth] and centred: past that, a two-pane layout
+/// stops using extra width to pull its halves apart. Callers whose flexible
+/// half genuinely wants every pixel (a grid) pass `double.infinity`.
+class SplitPanes extends StatelessWidget {
+  const SplitPanes({
+    required this.fixed,
+    required this.fixedWidth,
+    required this.flexible,
+    this.fixedFirst = true,
+    this.maxWidth = maxPaneLayoutWidth,
+    super.key,
+  });
+
+  /// The pane with a natural width — a cover and its actions, one album's page.
+  final Widget fixed;
+  final double fixedWidth;
+
+  /// The pane that takes the rest, usually a list or a grid.
+  final Widget flexible;
+
+  /// Whether [fixed] sits before [flexible] in the reading order.
+  final bool fixedFirst;
+
+  final double maxWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final Widget fixedPane = SizedBox(width: fixedWidth, child: fixed);
+    final Widget row = Row(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        if (fixedFirst) fixedPane else Expanded(child: flexible),
+        const VerticalDivider(width: 1),
+        if (fixedFirst) Expanded(child: flexible) else fixedPane,
+      ],
+    );
+    if (!maxWidth.isFinite) return row;
+    return Center(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: maxWidth),
+        child: row,
+      ),
+    );
+  }
+}
+
+/// The calm "nothing picked yet" state for a [ListDetailPanes] pane.
+class DetailPanePlaceholder extends StatelessWidget {
+  const DetailPanePlaceholder({
+    required this.icon,
+    required this.message,
+    super.key,
+  });
+
+  final IconData icon;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.45);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(icon, size: 40, color: muted),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(color: muted),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/context_menu_region.dart
+++ b/lib/shared/widgets/context_menu_region.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Opens a menu on right-click, and on the keyboard's menu key.
+///
+/// The desktop half of the per-item actions Linthra already has (#386). Every
+/// menu here is the *same* menu the row's 3-dot button opens — same entries,
+/// same state, same commands — so a right-click can never offer something a tap
+/// cannot, or run it differently.
+///
+/// Keyboard parity comes with it rather than as an afterthought: with the row
+/// focused, the context-menu key (or Shift+F10, which keyboards without one
+/// send) opens the same menu, centred on the row. Key events bubble from the
+/// focused descendant, so a row only has to be focusable — which every tappable
+/// row already is.
+///
+/// Touch is untouched: a long-press is still whatever the child made it, and
+/// nothing here responds to a primary tap.
+class ContextMenuRegion<T> extends StatelessWidget {
+  const ContextMenuRegion({
+    required this.itemBuilder,
+    required this.onSelected,
+    required this.child,
+    this.enabled = true,
+    super.key,
+  });
+
+  /// Built fresh every time the menu opens, so it reflects the state as it is
+  /// at that moment — downloaded, favorited, what the queue holds.
+  final List<PopupMenuEntry<T>> Function(BuildContext context) itemBuilder;
+
+  final void Function(T value) onSelected;
+
+  final Widget child;
+
+  /// Whether the menu can be opened at all. A row in selection mode, say, is
+  /// acting on a set rather than on itself.
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!enabled) return child;
+    return Focus(
+      // Not focusable itself: this only listens to what the row inside it does
+      // with the keyboard. Adding a stop of its own would put an empty node in
+      // everyone's Tab order.
+      canRequestFocus: false,
+      skipTraversal: true,
+      onKeyEvent: (FocusNode node, KeyEvent event) {
+        if (event is! KeyDownEvent) return KeyEventResult.ignored;
+        final bool isMenuKey =
+            event.logicalKey == LogicalKeyboardKey.contextMenu ||
+                (event.logicalKey == LogicalKeyboardKey.f10 &&
+                    HardwareKeyboard.instance.isShiftPressed);
+        if (!isMenuKey) return KeyEventResult.ignored;
+        _openAt(context, _centreOf(context));
+        return KeyEventResult.handled;
+      },
+      child: GestureDetector(
+        // Secondary buttons only: a primary tap is the child's, and the child
+        // is hit first either way.
+        behavior: HitTestBehavior.translucent,
+        onSecondaryTapUp: (TapUpDetails details) =>
+            _openAt(context, details.globalPosition),
+        child: child,
+      ),
+    );
+  }
+
+  /// Where a keyboard-opened menu appears: the middle of the row, which is
+  /// where a pointer user would have clicked.
+  Offset _centreOf(BuildContext context) {
+    final RenderObject? box = context.findRenderObject();
+    if (box is! RenderBox || !box.hasSize) return Offset.zero;
+    return box.localToGlobal(box.size.center(Offset.zero));
+  }
+
+  Future<void> _openAt(BuildContext context, Offset globalPosition) async {
+    final List<PopupMenuEntry<T>> items = itemBuilder(context);
+    if (items.isEmpty) return;
+    final RenderObject? overlay =
+        Overlay.of(context).context.findRenderObject();
+    if (overlay is! RenderBox) return;
+
+    final T? value = await showMenu<T>(
+      context: context,
+      position: RelativeRect.fromRect(
+        Rect.fromPoints(globalPosition, globalPosition),
+        Offset.zero & overlay.size,
+      ),
+      items: items,
+    );
+    if (value != null) onSelected(value);
+  }
+}

--- a/lib/shared/widgets/context_menu_region.dart
+++ b/lib/shared/widgets/context_menu_region.dart
@@ -82,10 +82,18 @@ class ContextMenuRegion<T> extends StatelessWidget {
         Overlay.of(context).context.findRenderObject();
     if (overlay is! RenderBox) return;
 
+    // showMenu reads its position in the *overlay's* coordinate space, not in
+    // screen coordinates — and the nearest overlay is rarely at the screen
+    // origin. Inside the desktop shell it belongs to the branch navigator,
+    // which starts after the navigation rail, so handing it a raw global
+    // position would slide every menu across by the rail's width and clamp it
+    // against bounds measured from the wrong corner.
+    final Offset anchor = overlay.globalToLocal(globalPosition);
+
     final T? value = await showMenu<T>(
       context: context,
       position: RelativeRect.fromRect(
-        Rect.fromPoints(globalPosition, globalPosition),
+        Rect.fromPoints(anchor, anchor),
         Offset.zero & overlay.size,
       ),
       items: items,

--- a/lib/shared/widgets/context_menu_region.dart
+++ b/lib/shared/widgets/context_menu_region.dart
@@ -98,6 +98,11 @@ class ContextMenuRegion<T> extends StatelessWidget {
       ),
       items: items,
     );
-    if (value != null) onSelected(value);
+    // The menu is a route and outlives the surface it came from: a resize that
+    // crosses a pane threshold takes this region away while the popup is still
+    // up. Whatever the action would reach for — the row's ref, an ancestor to
+    // hang a dialog on — is gone with it, so a pick that lands after that is
+    // dropped rather than dispatched into a dead tree.
+    if (value != null && context.mounted) onSelected(value);
   }
 }

--- a/lib/shared/widgets/hover_highlight.dart
+++ b/lib/shared/widgets/hover_highlight.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+
+/// Tells a child whether a pointer is over it, so surfaces that ink cannot
+/// reach can answer a hover themselves.
+///
+/// Most of Linthra hovers for free: a [ListTile], an [InkWell], a button or a
+/// navigation destination all draw the theme's `hoverColor` as an ink overlay,
+/// so one value in the theme covers rows, buttons, menus and the rail at once
+/// (#385). This exists for the one case that does not work: a card whose child
+/// is an opaque image. Ink is painted on the [Material] *behind* the child, so
+/// an album cover hides the highlight and leaves a mouse user with feedback on
+/// the label strip and nothing on the artwork they are actually pointing at.
+///
+/// It is deliberately a signal rather than a decoration: the card decides what
+/// hovering looks like, and there is one [MouseRegion] to reason about instead
+/// of one per surface. Nothing here fires on a touch device, so mobile is
+/// untouched by construction.
+class HoverHighlight extends StatefulWidget {
+  const HoverHighlight({required this.builder, super.key});
+
+  final Widget Function(BuildContext context, bool hovered) builder;
+
+  @override
+  State<HoverHighlight> createState() => _HoverHighlightState();
+}
+
+class _HoverHighlightState extends State<HoverHighlight> {
+  bool _hovered = false;
+
+  void _setHovered(bool value) {
+    if (_hovered == value) return;
+    setState(() => _hovered = value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      onEnter: (_) => _setHovered(true),
+      onExit: (_) => _setHovered(false),
+      // The cursor is the other half of "this is interactive", and it costs
+      // nothing to be right about it here.
+      cursor: SystemMouseCursors.click,
+      child: widget.builder(context, _hovered),
+    );
+  }
+}
+
+/// A subtle veil drawn over artwork while the pointer is on it.
+///
+/// The same weight as the theme's `hoverColor`, so a hovered cover and a
+/// hovered row read as the same gesture rather than two different ideas. Quiet
+/// on purpose: this says "clickable", not "selected".
+class HoverArtworkVeil extends StatelessWidget {
+  const HoverArtworkVeil({
+    required this.hovered,
+    required this.child,
+    this.borderRadius,
+    super.key,
+  });
+
+  final bool hovered;
+  final Widget child;
+  final BorderRadius? borderRadius;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      fit: StackFit.passthrough,
+      children: <Widget>[
+        child,
+        // Always in the tree, only ever opaque on hover: fading a decoration in
+        // and out costs one animation instead of a layout change, so nothing
+        // around the cover moves as the pointer crosses it.
+        Positioned.fill(
+          child: IgnorePointer(
+            child: AnimatedOpacity(
+              opacity: hovered ? 1 : 0,
+              duration: const Duration(milliseconds: 120),
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  borderRadius: borderRadius,
+                  color: Theme.of(context).hoverColor,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/linux/runner/CMakeLists.txt
+++ b/linux/runner/CMakeLists.txt
@@ -10,12 +10,25 @@ add_executable(${BINARY_NAME}
   "main.cc"
   "my_application.cc"
   "folder_picker_channel.cc"
+  "window_state_store.cc"
+  # The pure half of the window-state policy (#383). Compiled straight into the
+  # runner rather than linked as a library so the Flutter build stays one
+  # CMake invocation; native/linthra_desktop builds and tests the same sources
+  # on their own, with no GTK and no display server.
+  "${CMAKE_SOURCE_DIR}/../native/linthra_desktop/src/window_state.cpp"
   "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
 )
 
 # Apply the standard set of build settings. This can be removed for applications
 # that need different build settings.
 apply_standard_settings(${BINARY_NAME})
+
+# The window-state policy (#383) is C++17: string_view, from_chars, and
+# aggregates with default member initialisers. apply_standard_settings asks for
+# cxx_std_14, which is a floor rather than a cap, so the standard the runner
+# actually compiles with would otherwise be whatever the host compiler defaults
+# to. Say it instead of depending on that.
+target_compile_features(${BINARY_NAME} PUBLIC cxx_std_17)
 
 # Add preprocessor definitions for the application ID.
 add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
@@ -25,3 +38,5 @@ target_link_libraries(${BINARY_NAME} PRIVATE flutter)
 target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
 
 target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")
+target_include_directories(${BINARY_NAME} PRIVATE
+  "${CMAKE_SOURCE_DIR}/../native/linthra_desktop/include")

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -7,6 +7,7 @@
 
 #include "flutter/generated_plugin_registrant.h"
 #include "folder_picker_channel.h"
+#include "window_state_store.h"
 
 // The user-visible application name. Kept as one constant so the header bar,
 // the fallback title bar, and anything added later can never drift apart — and
@@ -32,6 +33,10 @@ struct _MyApplication {
   // here because it needs the application's own window as the dialog parent,
   // which a plugin registrant does not have.
   FolderPickerChannel* folder_picker;
+  // Remembers the window's size, maximized state and position across restarts
+  // (#383). Owned here so it outlives the window and can still be written on
+  // shutdown, after GtkApplication has destroyed the window itself.
+  WindowStateStore* window_state;
 };
 
 G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
@@ -74,17 +79,21 @@ static void my_application_activate(GApplication* application) {
     gtk_window_set_title(window, kApplicationName);
   }
 
-  gtk_window_set_default_size(window, kDefaultWindowWidth,
-                              kDefaultWindowHeight);
-
-  // Floor the window at a size the current (phone-first) Flutter layout can
-  // still render without overflowing. Linthra's desktop layout lands in a later
-  // PR; until then this keeps a dragged-narrow window usable for development
-  // rather than letting it collapse into a wall of overflow errors.
+  // Floor the window at a size the shared layout can still render without
+  // overflowing. Set before the state is restored, so a saved size below the
+  // floor is clamped by the same rule a dragged one is.
   GdkGeometry geometry;
   geometry.min_width = kMinimumWindowWidth;
   geometry.min_height = kMinimumWindowHeight;
   gtk_window_set_geometry_hints(window, nullptr, &geometry, GDK_HINT_MIN_SIZE);
+
+  // Restore the remembered geometry, falling back to the opening default above
+  // on a first launch or an unusable saved state. Before the window is shown
+  // (first_frame_cb does that), so a restored window is drawn at its size
+  // rather than resizing in front of the user.
+  self->window_state =
+      window_state_store_new(window, kMinimumWindowWidth, kMinimumWindowHeight,
+                             kDefaultWindowWidth, kDefaultWindowHeight);
 
   g_autoptr(FlDartProject) project = fl_dart_project_new();
   fl_dart_project_set_dart_entrypoint_arguments(
@@ -193,9 +202,12 @@ static void my_application_startup(GApplication* application) {
 
 // Implements GApplication::shutdown.
 static void my_application_shutdown(GApplication* application) {
-  // MyApplication* self = MY_APPLICATION(object);
+  MyApplication* self = MY_APPLICATION(application);
 
-  // Perform any actions required at application shutdown.
+  // Last chance to write the window geometry: the window itself is already
+  // gone by now, which is why the store tracks the geometry rather than reading
+  // it back off the window here.
+  window_state_store_save(self->window_state);
 
   G_APPLICATION_CLASS(my_application_parent_class)->shutdown(application);
 }
@@ -205,6 +217,7 @@ static void my_application_dispose(GObject* object) {
   MyApplication* self = MY_APPLICATION(object);
   g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
   g_clear_pointer(&self->folder_picker, folder_picker_channel_free);
+  g_clear_pointer(&self->window_state, window_state_store_free);
   G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
 }
 

--- a/linux/runner/window_state_store.cc
+++ b/linux/runner/window_state_store.cc
@@ -1,0 +1,216 @@
+#include "window_state_store.h"
+
+#include <gdk/gdk.h>
+#ifdef GDK_WINDOWING_X11
+#include <gdk/gdkx.h>
+#endif
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "linthra_desktop/window_state.hpp"
+
+using linthra::desktop::FormatWindowState;
+using linthra::desktop::ResolveWindowState;
+using linthra::desktop::WindowGeometry;
+using linthra::desktop::WindowLimits;
+using linthra::desktop::WorkArea;
+
+// Name of the state file inside the app's own config directory. A plain file
+// rather than GSettings: the geometry is a local convenience, not a preference
+// worth a schema that has to be installed before the app can start.
+static constexpr const char* kStateFileName = "window-state";
+
+struct _WindowStateStore {
+    GtkWindow* window;
+    WindowLimits limits;
+
+    // The last size the window had while it was an ordinary, restored window.
+    // See the header: GTK will not tell us this after the fact.
+    WindowGeometry tracked;
+
+    gboolean maximized;
+    gboolean fullscreen;
+
+    gulong configure_handler;
+    gulong state_handler;
+};
+
+namespace {
+
+// Whether this session can report and set window positions at all.
+bool SessionHasWindowPositions(GtkWindow* window) {
+#ifdef GDK_WINDOWING_X11
+    GdkDisplay* display = gtk_widget_get_display(GTK_WIDGET(window));
+    return display != nullptr && GDK_IS_X11_DISPLAY(display);
+#else
+    (void)window;
+    return false;
+#endif
+}
+
+gchar* StateFilePath() {
+    return g_build_filename(g_get_user_config_dir(), APPLICATION_ID,
+                            kStateFileName, nullptr);
+}
+
+WindowGeometry LoadSavedState() {
+    g_autofree gchar* path = StateFilePath();
+    g_autofree gchar* contents = nullptr;
+    gsize length = 0;
+    if (!g_file_get_contents(path, &contents, &length, nullptr)) {
+        // No file yet is the ordinary first-launch case, not a failure worth
+        // logging at the user.
+        return WindowGeometry{};
+    }
+    return linthra::desktop::ParseWindowState(
+        std::string_view(contents, length));
+}
+
+// The work areas of every monitor attached right now, so a saved position can
+// be checked against the desktop as it *is* rather than as it was.
+std::vector<WorkArea> CurrentWorkAreas(GtkWindow* window) {
+    std::vector<WorkArea> areas;
+    GdkDisplay* display = gtk_widget_get_display(GTK_WIDGET(window));
+    if (display == nullptr) {
+        return areas;
+    }
+    const int count = gdk_display_get_n_monitors(display);
+    for (int i = 0; i < count; ++i) {
+        GdkMonitor* monitor = gdk_display_get_monitor(display, i);
+        if (monitor == nullptr) {
+            continue;
+        }
+        GdkRectangle rectangle;
+        gdk_monitor_get_workarea(monitor, &rectangle);
+        areas.push_back(
+            WorkArea{rectangle.x, rectangle.y, rectangle.width,
+                     rectangle.height});
+    }
+    return areas;
+}
+
+gboolean OnConfigure(GtkWidget* widget, GdkEventConfigure* event,
+                     gpointer user_data) {
+    (void)widget;
+    WindowStateStore* self = static_cast<WindowStateStore*>(user_data);
+    // Only an ordinary window's geometry is worth remembering: a maximized or
+    // fullscreen one describes the screen, not the size to come back to.
+    if (self->maximized || self->fullscreen) {
+        return FALSE;
+    }
+    self->tracked.width = event->width;
+    self->tracked.height = event->height;
+    if (self->tracked.has_position) {
+        gtk_window_get_position(self->window, &self->tracked.x,
+                                &self->tracked.y);
+    }
+    return FALSE;  // Never stop the event: GTK still has to lay the window out.
+}
+
+gboolean OnWindowState(GtkWidget* widget, GdkEventWindowState* event,
+                       gpointer user_data) {
+    (void)widget;
+    WindowStateStore* self = static_cast<WindowStateStore*>(user_data);
+    if (event->changed_mask & GDK_WINDOW_STATE_MAXIMIZED) {
+        self->maximized =
+            (event->new_window_state & GDK_WINDOW_STATE_MAXIMIZED) != 0;
+    }
+    if (event->changed_mask & GDK_WINDOW_STATE_FULLSCREEN) {
+        self->fullscreen =
+            (event->new_window_state & GDK_WINDOW_STATE_FULLSCREEN) != 0;
+    }
+    return FALSE;
+}
+
+// The window is destroyed before GApplication::shutdown runs, so the store
+// outlives it. Forgetting it here is what lets the teardown stay simple:
+// nothing after this point touches a dead object, and the geometry still to be
+// written is tracked in the store rather than read back off the window.
+void OnDestroy(GtkWidget* widget, gpointer user_data) {
+    (void)widget;
+    WindowStateStore* self = static_cast<WindowStateStore*>(user_data);
+    self->window = nullptr;
+}
+
+}  // namespace
+
+WindowStateStore* window_state_store_new(GtkWindow* window, int min_width,
+                                         int min_height, int default_width,
+                                         int default_height) {
+    WindowStateStore* self = g_new0(WindowStateStore, 1);
+    self->window = window;
+    self->limits =
+        WindowLimits{min_width, min_height, default_width, default_height};
+
+    const WindowGeometry resolved = ResolveWindowState(
+        LoadSavedState(), self->limits,
+        SessionHasWindowPositions(window) ? CurrentWorkAreas(window)
+                                          : std::vector<WorkArea>{});
+
+    gtk_window_set_default_size(window, resolved.width, resolved.height);
+    if (resolved.has_position) {
+        gtk_window_move(window, resolved.x, resolved.y);
+    }
+    if (resolved.maximized) {
+        gtk_window_maximize(window);
+    }
+
+    self->tracked = resolved;
+    // Whether *future* positions are worth recording is a property of the
+    // session, not of what happened to be saved: a first launch under X11 has
+    // no saved position and still wants to remember the one it ends up with.
+    self->tracked.has_position = SessionHasWindowPositions(window);
+    self->maximized = resolved.maximized ? TRUE : FALSE;
+    self->fullscreen = FALSE;
+
+    self->configure_handler = g_signal_connect(
+        window, "configure-event", G_CALLBACK(OnConfigure), self);
+    self->state_handler = g_signal_connect(
+        window, "window-state-event", G_CALLBACK(OnWindowState), self);
+    g_signal_connect(window, "destroy", G_CALLBACK(OnDestroy), self);
+    return self;
+}
+
+void window_state_store_save(WindowStateStore* self) {
+    if (self == nullptr) {
+        return;
+    }
+    WindowGeometry geometry = self->tracked;
+    geometry.maximized = self->maximized != FALSE;
+
+    g_autofree gchar* path = StateFilePath();
+    g_autofree gchar* directory = g_path_get_dirname(path);
+    if (g_mkdir_with_parents(directory, 0755) != 0) {
+        g_warning("Could not create %s, so the window size will not be "
+                  "remembered",
+                  directory);
+        return;
+    }
+
+    const std::string contents = FormatWindowState(geometry);
+    g_autoptr(GError) error = nullptr;
+    if (!g_file_set_contents(path, contents.c_str(),
+                             static_cast<gssize>(contents.size()), &error)) {
+        // A window size is never worth failing a shutdown over.
+        g_warning("Could not save the window state: %s", error->message);
+    }
+}
+
+void window_state_store_free(WindowStateStore* self) {
+    if (self == nullptr) {
+        return;
+    }
+    // Only where the window is still alive: a destroyed one dropped its
+    // handlers with itself, and OnDestroy has already cleared the pointer.
+    if (self->window != nullptr) {
+        if (self->configure_handler != 0) {
+            g_signal_handler_disconnect(self->window, self->configure_handler);
+        }
+        if (self->state_handler != 0) {
+            g_signal_handler_disconnect(self->window, self->state_handler);
+        }
+    }
+    g_free(self);
+}

--- a/linux/runner/window_state_store.cc
+++ b/linux/runner/window_state_store.cc
@@ -35,6 +35,7 @@ struct _WindowStateStore {
 
     gulong configure_handler;
     gulong state_handler;
+    gulong destroy_handler;
 };
 
 namespace {
@@ -169,7 +170,8 @@ WindowStateStore* window_state_store_new(GtkWindow* window, int min_width,
         window, "configure-event", G_CALLBACK(OnConfigure), self);
     self->state_handler = g_signal_connect(
         window, "window-state-event", G_CALLBACK(OnWindowState), self);
-    g_signal_connect(window, "destroy", G_CALLBACK(OnDestroy), self);
+    self->destroy_handler =
+        g_signal_connect(window, "destroy", G_CALLBACK(OnDestroy), self);
     return self;
 }
 
@@ -204,12 +206,19 @@ void window_state_store_free(WindowStateStore* self) {
     }
     // Only where the window is still alive: a destroyed one dropped its
     // handlers with itself, and OnDestroy has already cleared the pointer.
+    //
+    // The destroy handler goes with the other two rather than being left
+    // behind. Freeing the store while its window is still alive is the unusual
+    // order — a disposal, or a startup unwound before GTK destroys anything —
+    // and leaving that one handler registered would hand OnDestroy this freed
+    // struct the moment the window did go away.
     if (self->window != nullptr) {
-        if (self->configure_handler != 0) {
-            g_signal_handler_disconnect(self->window, self->configure_handler);
-        }
-        if (self->state_handler != 0) {
-            g_signal_handler_disconnect(self->window, self->state_handler);
+        for (const gulong handler : {self->configure_handler,
+                                     self->state_handler,
+                                     self->destroy_handler}) {
+            if (handler != 0) {
+                g_signal_handler_disconnect(self->window, handler);
+            }
         }
     }
     g_free(self);

--- a/linux/runner/window_state_store.h
+++ b/linux/runner/window_state_store.h
@@ -1,0 +1,52 @@
+#ifndef RUNNER_WINDOW_STATE_STORE_H_
+#define RUNNER_WINDOW_STATE_STORE_H_
+
+#include <gtk/gtk.h>
+
+G_BEGIN_DECLS
+
+// Remembers the window's size, maximized state and (where the session can) its
+// position across restarts — issue #383.
+//
+// The toolkit half only. Every rule about what a saved geometry means lives in
+// native/linthra_desktop (`linthra::desktop`), which is pure and unit-tested;
+// this file reads and writes the file, asks GDK which monitors exist, and moves
+// the window.
+//
+// Two things are worth knowing about the shape of it:
+//
+//  * GTK 3 does not remember the *unmaximized* size for you:
+//    gtk_window_get_size() on a maximized window returns the maximized size, so
+//    restoring it would leave a window that un-maximizes to full screen. The
+//    store therefore tracks the last size the window had while it was neither
+//    maximized nor fullscreen, and saves that.
+//
+//  * Position is X11-only. Wayland gives a client neither its own position nor
+//    a way to set one, so under Wayland the store saves a size and no position
+//    and lets the compositor place the window — which is the behaviour Wayland
+//    users expect, not a limitation to work around.
+typedef struct _WindowStateStore WindowStateStore;
+
+// Restores `window`'s geometry from disk and starts tracking changes to it.
+//
+// Call before the window is shown: it sets the default size, so a restored
+// window is drawn at its remembered size on the first frame rather than
+// resizing in front of the user. Falls back to `default_width`/`default_height`
+// for a missing, damaged or unusable saved state, and never returns a size
+// below `min_width`/`min_height`. Never returns NULL.
+WindowStateStore* window_state_store_new(GtkWindow* window, int min_width,
+                                         int min_height, int default_width,
+                                         int default_height);
+
+// Writes the tracked geometry to disk. Safe to call more than once; a failure
+// to write is logged and otherwise ignored, since losing a window size must
+// never take the shutdown with it.
+void window_state_store_save(WindowStateStore* self);
+
+// Stops tracking and frees the store. Does not save: call
+// window_state_store_save() first if the geometry still matters.
+void window_state_store_free(WindowStateStore* self);
+
+G_END_DECLS
+
+#endif  // RUNNER_WINDOW_STATE_STORE_H_

--- a/native/linthra_desktop/CMakeLists.txt
+++ b/native/linthra_desktop/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.16)
+project(linthra_desktop LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Pure desktop-shell policy: no GTK, no GDK, no filesystem. The Linux runner
+# links these sources straight from linux/runner/CMakeLists.txt; this project
+# exists so the same code can be built and tested on its own, without a display
+# server or a window manager.
+add_library(linthra_desktop STATIC
+    src/window_state.cpp
+)
+
+target_include_directories(linthra_desktop
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+target_compile_options(linthra_desktop PRIVATE
+    $<$<CXX_COMPILER_ID:Clang,GNU>:-Wall -Wextra -Wpedantic -Werror>
+)
+
+add_executable(linthra_desktop_tests tests/window_state_test.cpp)
+target_link_libraries(linthra_desktop_tests PRIVATE linthra_desktop)
+
+enable_testing()
+add_test(NAME linthra_desktop_tests COMMAND linthra_desktop_tests)

--- a/native/linthra_desktop/README.md
+++ b/native/linthra_desktop/README.md
@@ -1,0 +1,21 @@
+# linthra_desktop
+
+The parts of Linthra's Linux desktop shell that are pure decisions rather than
+toolkit calls, so they can be tested without a display server.
+
+Today that is the window-state policy behind #383: what a saved geometry means,
+when it is too damaged to trust, and whether a remembered position still lands
+on a monitor that exists. `linux/runner/` does the GTK/GDK half — reading the
+config file, asking GDK for the monitors, moving the window — and calls in here
+for every rule.
+
+Build and test it on its own:
+
+```sh
+cmake -S native/linthra_desktop -B build/linthra_desktop
+cmake --build build/linthra_desktop --parallel
+ctest --test-dir build/linthra_desktop --output-on-failure
+```
+
+CI runs exactly that, in Debug and Release, from
+`.github/workflows/cpp-desktop-window.yml`.

--- a/native/linthra_desktop/include/linthra_desktop/window_state.hpp
+++ b/native/linthra_desktop/include/linthra_desktop/window_state.hpp
@@ -1,0 +1,94 @@
+#ifndef LINTHRA_DESKTOP_WINDOW_STATE_HPP_
+#define LINTHRA_DESKTOP_WINDOW_STATE_HPP_
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+// Remembering the Linux window's geometry across restarts (issue #383).
+//
+// Everything in this header is pure: no GTK, no GDK, no filesystem. That is the
+// point. The Linux runner has to do the toolkit half — read the config file,
+// ask GDK for the monitors, call gtk_window_move() — but every rule about what
+// a saved geometry *means* lives here, where it can be tested without a display
+// server, a window manager, or a second monitor to unplug.
+namespace linthra::desktop {
+
+// One window geometry, as saved or as resolved.
+struct WindowGeometry {
+    int width = 0;
+    int height = 0;
+    int x = 0;
+    int y = 0;
+
+    // Whether x/y carry a real position. A Wayland session cannot report or
+    // restore one, so a state file written there has a size and no position,
+    // and that is not a defect to repair.
+    bool has_position = false;
+
+    bool maximized = false;
+};
+
+// A monitor's usable area, panels and docks already subtracted.
+struct WorkArea {
+    int x = 0;
+    int y = 0;
+    int width = 0;
+    int height = 0;
+};
+
+// What the runner will accept, and what it falls back to.
+struct WindowLimits {
+    int min_width = 0;
+    int min_height = 0;
+    int default_width = 0;
+    int default_height = 0;
+};
+
+// Largest dimension a saved size may claim before it is treated as corrupt
+// rather than as an enormous monitor. Well past any real display, and far short
+// of the values a truncated or hand-edited file produces.
+inline constexpr int kMaxReasonableDimension = 32000;
+
+// How much of the window has to land on a monitor for its saved position to be
+// worth restoring. A window peeking in by a few pixels is, in practice, a
+// window the user cannot grab.
+inline constexpr int kMinVisibleWidth = 120;
+inline constexpr int kMinVisibleHeight = 60;
+
+// Parses the `key=value` text written by FormatWindowState.
+//
+// Deliberately forgiving: unknown keys, blank lines, comments and malformed
+// numbers are ignored rather than failing the whole file. A state file is a
+// convenience, and the worst it may ever do is cost the user their window size
+// — never a launch.
+WindowGeometry ParseWindowState(std::string_view text);
+
+// Renders a geometry as the text the state file holds.
+std::string FormatWindowState(const WindowGeometry& geometry);
+
+// Whether a saved size is usable at all, before any clamping.
+bool IsSizeUsable(const WindowGeometry& saved);
+
+// Whether a saved position still lands on one of the monitors that exist now.
+//
+// Requires a real patch of the window to be inside a work area *and* its top
+// edge not to sit above that area: a window whose title bar is off the top of
+// the screen cannot be moved with the mouse, which is the state a disconnected
+// monitor used to leave behind.
+bool IsPositionUsable(const WindowGeometry& saved,
+                      const std::vector<WorkArea>& work_areas);
+
+// The geometry to open with: the saved one where it is sane, the defaults where
+// it is not, clamped to the runner's minimum either way.
+//
+// The returned geometry's has_position is false whenever the caller should let
+// the window manager place the window itself, which is both the Wayland case
+// and the disconnected-monitor one.
+WindowGeometry ResolveWindowState(const WindowGeometry& saved,
+                                  const WindowLimits& limits,
+                                  const std::vector<WorkArea>& work_areas);
+
+}  // namespace linthra::desktop
+
+#endif  // LINTHRA_DESKTOP_WINDOW_STATE_HPP_

--- a/native/linthra_desktop/src/window_state.cpp
+++ b/native/linthra_desktop/src/window_state.cpp
@@ -1,0 +1,175 @@
+#include "linthra_desktop/window_state.hpp"
+
+#include <algorithm>
+#include <charconv>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace linthra::desktop {
+namespace {
+
+constexpr std::string_view kWhitespace = " \t\r\n";
+
+std::string_view Trim(std::string_view value) {
+    const std::size_t begin = value.find_first_not_of(kWhitespace);
+    if (begin == std::string_view::npos) {
+        return {};
+    }
+    const std::size_t end = value.find_last_not_of(kWhitespace);
+    return value.substr(begin, end - begin + 1);
+}
+
+// Reads a whole decimal integer, or leaves `out` untouched. from_chars is used
+// rather than std::stoi because a malformed value here is ordinary input, not
+// an exceptional case: half of what this parser has to survive is a file that
+// was truncated mid-write by a crash or a full disk.
+bool ReadInt(std::string_view value, int* out) {
+    value = Trim(value);
+    if (value.empty()) {
+        return false;
+    }
+    int parsed = 0;
+    const char* begin = value.data();
+    const char* end = begin + value.size();
+    const std::from_chars_result result = std::from_chars(begin, end, parsed);
+    if (result.ec != std::errc() || result.ptr != end) {
+        return false;
+    }
+    *out = parsed;
+    return true;
+}
+
+void ReadBool(std::string_view value, bool* out) {
+    value = Trim(value);
+    if (value == "true" || value == "1") {
+        *out = true;
+    } else if (value == "false" || value == "0") {
+        *out = false;
+    }
+}
+
+// The overlap between two rectangles, in pixels. Zero on either axis means they
+// do not meet.
+void Intersection(const WindowGeometry& window, const WorkArea& area,
+                  int* overlap_width, int* overlap_height) {
+    const int left = std::max(window.x, area.x);
+    const int right = std::min(window.x + window.width, area.x + area.width);
+    const int top = std::max(window.y, area.y);
+    const int bottom = std::min(window.y + window.height, area.y + area.height);
+    *overlap_width = std::max(0, right - left);
+    *overlap_height = std::max(0, bottom - top);
+}
+
+}  // namespace
+
+WindowGeometry ParseWindowState(std::string_view text) {
+    WindowGeometry geometry;
+    bool saw_x = false;
+    bool saw_y = false;
+
+    while (!text.empty()) {
+        const std::size_t newline = text.find('\n');
+        const std::string_view line =
+            Trim(newline == std::string_view::npos ? text
+                                                   : text.substr(0, newline));
+        text = newline == std::string_view::npos ? std::string_view()
+                                                 : text.substr(newline + 1);
+        if (line.empty() || line.front() == '#' || line.front() == '[') {
+            continue;
+        }
+        const std::size_t separator = line.find('=');
+        if (separator == std::string_view::npos) {
+            continue;
+        }
+        const std::string_view key = Trim(line.substr(0, separator));
+        const std::string_view value = line.substr(separator + 1);
+
+        if (key == "width") {
+            ReadInt(value, &geometry.width);
+        } else if (key == "height") {
+            ReadInt(value, &geometry.height);
+        } else if (key == "x") {
+            saw_x = ReadInt(value, &geometry.x) || saw_x;
+        } else if (key == "y") {
+            saw_y = ReadInt(value, &geometry.y) || saw_y;
+        } else if (key == "maximized") {
+            ReadBool(value, &geometry.maximized);
+        }
+    }
+
+    geometry.has_position = saw_x && saw_y;
+    return geometry;
+}
+
+std::string FormatWindowState(const WindowGeometry& geometry) {
+    std::string out;
+    out += "# Linthra window state. Deleting this file resets the window.\n";
+    out += "width=" + std::to_string(geometry.width) + "\n";
+    out += "height=" + std::to_string(geometry.height) + "\n";
+    if (geometry.has_position) {
+        out += "x=" + std::to_string(geometry.x) + "\n";
+        out += "y=" + std::to_string(geometry.y) + "\n";
+    }
+    out += std::string("maximized=") + (geometry.maximized ? "true" : "false") +
+           "\n";
+    return out;
+}
+
+bool IsSizeUsable(const WindowGeometry& saved) {
+    return saved.width > 0 && saved.height > 0 &&
+           saved.width <= kMaxReasonableDimension &&
+           saved.height <= kMaxReasonableDimension;
+}
+
+bool IsPositionUsable(const WindowGeometry& saved,
+                      const std::vector<WorkArea>& work_areas) {
+    if (!saved.has_position || !IsSizeUsable(saved)) {
+        return false;
+    }
+    for (const WorkArea& area : work_areas) {
+        if (area.width <= 0 || area.height <= 0) {
+            continue;
+        }
+        // A title bar above the monitor's work area cannot be grabbed, so a
+        // window there is unreachable however much of its body is visible.
+        if (saved.y < area.y) {
+            continue;
+        }
+        int overlap_width = 0;
+        int overlap_height = 0;
+        Intersection(saved, area, &overlap_width, &overlap_height);
+        if (overlap_width >= std::min(kMinVisibleWidth, saved.width) &&
+            overlap_height >= std::min(kMinVisibleHeight, saved.height)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+WindowGeometry ResolveWindowState(const WindowGeometry& saved,
+                                  const WindowLimits& limits,
+                                  const std::vector<WorkArea>& work_areas) {
+    WindowGeometry resolved;
+    if (IsSizeUsable(saved)) {
+        resolved.width = saved.width;
+        resolved.height = saved.height;
+        resolved.maximized = saved.maximized;
+    } else {
+        // A corrupt size says nothing about whether the window was maximized,
+        // so a first-launch default is the honest answer for both.
+        resolved.width = limits.default_width;
+        resolved.height = limits.default_height;
+    }
+    resolved.width = std::max(resolved.width, limits.min_width);
+    resolved.height = std::max(resolved.height, limits.min_height);
+
+    if (IsPositionUsable(saved, work_areas)) {
+        resolved.x = saved.x;
+        resolved.y = saved.y;
+        resolved.has_position = true;
+    }
+    return resolved;
+}
+
+}  // namespace linthra::desktop

--- a/native/linthra_desktop/src/window_state.cpp
+++ b/native/linthra_desktop/src/window_state.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <charconv>
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -51,14 +52,28 @@ void ReadBool(std::string_view value, bool* out) {
 
 // The overlap between two rectangles, in pixels. Zero on either axis means they
 // do not meet.
+//
+// Widened to 64 bits on purpose. A hand-edited or truncated state file can hold
+// a coordinate near INT_MAX that parses perfectly well, and adding a width to it
+// in `int` is signed overflow — undefined behaviour, which an optimising build
+// is free to turn into a crash or into a nonsense answer, before the caller ever
+// gets to reject the position. In 64 bits every value this parser can produce
+// adds and subtracts exactly, so the rejection happens on the numbers rather
+// than on the compiler's mood. The result is clamped back to an int, which it
+// always fits: an overlap is never wider than the work area.
 void Intersection(const WindowGeometry& window, const WorkArea& area,
                   int* overlap_width, int* overlap_height) {
-    const int left = std::max(window.x, area.x);
-    const int right = std::min(window.x + window.width, area.x + area.width);
-    const int top = std::max(window.y, area.y);
-    const int bottom = std::min(window.y + window.height, area.y + area.height);
-    *overlap_width = std::max(0, right - left);
-    *overlap_height = std::max(0, bottom - top);
+    const std::int64_t left =
+        std::max<std::int64_t>(window.x, area.x);
+    const std::int64_t right = std::min<std::int64_t>(
+        static_cast<std::int64_t>(window.x) + window.width,
+        static_cast<std::int64_t>(area.x) + area.width);
+    const std::int64_t top = std::max<std::int64_t>(window.y, area.y);
+    const std::int64_t bottom = std::min<std::int64_t>(
+        static_cast<std::int64_t>(window.y) + window.height,
+        static_cast<std::int64_t>(area.y) + area.height);
+    *overlap_width = static_cast<int>(std::max<std::int64_t>(0, right - left));
+    *overlap_height = static_cast<int>(std::max<std::int64_t>(0, bottom - top));
 }
 
 }  // namespace
@@ -164,9 +179,18 @@ WindowGeometry ResolveWindowState(const WindowGeometry& saved,
     resolved.width = std::max(resolved.width, limits.min_width);
     resolved.height = std::max(resolved.height, limits.min_height);
 
-    if (IsPositionUsable(saved, work_areas)) {
-        resolved.x = saved.x;
-        resolved.y = saved.y;
+    // Checked against the geometry the window will actually open with, not the
+    // one the file claimed. A saved 1x1 window at the very corner of a monitor
+    // is "visible" as a 1x1 rectangle and completely unreachable once the
+    // minimum size has been applied to it, so validating the saved size would
+    // accept a position that strands the real window off the screen.
+    WindowGeometry candidate = resolved;
+    candidate.x = saved.x;
+    candidate.y = saved.y;
+    candidate.has_position = saved.has_position;
+    if (IsPositionUsable(candidate, work_areas)) {
+        resolved.x = candidate.x;
+        resolved.y = candidate.y;
         resolved.has_position = true;
     }
     return resolved;

--- a/native/linthra_desktop/tests/window_state_test.cpp
+++ b/native/linthra_desktop/tests/window_state_test.cpp
@@ -182,6 +182,23 @@ int main() {
     }
 
     {
+        // A coordinate near the end of the int range parses fine and must be
+        // rejected on the numbers, not by overflowing the rectangle arithmetic
+        // on the way there. Built through the parser, since that is where such
+        // a value comes from.
+        const WindowGeometry parsed = ParseWindowState(
+            "width=1200\nheight=800\nx=2147483647\ny=2147483647\n");
+        CHECK(parsed.has_position);
+        CHECK(!IsPositionUsable(parsed, single_monitor));
+        CHECK(!ResolveWindowState(parsed, limits, single_monitor).has_position);
+
+        const WindowGeometry negative = ParseWindowState(
+            "width=1200\nheight=800\nx=-2147483648\ny=-2147483648\n");
+        CHECK(negative.has_position);
+        CHECK(!IsPositionUsable(negative, single_monitor));
+    }
+
+    {
         // No monitors reported at all (a session still coming up): place
         // nothing rather than guessing.
         WindowGeometry saved;
@@ -242,6 +259,28 @@ int main() {
             single_monitor);
         CHECK(!resolved.maximized);
         CHECK(resolved.width == limits.default_width);
+    }
+
+    {
+        // A saved size below the floor is clamped up, so the position has to be
+        // judged on the clamped rectangle. A 1x1 window in the very corner is
+        // "visible" as one pixel and completely unreachable at 420x600.
+        const WindowGeometry resolved = ResolveWindowState(
+            ParseWindowState("width=1\nheight=1\nx=1919\ny=1049\n"), limits,
+            single_monitor);
+        CHECK(resolved.width == limits.min_width);
+        CHECK(resolved.height == limits.min_height);
+        CHECK(!resolved.has_position);
+    }
+
+    {
+        // The same position with a real size is still fine: the rule is about
+        // what actually opens, not about distrusting corners.
+        const WindowGeometry resolved = ResolveWindowState(
+            ParseWindowState("width=800\nheight=600\nx=1200\ny=400\n"),
+            limits, single_monitor);
+        CHECK(resolved.has_position);
+        CHECK(resolved.x == 1200);
     }
 
     {

--- a/native/linthra_desktop/tests/window_state_test.cpp
+++ b/native/linthra_desktop/tests/window_state_test.cpp
@@ -1,0 +1,261 @@
+#include "linthra_desktop/window_state.hpp"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+// Ordinary code rather than assert(): CI builds this target in Release, and
+// Release defines NDEBUG, which would expand every assert() to nothing and let
+// the binary exit 0 without checking anything. Same reasoning as the audio DSP
+// tests next door.
+void check(bool condition, const char* expression, const char* file, int line) {
+    if (condition) {
+        return;
+    }
+    std::cerr << file << ':' << line << ": CHECK failed: " << expression << '\n';
+    ++failures;
+}
+
+}  // namespace
+
+#define CHECK(condition) check((condition), #condition, __FILE__, __LINE__)
+
+int main() {
+    using linthra::desktop::FormatWindowState;
+    using linthra::desktop::IsPositionUsable;
+    using linthra::desktop::IsSizeUsable;
+    using linthra::desktop::ParseWindowState;
+    using linthra::desktop::ResolveWindowState;
+    using linthra::desktop::WindowGeometry;
+    using linthra::desktop::WindowLimits;
+    using linthra::desktop::WorkArea;
+
+    // The runner's own numbers, so the expectations below mean what they say.
+    const WindowLimits limits{420, 600, 1180, 780};
+    const std::vector<WorkArea> single_monitor{WorkArea{0, 0, 1920, 1050}};
+
+    // --- parsing ---------------------------------------------------------
+
+    {
+        const WindowGeometry parsed = ParseWindowState(
+            "# a comment\n"
+            "width=1400\n"
+            "height=900\n"
+            "x=120\n"
+            "y=64\n"
+            "maximized=true\n");
+        CHECK(parsed.width == 1400);
+        CHECK(parsed.height == 900);
+        CHECK(parsed.x == 120);
+        CHECK(parsed.y == 64);
+        CHECK(parsed.has_position);
+        CHECK(parsed.maximized);
+    }
+
+    {
+        // A Wayland session saves a size and no position, and that is a
+        // complete file rather than a damaged one.
+        const WindowGeometry parsed =
+            ParseWindowState("width=1400\nheight=900\nmaximized=false\n");
+        CHECK(parsed.width == 1400);
+        CHECK(!parsed.has_position);
+        CHECK(!parsed.maximized);
+    }
+
+    {
+        // A position needs both halves; one alone places nothing.
+        const WindowGeometry parsed =
+            ParseWindowState("width=1400\nheight=900\nx=10\n");
+        CHECK(!parsed.has_position);
+    }
+
+    {
+        // Zero is a real coordinate: a window flush against the top-left of the
+        // first monitor is exactly where a tiling WM puts one.
+        const WindowGeometry parsed =
+            ParseWindowState("width=1400\nheight=900\nx=0\ny=0\n");
+        CHECK(parsed.has_position);
+        CHECK(parsed.x == 0);
+        CHECK(parsed.y == 0);
+    }
+
+    {
+        // Junk is skipped, not fatal, and it does not poison the good keys.
+        const WindowGeometry parsed = ParseWindowState(
+            "\n"
+            "[Window]\n"
+            "width=1400\n"
+            "height=nine hundred\n"
+            "height=880\n"
+            "nonsense\n"
+            "unknown=42\n"
+            "maximized=perhaps\n");
+        CHECK(parsed.width == 1400);
+        CHECK(parsed.height == 880);
+        CHECK(!parsed.maximized);
+    }
+
+    {
+        // Truncated mid-write, the shape a crash or a full disk leaves behind.
+        const WindowGeometry parsed = ParseWindowState("width=14");
+        CHECK(parsed.width == 14);
+        CHECK(parsed.height == 0);
+        CHECK(!IsSizeUsable(parsed));
+    }
+
+    {
+        const WindowGeometry parsed = ParseWindowState("");
+        CHECK(!IsSizeUsable(parsed));
+        CHECK(!parsed.has_position);
+    }
+
+    {
+        // A negative size is not a small window, it is a broken file.
+        CHECK(!IsSizeUsable(ParseWindowState("width=-1400\nheight=900\n")));
+        CHECK(!IsSizeUsable(ParseWindowState("width=1400\nheight=0\n")));
+        CHECK(!IsSizeUsable(ParseWindowState("width=99999\nheight=900\n")));
+    }
+
+    // --- round trip ------------------------------------------------------
+
+    {
+        WindowGeometry saved;
+        saved.width = 1300;
+        saved.height = 820;
+        saved.x = 40;
+        saved.y = 28;
+        saved.has_position = true;
+        saved.maximized = true;
+
+        const WindowGeometry parsed = ParseWindowState(FormatWindowState(saved));
+        CHECK(parsed.width == saved.width);
+        CHECK(parsed.height == saved.height);
+        CHECK(parsed.x == saved.x);
+        CHECK(parsed.y == saved.y);
+        CHECK(parsed.has_position);
+        CHECK(parsed.maximized);
+    }
+
+    {
+        WindowGeometry saved;
+        saved.width = 1300;
+        saved.height = 820;
+        const WindowGeometry parsed = ParseWindowState(FormatWindowState(saved));
+        CHECK(!parsed.has_position);
+        CHECK(parsed.width == 1300);
+    }
+
+    // --- position validity ------------------------------------------------
+
+    {
+        WindowGeometry saved;
+        saved.width = 1200;
+        saved.height = 800;
+        saved.x = 100;
+        saved.y = 50;
+        saved.has_position = true;
+        CHECK(IsPositionUsable(saved, single_monitor));
+
+        // The second monitor it was on has been unplugged.
+        saved.x = 2400;
+        CHECK(!IsPositionUsable(saved, single_monitor));
+        CHECK(IsPositionUsable(
+            saved, {WorkArea{0, 0, 1920, 1050}, WorkArea{1920, 0, 1920, 1050}}));
+
+        // Barely peeking in from the right is not reachable enough to keep.
+        saved.x = 1900;
+        CHECK(!IsPositionUsable(saved, single_monitor));
+
+        // A title bar above the work area cannot be grabbed with the mouse,
+        // however much of the body shows.
+        saved.x = 100;
+        saved.y = -40;
+        CHECK(!IsPositionUsable(saved, single_monitor));
+
+        // A panel at the top of the screen moves the work area down with it.
+        saved.y = 20;
+        CHECK(!IsPositionUsable(saved, {WorkArea{0, 32, 1920, 1018}}));
+    }
+
+    {
+        // No monitors reported at all (a session still coming up): place
+        // nothing rather than guessing.
+        WindowGeometry saved;
+        saved.width = 1200;
+        saved.height = 800;
+        saved.has_position = true;
+        CHECK(!IsPositionUsable(saved, {}));
+    }
+
+    // --- resolution -------------------------------------------------------
+
+    {
+        const WindowGeometry resolved = ResolveWindowState(
+            ParseWindowState("width=1400\nheight=900\nx=64\ny=48\n"), limits,
+            single_monitor);
+        CHECK(resolved.width == 1400);
+        CHECK(resolved.height == 900);
+        CHECK(resolved.has_position);
+        CHECK(resolved.x == 64);
+        CHECK(!resolved.maximized);
+    }
+
+    {
+        // First launch, and every damaged file: the documented default.
+        const WindowGeometry resolved =
+            ResolveWindowState(ParseWindowState(""), limits, single_monitor);
+        CHECK(resolved.width == limits.default_width);
+        CHECK(resolved.height == limits.default_height);
+        CHECK(!resolved.has_position);
+        CHECK(!resolved.maximized);
+    }
+
+    {
+        // A size below the runner's floor comes back at the floor, not below
+        // it, so the window never opens already clamped by GTK.
+        const WindowGeometry resolved = ResolveWindowState(
+            ParseWindowState("width=200\nheight=120\n"), limits,
+            single_monitor);
+        CHECK(resolved.width == limits.min_width);
+        CHECK(resolved.height == limits.min_height);
+    }
+
+    {
+        // Maximized survives a restart; the size under it is remembered too, so
+        // un-maximizing lands back where the user left it.
+        const WindowGeometry resolved = ResolveWindowState(
+            ParseWindowState("width=1400\nheight=900\nmaximized=true\n"),
+            limits, single_monitor);
+        CHECK(resolved.maximized);
+        CHECK(resolved.width == 1400);
+    }
+
+    {
+        // A corrupt size drops the maximized flag with it rather than opening
+        // a default-sized window maximized for reasons the file cannot support.
+        const WindowGeometry resolved = ResolveWindowState(
+            ParseWindowState("width=0\nheight=0\nmaximized=true\n"), limits,
+            single_monitor);
+        CHECK(!resolved.maximized);
+        CHECK(resolved.width == limits.default_width);
+    }
+
+    {
+        // The size is kept even when the position has to be thrown away: losing
+        // a monitor should not also lose the window's shape.
+        const WindowGeometry resolved = ResolveWindowState(
+            ParseWindowState("width=1400\nheight=900\nx=4000\ny=10\n"), limits,
+            single_monitor);
+        CHECK(resolved.width == 1400);
+        CHECK(!resolved.has_position);
+    }
+
+    if (failures == 0) {
+        std::cout << "window_state tests passed\n";
+    }
+    return failures == 0 ? 0 : 1;
+}

--- a/scripts/check_linux_runner.py
+++ b/scripts/check_linux_runner.py
@@ -99,6 +99,10 @@ CMAKELISTS = Path("linux") / "CMakeLists.txt"
 MY_APPLICATION = Path("linux") / "runner" / "my_application.cc"
 RUNNER_CMAKELISTS = Path("linux") / "runner" / "CMakeLists.txt"
 FOLDER_PICKER_CHANNEL_SOURCE = Path("linux") / "runner" / "folder_picker_channel.cc"
+WINDOW_STATE_STORE_SOURCE = Path("linux") / "runner" / "window_state_store.cc"
+WINDOW_STATE_POLICY_SOURCE = (
+    Path("native") / "linthra_desktop" / "src" / "window_state.cpp"
+)
 FOLDER_PICKER_DART = (
     Path("lib") / "core" / "services" / "method_channel_linux_folder_picker.dart"
 )
@@ -830,6 +834,46 @@ def _function_body(code: str, signature: str, where: Path) -> tuple[int, int]:
     raise CheckError(f"{where}: {signature} has an unterminated body")
 
 
+def window_state_problems(root: Path) -> list[str]:
+    """Ways the window-state wiring (#383) can vanish without failing a build.
+
+    Losing any one of these still compiles and still launches. The window just
+    stops remembering its size, which nobody notices in review and everybody
+    notices on the next launch.
+    """
+    problems: list[str] = []
+
+    runner_cmakelists = _read(root, RUNNER_CMAKELISTS)
+    for source in (WINDOW_STATE_STORE_SOURCE, WINDOW_STATE_POLICY_SOURCE):
+        if source.name not in runner_cmakelists:
+            problems.append(
+                f"{RUNNER_CMAKELISTS} does not compile {source.name}, so the "
+                "window cannot remember its size"
+            )
+    # The policy is C++17 (string_view, from_chars). apply_standard_settings
+    # only asks for cxx_std_14, which is a floor: without this the standard is
+    # whatever the host compiler happens to default to.
+    if "cxx_std_17" not in runner_cmakelists:
+        problems.append(
+            f"{RUNNER_CMAKELISTS} no longer requires cxx_std_17, which the "
+            f"{WINDOW_STATE_POLICY_SOURCE.name} policy needs"
+        )
+
+    my_application = _read(root, MY_APPLICATION)
+    if "window_state_store_new" not in my_application:
+        problems.append(
+            f"{MY_APPLICATION} never calls window_state_store_new(), so the "
+            "saved window geometry is never restored"
+        )
+    if "window_state_store_save" not in my_application:
+        problems.append(
+            f"{MY_APPLICATION} never calls window_state_store_save(), so the "
+            "window geometry is never written and every launch is a first one"
+        )
+
+    return problems
+
+
 def runner_identity_problems(root: Path) -> list[str]:
     """Identity calls the runner has to make, in the places they still work.
 
@@ -967,6 +1011,7 @@ def check(root: Path) -> list[str]:
     # window answer to the same id as everything installed above, in the places
     # where they still take effect.
     problems.extend(runner_identity_problems(root))
+    problems.extend(window_state_problems(root))
 
     # Window metrics: a minimum larger than the default would open the window
     # already clamped, which reads as the app ignoring its own default.

--- a/scripts/check_linux_runner.py
+++ b/scripts/check_linux_runner.py
@@ -281,6 +281,7 @@ NON_UNIQUE_FLAG = "G_APPLICATION_NON_UNIQUE"
 # than being pasted into the runner as a second copy.
 RUNNER_IDENTITY_NEW_FUNCTION = "MyApplication* my_application_new()"
 RUNNER_IDENTITY_STARTUP_FUNCTION = "static void my_application_startup("
+RUNNER_SHUTDOWN_FUNCTION = "static void my_application_shutdown("
 RUNNER_STARTUP_CHAIN_UP = (
     "G_APPLICATION_CLASS(my_application_parent_class)->startup(application)"
 )
@@ -955,16 +956,26 @@ def window_state_problems(root: Path) -> list[str]:
             f"{WINDOW_STATE_POLICY_SOURCE.name} policy needs"
         )
 
-    my_application = _read(root, MY_APPLICATION)
+    my_application = _blank(_read(root, MY_APPLICATION))
     if "window_state_store_new" not in my_application:
         problems.append(
             f"{MY_APPLICATION} never calls window_state_store_new(), so the "
             "saved window geometry is never restored"
         )
-    if "window_state_store_save" not in my_application:
+
+    # Specifically inside my_application_shutdown(), not just somewhere in the
+    # file. There is a second save on the window-recreation path in activate(),
+    # so a plain substring search would keep passing while the one that runs on
+    # every ordinary exit — the only one that persists the geometry a session
+    # ends with — had been dropped by a merge or a regeneration.
+    shutdown_start, shutdown_end = _function_body(
+        my_application, RUNNER_SHUTDOWN_FUNCTION, MY_APPLICATION
+    )
+    if "window_state_store_save" not in my_application[shutdown_start:shutdown_end]:
         problems.append(
-            f"{MY_APPLICATION} never calls window_state_store_save(), so the "
-            "window geometry is never written and every launch is a first one"
+            f"{MY_APPLICATION}: my_application_shutdown() never calls "
+            "window_state_store_save(), so an ordinary exit never writes the "
+            "window geometry and every launch is a first one"
         )
 
     return problems

--- a/test/features/library/content_density_test.dart
+++ b/test/features/library/content_density_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/app/brand_theme.dart';
+import 'package:linthra/app/theme.dart';
+import 'package:linthra/core/models/artist.dart';
+import 'package:linthra/features/library/widgets/artist_grid.dart';
+import 'package:linthra/features/library/widgets/artist_tile.dart';
+
+/// Desktop density (#384): a Linux window fits materially more of a library per
+/// screen, and a phone's rows do not move a pixel. The signal is the platform,
+/// not the width — an Android tablet in landscape is as wide as a desktop window
+/// and still driven by a thumb.
+final List<Artist> _artists = <Artist>[
+  for (int i = 0; i < 12; i++)
+    Artist(id: '$i', name: 'Artist $i', albumCount: 2, trackCount: 9),
+];
+
+/// The row height a touch layout has always had: a two-line ListTile.
+const double _touchRowHeight = 72;
+
+ThemeData _theme() => AppTheme.dark(BrandPalettes.classic);
+
+/// Runs [body] as if Linthra were on [platform].
+///
+/// The override has to be cleared inside the test body rather than in a
+/// tearDown: the framework asserts that no foundation debug variable is still
+/// set when the body returns.
+Future<void> _onPlatform(
+  TargetPlatform platform,
+  Future<void> Function() body,
+) async {
+  debugDefaultTargetPlatformOverride = platform;
+  try {
+    await body();
+  } finally {
+    debugDefaultTargetPlatformOverride = null;
+  }
+}
+
+Future<void> _pumpArtists(WidgetTester tester) async {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = const Size(1280, 900);
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        theme: _theme(),
+        home: Scaffold(
+          body: ArtistGrid(artists: _artists, onOpen: (_) {}),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+double _rowHeight(WidgetTester tester) =>
+    tester.getRect(find.byType(ArtistTile).first).height;
+
+void main() {
+  group('content density', () {
+    test('the theme is compact on a desktop host and standard on a phone', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      expect(_theme().visualDensity, VisualDensity.compact);
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      expect(_theme().visualDensity, VisualDensity.standard);
+    });
+
+    testWidgets('a wide touch window keeps the row height it always had',
+        (tester) async {
+      await _onPlatform(TargetPlatform.android, () async {
+        await _pumpArtists(tester);
+        expect(_rowHeight(tester), _touchRowHeight);
+      });
+    });
+
+    testWidgets('a desktop host fits more rows in the same window',
+        (tester) async {
+      await _onPlatform(TargetPlatform.linux, () async {
+        await _pumpArtists(tester);
+
+        final double height = _rowHeight(tester);
+        expect(height, lessThan(_touchRowHeight));
+        // Density buys back padding, never the row: still clickable.
+        expect(height, greaterThanOrEqualTo(48));
+        expect(tester.takeException(), isNull);
+      });
+    });
+
+    testWidgets('a row control stays a real click target when compact',
+        (tester) async {
+      await _onPlatform(TargetPlatform.linux, () async {
+        await tester.pumpWidget(
+          ProviderScope(
+            child: MaterialApp(
+              theme: _theme(),
+              home: Scaffold(
+                body: ListTile(
+                  title: const Text('Song One'),
+                  trailing: IconButton(
+                    onPressed: () {},
+                    icon: const Icon(Icons.more_vert),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final Size button = tester.getSize(find.byType(IconButton));
+        expect(button.width, greaterThanOrEqualTo(40));
+        expect(button.height, greaterThanOrEqualTo(40));
+      });
+    });
+  });
+}

--- a/test/features/library/context_menu_test.dart
+++ b/test/features/library/context_menu_test.dart
@@ -1,0 +1,347 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:linthra/app/routes.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/favorites_repository_provider.dart';
+import 'package:linthra/data/repositories/in_memory_playlist_store.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/data/repositories/playlist_repository_provider.dart';
+import 'package:linthra/features/library/album_detail_screen.dart';
+import 'package:linthra/features/library/artist_detail_screen.dart';
+import 'package:linthra/features/library/library_screen.dart';
+import 'package:linthra/features/library/widgets/track_tile.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/player_screen.dart';
+import 'package:linthra/shared/widgets/context_menu_region.dart';
+
+import '../player/fake_playback_controller.dart';
+import 'fake_music_library_repository.dart';
+
+/// Right-click menus (#386). Same entries as the row's 3-dot button, same
+/// commands behind them, and a keyboard way in — a menu a mouse can reach and a
+/// keyboard cannot is not an accessible menu.
+final List<Track> _tracks = <Track>[
+  for (int i = 0; i < 3; i++)
+    Track(
+      id: '$i',
+      title: 'Song $i',
+      uri: 'jellyfin:$i',
+      artistName: 'Daft Punk',
+      albumName: 'Discovery',
+      trackNumber: i + 1,
+    ),
+];
+
+/// A local track with no album or artist tags: nowhere to navigate to.
+const Track _untagged = Track(id: '9', title: 'Untitled', uri: '/music/9.mp3');
+
+Future<void> _pumpLibrary(WidgetTester tester, {List<Track>? tracks}) async {
+  tester.view.devicePixelRatio = 1.0;
+  // Narrow enough that the Albums grid has no detail pane, so the songs list is
+  // the only thing on screen.
+  tester.view.physicalSize = const Size(800, 900);
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        musicLibraryRepositoryProvider.overrideWithValue(
+          FakeMusicLibraryRepository(tracks: tracks ?? _tracks),
+        ),
+        playlistStoreProvider.overrideWithValue(InMemoryPlaylistStore()),
+        playbackControllerProvider.overrideWithValue(FakePlaybackController()),
+      ],
+      child: MaterialApp.router(
+        routerConfig: GoRouter(
+          initialLocation: AppRoutes.library,
+          routes: <RouteBase>[
+            GoRoute(
+              path: AppRoutes.library,
+              builder: (_, __) => const LibraryScreen(),
+            ),
+            GoRoute(
+              path: '/library/album/:id',
+              builder: (_, GoRouterState s) =>
+                  AlbumDetailScreen(albumId: s.pathParameters['id']!),
+            ),
+            GoRoute(
+              path: '/library/artist/:id',
+              builder: (_, GoRouterState s) =>
+                  ArtistDetailScreen(artistId: s.pathParameters['id']!),
+            ),
+            GoRoute(
+              path: AppRoutes.player,
+              builder: (_, __) => const PlayerScreen(),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// Right-clicks the first track row.
+Future<void> _rightClickFirstTrack(WidgetTester tester) async {
+  final Offset where = tester.getCenter(find.byType(TrackTile).first);
+  final TestGesture gesture = await tester.startGesture(
+    where,
+    kind: PointerDeviceKind.mouse,
+    buttons: kSecondaryMouseButton,
+  );
+  await gesture.up();
+  await tester.pumpAndSettle();
+}
+
+ProviderContainer _container(WidgetTester tester) =>
+    ProviderScope.containerOf(tester.element(find.byType(LibraryScreen)));
+
+void main() {
+  group('track row context menu', () {
+    testWidgets('right-click opens the row actions', (tester) async {
+      await _pumpLibrary(tester);
+      await _rightClickFirstTrack(tester);
+
+      expect(find.text('Play next'), findsOneWidget);
+      expect(find.text('Add to queue'), findsOneWidget);
+      expect(find.text('Add to playlist'), findsOneWidget);
+      expect(find.text('Add to favorites'), findsOneWidget);
+      expect(find.text('Show album'), findsOneWidget);
+      expect(find.text('Show artist'), findsOneWidget);
+      expect(find.text('Remove from Linthra'), findsOneWidget);
+    });
+
+    testWidgets('an action runs the same command the button would',
+        (tester) async {
+      await _pumpLibrary(tester);
+      await _rightClickFirstTrack(tester);
+
+      await tester.tap(find.text('Add to queue'));
+      await tester.pumpAndSettle();
+
+      // Nothing was playing, so the shared command starts the queued track
+      // rather than leaving it queued behind silence — exactly what the 3-dot
+      // button does with the same action.
+      final FakePlaybackController controller = _container(tester)
+          .read(playbackControllerProvider) as FakePlaybackController;
+      expect(controller.state.currentTrack?.title, 'Song 0');
+    });
+
+    testWidgets('the menu reflects state as it is when it opens',
+        (tester) async {
+      await _pumpLibrary(tester);
+      await _rightClickFirstTrack(tester);
+
+      await tester.tap(find.text('Add to favorites'));
+      await tester.pumpAndSettle();
+      expect(
+        _container(tester).read(favoritesRepositoryProvider).isFavorite(
+              'jellyfin:0',
+            ),
+        isTrue,
+      );
+
+      // Opened again, the same entry now offers the other half of the toggle.
+      await _rightClickFirstTrack(tester);
+      expect(find.text('Remove from favorites'), findsOneWidget);
+      expect(find.text('Add to favorites'), findsNothing);
+    });
+
+    testWidgets('Show album opens the album page', (tester) async {
+      await _pumpLibrary(tester);
+      await _rightClickFirstTrack(tester);
+
+      await tester.tap(find.text('Show album'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlbumDetailScreen), findsOneWidget);
+      expect(find.text('Discovery'), findsWidgets);
+    });
+
+    testWidgets('a track with no tags is offered nowhere to go',
+        (tester) async {
+      await _pumpLibrary(tester, tracks: <Track>[_untagged]);
+      await _rightClickFirstTrack(tester);
+
+      expect(find.text('Play next'), findsOneWidget);
+      expect(find.text('Show album'), findsNothing);
+      expect(find.text('Show artist'), findsNothing);
+    });
+  });
+
+  group('album and artist context menus', () {
+    Future<void> openTab(WidgetTester tester, String tab) async {
+      await tester.tap(find.text(tab));
+      await tester.pumpAndSettle();
+    }
+
+    Future<void> rightClick(WidgetTester tester, Finder target) async {
+      final TestGesture gesture = await tester.startGesture(
+        tester.getCenter(target),
+        kind: PointerDeviceKind.mouse,
+        buttons: kSecondaryMouseButton,
+      );
+      await gesture.up();
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('an album card offers what its page already does',
+        (tester) async {
+      await _pumpLibrary(tester);
+      await openTab(tester, 'Albums');
+      await rightClick(tester, find.text('Discovery').first);
+
+      expect(find.text('Play'), findsOneWidget);
+      expect(find.text('Shuffle'), findsOneWidget);
+      expect(find.text('Play next'), findsOneWidget);
+      expect(find.text('Add to queue'), findsOneWidget);
+      expect(find.text('Add to playlist'), findsOneWidget);
+    });
+
+    testWidgets('queueing an album keeps it in album order', (tester) async {
+      await _pumpLibrary(tester);
+      await openTab(tester, 'Albums');
+      await rightClick(tester, find.text('Discovery').first);
+
+      await tester.tap(find.text('Add to queue'));
+      await tester.pumpAndSettle();
+
+      final FakePlaybackController controller = _container(tester)
+          .read(playbackControllerProvider) as FakePlaybackController;
+      expect(controller.state.currentTrack?.title, 'Song 0');
+      expect(
+        controller.state.upNext.map((Track t) => t.title).toList(),
+        <String>['Song 1', 'Song 2'],
+      );
+    });
+
+    testWidgets('Play next queues an album front to back', (tester) async {
+      await _pumpLibrary(tester);
+      await openTab(tester, 'Albums');
+
+      // Something has to be playing for "next" to have a "current" to sit
+      // after — the case where the insert order actually matters.
+      final FakePlaybackController controller = _container(tester)
+          .read(playbackControllerProvider) as FakePlaybackController;
+      await controller.playTracks(<Track>[_tracks.first]);
+      await tester.pumpAndSettle();
+
+      await rightClick(tester, find.text('Discovery').first);
+      await tester.tap(find.text('Play next'));
+      await tester.pumpAndSettle();
+
+      // Each insert lands right after the current track, so the album would
+      // play backwards if the menu did not reverse them.
+      expect(
+        controller.state.upNext.map((Track t) => t.title).toList(),
+        <String>['Song 0', 'Song 1', 'Song 2'],
+      );
+    });
+
+    testWidgets('Play next from silence just starts the album', (tester) async {
+      await _pumpLibrary(tester);
+      await openTab(tester, 'Albums');
+      await rightClick(tester, find.text('Discovery').first);
+
+      await tester.tap(find.text('Play next'));
+      await tester.pumpAndSettle();
+
+      // There is no "next" to insert before, so the album plays from the top
+      // rather than backwards from its last track.
+      final FakePlaybackController controller = _container(tester)
+          .read(playbackControllerProvider) as FakePlaybackController;
+      expect(controller.state.currentTrack?.title, 'Song 0');
+      expect(
+        controller.state.upNext.map((Track t) => t.title).toList(),
+        <String>['Song 1', 'Song 2'],
+      );
+    });
+
+    testWidgets('an artist row offers the same set', (tester) async {
+      await _pumpLibrary(tester);
+      await openTab(tester, 'Artists');
+      await rightClick(tester, find.text('Daft Punk').first);
+
+      expect(find.text('Play'), findsOneWidget);
+      expect(find.text('Add to playlist'), findsOneWidget);
+    });
+  });
+
+  group('ContextMenuRegion keyboard access', () {
+    Future<void> pumpRegion(
+      WidgetTester tester, {
+      bool enabled = true,
+      required List<String> opened,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: ContextMenuRegion<String>(
+                enabled: enabled,
+                itemBuilder: (BuildContext context) =>
+                    const <PopupMenuEntry<String>>[
+                  PopupMenuItem<String>(value: 'a', child: Text('Play next')),
+                ],
+                onSelected: opened.add,
+                child: const Focus(
+                  autofocus: true,
+                  child: SizedBox(width: 200, height: 60),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('the menu key opens the menu on the focused row',
+        (tester) async {
+      final List<String> chosen = <String>[];
+      await pumpRegion(tester, opened: chosen);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.contextMenu);
+      await tester.pumpAndSettle();
+      expect(find.text('Play next'), findsOneWidget);
+
+      await tester.tap(find.text('Play next'));
+      await tester.pumpAndSettle();
+      expect(chosen, <String>['a']);
+    });
+
+    testWidgets('Shift+F10 does the same, for keyboards without a menu key',
+        (tester) async {
+      await pumpRegion(tester, opened: <String>[]);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.f10);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Play next'), findsOneWidget);
+    });
+
+    testWidgets('F10 on its own is left alone', (tester) async {
+      await pumpRegion(tester, opened: <String>[]);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.f10);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Play next'), findsNothing);
+    });
+
+    testWidgets('a disabled region offers nothing', (tester) async {
+      await pumpRegion(tester, enabled: false, opened: <String>[]);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.contextMenu);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Play next'), findsNothing);
+    });
+  });
+}

--- a/test/features/library/detail_desktop_layout_test.dart
+++ b/test/features/library/detail_desktop_layout_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:linthra/app/routes.dart';
+import 'package:linthra/core/catalog/library_grouping.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/data/repositories/in_memory_playlist_store.dart';
 import 'package:linthra/data/repositories/music_library_repository_provider.dart';
@@ -29,9 +30,9 @@ final List<Track> _tracks = <Track>[
     ),
 ];
 
-GoRouter _router() {
+GoRouter _router(String initialLocation) {
   return GoRouter(
-    initialLocation: AppRoutes.library,
+    initialLocation: initialLocation,
     routes: <RouteBase>[
       GoRoute(
         path: AppRoutes.library,
@@ -56,6 +57,7 @@ Future<void> _pumpLibrary(
   WidgetTester tester,
   Size size, {
   TextScaler textScaler = TextScaler.noScaling,
+  String initialLocation = AppRoutes.library,
 }) async {
   tester.view.devicePixelRatio = 1.0;
   tester.view.physicalSize = size;
@@ -75,23 +77,28 @@ Future<void> _pumpLibrary(
           data: MediaQuery.of(context).copyWith(textScaler: textScaler),
           child: child!,
         ),
-        routerConfig: _router(),
+        routerConfig: _router(initialLocation),
       ),
     ),
   );
   await tester.pumpAndSettle();
 }
 
+/// Opens the detail *screen*, which is what these tests are about — on its own
+/// route, the way Folders, search and a narrow window all reach it. A wide
+/// Library window opens the same screen as a pane beside the grid instead; that
+/// path has its own tests in `library_detail_pane_test.dart`.
 Future<void> _openAlbum(
   WidgetTester tester,
   Size size, {
   TextScaler textScaler = TextScaler.noScaling,
 }) async {
-  await _pumpLibrary(tester, size, textScaler: textScaler);
-  await tester.tap(find.text('Albums'));
-  await tester.pumpAndSettle();
-  await tester.tap(find.text('Discovery').first);
-  await tester.pumpAndSettle();
+  await _pumpLibrary(
+    tester,
+    size,
+    textScaler: textScaler,
+    initialLocation: '/library/album/${albumIdForTrack(_tracks.first)}',
+  );
 }
 
 Future<void> _openArtist(
@@ -99,11 +106,12 @@ Future<void> _openArtist(
   Size size, {
   TextScaler textScaler = TextScaler.noScaling,
 }) async {
-  await _pumpLibrary(tester, size, textScaler: textScaler);
-  await tester.tap(find.text('Artists'));
-  await tester.pumpAndSettle();
-  await tester.tap(find.text('Daft Punk').first);
-  await tester.pumpAndSettle();
+  await _pumpLibrary(
+    tester,
+    size,
+    textScaler: textScaler,
+    initialLocation: '/library/artist/${artistIdForTrack(_tracks.first)}',
+  );
 }
 
 Rect _headerRect(WidgetTester tester, String playLabel) =>

--- a/test/features/library/detail_selection_escape_test.dart
+++ b/test/features/library/detail_selection_escape_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:linthra/app/routes.dart';
+import 'package:linthra/core/catalog/library_grouping.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/in_memory_playlist_store.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/data/repositories/playlist_repository_provider.dart';
+import 'package:linthra/features/library/album_detail_screen.dart';
+import 'package:linthra/features/library/artist_detail_screen.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/player_screen.dart';
+
+import '../player/fake_playback_controller.dart';
+import 'fake_music_library_repository.dart';
+
+/// Escape leaves a selection wherever one can be started (#387). Album and
+/// artist detail take the same Ctrl and Shift clicks the songs list does, so a
+/// keyboard user has to be able to get back out of them the same way — without
+/// reaching for the app bar's close button with the mouse.
+final List<Track> _tracks = <Track>[
+  for (int i = 0; i < 4; i++)
+    Track(
+      id: '$i',
+      title: 'Song $i',
+      uri: 'jellyfin:$i',
+      artistName: 'Daft Punk',
+      albumName: 'Discovery',
+      trackNumber: i + 1,
+    ),
+];
+
+Future<void> _pump(WidgetTester tester, String location) async {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = const Size(1280, 900);
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        musicLibraryRepositoryProvider
+            .overrideWithValue(FakeMusicLibraryRepository(tracks: _tracks)),
+        playlistStoreProvider.overrideWithValue(InMemoryPlaylistStore()),
+        playbackControllerProvider.overrideWithValue(FakePlaybackController()),
+      ],
+      child: MaterialApp.router(
+        routerConfig: GoRouter(
+          initialLocation: location,
+          routes: <RouteBase>[
+            GoRoute(
+              path: '/library/album/:id',
+              builder: (_, GoRouterState s) =>
+                  AlbumDetailScreen(albumId: s.pathParameters['id']!),
+            ),
+            GoRoute(
+              path: '/library/artist/:id',
+              builder: (_, GoRouterState s) =>
+                  ArtistDetailScreen(artistId: s.pathParameters['id']!),
+            ),
+            GoRoute(
+              path: AppRoutes.player,
+              builder: (_, __) => const PlayerScreen(),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> _ctrlClick(WidgetTester tester, String title) async {
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+  await tester.tap(find.text(title));
+  await tester.pumpAndSettle();
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+}
+
+void main() {
+  group('Escape leaves a detail-page selection', () {
+    testWidgets('on an album page', (tester) async {
+      await _pump(
+        tester,
+        '/library/album/${albumIdForTrack(_tracks.first)}',
+      );
+
+      await _ctrlClick(tester, 'Song 0');
+      expect(find.text('1 selected'), findsOneWidget);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pumpAndSettle();
+
+      expect(find.text('1 selected'), findsNothing);
+      // Back on the album's own app bar, with nothing selected.
+      expect(find.text('Discovery'), findsWidgets);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('on an artist page', (tester) async {
+      await _pump(
+        tester,
+        '/library/artist/${artistIdForTrack(_tracks.first)}',
+      );
+
+      await _ctrlClick(tester, 'Song 0');
+      expect(find.text('1 selected'), findsOneWidget);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pumpAndSettle();
+
+      expect(find.text('1 selected'), findsNothing);
+      expect(find.text('Daft Punk'), findsWidgets);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('Escape does nothing when nothing is selected', (tester) async {
+      await _pump(
+        tester,
+        '/library/album/${albumIdForTrack(_tracks.first)}',
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlbumDetailScreen), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+  });
+}

--- a/test/features/library/folder_track_menu_test.dart
+++ b/test/features/library/folder_track_menu_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:linthra/core/models/music_folder.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/folder_browsable_music_source.dart';
+import 'package:linthra/features/library/folder_browser_providers.dart';
+import 'package:linthra/features/library/folders_screen.dart';
+import 'package:linthra/features/library/unified_library_providers.dart';
+import 'package:linthra/features/library/widgets/track_tile.dart';
+import 'package:linthra/features/player/player_providers.dart';
+
+import '../player/fake_playback_controller.dart';
+
+/// "Show album" has to lead somewhere (#386).
+///
+/// The folder browser lists a server's tree on demand, so it happily shows a
+/// well-tagged track the flat catalog has never seen — browsed before a sync,
+/// or from a library the user never synced at all. The album page resolves its
+/// id against that catalog alone, so offering the action there drops the user
+/// on "Album not found" straight after they picked a song that plays fine.
+const Track _track = Track(
+  id: 'f1',
+  title: 'One More Time',
+  uri: 'subsonic:f1',
+  artistName: 'Daft Punk',
+  albumName: 'Discovery',
+);
+
+class _FakeFolderSource implements FolderBrowsableMusicSource {
+  @override
+  String get id => 'subsonic';
+
+  @override
+  String get displayName => 'Navidrome';
+
+  @override
+  Future<List<MusicFolder>> fetchRootFolders() async =>
+      const <MusicFolder>[MusicFolder(id: 'r1', name: 'Music')];
+
+  @override
+  Future<MusicFolderListing> fetchFolder(String folderId) async =>
+      const MusicFolderListing(tracks: <Track>[_track]);
+}
+
+/// Pumps the folder browser one level in, over a catalog holding [catalog].
+Future<void> _pumpInFolder(
+  WidgetTester tester, {
+  required List<Track> catalog,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        folderBrowsableSourcesProvider
+            .overrideWithValue(<FolderBrowsableMusicSource>[
+          _FakeFolderSource(),
+        ]),
+        libraryUnifiedTracksProvider.overrideWithValue(catalog),
+        playbackControllerProvider.overrideWithValue(FakePlaybackController()),
+      ],
+      child: MaterialApp.router(
+        routerConfig: GoRouter(
+          routes: <RouteBase>[
+            GoRoute(path: '/', builder: (_, __) => const FoldersScreen()),
+          ],
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+
+  await tester.tap(find.text('Music'));
+  await tester.pumpAndSettle();
+  expect(find.byType(TrackTile), findsOneWidget);
+}
+
+Future<void> _rightClickTrack(WidgetTester tester) async {
+  final TestGesture gesture = await tester.startGesture(
+    tester.getCenter(find.byType(TrackTile)),
+    kind: PointerDeviceKind.mouse,
+    buttons: kSecondaryMouseButton,
+  );
+  await gesture.up();
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('a browsed track that the catalog does not have', () {
+    testWidgets('is not offered a collection page it cannot open',
+        (tester) async {
+      await _pumpInFolder(tester, catalog: const <Track>[]);
+      await _rightClickTrack(tester);
+
+      // Everything that acts on the track itself still works from here.
+      expect(find.text('Play next'), findsOneWidget);
+      expect(find.text('Add to queue'), findsOneWidget);
+      // The two that would navigate into the catalog are the ones withheld.
+      expect(find.text('Show album'), findsNothing);
+      expect(find.text('Show artist'), findsNothing);
+    });
+
+    testWidgets('gets both back once the catalog knows the track',
+        (tester) async {
+      await _pumpInFolder(tester, catalog: const <Track>[_track]);
+      await _rightClickTrack(tester);
+
+      expect(find.text('Show album'), findsOneWidget);
+      expect(find.text('Show artist'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/library/hover_states_test.dart
+++ b/test/features/library/hover_states_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/app/brand_theme.dart';
+import 'package:linthra/app/theme.dart';
+import 'package:linthra/core/models/album.dart';
+import 'package:linthra/features/library/widgets/album_grid.dart';
+import 'package:linthra/features/library/widgets/album_grid_card.dart';
+import 'package:linthra/shared/widgets/hover_highlight.dart';
+
+/// Hover feedback (#385). A mouse user has to be able to tell what is
+/// interactive, and hover has to stay distinct from selected, focused and
+/// pressed — a row that looks selected because a pointer is resting on it is
+/// worse than no feedback at all.
+final List<Album> _albums = <Album>[
+  for (int i = 0; i < 6; i++)
+    Album(id: '$i', title: 'Album $i', artistName: 'Artist $i', trackCount: 9),
+];
+
+Future<void> _pumpGrid(WidgetTester tester) async {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = const Size(1280, 900);
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        theme: AppTheme.dark(BrandPalettes.classic),
+        home: Scaffold(
+          body: AlbumGrid(albums: _albums, onOpen: (_) {}),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// A real mouse, so hover happens at all: a touch pointer never enters.
+Future<TestGesture> _mouse(WidgetTester tester) async {
+  final TestGesture gesture =
+      await tester.createGesture(kind: PointerDeviceKind.mouse);
+  await gesture.addPointer(location: Offset.zero);
+  addTearDown(gesture.removePointer);
+  return gesture;
+}
+
+double _veilOpacity(WidgetTester tester) {
+  return tester
+      .widget<AnimatedOpacity>(
+        find
+            .descendant(
+              of: find.byType(HoverArtworkVeil),
+              matching: find.byType(AnimatedOpacity),
+            )
+            .first,
+      )
+      .opacity;
+}
+
+void main() {
+  group('hover feedback', () {
+    testWidgets('an album cover answers the pointer', (tester) async {
+      await _pumpGrid(tester);
+      expect(_veilOpacity(tester), 0);
+
+      final TestGesture gesture = await _mouse(tester);
+      await gesture.moveTo(tester.getCenter(find.byType(AlbumGridCard).first));
+      await tester.pumpAndSettle();
+      expect(_veilOpacity(tester), 1);
+
+      await gesture.moveTo(Offset.zero);
+      await tester.pumpAndSettle();
+      expect(_veilOpacity(tester), 0);
+    });
+
+    testWidgets('only the card under the pointer lights up', (tester) async {
+      await _pumpGrid(tester);
+      final TestGesture gesture = await _mouse(tester);
+      await gesture.moveTo(tester.getCenter(find.byType(AlbumGridCard).first));
+      await tester.pumpAndSettle();
+
+      final Iterable<AnimatedOpacity> veils =
+          tester.widgetList<AnimatedOpacity>(
+        find.descendant(
+          of: find.byType(HoverArtworkVeil),
+          matching: find.byType(AnimatedOpacity),
+        ),
+      );
+      expect(veils.where((AnimatedOpacity o) => o.opacity == 1), hasLength(1));
+    });
+
+    testWidgets('nothing hovers without a pointer', (tester) async {
+      await _pumpGrid(tester);
+
+      // A touch device never sends an enter event, so the grid looks exactly
+      // as it did before any of this existed.
+      expect(_veilOpacity(tester), 0);
+      expect(tester.takeException(), isNull);
+    });
+
+    test('hover is distinct from selection, in both themes', () {
+      for (final ThemeData theme in <ThemeData>[
+        AppTheme.dark(BrandPalettes.classic),
+        AppTheme.light(BrandPalettes.classicLight),
+      ]) {
+        final Color hover = theme.hoverColor;
+        final Color? selected = theme.listTileTheme.selectedTileColor;
+
+        // Visible at all: Material's 4% default is close to invisible on a
+        // black-first surface.
+        expect(hover.a, greaterThan(0.05));
+        // …and quiet enough to read as a hint rather than a state.
+        expect(hover.a, lessThan(0.2));
+        // Near-neutral, not the violet that means "selected": the channels
+        // stay within a hair of each other, where the brand primary pulls them
+        // far apart.
+        expect(hover, isNot(selected));
+        expect(hover.r, closeTo(hover.g, 0.06));
+        expect(hover.g, closeTo(hover.b, 0.06));
+      }
+    });
+  });
+}

--- a/test/features/library/library_detail_pane_test.dart
+++ b/test/features/library/library_detail_pane_test.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:linthra/app/routes.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/in_memory_playlist_store.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/data/repositories/playlist_repository_provider.dart';
+import 'package:linthra/features/library/album_detail_screen.dart';
+import 'package:linthra/features/library/artist_detail_screen.dart';
+import 'package:linthra/features/library/library_screen.dart';
+import 'package:linthra/features/library/widgets/track_tile.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/player_screen.dart';
+
+import '../player/fake_playback_controller.dart';
+import 'fake_music_library_repository.dart';
+
+/// A window wide enough for three panes — rail, grid, detail — keeps the grid
+/// on screen while an album is open, so browsing a shelf of albums is a click
+/// each rather than a click and a trip back. Narrower windows push the same
+/// screen as a route, which is the phone behaviour and stays untouched.
+final List<Track> _tracks = <Track>[
+  for (int i = 0; i < 4; i++)
+    Track(
+      id: '$i',
+      title: 'Song $i',
+      uri: 'jellyfin:$i',
+      artistName: i.isEven ? 'Daft Punk' : 'Air',
+      albumName: i.isEven ? 'Discovery' : 'Moon Safari',
+      trackNumber: i + 1,
+    ),
+];
+
+/// Comfortably past `listDetailMinWidth` (460 + 600).
+const Size _paneWindow = Size(1280, 900);
+
+/// A window with room for the grid alone.
+const Size _narrowWindow = Size(800, 900);
+
+Future<void> _pumpLibrary(WidgetTester tester, Size size) async {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = size;
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        musicLibraryRepositoryProvider.overrideWithValue(
+          FakeMusicLibraryRepository(tracks: _tracks),
+        ),
+        playlistStoreProvider.overrideWithValue(InMemoryPlaylistStore()),
+        playbackControllerProvider.overrideWithValue(FakePlaybackController()),
+      ],
+      child: MaterialApp.router(
+        routerConfig: GoRouter(
+          initialLocation: AppRoutes.library,
+          routes: <RouteBase>[
+            GoRoute(
+              path: AppRoutes.library,
+              builder: (_, __) => const LibraryScreen(),
+            ),
+            GoRoute(
+              path: '/library/album/:id',
+              builder: (_, GoRouterState s) =>
+                  AlbumDetailScreen(albumId: s.pathParameters['id']!),
+            ),
+            GoRoute(
+              path: '/library/artist/:id',
+              builder: (_, GoRouterState s) =>
+                  ArtistDetailScreen(artistId: s.pathParameters['id']!),
+            ),
+            GoRoute(
+              path: AppRoutes.player,
+              builder: (_, __) => const PlayerScreen(),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> _openTab(WidgetTester tester, String tab) async {
+  await tester.tap(find.text(tab));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('Library detail pane', () {
+    testWidgets('a wide window opens an album beside the grid', (tester) async {
+      await _pumpLibrary(tester, _paneWindow);
+      await _openTab(tester, 'Albums');
+
+      expect(find.text('Pick an album to see its songs here.'), findsOneWidget);
+
+      await tester.tap(find.text('Discovery').first);
+      await tester.pumpAndSettle();
+
+      // The grid is still there beside the album's tracks.
+      expect(find.text('Moon Safari'), findsWidgets);
+      expect(find.byType(TrackTile), findsWidgets);
+      expect(
+        tester.getRect(find.byType(TrackTile).first).left,
+        greaterThan(tester.getRect(find.text('Moon Safari').first).left),
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('a second album replaces the pane without a trip back',
+        (tester) async {
+      await _pumpLibrary(tester, _paneWindow);
+      await _openTab(tester, 'Albums');
+
+      await tester.tap(find.text('Discovery').first);
+      await tester.pumpAndSettle();
+      expect(find.text('Song 0'), findsOneWidget);
+
+      await tester.tap(find.text('Moon Safari').first);
+      await tester.pumpAndSettle();
+      expect(find.text('Song 1'), findsOneWidget);
+      expect(find.text('Song 0'), findsNothing);
+    });
+
+    testWidgets('artists get the same pane', (tester) async {
+      await _pumpLibrary(tester, _paneWindow);
+      await _openTab(tester, 'Artists');
+
+      expect(
+        find.text('Pick an artist to see their albums here.'),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.text('Daft Punk').first);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Air'), findsWidgets);
+      expect(find.byType(TrackTile), findsWidgets);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('a narrow window pushes the detail as a page', (tester) async {
+      await _pumpLibrary(tester, _narrowWindow);
+      await _openTab(tester, 'Albums');
+
+      await tester.tap(find.text('Discovery').first);
+      await tester.pumpAndSettle();
+
+      // The grid is gone: this is the pushed route, not a pane.
+      expect(find.text('Moon Safari'), findsNothing);
+      expect(find.byType(TrackTile), findsWidgets);
+    });
+
+    testWidgets('narrowing hides the pane and keeps the selection',
+        (tester) async {
+      await _pumpLibrary(tester, _paneWindow);
+      await _openTab(tester, 'Albums');
+      await tester.tap(find.text('Discovery').first);
+      await tester.pumpAndSettle();
+      expect(find.text('Song 0'), findsOneWidget);
+
+      tester.view.physicalSize = _narrowWindow;
+      await tester.pumpAndSettle();
+
+      // Just the grid, at its narrow-window layout — and still on the Albums
+      // tab, not thrown back anywhere.
+      expect(find.text('Song 0'), findsNothing);
+      expect(find.text('Discovery'), findsWidgets);
+      expect(tester.takeException(), isNull);
+
+      tester.view.physicalSize = _paneWindow;
+      await tester.pumpAndSettle();
+      expect(find.text('Song 0'), findsOneWidget);
+    });
+
+    testWidgets('a search that hides the album clears the pane with it',
+        (tester) async {
+      await _pumpLibrary(tester, _paneWindow);
+      await _openTab(tester, 'Albums');
+      await tester.tap(find.text('Discovery').first);
+      await tester.pumpAndSettle();
+      expect(find.text('Song 0'), findsOneWidget);
+
+      await tester.enterText(find.byType(TextField), 'Moon');
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      // The pane cannot keep showing an album the grid beside it says is not
+      // there.
+      expect(find.text('Song 0'), findsNothing);
+      expect(find.text('Pick an album to see its songs here.'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/library/library_detail_pane_test.dart
+++ b/test/features/library/library_detail_pane_test.dart
@@ -244,6 +244,33 @@ void main() {
       expect(find.text('Song 1'), findsOneWidget);
     });
 
+    testWidgets('is ended by an action that finishes after the pane is gone',
+        (tester) async {
+      await _pumpLibrary(tester, _paneWindow);
+      await _openTab(tester, 'Albums');
+      await tester.tap(find.text('Discovery').first);
+      await tester.pumpAndSettle();
+
+      await ctrlClick(tester, 'Song 0');
+      expect(find.text('1 selected'), findsOneWidget);
+
+      await tester.tap(find.byTooltip('Add to playlist'));
+      await tester.pumpAndSettle();
+      expect(find.text('Add to playlist'), findsWidgets);
+
+      // The window narrows while the sheet is up: the detail screen goes, the
+      // sheet stays, and the selection it is acting on is the host's now.
+      await resizeTo(tester, _narrowWindow);
+      await tester.tapAt(const Offset(400, 20));
+      await tester.pumpAndSettle();
+
+      // Widening must not bring back a selection whose work is done.
+      await resizeTo(tester, _paneWindow);
+      expect(find.text('1 selected'), findsNothing);
+      expect(find.text('Song 0'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('artists keep their own, separate from the albums pane',
         (tester) async {
       await _pumpLibrary(tester, _paneWindow);

--- a/test/features/library/library_detail_pane_test.dart
+++ b/test/features/library/library_detail_pane_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -190,6 +191,78 @@ void main() {
       // there.
       expect(find.text('Song 0'), findsNothing);
       expect(find.text('Pick an album to see its songs here.'), findsOneWidget);
+    });
+  });
+
+  /// Dropping the pane unmounts the detail screen inside it, so anything that
+  /// screen held itself would go with it. A track selection has to outlive the
+  /// pane: narrowing the window is not something the user does to leave a
+  /// selection, and they cannot even see it happen while the pane is gone.
+  group('a selection in the pane', () {
+    Future<void> ctrlClick(WidgetTester tester, String title) async {
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.tap(find.text(title));
+      await tester.pumpAndSettle();
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    }
+
+    Future<void> resizeTo(WidgetTester tester, Size size) async {
+      tester.view.physicalSize = size;
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('survives the window narrowing past the pane and back',
+        (tester) async {
+      await _pumpLibrary(tester, _paneWindow);
+      await _openTab(tester, 'Albums');
+      await tester.tap(find.text('Discovery').first);
+      await tester.pumpAndSettle();
+
+      await ctrlClick(tester, 'Song 0');
+      expect(find.text('1 selected'), findsOneWidget);
+
+      await resizeTo(tester, _narrowWindow);
+      await resizeTo(tester, _paneWindow);
+
+      expect(find.text('1 selected'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('does not follow the pane onto another album', (tester) async {
+      await _pumpLibrary(tester, _paneWindow);
+      await _openTab(tester, 'Albums');
+      await tester.tap(find.text('Discovery').first);
+      await tester.pumpAndSettle();
+
+      await ctrlClick(tester, 'Song 0');
+      expect(find.text('1 selected'), findsOneWidget);
+
+      // A selection only means anything against the list it was made in.
+      await tester.tap(find.text('Moon Safari').first);
+      await tester.pumpAndSettle();
+      expect(find.text('1 selected'), findsNothing);
+      expect(find.text('Song 1'), findsOneWidget);
+    });
+
+    testWidgets('artists keep their own, separate from the albums pane',
+        (tester) async {
+      await _pumpLibrary(tester, _paneWindow);
+      await _openTab(tester, 'Artists');
+      await tester.tap(find.text('Daft Punk').first);
+      await tester.pumpAndSettle();
+
+      await ctrlClick(tester, 'Song 0');
+      expect(find.text('1 selected'), findsOneWidget);
+
+      await resizeTo(tester, _narrowWindow);
+      await resizeTo(tester, _paneWindow);
+      expect(find.text('1 selected'), findsOneWidget);
+
+      // The albums pane was never told about any of it.
+      await _openTab(tester, 'Albums');
+      await tester.tap(find.text('Discovery').first);
+      await tester.pumpAndSettle();
+      expect(find.text('1 selected'), findsNothing);
     });
   });
 }

--- a/test/features/library/modifier_selection_test.dart
+++ b/test/features/library/modifier_selection_test.dart
@@ -1,0 +1,184 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/download_repository_provider.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/library/library_screen.dart';
+import 'package:linthra/features/library/widgets/track_tile.dart';
+import 'package:linthra/features/player/player_providers.dart';
+
+import '../player/fake_playback_controller.dart';
+import 'fake_music_library_repository.dart';
+import 'fake_remote_track_downloader.dart';
+
+/// Ctrl and Shift clicking in the songs list (#387). The rules are the ones
+/// every desktop list has: Ctrl picks one row out (and starts a selection when
+/// there is none), Shift takes everything between, and a plain click still
+/// plays.
+final List<Track> _songs = <Track>[
+  for (int i = 0; i < 6; i++)
+    Track(
+      id: 'song-$i',
+      title: 'Song ${i.toString().padLeft(2, '0')}',
+      uri: 'jellyfin:song-$i',
+    ),
+];
+
+Future<void> _pump(WidgetTester tester) async {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = const Size(1000, 900);
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        musicLibraryRepositoryProvider
+            .overrideWithValue(FakeMusicLibraryRepository(tracks: _songs)),
+        remoteTrackDownloaderProvider
+            .overrideWithValue(FakeRemoteTrackDownloader()),
+        playbackControllerProvider.overrideWithValue(FakePlaybackController()),
+      ],
+      child: const MaterialApp(home: LibraryScreen()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> _clickWith(
+  WidgetTester tester,
+  String title, {
+  LogicalKeyboardKey? modifier,
+}) async {
+  if (modifier != null) await tester.sendKeyDownEvent(modifier);
+  await tester.tap(find.text(title));
+  await tester.pumpAndSettle();
+  if (modifier != null) await tester.sendKeyUpEvent(modifier);
+}
+
+/// The titles of the rows currently drawn as selected.
+List<String> _selectedTitles(WidgetTester tester) {
+  return <String>[
+    for (final TrackTile tile in tester.widgetList<TrackTile>(
+      find.byType(TrackTile),
+    ))
+      if (tile.selected) tile.tracks[tile.index].title,
+  ]..sort();
+}
+
+FakePlaybackController _controller(WidgetTester tester) {
+  return ProviderScope.containerOf(
+    tester.element(find.byType(LibraryScreen)),
+  ).read(playbackControllerProvider) as FakePlaybackController;
+}
+
+void main() {
+  group('Ctrl and Shift selection', () {
+    testWidgets('Ctrl-click starts a selection and adds to it', (tester) async {
+      await _pump(tester);
+
+      await _clickWith(tester, 'Song 01',
+          modifier: LogicalKeyboardKey.controlLeft);
+      expect(_selectedTitles(tester), <String>['Song 01']);
+      // A selection is running: the app bar is the selection one now.
+      expect(find.text('1 selected'), findsOneWidget);
+      // …and nothing started playing.
+      expect(_controller(tester).state.currentTrack, isNull);
+
+      await _clickWith(tester, 'Song 03',
+          modifier: LogicalKeyboardKey.controlLeft);
+      expect(_selectedTitles(tester), <String>['Song 01', 'Song 03']);
+      expect(find.text('2 selected'), findsOneWidget);
+    });
+
+    testWidgets('Ctrl-click takes a row back out again', (tester) async {
+      await _pump(tester);
+
+      await _clickWith(tester, 'Song 01',
+          modifier: LogicalKeyboardKey.controlLeft);
+      await _clickWith(tester, 'Song 01',
+          modifier: LogicalKeyboardKey.controlLeft);
+
+      expect(_selectedTitles(tester), isEmpty);
+      // The last row out ends the selection rather than leaving an empty one.
+      expect(find.text('0 selected'), findsNothing);
+      expect(find.text('Library'), findsOneWidget);
+    });
+
+    testWidgets('Shift-click takes everything between', (tester) async {
+      await _pump(tester);
+
+      await _clickWith(tester, 'Song 01',
+          modifier: LogicalKeyboardKey.controlLeft);
+      await _clickWith(tester, 'Song 04',
+          modifier: LogicalKeyboardKey.shiftLeft);
+
+      expect(
+        _selectedTitles(tester),
+        <String>['Song 01', 'Song 02', 'Song 03', 'Song 04'],
+      );
+      expect(find.text('4 selected'), findsOneWidget);
+    });
+
+    testWidgets('Shift-click on its own picks just that row', (tester) async {
+      await _pump(tester);
+
+      await _clickWith(tester, 'Song 02',
+          modifier: LogicalKeyboardKey.shiftLeft);
+
+      // No anchor to measure from, so extending from nowhere is a plain pick
+      // rather than an arbitrary run.
+      expect(_selectedTitles(tester), <String>['Song 02']);
+    });
+
+    testWidgets('a plain click still plays, even mid-selection',
+        (tester) async {
+      await _pump(tester);
+
+      await _clickWith(tester, 'Song 01',
+          modifier: LogicalKeyboardKey.controlLeft);
+      expect(_controller(tester).state.currentTrack, isNull);
+
+      // Inside a selection a plain click still toggles, as it always has —
+      // that is the mobile behaviour and it does not move.
+      await _clickWith(tester, 'Song 02');
+      expect(_selectedTitles(tester), <String>['Song 01', 'Song 02']);
+      expect(_controller(tester).state.currentTrack, isNull);
+    });
+
+    testWidgets('Escape leaves the selection', (tester) async {
+      await _pump(tester);
+
+      await _clickWith(tester, 'Song 01',
+          modifier: LogicalKeyboardKey.controlLeft);
+      expect(find.text('1 selected'), findsOneWidget);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pumpAndSettle();
+
+      expect(_selectedTitles(tester), isEmpty);
+      expect(find.text('Library'), findsOneWidget);
+    });
+
+    testWidgets('the selection survives a catalog refresh', (tester) async {
+      await _pump(tester);
+
+      await _clickWith(tester, 'Song 01',
+          modifier: LogicalKeyboardKey.controlLeft);
+      await _clickWith(tester, 'Song 03',
+          modifier: LogicalKeyboardKey.shiftLeft);
+      expect(find.text('3 selected'), findsOneWidget);
+
+      // A harmless rebuild — the kind a download finishing or a sync tick
+      // causes — must not drop what the user picked.
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      expect(
+        _selectedTitles(tester),
+        <String>['Song 01', 'Song 02', 'Song 03'],
+      );
+    });
+  });
+}

--- a/test/features/library/track_selection_test.dart
+++ b/test/features/library/track_selection_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/features/library/track_selection.dart';
+
+/// The awkward halves of desktop multi-select (#387): an anchor for a row that
+/// has since been filtered out, a range dragged backwards, and a selection that
+/// outlives the tracks it named. All of it decided here, where it can be
+/// checked without pumping a list.
+List<Track> _tracks(int count, {String provider = 'jellyfin'}) => <Track>[
+      for (int i = 0; i < count; i++)
+        Track(id: '$i', title: 'Song $i', uri: '$provider:$i'),
+    ];
+
+List<String> _titles(List<Track> tracks) =>
+    <String>[for (final Track track in tracks) track.title];
+
+void main() {
+  group('TrackSelection', () {
+    test('starts empty', () {
+      final TrackSelection selection = TrackSelection();
+      expect(selection.isActive, isFalse);
+      expect(selection.length, 0);
+      expect(selection.anchorUri, isNull);
+    });
+
+    test('a long-press replaces whatever was picked', () {
+      final List<Track> tracks = _tracks(4);
+      final TrackSelection selection = TrackSelection()
+        ..toggle(tracks[0])
+        ..toggle(tracks[1])
+        ..start(tracks[3]);
+
+      expect(_titles(selection.resolve(tracks)), <String>['Song 3']);
+      expect(selection.anchorUri, tracks[3].uri);
+    });
+
+    test('Ctrl-click adds and removes one row at a time', () {
+      final List<Track> tracks = _tracks(4);
+      final TrackSelection selection = TrackSelection()
+        ..toggle(tracks[0])
+        ..toggle(tracks[2]);
+      expect(_titles(selection.resolve(tracks)), <String>['Song 0', 'Song 2']);
+
+      selection.toggle(tracks[0]);
+      expect(_titles(selection.resolve(tracks)), <String>['Song 2']);
+
+      selection.toggle(tracks[2]);
+      expect(selection.isActive, isFalse);
+      // Nothing left to extend from.
+      expect(selection.anchorUri, isNull);
+    });
+
+    test('Shift-click takes everything between, in either direction', () {
+      final List<Track> tracks = _tracks(6);
+      final TrackSelection down = TrackSelection()
+        ..start(tracks[1])
+        ..extendTo(tracks, 4);
+      expect(
+        _titles(down.resolve(tracks)),
+        <String>['Song 1', 'Song 2', 'Song 3', 'Song 4'],
+      );
+
+      final TrackSelection up = TrackSelection()
+        ..start(tracks[4])
+        ..extendTo(tracks, 1);
+      expect(
+        _titles(up.resolve(tracks)),
+        <String>['Song 1', 'Song 2', 'Song 3', 'Song 4'],
+      );
+    });
+
+    test('the anchor stays put, so a range can be dragged back', () {
+      final List<Track> tracks = _tracks(6);
+      final TrackSelection selection = TrackSelection()
+        ..start(tracks[1])
+        ..extendTo(tracks, 5)
+        ..extendTo(tracks, 2);
+
+      expect(selection.anchorUri, tracks[1].uri);
+      // Everything reached so far stays picked: extending never un-picks, which
+      // is what makes Ctrl-click the way to drop a row.
+      expect(selection.length, 5);
+    });
+
+    test('Shift-click with no anchor is just a click', () {
+      final List<Track> tracks = _tracks(4);
+      final TrackSelection selection = TrackSelection()..extendTo(tracks, 2);
+
+      expect(_titles(selection.resolve(tracks)), <String>['Song 2']);
+      expect(selection.anchorUri, tracks[2].uri);
+    });
+
+    test('an anchor filtered out of the list cannot select a stray run', () {
+      final List<Track> all = _tracks(6);
+      final TrackSelection selection = TrackSelection()..start(all[0]);
+
+      // The search narrowed the list, and the anchored row is no longer in it.
+      final List<Track> filtered = <Track>[all[3], all[4], all[5]];
+      selection.extendTo(filtered, 2);
+
+      expect(_titles(selection.resolve(filtered)), <String>['Song 5']);
+    });
+
+    test('an index outside the list does nothing', () {
+      final List<Track> tracks = _tracks(3);
+      final TrackSelection selection = TrackSelection()..start(tracks[0]);
+
+      selection
+        ..extendTo(tracks, 7)
+        ..extendTo(tracks, -1)
+        ..extendTo(<Track>[], 0);
+
+      expect(_titles(selection.resolve(tracks)), <String>['Song 0']);
+    });
+
+    test('a bulk action only ever sees rows that are still in the list', () {
+      final List<Track> tracks = _tracks(4);
+      final TrackSelection selection = TrackSelection()
+        ..start(tracks[0])
+        ..extendTo(tracks, 3);
+
+      // Two of them have since been removed from the catalog.
+      final List<Track> remaining = <Track>[tracks[1], tracks[2]];
+      expect(
+          _titles(selection.resolve(remaining)), <String>['Song 1', 'Song 2']);
+    });
+
+    test('resolve returns rows in the list order, not the click order', () {
+      final List<Track> tracks = _tracks(4);
+      final TrackSelection selection = TrackSelection()
+        ..toggle(tracks[3])
+        ..toggle(tracks[0])
+        ..toggle(tracks[2]);
+
+      expect(
+        _titles(selection.resolve(tracks)),
+        <String>['Song 0', 'Song 2', 'Song 3'],
+      );
+    });
+
+    test('two providers’ same-id copies are different rows', () {
+      final List<Track> jellyfin = _tracks(2);
+      final List<Track> subsonic = _tracks(2, provider: 'subsonic');
+      final TrackSelection selection = TrackSelection()..toggle(jellyfin[0]);
+
+      expect(selection.contains(jellyfin[0].uri), isTrue);
+      expect(selection.contains(subsonic[0].uri), isFalse);
+      expect(selection.resolve(subsonic), isEmpty);
+    });
+
+    test('clearing forgets the anchor too', () {
+      final List<Track> tracks = _tracks(4);
+      final TrackSelection selection = TrackSelection()
+        ..start(tracks[1])
+        ..clear();
+
+      expect(selection.isActive, isFalse);
+      expect(selection.anchorUri, isNull);
+
+      // …so the next Shift-click starts a fresh selection rather than reaching
+      // back to a row from before.
+      selection.extendTo(tracks, 3);
+      expect(_titles(selection.resolve(tracks)), <String>['Song 3']);
+    });
+  });
+}

--- a/test/features/player/mini_player_seek_test.dart
+++ b/test/features/player/mini_player_seek_test.dart
@@ -80,7 +80,8 @@ void main() {
       expect(seeks, hasLength(1));
       // The exact millisecond depends on the marker inset the painter reserves,
       // so this pins the quarter it landed in rather than a hard-coded value.
-      expect(seeks.single, greaterThan(const Duration(minutes: 2, seconds: 40)));
+      expect(
+          seeks.single, greaterThan(const Duration(minutes: 2, seconds: 40)));
       expect(seeks.single, lessThan(const Duration(minutes: 3, seconds: 20)));
     });
 

--- a/test/features/player/mini_player_seek_test.dart
+++ b/test/features/player/mini_player_seek_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/data/repositories/host_platform_provider.dart';
+import 'package:linthra/features/player/mini_player.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/widgets/playback_progress_bar.dart';
+
+import 'fake_playback_controller.dart';
+
+/// The now-playing bar's top edge is a readout on a phone and a control on a
+/// desktop. That split is the whole point: a pointer can aim at a slim line and
+/// a thumb cannot, and on a phone that strip is exactly where a thumb lands
+/// reaching for the bar itself.
+const _track = Track(
+  id: '1',
+  title: 'Song One',
+  uri: 'subsonic:1',
+  artistName: 'Artist A',
+  albumName: 'Album B',
+);
+
+const _state = PlaybackState(
+  status: PlaybackStatus.playing,
+  currentTrack: _track,
+  position: Duration.zero,
+  duration: Duration(minutes: 4),
+);
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required HostPlatform host,
+  double width = 1280,
+}) async {
+  tester.view.devicePixelRatio = 1;
+  tester.view.physicalSize = Size(width, 800);
+  addTearDown(tester.view.resetDevicePixelRatio);
+  addTearDown(tester.view.resetPhysicalSize);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        hostPlatformProvider.overrideWithValue(host),
+        playbackControllerProvider
+            .overrideWithValue(FakePlaybackController(initial: _state)),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(
+          body: SizedBox.expand(),
+          bottomNavigationBar: MiniPlayer(),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+FakePlaybackController _controller(WidgetTester tester) {
+  return ProviderScope.containerOf(
+    tester.element(find.byType(MiniPlayer)),
+  ).read(playbackControllerProvider) as FakePlaybackController;
+}
+
+void main() {
+  group('MiniPlayer seeking', () {
+    testWidgets('a click along the line seeks there on a desktop host',
+        (tester) async {
+      await _pump(tester, host: HostPlatform.linux);
+
+      final Rect bar = tester.getRect(find.byType(PlaybackProgressBar));
+      // Three quarters of the way along a four-minute track.
+      await tester.tapAt(Offset(bar.left + bar.width * 0.75, bar.center.dy));
+      await tester.pumpAndSettle();
+
+      final List<Duration> seeks = _controller(tester).seeks;
+      expect(seeks, hasLength(1));
+      // The exact millisecond depends on the marker inset the painter reserves,
+      // so this pins the quarter it landed in rather than a hard-coded value.
+      expect(seeks.single, greaterThan(const Duration(minutes: 2, seconds: 40)));
+      expect(seeks.single, lessThan(const Duration(minutes: 3, seconds: 20)));
+    });
+
+    testWidgets('the arrow keys seek once the line has focus', (tester) async {
+      await _pump(tester, host: HostPlatform.linux);
+
+      final Rect bar = tester.getRect(find.byType(PlaybackProgressBar));
+      // Clicking hands the line the keyboard, exactly as it does in the full
+      // player, so the arrows carry on from where the pointer left off.
+      await tester.tapAt(Offset(bar.left + 1, bar.center.dy));
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pumpAndSettle();
+
+      final List<Duration> seeks = _controller(tester).seeks;
+      expect(seeks, hasLength(2));
+      // 5% of four minutes, forward from the start the click set.
+      expect(seeks.last, greaterThan(seeks.first));
+      expect(seeks.last, lessThan(const Duration(seconds: 30)));
+    });
+
+    testWidgets('a touch host keeps the plain, unseekable line',
+        (tester) async {
+      await _pump(tester, host: HostPlatform.android, width: 411);
+
+      expect(find.byType(PlaybackProgressBar), findsNothing);
+      expect(_controller(tester).seeks, isEmpty);
+    });
+
+    testWidgets('a wide touch window is still not a seek surface',
+        (tester) async {
+      // Width alone must not turn it into a control: an Android tablet in
+      // landscape is as wide as a desktop window and still driven by a thumb.
+      await _pump(tester, host: HostPlatform.android, width: 1280);
+
+      expect(find.byType(PlaybackProgressBar), findsNothing);
+    });
+  });
+}

--- a/test/features/player/playback_progress_bar_test.dart
+++ b/test/features/player/playback_progress_bar_test.dart
@@ -22,6 +22,7 @@ Future<List<Duration>> _pumpBar(
   bool seekable = true,
   bool playing = false,
   PlaybackProgressStyle style = PlaybackProgressStyle.wave,
+  WavySeekBarDensity density = WavySeekBarDensity.standard,
   List<Duration>? seeks,
 }) async {
   seeks ??= <Duration>[];
@@ -36,6 +37,7 @@ Future<List<Duration>> _pumpBar(
               duration: duration,
               playing: playing,
               style: style,
+              density: density,
               onSeek: seekable ? seeks.add : null,
               // Keyed so a re-pump with a new position updates this bar rather
               // than replacing it — the state under test has to survive.
@@ -417,6 +419,68 @@ void main() {
       expect(slider.label, 'Playback position');
       expect(slider.value, 'Unknown');
       handle.dispose();
+    });
+
+    // Flipping defaultPlaybackProgressStyle back to the slider is meant to be a
+    // one-constant change. The mini player asks for a compact bar and keeps 64dp
+    // for the whole thing, so a fallback that ignored the density would take the
+    // room its transport row needs.
+    //
+    // Both densities are pumped in one tree: the Material slider only repaints
+    // when its theme changes, so measuring one after the other in the same
+    // element would read the first one's size twice.
+    testWidgets('a compact slider still fits the mini player', (tester) async {
+      final List<Duration> seeks = <Duration>[];
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Row(
+              children: <Widget>[
+                for (final WavySeekBarDensity density
+                    in WavySeekBarDensity.values)
+                  SizedBox(
+                    width: _barWidth,
+                    child: PlaybackProgressBar(
+                      key: ValueKey<WavySeekBarDensity>(density),
+                      position: Duration.zero,
+                      duration: _total,
+                      style: PlaybackProgressStyle.slider,
+                      density: density,
+                      onSeek: seeks.add,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      double heightOf(WavySeekBarDensity density) => tester
+          .getSize(
+            find.descendant(
+              of: find.byKey(ValueKey<WavySeekBarDensity>(density)),
+              matching: find.byType(Slider),
+            ),
+          )
+          .height;
+
+      final double compact = heightOf(WavySeekBarDensity.compact);
+      expect(compact, lessThan(heightOf(WavySeekBarDensity.standard)));
+      // 64dp bar, 48dp of transport buttons under it.
+      expect(compact, lessThanOrEqualTo(16));
+
+      // Still a seek bar, not just a thinner drawing of one.
+      await tester.tap(
+        find.descendant(
+          of: find.byKey(
+            const ValueKey<WavySeekBarDensity>(WavySeekBarDensity.compact),
+          ),
+          matching: find.byType(Slider),
+        ),
+      );
+      await tester.pump();
+      expect(seeks, hasLength(1));
     });
   });
 }

--- a/test/features/player/player_queue_pane_test.dart
+++ b/test/features/player/player_queue_pane_test.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/lyrics.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/lyrics_service.dart';
+import 'package:linthra/features/player/lyrics_providers.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/player_screen.dart';
+import 'package:linthra/features/player/widgets/album_artwork.dart';
+import 'package:linthra/features/player/widgets/lyrics_view.dart';
+import 'package:linthra/features/player/widgets/queue_sheet.dart';
+
+import 'fake_playback_controller.dart';
+
+/// A window wide enough for a third column shows the queue beside the cover
+/// instead of over it — the point of the width being that lyrics and up-next
+/// are readable at the same time. Narrower windows keep the sheet, so the queue
+/// is reachable at every size, and the pane never squeezes the cover and the
+/// transport to make room for itself.
+class _FakeLyricsService implements LyricsService {
+  _FakeLyricsService(this._lyrics);
+
+  final Lyrics? _lyrics;
+
+  @override
+  Future<Lyrics?> lyricsFor(Track track) async => _lyrics;
+}
+
+const Track _track = Track(
+  id: '1',
+  title: 'Song One',
+  uri: '/music/song1.mp3',
+  artistName: 'Artist A',
+  albumName: 'Album B',
+);
+
+const Track _next = Track(
+  id: '2',
+  title: 'Song Two',
+  uri: '/music/song2.mp3',
+  artistName: 'Artist A',
+);
+
+const Lyrics _lyrics = Lyrics(
+  lines: <LyricLine>[
+    LyricLine(text: 'First line'),
+    LyricLine(text: 'Second line'),
+  ],
+);
+
+/// Just above `_queuePaneMinWidth` (1000 + 340 + 24).
+const Size _paneWindow = Size(1400, 900);
+
+/// A desktop window that is wide enough for two columns but not three.
+const Size _twoColumnWindow = Size(1280, 800);
+
+Future<void> _pumpPlayer(WidgetTester tester, {required Size size}) async {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = size;
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        playbackControllerProvider.overrideWithValue(
+          FakePlaybackController(
+            initial: const PlaybackState(
+              status: PlaybackStatus.playing,
+              currentTrack: _track,
+              upNext: <Track>[_next],
+            ),
+          ),
+        ),
+        lyricsServiceProvider.overrideWithValue(_FakeLyricsService(_lyrics)),
+      ],
+      child: const MaterialApp(home: PlayerScreen()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> _resize(WidgetTester tester, Size size) async {
+  tester.view.physicalSize = size;
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('Now Playing queue pane', () {
+    testWidgets('a wide window opens the queue beside the cover',
+        (tester) async {
+      await _pumpPlayer(tester, size: _paneWindow);
+
+      expect(find.byType(QueueSheet), findsNothing);
+      await tester.tap(find.byTooltip('Show queue'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(QueueSheet), findsOneWidget);
+      // A pane, not a sheet: nothing is covering the rest of the screen.
+      expect(find.byType(BottomSheet), findsNothing);
+      expect(
+        tester.getRect(find.byType(AlbumArtwork).first).right,
+        lessThanOrEqualTo(tester.getRect(find.byType(QueueSheet)).left),
+      );
+      expect(find.text('Song Two'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('lyrics and the queue sit side by side', (tester) async {
+      await _pumpPlayer(tester, size: _paneWindow);
+
+      await tester.tap(find.byTooltip('Show queue'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byTooltip('Lyrics'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(LyricsView), findsOneWidget);
+      expect(find.byType(QueueSheet), findsOneWidget);
+      expect(
+        tester.getRect(find.byType(LyricsView)).right,
+        lessThanOrEqualTo(tester.getRect(find.byType(QueueSheet)).left),
+      );
+      // The transport is still where it was, under both of them.
+      expect(find.byTooltip('Pause'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('the toggle closes it again', (tester) async {
+      await _pumpPlayer(tester, size: _paneWindow);
+
+      await tester.tap(find.byTooltip('Show queue'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byTooltip('Hide queue'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(QueueSheet), findsNothing);
+      expect(find.byTooltip('Show queue'), findsOneWidget);
+    });
+
+    testWidgets('narrowing hides the pane and widening brings it back',
+        (tester) async {
+      await _pumpPlayer(tester, size: _paneWindow);
+
+      await tester.tap(find.byTooltip('Show queue'));
+      await tester.pumpAndSettle();
+      expect(find.byType(QueueSheet), findsOneWidget);
+
+      await _resize(tester, _twoColumnWindow);
+      expect(find.byType(QueueSheet), findsNothing);
+      // Playback is untouched, and the queue is still reachable as a sheet.
+      expect(find.byTooltip('Pause'), findsOneWidget);
+      expect(find.byTooltip('Queue'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+
+      await _resize(tester, _paneWindow);
+      expect(find.byType(QueueSheet), findsOneWidget);
+    });
+
+    testWidgets('a window without room for a third column keeps the sheet',
+        (tester) async {
+      await _pumpPlayer(tester, size: _twoColumnWindow);
+
+      expect(find.byTooltip('Show queue'), findsNothing);
+      await tester.tap(find.byTooltip('Queue'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(BottomSheet), findsOneWidget);
+      expect(find.byType(QueueSheet), findsOneWidget);
+    });
+
+    testWidgets('a phone keeps the sheet too', (tester) async {
+      await _pumpPlayer(tester, size: const Size(390, 844));
+
+      await tester.tap(find.byTooltip('Queue'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(BottomSheet), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+  });
+}

--- a/test/features/player/player_queue_pane_test.dart
+++ b/test/features/player/player_queue_pane_test.dart
@@ -3,8 +3,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/lyrics.dart';
 import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/playlist.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/services/lyrics_service.dart';
+import 'package:linthra/data/repositories/in_memory_playlist_store.dart';
+import 'package:linthra/data/repositories/playlist_repository_provider.dart';
 import 'package:linthra/features/player/lyrics_providers.dart';
 import 'package:linthra/features/player/player_providers.dart';
 import 'package:linthra/features/player/player_screen.dart';
@@ -56,7 +59,11 @@ const Size _paneWindow = Size(1400, 900);
 /// A desktop window that is wide enough for two columns but not three.
 const Size _twoColumnWindow = Size(1280, 800);
 
-Future<void> _pumpPlayer(WidgetTester tester, {required Size size}) async {
+Future<void> _pumpPlayer(
+  WidgetTester tester, {
+  required Size size,
+  InMemoryPlaylistStore? store,
+}) async {
   tester.view.devicePixelRatio = 1.0;
   tester.view.physicalSize = size;
   addTearDown(tester.view.reset);
@@ -74,6 +81,7 @@ Future<void> _pumpPlayer(WidgetTester tester, {required Size size}) async {
           ),
         ),
         lyricsServiceProvider.overrideWithValue(_FakeLyricsService(_lyrics)),
+        if (store != null) playlistStoreProvider.overrideWithValue(store),
       ],
       child: const MaterialApp(home: PlayerScreen()),
     ),
@@ -176,6 +184,38 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(BottomSheet), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    /// As a sheet the queue is a route and outlives its own dialogs. As a pane
+    /// it is just a widget in the layout, and narrowing the window takes it off
+    /// screen mid-action — with the name prompt still up on top.
+    testWidgets('saving survives the pane closing under the dialog',
+        (tester) async {
+      final InMemoryPlaylistStore store = InMemoryPlaylistStore();
+      await _pumpPlayer(tester, size: _paneWindow, store: store);
+
+      await tester.tap(find.byTooltip('Show queue'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byTooltip('Save queue as playlist'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField).first, 'My Queue');
+      await tester.pumpAndSettle();
+
+      // The window narrows while the prompt is open: the pane goes, the dialog
+      // stays.
+      await _resize(tester, _twoColumnWindow);
+      expect(find.byType(QueueSheet), findsNothing);
+      expect(find.text('Create'), findsOneWidget);
+
+      await tester.tap(find.text('Create'));
+      await tester.pumpAndSettle();
+
+      final List<Playlist> saved = await store.load();
+      expect(saved, hasLength(1));
+      expect(saved.single.name, 'My Queue');
+      expect(saved.single.trackIds, <String>[_track.uri, _next.uri]);
       expect(tester.takeException(), isNull);
     });
   });

--- a/test/shared/context_menu_anchor_test.dart
+++ b/test/shared/context_menu_anchor_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/shared/widgets/context_menu_region.dart';
+
+/// A context menu has to open where it was asked for (#386).
+///
+/// `showMenu` reads its position in the coordinate space of the nearest
+/// [Overlay], not in screen coordinates — and inside the desktop shell that
+/// overlay is the branch navigator's, which starts after the navigation rail.
+/// Handing it a raw global position therefore slides every menu across by the
+/// rail's width, and clamps it against the wrong bounds near the right edge.
+///
+/// This pumps the same shape the shell has: a fixed-width column, then a
+/// [Navigator] (which brings its own Overlay) holding the row.
+const double _railWidth = 200;
+
+Future<void> _pump(WidgetTester tester) async {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = const Size(1000, 600);
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Row(
+          children: <Widget>[
+            const SizedBox(
+                width: _railWidth,
+                child: ColoredBox(
+                  color: Color(0xFF202020),
+                )),
+            Expanded(
+              child: Navigator(
+                onGenerateRoute: (RouteSettings settings) {
+                  return MaterialPageRoute<void>(
+                    builder: (BuildContext context) =>
+                        ContextMenuRegion<String>(
+                      itemBuilder: (BuildContext context) =>
+                          const <PopupMenuEntry<String>>[
+                        PopupMenuItem<String>(
+                          value: 'a',
+                          child: Text('Play next'),
+                        ),
+                      ],
+                      onSelected: (_) {},
+                      child: const Focus(
+                        autofocus: true,
+                        child: SizedBox.expand(
+                          child: Center(child: Text('row')),
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> _rightClickAt(WidgetTester tester, Offset where) async {
+  final TestGesture gesture = await tester.startGesture(
+    where,
+    kind: PointerDeviceKind.mouse,
+    buttons: kSecondaryMouseButton,
+  );
+  await gesture.up();
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('ContextMenuRegion anchoring', () {
+    testWidgets('opens at the pointer, not shifted by the rail beside it',
+        (tester) async {
+      await _pump(tester);
+
+      const Offset click = Offset(400, 300);
+      await _rightClickAt(tester, click);
+
+      expect(find.text('Play next'), findsOneWidget);
+      final Rect menu = tester.getRect(find.text('Play next'));
+      // Menus get padding and can be nudged to fit, but they open *at* the
+      // pointer: anything near the rail's width away is the overlay offset
+      // leaking into the anchor.
+      expect((menu.left - click.dx).abs(), lessThan(_railWidth / 2));
+    });
+
+    testWidgets('a keyboard-opened menu lands on its row too', (tester) async {
+      await _pump(tester);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.contextMenu);
+      await tester.pumpAndSettle();
+
+      // The row fills everything right of the rail, so the menu key opens the
+      // menu at the middle of that remaining space — measured the same way.
+      final double rowCentreX = tester.getCenter(find.text('row')).dx;
+      expect(find.text('Play next'), findsOneWidget);
+      final Rect menu = tester.getRect(find.text('Play next'));
+      expect((menu.left - rowCentreX).abs(), lessThan(_railWidth / 2));
+    });
+
+    testWidgets('a click near the right edge stays on screen', (tester) async {
+      await _pump(tester);
+
+      await _rightClickAt(tester, const Offset(980, 300));
+
+      expect(find.text('Play next'), findsOneWidget);
+      final Rect menu = tester.getRect(find.byType(PopupMenuItem<String>));
+      expect(menu.right, lessThanOrEqualTo(1000));
+      expect(menu.left, greaterThanOrEqualTo(0));
+    });
+  });
+}

--- a/test/shared/context_menu_lifecycle_test.dart
+++ b/test/shared/context_menu_lifecycle_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/shared/widgets/context_menu_region.dart';
+
+/// A menu is a route, so it outlives the surface that opened it (#386).
+///
+/// Inside the desktop shell that surface can be a pane, and a pane goes away on
+/// an ordinary resize. The popup stays up on the navigator, so a pick can land
+/// after the row that offered it has been unmounted, and everything the action
+/// would reach for (the row's ref, an ancestor to hang a dialog on) has gone
+/// with it.
+class _Host extends StatefulWidget {
+  const _Host({required this.onSelected, super.key});
+
+  final ValueChanged<String> onSelected;
+
+  @override
+  State<_Host> createState() => _HostState();
+}
+
+class _HostState extends State<_Host> {
+  bool _showRegion = true;
+
+  /// Stands in for the resize that drops the pane.
+  void removeRegion() => setState(() => _showRegion = false);
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_showRegion) return const Center(child: Text('pane gone'));
+    return ContextMenuRegion<String>(
+      itemBuilder: (BuildContext context) => const <PopupMenuEntry<String>>[
+        PopupMenuItem<String>(value: 'a', child: Text('Play next')),
+      ],
+      onSelected: widget.onSelected,
+      child: const SizedBox.expand(child: Center(child: Text('row'))),
+    );
+  }
+}
+
+void main() {
+  testWidgets('a pick that lands after the region is gone is dropped',
+      (tester) async {
+    final List<String> picked = <String>[];
+    final GlobalKey<_HostState> key = GlobalKey<_HostState>();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: _Host(key: key, onSelected: picked.add)),
+      ),
+    );
+
+    final TestGesture gesture = await tester.startGesture(
+      tester.getCenter(find.text('row')),
+      kind: PointerDeviceKind.mouse,
+      buttons: kSecondaryMouseButton,
+    );
+    await gesture.up();
+    await tester.pumpAndSettle();
+    expect(find.text('Play next'), findsOneWidget);
+
+    // The window crosses a pane threshold: the row is unmounted, the menu is
+    // still up on top of what replaced it.
+    key.currentState!.removeRegion();
+    await tester.pumpAndSettle();
+    expect(find.text('pane gone'), findsOneWidget);
+    expect(find.text('Play next'), findsOneWidget);
+
+    await tester.tap(find.text('Play next'));
+    await tester.pumpAndSettle();
+
+    // Nothing dispatched into the dead tree, and nothing thrown.
+    expect(picked, isEmpty);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('a pick on a region that is still there runs as usual',
+      (tester) async {
+    final List<String> picked = <String>[];
+
+    await tester.pumpWidget(
+      MaterialApp(home: Scaffold(body: _Host(onSelected: picked.add))),
+    );
+
+    final TestGesture gesture = await tester.startGesture(
+      tester.getCenter(find.text('row')),
+      kind: PointerDeviceKind.mouse,
+      buttons: kSecondaryMouseButton,
+    );
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Play next'));
+    await tester.pumpAndSettle();
+
+    expect(picked, <String>['a']);
+  });
+}

--- a/test/tooling/check_linux_runner_test.py
+++ b/test/tooling/check_linux_runner_test.py
@@ -100,6 +100,13 @@ static constexpr int kMinimumWindowHeight = 600;
 
 static void activate() {{
   self->folder_picker = folder_picker_channel_new(view, window);
+  self->window_state =
+      window_state_store_new(window, kMinimumWindowWidth, kMinimumWindowHeight,
+                             kDefaultWindowWidth, kDefaultWindowHeight);
+}}
+
+static void my_application_shutdown(GApplication* application) {{
+  window_state_store_save(self->window_state);
 }}
 
 static void my_application_startup(GApplication* application) {{
@@ -125,7 +132,11 @@ add_executable(${{BINARY_NAME}}
   "main.cc"
   "my_application.cc"
   "folder_picker_channel.cc"
+  "window_state_store.cc"
+  "${{CMAKE_SOURCE_DIR}}/../native/linthra_desktop/src/window_state.cpp"
 )
+
+target_compile_features(${{BINARY_NAME}} PUBLIC cxx_std_17)
 """
 
 # The two halves of the folder-picker channel, reduced to the strings the
@@ -1399,6 +1410,83 @@ class MissingFileTest(CheckoutCase):
 
     def test_main_reports_a_read_failure_as_exit_two(self) -> None:
         self.assertEqual(checker.main(["--root", str(self.root)]), 2)
+
+
+class WindowStateWiringTest(CheckoutCase):
+    """The window-state wiring (#383), which fails silently when it breaks.
+
+    Every case below still compiles and still launches. The window simply stops
+    remembering its size, which is exactly the kind of regression a template
+    regeneration or a careless merge produces.
+    """
+
+    def test_a_consistent_checkout_is_accepted(self) -> None:
+        build_checkout(self.root)
+        self.assertEqual(checker.check(self.root), [])
+
+    def test_dropping_the_store_from_the_runner_build_is_caught(self) -> None:
+        build_checkout(
+            self.root,
+            runner_cmakelists=RUNNER_CMAKELISTS.replace(
+                '  "window_state_store.cc"\n', ""
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("window_state_store.cc", problems[0])
+
+    def test_dropping_the_policy_source_is_caught(self) -> None:
+        build_checkout(
+            self.root,
+            runner_cmakelists=RUNNER_CMAKELISTS.replace(
+                '  "${{CMAKE_SOURCE_DIR}}/../native/linthra_desktop/src/'
+                'window_state.cpp"\n',
+                "",
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("window_state.cpp", problems[0])
+
+    def test_dropping_cxx_std_17_is_caught(self) -> None:
+        # The policy is C++17; without the explicit requirement the runner
+        # compiles at whatever the host compiler defaults to, which is a build
+        # that breaks somewhere else rather than here.
+        build_checkout(
+            self.root,
+            runner_cmakelists=RUNNER_CMAKELISTS.replace(
+                "target_compile_features(${{BINARY_NAME}} PUBLIC "
+                "cxx_std_17)\n",
+                "",
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("cxx_std_17", problems[0])
+
+    def test_never_restoring_the_geometry_is_caught(self) -> None:
+        build_checkout(
+            self.root,
+            my_application=MY_APPLICATION.format(display_name=DISPLAY_NAME).replace(
+                "window_state_store_new", "no_window_state_here"
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("window_state_store_new", problems[0])
+
+    def test_never_saving_the_geometry_is_caught(self) -> None:
+        # Restoring without saving is the worst of the three: it looks wired,
+        # and every launch is a first launch.
+        build_checkout(
+            self.root,
+            my_application=MY_APPLICATION.format(display_name=DISPLAY_NAME).replace(
+                "  window_state_store_save(self->window_state);\n", ""
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("window_state_store_save", problems[0])
 
 
 class RealRepositoryTest(unittest.TestCase):

--- a/test/tooling/check_linux_runner_test.py
+++ b/test/tooling/check_linux_runner_test.py
@@ -105,6 +105,9 @@ static void activate() {{
   }}
   self->folder_picker = folder_picker_channel_new(view, window);
   self->window_lifecycle = window_lifecycle_channel_new(view, window);
+  if (self->window_state != nullptr) {{
+    window_state_store_save(self->window_state);
+  }}
   self->window_state =
       window_state_store_new(window, kMinimumWindowWidth, kMinimumWindowHeight,
                              kDefaultWindowWidth, kDefaultWindowHeight);
@@ -1638,12 +1641,52 @@ class WindowStateWiringTest(CheckoutCase):
         build_checkout(
             self.root,
             my_application=MY_APPLICATION.format(display_name=DISPLAY_NAME).replace(
-                "  window_state_store_save(self->window_state);\n", ""
+                "window_state_store_save", "no_save_here"
             ),
         )
         problems = checker.check(self.root)
         self.assertEqual(len(problems), 1)
         self.assertIn("window_state_store_save", problems[0])
+
+    def test_dropping_only_the_shutdown_save_is_caught(self) -> None:
+        # The one that matters: the runner keeps a save on the rare
+        # window-recreation path in activate(), so a checker that only searched
+        # the file would keep passing while every ordinary exit stopped
+        # persisting anything.
+        my_application = MY_APPLICATION.format(display_name=DISPLAY_NAME)
+        shutdown = my_application.index("static void my_application_shutdown(")
+        build_checkout(
+            self.root,
+            my_application=(
+                my_application[:shutdown]
+                + my_application[shutdown:].replace(
+                    "  window_state_store_save(self->window_state);\n", "", 1
+                )
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("my_application_shutdown()", problems[0])
+
+    def test_a_save_only_in_a_comment_does_not_count(self) -> None:
+        # Blanked comments are what stop a call that is merely *described* from
+        # standing in for one that runs.
+        my_application = MY_APPLICATION.format(display_name=DISPLAY_NAME)
+        shutdown = my_application.index("static void my_application_shutdown(")
+        build_checkout(
+            self.root,
+            my_application=(
+                my_application[:shutdown]
+                + my_application[shutdown:].replace(
+                    "  window_state_store_save(self->window_state);\n",
+                    "  // window_state_store_save(self->window_state);\n",
+                    1,
+                )
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("my_application_shutdown()", problems[0])
 
 
 class RealRepositoryTest(unittest.TestCase):


### PR DESCRIPTION
Eight issues from the desktop milestone (#376), one commit each so they can be read (or dropped) separately.

Closes #380
Closes #381
Closes #382
Closes #383
Closes #384
Closes #385
Closes #386
Closes #387

## What each commit does

**#380 - the now-playing bar is seekable.** The bar already carried the whole transport on a desktop window; the progress line was a readout, so jumping back thirty seconds meant opening the full player. On a desktop host it is now the same `PlaybackProgressBar` the full player uses, at a new compact density and without the time caption. Reusing it means the same drag preview, the same optimistic hold until playback acknowledges the seek, the same slider semantics and arrow keys.

**#381 - the queue sits beside the cover.** A window wide enough for a third column draws the queue as that column instead of a sheet over the top, so lyrics and up-next are readable at once. Same `QueueSheet`, in an embedded mode; the action row's queue button becomes the pane toggle. Narrower windows keep the sheet.

**#382 - the library gets a detail pane, and the pane layout is shared.** Album and artist detail had each hand-rolled the same desktop composition down to their own copy of the 320 px constant; that is now `SplitPanes` in `shared/layout`. And picking an album from the grid no longer replaces the whole view: past `listDetailMinWidth` the grid stays and the album opens beside it, which with the navigation rail is navigation · content · detail. Below that width the same screen is pushed as a route, as before.

**#383 - the window remembers its geometry.** Size and maximized state survive a restart; position too, on X11 (Wayland gives a client neither its own position nor a way to set one). The size saved is the *unmaximized* one, since GTK will not tell you that after the fact. A saved position is re-checked against the monitors attached now, so unplugging a monitor drops the position rather than restoring the window off-screen — the size survives either way. The rules live in a new `native/linthra_desktop`: pure C++, no GTK, no filesystem, unit-tested without a display server. `check_linux_runner.py` grows a guard, because losing any of the wiring still compiles and still launches.

**#384 - content density follows the pointer.** The theme uses `VisualDensity.adaptivePlatformDensity`: compact on desktop, standard everywhere touch-first. The two places that sized rows with a hard-coded number now follow it — the songs list's fixed row extent (which the A–Z index measures its scroll offsets in) and the artist grid's cell floor — and both only give back padding.

**#385 - hover you can actually see.** Material's 4% default is invisible on a black-first theme. One `hoverColor` reaches every ink surface at once, neutral rather than brand-tinted so it stays distinct from selection. `HoverHighlight` covers the one case ink cannot: an album cover hides the overlay painted on the Material behind it.

**#386 - right-click context menus.** `ContextMenuRegion` opens a surface's existing menu on secondary click and on the keyboard's menu key (or Shift+F10). Track rows share one list and one dispatcher with their 3-dot button, and gain Show album / Show artist. Albums and artists get Play · Shuffle · Play next · Add to queue · Add to playlist, each a command their detail pages already call. Playlists reuse their rename/delete pair.

**#387 - Ctrl and Shift multi-select.** Ctrl (or Cmd) picks one row out and starts a selection when there is none; Shift takes everything between. `TrackSelection` holds it for the songs list and album/artist detail, keyed by the provider-namespaced uri, and resolves a bulk action against the list as shown. Escape leaves the selection.

## Review fixes

Four review rounds landed on top of the eight, each with a test verified to fail without its fix. Grouped, they were:

- **Window state (#383):** rectangle arithmetic in `int64_t` (a coordinate near `INT_MAX` was signed-overflow UB, confirmed under UBSan), the saved position validated against the geometry the window actually opens with rather than the one the file claimed, the destroy handler disconnected with the other two, and `check_linux_runner.py` looking for the save inside `my_application_shutdown()` specifically.
- **Menus (#386):** the anchor converted into the overlay's coordinate space (every menu was sliding across by the navigation rail's width), Show album / Show artist gated on catalog membership so a folder-browsed track is not offered a page that says "not found", and a pick dropped when the region that opened it is gone.
- **Panes (#381, #382, #387):** the panes are widgets in a layout rather than routes, so a resize unmounts them mid-action. The queue's "save as playlist" captures its repository before the name prompt; the panes' track selection is held by `LibraryScreen` so a resize does not discard it; and leaving a selection no longer depends on the screen still being mounted.
- **Selection (#387):** `SelectionEscapeScope`, so Escape leaves a selection on the detail pages too, not just the songs list.

## Testing

- `flutter analyze` clean, `flutter test` green (4693 tests, ~140 new).
- New C++ tests for the window-state policy: `ctest --test-dir build/linthra_desktop`, wired into a new `cpp-desktop-window.yml` workflow alongside the audio DSP one.
- `scripts/check_linux_runner.py` and its tooling tests pass, including the new cases for the window-state wiring.
- `linux/runner/window_state_store.cc` and `my_application.cc` compile clean against GTK 3 with `-Wall -Werror`; the full Linux build is CI's to prove.

## Notes

- Two existing tests in `detail_desktop_layout_test.dart` now open the detail screens on their own route rather than by tapping the grid. They test the detail screen's internal two-pane layout, and on a wide Library that tap now opens a pane instead — the route is still how Folders, search and a narrow window reach it.
- Playlist detail keeps its own selection: its rows are a reorderable list rather than `TrackTile`, so bringing it onto `TrackSelection` is a separate change.
- Position restoration and the GTK half of #383 can only really be judged on a real session — worth a manual pass on both X11 and Wayland, and with a monitor unplugged between launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWjKwW5dZSDVXUeixZkf7e