### PR TITLE
feat(cast): remember receivers across restarts, and let users forget one (#575)

### DIFF
--- a/.github/workflows/linux-desktop-build.yml
+++ b/.github/workflows/linux-desktop-build.yml
@@ -146,21 +146,26 @@ jobs:
       - name: Install Linux build dependencies
         run: |
           set -euo pipefail
-          # The runner image ships third-party apt sources (Google Chrome,
-          # Microsoft) that none of the packages below come from. When one of
-          # them serves an index that disagrees with its own Release file,
-          # `apt-get update` exits 100 and `set -e` takes the whole build with
-          # it, minutes before anything of ours has run. Dropping the lists we
-          # do not need turns somebody else's mirror hiccup back into a
-          # non-event.
+          # `apt-get update` exits 100 if *any* configured source fails, and the
+          # runner image ships third-party ones (Google Chrome, Microsoft) that
+          # none of the packages below come from. When one of those serves an
+          # index that disagrees with its own Release file, the whole job dies
+          # seconds in, having fetched every Ubuntu index perfectly well:
           #
-          # Deliberately a targeted removal rather than
-          # `-o Dir::Etc::sourceparts=/dev/null`: on noble the Ubuntu sources
-          # themselves live in sources.list.d/ubuntu.sources, so ignoring that
-          # directory wholesale would drop the sources we actually install from.
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
-                     /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
+          #   E: Failed to fetch .../chrome-stable/.../Packages.gz
+          #      Hash Sum mismatch
+          #
+          # So a partial update is tolerated and `apt-get install` below stays
+          # strict. That is the step whose success actually matters: if an index
+          # we really need is missing, the install fails on the package it
+          # cannot find, which is both louder and more honest than guessing here
+          # which sources were the important ones.
+          #
+          # Deliberately not deleting the offending source lists instead. Their
+          # names and format are the image's business (noble moved several to
+          # deb822 `.sources`), so matching on them is a check that silently
+          # stops working the next time the image is rebuilt.
+          sudo apt-get update || echo 'apt-get update was incomplete; the install below decides'
           sudo apt-get install -y --no-install-recommends \
             clang \
             cmake \

--- a/.github/workflows/linux-desktop-build.yml
+++ b/.github/workflows/linux-desktop-build.yml
@@ -146,6 +146,20 @@ jobs:
       - name: Install Linux build dependencies
         run: |
           set -euo pipefail
+          # The runner image ships third-party apt sources (Google Chrome,
+          # Microsoft) that none of the packages below come from. When one of
+          # them serves an index that disagrees with its own Release file,
+          # `apt-get update` exits 100 and `set -e` takes the whole build with
+          # it, minutes before anything of ours has run. Dropping the lists we
+          # do not need turns somebody else's mirror hiccup back into a
+          # non-event.
+          #
+          # Deliberately a targeted removal rather than
+          # `-o Dir::Etc::sourceparts=/dev/null`: on noble the Ubuntu sources
+          # themselves live in sources.list.d/ubuntu.sources, so ignoring that
+          # directory wholesale would drop the sources we actually install from.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             clang \

--- a/docs/cast-hardened-design.md
+++ b/docs/cast-hardened-design.md
@@ -7,11 +7,13 @@ enforces: no verified identity, no session, no media. This page is the answer to
 the next question, the one that decides whether the feature ever comes back:
 what would a receiver check have to be, concretely, for it to be worth trusting?
 
-It is a design, not a plan of record. Nothing here is wired into production,
+It is a design, not a plan of record. None of the protocol work exists yet,
 nothing here changes the containment, and the restoration remains one reviewed
-change ([#575](https://github.com/TheZupZup/Linthra/issues/575)). The report
-itself and the assessment of any specific implementation stay in the private
-advisory.
+change ([#575](https://github.com/TheZupZup/Linthra/issues/575)). The two
+app-side layers (3 and 5) are built, and the app does carry the pin store they
+need, which is a preference rather than a path to a receiver: no shipped build
+opens a cast socket. The report itself and the assessment of any specific
+implementation stay in the private advisory.
 
 ## The short version
 
@@ -21,7 +23,7 @@ Five layers, each doing one job, and none of them a substitute for another:
 | --- | --- | --- |
 | 1. Transport | Is the channel private? | TLS exists today, and proves nothing about who is on the far end |
 | 2. Device authentication | Is this a genuine Cast receiver? | Not implemented anywhere in the tree, and the package we depend on cannot express the modern challenge |
-| 3. Device pinning | Is it *your* receiver, the same one as last time? | Built and tested (`cast_receiver_pinning.dart`) |
+| 3. Device pinning | Is it *your* receiver, the same one as last time? | Built and tested (`cast_receiver_pinning.dart`), persistent in production, with the sheet's forget action |
 | 4. Least privilege | If it is, how little can it be handed? | Modelled and documented ([cast-media-access.md](cast-media-access.md)) |
 | 5. Fail-closed boundary | Does any doubt end in silence? | Built and tested (`trust_gated_cast_transport.dart`) |
 
@@ -241,10 +243,37 @@ The user-facing half is a distinct failure kind
 every other refusal this one has an action attached: if you really did replace
 the speaker, forget it and connect again.
 
-Two follow-ons for the restoration: the store has to be persistent (the shipped
-default is in-memory, chosen so that a missing store shortens the memory rather
-than removing the check), and the cast sheet needs the "forget this device"
-affordance the message points at.
+Both follow-ons this layer needed have landed, ahead of the protocol work and
+without touching the containment.
+
+The store is persistent in production
+(`lib/data/repositories/shared_preferences_cast_receiver_pin_store.dart`). An
+in-memory store makes every launch a first use, so a swapped receiver is noticed
+for one session and forgotten by the next; pins now outlive the app. It is
+deliberately the one `shared_preferences` store in the repository that throws
+rather than degrading to a default. Everywhere else, unreadable storage costing
+the user a default tab or a default theme is the right trade; here "I can't read
+the pin" resolving to "this device has no pin" would re-pin whichever receiver
+answered, which is the erase-the-check path the rules above exist to close. One
+key per device, keyed by a digest of the device id (for shape, not secrecy:
+discovery returns whatever a receiver advertises, and nothing about a device id
+should decide what a preference key looks like).
+
+The sheet carries the affordance the `changedReceiver` message points at, and
+getting there needed one more fix than expected: the sheet used to replace its
+device list with an empty state whenever the service reported an error, so a
+user told to "forget it in the cast list and try again" was looking at a screen
+with no cast list on it. A refusal now keeps the list it was caused from, which
+is both the retry and the recovery. "Forget this device" sits behind a
+confirmation that says what it costs, is offered only where there is a pin to
+drop, and is not offered for the connected device (that session already proved
+itself, so dropping its pin would change nothing now and read as if it had). A
+pin store that cannot answer still gets the menu item: whether the recovery is
+drawn is a UI question, not a trust one, and `TrustGatedCastTransport` refuses on
+that same throw regardless.
+
+What is left for the restoration is to hand the same store to
+`TrustGatedCastTransport`, which is step 7 below.
 
 ## Layer 4: hand over as little as possible
 
@@ -298,7 +327,8 @@ Staged, so that each step is reviewable and none of them relaxes the containment
    into production.
 4. **The authenticator** implementing `CastReceiverAuthenticator` on top of 2 and
    3, plugged into the existing gate. Still not wired into production.
-5. **A persistent pin store and the sheet's forget affordance.**
+5. ~~**A persistent pin store and the sheet's forget affordance.**~~ Done, see
+   layer 3.
 6. **Device matrix by hand**, results to the advisory.
 7. **The restoration itself**, per the checklist in
    [cast-receiver-trust.md](cast-receiver-trust.md#restoration-checklist): the
@@ -315,8 +345,12 @@ device testing has already been reviewed on its own terms.
 
 The app-side boundary is covered today
 (`test/core/services/cast/trust_gated_cast_transport_test.dart`), including the
-pinning cases above. The protocol side arrives with the implementation and owes,
-at minimum:
+pinning cases above, along with the persistent store's own rules
+(`test/data/repositories/shared_preferences_cast_receiver_pin_store_test.dart`:
+a pin survives a new instance, `remember` never replaces one, an unreadable
+entry throws rather than reading as a first use) and the sheet's recovery
+(`test/features/player/cast/cast_devices_sheet_test.dart`). The protocol side
+arrives with the implementation and owes, at minimum:
 
 - a response with a missing, empty, or altered `sender_nonce`;
 - a valid response replayed from another connection or another challenge;

--- a/docs/cast-receiver-trust.md
+++ b/docs/cast-receiver-trust.md
@@ -62,9 +62,13 @@ protocol rather than about the app's plumbing:
   the handshake honestly. So the fingerprint a device first proved itself with is
   recorded and required to match afterwards, a store that cannot answer refuses
   rather than re-pins, a mismatch never overwrites, and replacing a pin is an
-  explicit `forget()` by the user. The shipped default keeps pins in memory,
-  chosen so a missing store shortens the memory rather than removing the check;
-  a restoration supplies a persistent one.
+  explicit `forget()` by the user. Production stores pins in
+  `shared_preferences` (`SharedPreferencesCastReceiverPinStore`), so a swapped
+  receiver is caught across restarts rather than within one session, and that
+  store throws instead of degrading: unreadable storage must not read as "this
+  device has no pin". The in-memory default remains what an unconfigured app
+  gets, chosen so a missing store shortens the memory rather than removing the
+  check.
 - **`TrustGatedCastTransport`** (`lib/core/services/cast/trust_gated_cast_transport.dart`)
   — the readiness boundary. It wraps a `CastTransport`: a session is only handed
   out after the receiver authenticated *and* the identity matches both the
@@ -152,9 +156,11 @@ Restoring casting is one reviewed change, not a revert. It has to:
       handshake, reviewed in the advisory;
 - [ ] put the trust gate in front of the live transport in the production
       wiring, with no path around it and no runtime flag that skips it;
-- [ ] ship a persistent `CastReceiverPinStore` and the cast sheet's "forget this
+- [x] ship a persistent `CastReceiverPinStore` and the cast sheet's "forget this
       device" action, so pinning survives a restart and a genuinely replaced
-      receiver has a way back that is not a bypass;
+      receiver has a way back that is not a bypass. Landed ahead of the
+      restoration: the pins a restored feature checks have to predate the
+      release that restores it;
 - [ ] flip `CastContainment.isActive` and update the production wiring, the
       transport guards, `scripts/check_cast_containment.py` and
       `scripts/verify_release_containment.py` together — the containment

--- a/lib/app/application_container.dart
+++ b/lib/app/application_container.dart
@@ -5,6 +5,7 @@ import '../core/platform/host_platform.dart';
 import '../data/repositories/app_icon_variant_store_provider.dart';
 import '../data/repositories/audio_output_device_service_provider.dart';
 import '../data/repositories/audiobookshelf_session_store_provider.dart';
+import '../data/repositories/cast_receiver_pin_store_provider.dart';
 import '../data/repositories/default_provider_store_provider.dart';
 import '../data/repositories/desktop_window_controller_provider.dart';
 import '../data/repositories/desktop_window_preferences_provider.dart';
@@ -98,5 +99,10 @@ List<Override> productionApplicationOverrides({
     // Casting is withheld from production builds by the security
     // containment; see [CastContainment].
     containedCastServiceOverride,
+    // Which receiver each cast device is, remembered across restarts. Wired
+    // while casting is contained on purpose: the pins a restored cast feature
+    // will check have to outlive the release that restores it, and the cast
+    // sheet already reads this store to offer "forget this device".
+    sharedPreferencesCastReceiverPinStoreOverride,
   ];
 }

--- a/lib/data/repositories/cast_receiver_pin_store_provider.dart
+++ b/lib/data/repositories/cast_receiver_pin_store_provider.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/services/cast/cast_receiver_pinning.dart';
+import 'shared_preferences_cast_receiver_pin_store.dart';
+
+/// The single [CastReceiverPinStore] the app remembers cast receivers through.
+///
+/// Defaults to [InMemoryCastReceiverPinStore] so widget and unit tests stay free
+/// of platform plugins, and so that a missing override shortens how long the app
+/// remembers rather than turning pinning off. The running app overrides this
+/// with [sharedPreferencesCastReceiverPinStoreOverride].
+///
+/// Two callers, one of which does not exist yet. The cast sheet reads it to
+/// offer "forget this device", the recovery
+/// [CastTrustFailureKind.changedReceiver] points the user at. The reviewed
+/// restoration ([#575](https://github.com/TheZupZup/Linthra/issues/575)) hands
+/// it to [TrustGatedCastTransport], which is where it becomes a security
+/// boundary rather than a preference (see docs/cast-hardened-design.md).
+final castReceiverPinStoreProvider = Provider<CastReceiverPinStore>((ref) {
+  return InMemoryCastReceiverPinStore();
+});
+
+/// Production binding: pins survive a restart. Applied in
+/// [productionApplicationOverrides].
+final sharedPreferencesCastReceiverPinStoreOverride =
+    castReceiverPinStoreProvider.overrideWithValue(
+  const SharedPreferencesCastReceiverPinStore(),
+);

--- a/lib/data/repositories/shared_preferences_cast_receiver_pin_store.dart
+++ b/lib/data/repositories/shared_preferences_cast_receiver_pin_store.dart
@@ -1,0 +1,98 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/services/cast/cast_receiver_pinning.dart';
+
+/// A [CastReceiverPinStore] that remembers which receiver a cast device is
+/// across restarts, backed by `shared_preferences`.
+///
+/// [InMemoryCastReceiverPinStore] forgets every pin when the app closes, which
+/// makes each launch a first use: a swapped receiver is only caught within a
+/// single session. Persisting the fingerprint is what turns pinning into the
+/// check docs/cast-hardened-design.md describes, and it is the store a restored
+/// cast feature is expected to be given
+/// ([#575](https://github.com/TheZupZup/Linthra/issues/575)).
+///
+/// Fingerprints are digests of a certificate the receiver hands to anyone who
+/// connects, so there is nothing here to keep secret and no reason to reach for
+/// `flutter_secure_storage`. What this store owes is the other two properties:
+/// it must answer honestly, and it must not lose a write.
+///
+/// So, unlike most of Linthra's `shared_preferences` stores, **this one throws
+/// rather than degrading**. The others treat unreadable storage as "no
+/// preference" because the cost is a default tab or a default theme. Here the
+/// cost is the check itself: "I can't read the pin" resolving to "this device
+/// has no pin" would re-pin whichever receiver answered, and breaking the store
+/// would become the way to erase the check. [TrustGatedCastTransport] turns
+/// every throw here into a refusal, which is the direction to be wrong in.
+class SharedPreferencesCastReceiverPinStore implements CastReceiverPinStore {
+  const SharedPreferencesCastReceiverPinStore();
+
+  /// One key per device rather than one map for all of them: a device id that
+  /// cannot be parsed then costs that device its pin, not everybody else's, and
+  /// [forget] is a targeted removal instead of a rewrite of every other entry.
+  static const String keyPrefix = 'cast_receiver_pin_v1_';
+
+  /// The preference key holding [deviceId]'s pin.
+  ///
+  /// The id is hashed for shape, not for secrecy (a device id is a name on the
+  /// LAN). Discovery hands back whatever the receiver advertises, of whatever
+  /// length and with whatever characters in it, and a fixed-width hex digest
+  /// keeps that from deciding what a preference key looks like, including the
+  /// case where one id, concatenated onto the prefix, spells another id's key.
+  static String keyFor(String deviceId) =>
+      '$keyPrefix${sha256.convert(utf8.encode(deviceId))}';
+
+  @override
+  Future<String?> pinFor(String deviceId) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final String? stored = prefs.getString(keyFor(deviceId));
+    if (stored == null) return null;
+
+    // A key that exists but holds nothing usable is not a device that has never
+    // been cast to. Something wrote it, or something damaged it, and either way
+    // this store no longer knows what receiver was pinned. Returning null would
+    // re-pin the next one to answer; an empty string would compare equal to
+    // nothing and refuse forever with no explanation. Throwing says the true
+    // thing: the store cannot answer.
+    if (normalizeCastFingerprint(stored).isEmpty) {
+      throw StateError('cast receiver pin for a device is unreadable');
+    }
+    return stored;
+  }
+
+  @override
+  Future<void> remember(String deviceId, String fingerprint) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final String key = keyFor(deviceId);
+
+    // The contract says a pin is only ever recorded for a device that has none.
+    // Honouring that here, rather than assuming the caller checked, means a
+    // second connection racing the first cannot quietly replace what the first
+    // one pinned. The caller reads back afterwards and finds out it lost.
+    final String? existing = prefs.getString(key);
+    if (existing != null && normalizeCastFingerprint(existing).isNotEmpty) {
+      return;
+    }
+
+    if (!await prefs.setString(key, fingerprint)) {
+      // A write that reported failure has to be a failure to the caller too.
+      // Returning normally would hand out a session on a pin that was never
+      // recorded, leaving the device unpinned for the next receiver to claim.
+      throw StateError('could not record the cast receiver pin for a device');
+    }
+  }
+
+  @override
+  Future<void> forget(String deviceId) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    if (!await prefs.remove(keyFor(deviceId))) {
+      // Same reasoning in the other direction: a user who is told the device
+      // was forgotten will reconnect and hit the same refusal. Better to fail
+      // where the UI can say so.
+      throw StateError('could not forget the cast receiver pin for a device');
+    }
+  }
+}

--- a/lib/features/player/cast/cast_devices_sheet.dart
+++ b/lib/features/player/cast/cast_devices_sheet.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../app/dimens.dart';
 import '../../../core/models/cast_state.dart';
 import '../../../core/services/cast/cast_service.dart';
+import '../../../data/repositories/cast_receiver_pin_store_provider.dart';
 import '../../../shared/widgets/empty_state.dart';
 import 'cast_providers.dart';
 
@@ -121,7 +122,17 @@ class _Body extends ConsumerWidget {
     }
 
     if (state.hasError) {
-      final service = ref.read(castServiceProvider);
+      // A failed connection keeps the list the device was picked from, because
+      // the list is where the user acts next. It is the retry, and for
+      // [CastTrustFailureKind.changedReceiver] it is also the recovery: that
+      // refusal tells the user to forget the device "in the cast list", so
+      // replacing the list with an empty state would take away the one place
+      // the message points at. Discovery failing with nothing found still lands
+      // on the empty state below.
+      if (state.devices.isNotEmpty) {
+        return const _DeviceList();
+      }
+      final CastService service = ref.read(castServiceProvider);
       return Padding(
         padding: _pad,
         child: Column(
@@ -190,45 +201,162 @@ class _Body extends ConsumerWidget {
       );
     }
 
-    final service = ref.read(castServiceProvider);
+    return const _DeviceList();
+  }
+}
+
+/// The discovered devices, plus whatever note the current state carries.
+///
+/// Shared by the ordinary listing and by the error state, which keeps its list
+/// (see [_Body]) so a refusal can be acted on where it was caused.
+class _DeviceList extends ConsumerWidget {
+  const _DeviceList();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final CastService service = ref.watch(castServiceProvider);
+    final CastState state =
+        ref.watch(castStateProvider).valueOrNull ?? service.state;
+
     return ListView(
       shrinkWrap: true,
       children: [
-        // A non-fatal notice while connected (e.g. the current track is a local
-        // file that can't be cast).
-        if (state.isConnected && state.message != null)
-          _Notice(message: state.message!),
-        // Cast device volume — only while connected, since it controls the
+        // Whatever the state has to say, above the list it is about: a
+        // non-fatal notice while connected (the current track is a local file
+        // that can't be cast), or the reason the last connection was refused.
+        if (state.message != null) _Notice(message: state.message!),
+        // Cast device volume, only while connected, since it controls the
         // receiver's own volume (not the phone's).
         if (state.isConnected)
           CastVolumeControls(state: state, service: service),
-        for (final device in devices)
-          Builder(
-            builder: (BuildContext context) {
-              final bool isConnected = state.connectedDevice == device;
-              return ListTile(
-                // The connected row is deliberately not tappable (there is
-                // nothing to connect to twice). Marking it selected is what
-                // makes that read as "this is the one you're on" rather than
-                // as an inert row, and the glyph says the same thing for
-                // anyone who only hears the leading icon.
-                selected: isConnected,
-                leading: Icon(
-                  isConnected ? Icons.cast_connected : Icons.cast,
-                  semanticLabel: isConnected ? 'Connected' : null,
-                ),
-                title: Text(device.name),
-                trailing: isConnected
-                    ? TextButton(
-                        onPressed: service.disconnect,
-                        child: const Text('Disconnect'),
-                      )
-                    : null,
-                onTap: isConnected ? null : () => service.connect(device),
-              );
-            },
+        for (final CastDevice device in state.devices)
+          _DeviceTile(
+            device: device,
+            isConnected: state.connectedDevice == device,
+            service: service,
           ),
       ],
+    );
+  }
+}
+
+/// One discovered device, and the two things that can be done to it: connect or
+/// disconnect, and forget which receiver it is.
+///
+/// Stateful so the forget flow can check [mounted] after its confirmation
+/// dialog and its store write, rather than touching a context or a ref that may
+/// have gone away while the sheet was dismissed.
+class _DeviceTile extends ConsumerStatefulWidget {
+  const _DeviceTile({
+    required this.device,
+    required this.isConnected,
+    required this.service,
+  });
+
+  final CastDevice device;
+  final bool isConnected;
+  final CastService service;
+
+  @override
+  ConsumerState<_DeviceTile> createState() => _DeviceTileState();
+}
+
+class _DeviceTileState extends ConsumerState<_DeviceTile> {
+  /// Clears what Linthra remembers about which receiver this device is.
+  ///
+  /// This is the only path that may drop a pin. It weakens a check the user
+  /// cannot see (the next connection trusts whichever receiver answers, exactly
+  /// as a first use does), so it is confirmed rather than done on a tap, and
+  /// the dialog says what it costs. Nothing in the trust path calls this: see
+  /// [CastReceiverPinStore.forget] and docs/cast-hardened-design.md.
+  Future<void> _forget() async {
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    final String name = widget.device.name;
+
+    final bool confirmed = await showDialog<bool>(
+          context: context,
+          builder: (BuildContext context) => AlertDialog(
+            title: const Text('Forget this device?'),
+            content: Text(
+              "Linthra will stop checking that $name is the same device it "
+              'cast to before, and will trust whichever device answers to that '
+              'name next time. Do this if you replaced it.',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('Cancel'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: const Text('Forget'),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+    if (!confirmed || !mounted) return;
+
+    try {
+      await ref.read(castReceiverPinStoreProvider).forget(widget.device.id);
+    } catch (_) {
+      // A store that could not drop the pin has not dropped it, and the user
+      // would otherwise reconnect into the same refusal with no idea why.
+      messenger.showSnackBar(
+        SnackBar(content: Text("Linthra couldn't forget $name.")),
+      );
+      return;
+    }
+    if (!mounted) return;
+
+    ref.invalidate(castDeviceIsPinnedProvider(widget.device.id));
+    messenger.showSnackBar(
+      SnackBar(
+          content: Text('Linthra will check $name again when it connects.')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Only offered where there is something to forget, and only while
+    // disconnected: dropping the pin for the receiver currently playing would
+    // do nothing to the live session, which already proved itself, and would
+    // read as if it had.
+    final bool canForget = !widget.isConnected &&
+        (ref.watch(castDeviceIsPinnedProvider(widget.device.id)).valueOrNull ??
+            false);
+
+    return ListTile(
+      // The connected row is deliberately not tappable (there is nothing to
+      // connect to twice). Marking it selected is what makes that read as
+      // "this is the one you're on" rather than as an inert row, and the glyph
+      // says the same thing for anyone who only hears the leading icon.
+      selected: widget.isConnected,
+      leading: Icon(
+        widget.isConnected ? Icons.cast_connected : Icons.cast,
+        semanticLabel: widget.isConnected ? 'Connected' : null,
+      ),
+      title: Text(widget.device.name),
+      trailing: widget.isConnected
+          ? TextButton(
+              onPressed: widget.service.disconnect,
+              child: const Text('Disconnect'),
+            )
+          : canForget
+              ? PopupMenuButton<void>(
+                  icon: const Icon(Icons.more_vert),
+                  tooltip: 'More options for ${widget.device.name}',
+                  itemBuilder: (BuildContext context) => [
+                    PopupMenuItem<void>(
+                      onTap: () => unawaited(_forget()),
+                      child: const Text('Forget this device'),
+                    ),
+                  ],
+                )
+              : null,
+      onTap: widget.isConnected
+          ? null
+          : () => widget.service.connect(widget.device),
     );
   }
 }

--- a/lib/features/player/cast/cast_providers.dart
+++ b/lib/features/player/cast/cast_providers.dart
@@ -4,11 +4,13 @@ import '../../../core/lifecycle/async_disposal_registry.dart';
 import '../../../core/models/cast_state.dart';
 import '../../../core/services/cast/cast_containment.dart';
 import '../../../core/services/cast/cast_media_resolver.dart';
+import '../../../core/services/cast/cast_receiver_pinning.dart';
 import '../../../core/services/cast/cast_service.dart';
 import '../../../core/services/cast/routing_cast_media_resolver.dart';
 import '../../../core/services/cast/unavailable_cast_service.dart';
 import '../../../core/sources/jellyfin/jellyfin_cast_media_resolver.dart';
 import '../../../core/sources/subsonic/subsonic_cast_media_resolver.dart';
+import '../../../data/repositories/cast_receiver_pin_store_provider.dart';
 import '../../settings/jellyfin/jellyfin_settings_controller.dart';
 import '../../settings/subsonic/subsonic_settings_controller.dart';
 
@@ -67,4 +69,28 @@ final containedCastServiceOverride = castServiceProvider.overrideWith((ref) {
   );
   ref.onDisposeAsync(service.dispose);
   return service;
+});
+
+/// Whether Linthra already remembers which receiver a cast device is, so the
+/// sheet only offers "forget this device" where there is something to forget.
+///
+/// Auto-disposing and per-device: the sheet is opened, used and closed, and a
+/// pin read on one visit says nothing about the next. Invalidate it after a
+/// [CastReceiverPinStore.forget] so the row stops offering an action that has
+/// already been taken.
+///
+/// A store that throws answers *true* here. This provider decides whether a
+/// menu item is drawn, not whether a receiver is trusted. That is
+/// [TrustGatedCastTransport]'s job, and it refuses on the same throw. Hiding
+/// the recovery because the store is unhappy would strand a user whose only way
+/// forward is to clear a pin, and forgetting a device that has none does
+/// nothing.
+final castDeviceIsPinnedProvider = FutureProvider.autoDispose
+    .family<bool, String>((ref, String deviceId) async {
+  final CastReceiverPinStore store = ref.watch(castReceiverPinStoreProvider);
+  try {
+    return await store.pinFor(deviceId) != null;
+  } catch (_) {
+    return true;
+  }
 });

--- a/test/app/production_cast_containment_test.dart
+++ b/test/app/production_cast_containment_test.dart
@@ -5,9 +5,12 @@ import 'package:linthra/core/models/cast_state.dart';
 import 'package:linthra/core/models/theme_mode_preference.dart';
 import 'package:linthra/core/platform/host_platform.dart';
 import 'package:linthra/core/services/cast/cast_containment.dart';
+import 'package:linthra/core/services/cast/cast_receiver_pinning.dart';
 import 'package:linthra/core/services/cast/cast_service.dart';
 import 'package:linthra/core/services/cast/default_cast_service.dart';
 import 'package:linthra/core/services/cast/unavailable_cast_service.dart';
+import 'package:linthra/data/repositories/cast_receiver_pin_store_provider.dart';
+import 'package:linthra/data/repositories/shared_preferences_cast_receiver_pin_store.dart';
 import 'package:linthra/features/player/cast/cast_providers.dart';
 
 /// What a *shipped* build gets for casting, walked through the real production
@@ -97,6 +100,19 @@ void main() {
         expect(service.playbackStatus.status.name, 'idle');
       });
 
+      test('remembers receivers in a store that outlives the app', () {
+        // Pinning is only worth having if it survives a restart: an in-memory
+        // store makes every launch a first use, so a swapped receiver is
+        // caught for one session and then forgotten. Wired while casting is
+        // contained on purpose, because the pins a restored cast feature will
+        // check have to predate the release that restores it.
+        final CastReceiverPinStore pins =
+            productionContainer(host).read(castReceiverPinStoreProvider);
+
+        expect(pins, isA<SharedPreferencesCastReceiverPinStore>());
+        expect(pins, isNot(isA<InMemoryCastReceiverPinStore>()));
+      });
+
       test('repeated startup and disposal stay contained', () async {
         for (int run = 0; run < 3; run++) {
           final ProviderContainer container = ProviderContainer(
@@ -123,6 +139,7 @@ void main() {
     );
 
     expect(overrides, contains(containedCastServiceOverride));
+    expect(overrides, contains(sharedPreferencesCastReceiverPinStoreOverride));
   });
 
   test('an unavailable service without a message keeps the platform wording',

--- a/test/data/repositories/shared_preferences_cast_receiver_pin_store_test.dart
+++ b/test/data/repositories/shared_preferences_cast_receiver_pin_store_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/data/repositories/shared_preferences_cast_receiver_pin_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// The persistent half of receiver pinning (docs/cast-hardened-design.md,
+/// layer 3). What is being pinned down here is not "a value round-trips" but
+/// the two ways this store is allowed to be wrong: it may refuse, and it may
+/// not quietly forget. Every case below is one of the rules the design states,
+/// because [TrustGatedCastTransport] leans on all of them.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
+
+  const SharedPreferencesCastReceiverPinStore store =
+      SharedPreferencesCastReceiverPinStore();
+
+  group('SharedPreferencesCastReceiverPinStore', () {
+    test('a device that has never been cast to has no pin', () async {
+      expect(await store.pinFor('device-1'), isNull);
+    });
+
+    test('a pin survives a new store instance, which is the whole point',
+        () async {
+      await store.remember('device-1', 'sha256aabb');
+
+      expect(
+        await const SharedPreferencesCastReceiverPinStore().pinFor('device-1'),
+        'sha256aabb',
+      );
+    });
+
+    test('pins are per device', () async {
+      await store.remember('device-1', 'sha256aabb');
+      await store.remember('device-2', 'sha256ccdd');
+
+      expect(await store.pinFor('device-1'), 'sha256aabb');
+      expect(await store.pinFor('device-2'), 'sha256ccdd');
+    });
+
+    test('device ids that are not tidy strings still get their own pin',
+        () async {
+      // Discovery hands back whatever a receiver advertises. Nothing about a
+      // device id may decide which preference key gets written.
+      const String awkward = 'living room/tv#1 ::v2';
+      await store.remember(awkward, 'sha256aabb');
+      await store.remember('other', 'sha256ccdd');
+
+      expect(await store.pinFor(awkward), 'sha256aabb');
+      expect(await store.pinFor('other'), 'sha256ccdd');
+    });
+
+    test('remember never replaces a pin that is already there', () async {
+      await store.remember('device-1', 'sha256aabb');
+      await store.remember('device-1', 'sha256ccdd');
+
+      // A second connection racing the first must lose rather than re-pin: the
+      // caller reads back and finds out.
+      expect(await store.pinFor('device-1'), 'sha256aabb');
+    });
+
+    test('forget clears the pin so the next connection pins afresh', () async {
+      await store.remember('device-1', 'sha256aabb');
+      await store.forget('device-1');
+
+      expect(await store.pinFor('device-1'), isNull);
+
+      await store.remember('device-1', 'sha256ccdd');
+      expect(await store.pinFor('device-1'), 'sha256ccdd');
+    });
+
+    test('forgetting a device that was never pinned is not an error', () async {
+      // The sheet offers this recovery from a refusal; it must not throw at a
+      // user whose pin was already gone.
+      await expectLater(store.forget('device-1'), completes);
+    });
+
+    test('forget leaves every other device pinned', () async {
+      await store.remember('device-1', 'sha256aabb');
+      await store.remember('device-2', 'sha256ccdd');
+
+      await store.forget('device-1');
+
+      expect(await store.pinFor('device-2'), 'sha256ccdd');
+    });
+
+    test('an unreadable pin throws rather than reading as a first use',
+        () async {
+      // The failure this exists to stop: a damaged entry resolving to null
+      // would re-pin whichever receiver answered next, so breaking the store
+      // would be the way to erase the check.
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        SharedPreferencesCastReceiverPinStore.keyFor('device-1'): '   ',
+      });
+
+      await expectLater(store.pinFor('device-1'), throwsStateError);
+    });
+
+    test('an unreadable pin is replaced rather than kept forever', () async {
+      // The other half of the rule above: refusing is right, but the user has
+      // to be able to get out of it, and forget is the deliberate act that
+      // does it.
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        SharedPreferencesCastReceiverPinStore.keyFor('device-1'): '',
+      });
+
+      await store.forget('device-1');
+      await store.remember('device-1', 'sha256aabb');
+
+      expect(await store.pinFor('device-1'), 'sha256aabb');
+    });
+
+    test('an unreadable pin does not count as one for remember either',
+        () async {
+      // Otherwise a blank entry would be a pin that can never be recorded over
+      // and never matches anything.
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        SharedPreferencesCastReceiverPinStore.keyFor('device-1'): '',
+      });
+
+      await store.remember('device-1', 'sha256aabb');
+
+      expect(await store.pinFor('device-1'), 'sha256aabb');
+    });
+
+    test('keys are namespaced so nothing else in preferences is touched',
+        () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'theme_mode_v1': 'dark',
+      });
+
+      await store.remember('device-1', 'sha256aabb');
+      await store.forget('device-1');
+
+      final SharedPreferences prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('theme_mode_v1'), 'dark');
+      expect(
+        prefs.getKeys().where(
+              (String key) => key.startsWith(
+                SharedPreferencesCastReceiverPinStore.keyPrefix,
+              ),
+            ),
+        isEmpty,
+      );
+    });
+  });
+}

--- a/test/features/player/cast/cast_devices_sheet_test.dart
+++ b/test/features/player/cast/cast_devices_sheet_test.dart
@@ -3,15 +3,24 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/cast_state.dart';
 import 'package:linthra/core/services/cast/cast_containment.dart';
+import 'package:linthra/core/services/cast/cast_receiver_pinning.dart';
+import 'package:linthra/data/repositories/cast_receiver_pin_store_provider.dart';
 import 'package:linthra/features/player/cast/cast_devices_sheet.dart';
 import 'package:linthra/features/player/cast/cast_providers.dart';
 
 import 'fake_cast_service.dart';
 
-Future<void> _pumpSheet(WidgetTester tester, FakeCastService service) async {
+Future<void> _pumpSheet(
+  WidgetTester tester,
+  FakeCastService service, {
+  CastReceiverPinStore? pins,
+}) async {
   await tester.pumpWidget(
     ProviderScope(
-      overrides: [castServiceProvider.overrideWithValue(service)],
+      overrides: [
+        castServiceProvider.overrideWithValue(service),
+        if (pins != null) castReceiverPinStoreProvider.overrideWithValue(pins),
+      ],
       child: const MaterialApp(home: Scaffold(body: CastDevicesSheet())),
     ),
   );
@@ -292,4 +301,181 @@ void main() {
       expect(tester.widget<Slider>(find.byType(Slider)).value, 0.0);
     });
   });
+
+  /// Layer 3 of docs/cast-hardened-design.md reaches the user here. A receiver
+  /// that authenticated but is not the one this device was pinned to gets
+  /// refused with [CastTrustFailureKind.changedReceiver], whose message tells
+  /// the user to forget the device "in the cast list". These tests are about
+  /// that sentence being true: the list has to still be on screen, and it has
+  /// to carry the action.
+  group('CastDevicesSheet forgetting a receiver', () {
+    const String changedReceiver =
+        "This isn't the same device Linthra cast to before, so it stopped. If "
+        'you replaced it, forget it in the cast list and try again.';
+
+    CastState refused() => const CastState(
+          availability: CastAvailability.error,
+          devices: <CastDevice>[_device],
+          message: changedReceiver,
+        );
+
+    Future<CastReceiverPinStore> pinned() async {
+      final InMemoryCastReceiverPinStore pins = InMemoryCastReceiverPinStore();
+      await pins.remember(_device.id, 'sha256aabb');
+      return pins;
+    }
+
+    testWidgets('a refusal keeps the device list it points the user at',
+        (tester) async {
+      await _pumpSheet(
+        tester,
+        FakeCastService(initial: refused()),
+        pins: await pinned(),
+      );
+
+      expect(find.text(changedReceiver), findsOneWidget);
+      expect(find.text('Living Room'), findsOneWidget);
+      // The empty state would have replaced the one place the message names.
+      expect(find.text('No cast devices'), findsNothing);
+    });
+
+    testWidgets('the device can still be retried from the refusal',
+        (tester) async {
+      final service = FakeCastService(initial: refused());
+      await _pumpSheet(tester, service, pins: await pinned());
+
+      await tester.tap(find.text('Living Room'));
+      await tester.pump();
+
+      expect(service.connectRequests, <CastDevice>[_device]);
+    });
+
+    testWidgets('offers nothing to forget for a device with no pin',
+        (tester) async {
+      await _pumpSheet(
+        tester,
+        FakeCastService(initial: refused()),
+        pins: InMemoryCastReceiverPinStore(),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.more_vert), findsNothing);
+    });
+
+    testWidgets('forgetting is confirmed before the pin is dropped',
+        (tester) async {
+      final InMemoryCastReceiverPinStore pins =
+          await pinned() as InMemoryCastReceiverPinStore;
+      await _pumpSheet(tester, FakeCastService(initial: refused()), pins: pins);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.more_vert));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Forget this device'));
+      await tester.pumpAndSettle();
+
+      // The dialog is up and nothing has happened yet: dropping a pin weakens
+      // a check the user cannot see, so a stray tap must not be enough.
+      expect(find.text('Forget this device?'), findsOneWidget);
+      expect(pins.pins[_device.id], 'sha256aabb');
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(pins.pins[_device.id], 'sha256aabb');
+    });
+
+    testWidgets('confirming drops the pin and says so', (tester) async {
+      final InMemoryCastReceiverPinStore pins =
+          await pinned() as InMemoryCastReceiverPinStore;
+      await _pumpSheet(tester, FakeCastService(initial: refused()), pins: pins);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.more_vert));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Forget this device'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Forget'));
+      await tester.pumpAndSettle();
+
+      expect(pins.pins, isEmpty);
+      expect(
+        find.textContaining('will check Living Room again'),
+        findsOneWidget,
+      );
+      // The action is gone with the pin it cleared.
+      expect(find.byIcon(Icons.more_vert), findsNothing);
+    });
+
+    testWidgets('a store that cannot answer still offers the way out',
+        (tester) async {
+      // Refusing to draw the recovery because the store is unhappy would
+      // strand a user whose only way forward is to clear a pin.
+      await _pumpSheet(
+        tester,
+        FakeCastService(initial: refused()),
+        pins: _BrokenPinStore(),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.more_vert), findsOneWidget);
+    });
+
+    testWidgets('a forget that fails says so instead of claiming success',
+        (tester) async {
+      await _pumpSheet(
+        tester,
+        FakeCastService(initial: refused()),
+        pins: _BrokenPinStore(),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.more_vert));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Forget this device'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Forget'));
+      await tester.pumpAndSettle();
+
+      expect(
+          find.textContaining("couldn't forget Living Room"), findsOneWidget);
+    });
+
+    testWidgets('the connected device is not offered a forget', (tester) async {
+      // The live session already proved itself, so dropping its pin would
+      // change nothing now and read as if it had.
+      final InMemoryCastReceiverPinStore pins =
+          await pinned() as InMemoryCastReceiverPinStore;
+      await _pumpSheet(
+        tester,
+        FakeCastService(
+          initial: const CastState(
+            availability: CastAvailability.connected,
+            devices: <CastDevice>[_device],
+            connectedDevice: _device,
+          ),
+        ),
+        pins: pins,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Disconnect'), findsOneWidget);
+      expect(find.byIcon(Icons.more_vert), findsNothing);
+    });
+  });
+}
+
+/// A pin store that fails at everything, standing in for storage the app cannot
+/// reach. The sheet must neither hide the recovery nor pretend it worked.
+class _BrokenPinStore implements CastReceiverPinStore {
+  @override
+  Future<String?> pinFor(String deviceId) async =>
+      throw StateError('unavailable');
+
+  @override
+  Future<void> remember(String deviceId, String fingerprint) async =>
+      throw StateError('unavailable');
+
+  @override
+  Future<void> forget(String deviceId) async => throw StateError('unavailable');
 }


### PR DESCRIPTION
Part of #575. Deliberately not "Closes": this is step 5 of the 7-step plan in `docs/cast-hardened-design.md`, and the remediation #575 tracks is not done. See the last section.

Nothing here touches the containment. No shipped build opens a cast socket, and `scripts/check_cast_containment.py` plus `test/app/production_cast_containment_test.dart` still pass unchanged.

## Why

Layer 3 (device pinning) was already built and tested, but its shipped store kept pins in memory. That made every launch a first use: a swapped receiver was caught for one session and forgotten by the next, which is most of the value gone. The design doc listed two follow-ons for it, a persistent store and the sheet's "forget this device" action, and both are here.

## Persistent pin store

`SharedPreferencesCastReceiverPinStore`, wired in `productionApplicationOverrides`.

Fingerprints are digests of a certificate the receiver hands to anyone who connects, so there is nothing to encrypt. What the store owes is an honest answer and a write it does not lose, so it is deliberately the one preferences store in the repo that throws rather than degrading to a default. Everywhere else, unreadable storage costing a default tab or a default theme is the right trade. Here, "I can't read the pin" resolving to "this device has no pin" would re-pin whichever receiver answered, which would make breaking the store the way to erase the check. `TrustGatedCastTransport` already turns every throw into a refusal.

Details worth a look in review:

- one key per device, keyed by a digest of the device id. That is for shape, not secrecy: discovery returns whatever a receiver advertises, and nothing about a device id should decide what a preference key looks like.
- `remember` never overwrites an existing pin, so a second connection racing the first loses rather than re-pinning. The caller reads back and finds out.
- a blank stored value throws instead of reading as "never used", and `forget` is the way back out of it.

It is wired in production now rather than with the restoration on purpose: the pins a restored cast feature checks have to predate the release that restores it.

## The sheet's forget action

The `changedReceiver` refusal already told users to "forget it in the cast list and try again", and that sentence was not true yet. Two reasons:

1. The sheet replaced its device list with an empty state on any service error, so the one place the recovery lives was off screen. A refusal now keeps the list it was caused from, which is both the retry and the recovery. Discovery failing with nothing found still lands on the empty state.
2. There was no forget action. There is now, behind a confirmation that says what it costs, offered only where there is a pin to drop, and not offered for the connected device (that session already proved itself, so dropping its pin would change nothing now and would read as if it had).

A pin store that cannot answer still gets the menu item. Whether the recovery is drawn is a UI question, not a trust one, and the transport refuses on that same throw regardless.

## Tests

- `test/data/repositories/shared_preferences_cast_receiver_pin_store_test.dart`, 12 cases covering each rule the design states.
- `test/features/player/cast/cast_devices_sheet_test.dart`, 8 new cases: the refusal keeps its list, retry still works, no menu without a pin, cancel leaves the pin, confirm drops it, a broken store still offers the way out and does not claim success, and the connected device is left alone.
- `test/app/production_cast_containment_test.dart`, the persistent store is bound on every host and the override is in the production list.

Full suite green (4719 tests), `flutter analyze` clean, `dart format` clean, containment and secret guards pass.

## Why #575 stays open

Merging this leaves the reported issue unremediated and casting still contained. Outstanding:

- steps 1 to 4: vendored protocol definitions and the two pinned trust anchors, the certificate path validator, the narrow Cast client with a mandatory challenge, and the authenticator on top of them. Layer 2 (device authentication) does not exist anywhere in the tree, and it is the whole of the risk.
- step 6: the device matrix by hand, results to the advisory.
- step 7: the restoration itself, including handing this same store to `TrustGatedCastTransport` and flipping `CastContainment.isActive`, as its own reviewed change and its own release.

Docs updated: `docs/cast-hardened-design.md` (layer 3, the staged plan, the tests section) and `docs/cast-receiver-trust.md` (the component list and the restoration checklist).