### PR TITLE
feat(desktop): reorder a playlist with a mouse or a keyboard (#389)

### DIFF
--- a/docs/playlists-and-delete.md
+++ b/docs/playlists-and-delete.md
@@ -26,9 +26,36 @@ What you can do:
   Playing actions, or via multi-select.
 - **Remove tracks** from a playlist (per-row, with an Undo snackbar, or via
   multi-select).
-- **Reorder tracks** by dragging the handle on a row.
+- **Reorder tracks** by dragging the handle on a row — see
+  [Reordering a playlist](#reordering-a-playlist).
 - **Play** the playlist, or **Shuffle** it, from the detail screen. Tapping any
   track plays from there and queues the rest of the playlist behind it.
+
+### Reordering a playlist
+
+Drag a track by the handle on its row to move it. On desktop the handle behaves
+the way a desktop control should: the pointer turns into a grab cursor over it,
+hovering shows what it does, and the row lifts onto a shadow while it is being
+dragged so you can see what you picked up.
+
+**Without a pointer.** Tab to a row's handle and press **Ctrl + ↑ / ↓** (Cmd on
+macOS) to move that row one position. Focus follows the track, so holding the
+chord walks it up or down the playlist (the list scrolls along to keep the track
+you are moving in view). The same two moves are exposed to screen readers as the
+row's **Move up** / **Move down** actions, and a row at either end only offers
+the move that goes somewhere.
+
+Drag, keyboard and screen reader all run through the same
+`PlaylistRepository.reorderTracks` call, so nothing behaves differently
+depending on how you reached it. The new order is written locally first; a
+server that refuses it leaves the local order applied and the playlist marked
+`syncFailed` rather than losing the edit (see [Sync state](#sync-state)).
+
+Reordering is offered only when every stored track resolved to something in your
+library. If some entries are missing (the "N songs are no longer in your
+library" note), the list is not reorderable at all — the visible rows no longer
+line up 1:1 with the stored order, so a drag could scramble entries you cannot
+see.
 
 Playlists persist locally via `shared_preferences` (the same lightweight,
 plugin-only storage used for favourites and the offline-download set) — no

--- a/lib/features/player/widgets/queue_sheet.dart
+++ b/lib/features/player/widgets/queue_sheet.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../app/dimens.dart';
@@ -10,6 +8,8 @@ import '../../../core/models/track.dart';
 import '../../../core/repositories/playlist_repository.dart';
 import '../../../data/repositories/playlist_repository_provider.dart';
 import '../../../shared/widgets/now_playing_indicator.dart';
+import '../../../shared/widgets/reorder_focus_walk.dart';
+import '../../../shared/widgets/reorder_handle.dart';
 import '../../playlists/widgets/create_playlist_dialog.dart';
 import '../now_playing.dart';
 import '../player_providers.dart';
@@ -332,50 +332,21 @@ class _UpNextList extends ConsumerStatefulWidget {
 }
 
 class _UpNextListState extends ConsumerState<_UpNextList> {
-  final List<FocusNode> _handleFocusNodes = <FocusNode>[];
-
-  /// Where a keyboard walk started from and where it has actually put the
-  /// track, while the list catches up.
-  ///
-  /// The queue reaches this sheet through a stream, so a move is applied to the
-  /// queue before any frame rebuilds the rows with it. A held chord repeats
-  /// faster than that: the second press is fired by a handle still carrying the
-  /// pre-move index, and taking it at face value would move the track back
-  /// where it came from. [_walkOrigin] is that stale index, [_walkLanded] is
-  /// where the track really is, and both are dropped the moment the rebuild
-  /// makes the widgets truthful again.
-  int? _walkOrigin;
-  int? _walkLanded;
+  final ReorderFocusWalk _walk =
+      ReorderFocusWalk(debugLabelPrefix: 'queue-handle');
 
   @override
   void didUpdateWidget(_UpNextList oldWidget) {
     super.didUpdateWidget(oldWidget);
     // A reorder always produces a new list, so a changed identity means the
     // rows now carry post-move indices and the walk state has served its turn.
-    if (!identical(widget.tracks, oldWidget.tracks)) {
-      _walkOrigin = null;
-      _walkLanded = null;
-    }
+    if (!identical(widget.tracks, oldWidget.tracks)) _walk.reset();
   }
 
   @override
   void dispose() {
-    for (final FocusNode node in _handleFocusNodes) {
-      node.dispose();
-    }
+    _walk.dispose();
     super.dispose();
-  }
-
-  /// The handle focus node for row [index], grown on demand. The list only ever
-  /// grows within one sheet: a shrinking queue leaves spare nodes parked, which
-  /// costs nothing and keeps the indices stable.
-  FocusNode _focusNodeAt(int index) {
-    while (_handleFocusNodes.length <= index) {
-      _handleFocusNodes.add(
-        FocusNode(debugLabel: 'queue-handle-${_handleFocusNodes.length}'),
-      );
-    }
-    return _handleFocusNodes[index];
   }
 
   /// Moves the up-next track at [from] to [to] (both 0-based into up-next,
@@ -395,20 +366,12 @@ class _UpNextListState extends ConsumerState<_UpNextList> {
 
   /// Moves the track the handle on row [rowIndex] belongs to by [delta]
   /// positions — the keyboard and screen-reader route.
-  ///
-  /// [rowIndex] is only a starting point: while a walk is in flight the rows
-  /// still report their pre-move indices, so the real source comes from
-  /// [_walkLanded]. The substitution is guarded on [_walkOrigin] so a press on
-  /// some *other* row inside that same window is still taken at face value.
   void _moveBy(int rowIndex, int delta) {
-    final int from = _walkLanded != null && rowIndex == _walkOrigin
-        ? _walkLanded!
-        : rowIndex;
+    final int from = _walk.sourceFor(rowIndex);
     final int to = from + delta;
     if (!_move(from, to)) return;
-    _walkOrigin = rowIndex;
-    _walkLanded = to;
-    _followWalkTo(to, delta);
+    _walk.recordMove(rowIndex: rowIndex, to: to);
+    _walk.followTo(to, delta);
   }
 
   /// Applies a pointer drop, carrying keyboard focus along with the row that
@@ -423,48 +386,13 @@ class _UpNextListState extends ConsumerState<_UpNextList> {
   /// Nothing happens when no handle has focus, so a plain mouse drag never
   /// pulls focus into the list.
   void _moveByPointer(int from, int to) {
-    final int focused =
-        _handleFocusNodes.indexWhere((FocusNode node) => node.hasFocus);
+    final int focused = _walk.focusedIndex;
     if (!_move(from, to)) return;
     if (focused < 0) return;
-    _followWalkTo(_positionAfterMove(focused, from: from, to: to), to - from);
-  }
-
-  /// Where row [index] ends up once the row at [from] is moved to [to].
-  static int _positionAfterMove(
-    int index, {
-    required int from,
-    required int to,
-  }) {
-    if (index == from) return to;
-    if (from < index && index <= to) return index - 1;
-    if (to <= index && index < from) return index + 1;
-    return index;
-  }
-
-  /// Scrolls the moved track's handle into view and gives it focus, so a held
-  /// chord keeps walking the same track.
-  ///
-  /// The scroll is the part that makes this hold up on a long queue. Focus can
-  /// only land on a row the sliver has actually built, and a walk that never
-  /// scrolls eventually pushes the track past the built range: focus would stay
-  /// behind on the row a *different* track just slid into, and the next press
-  /// would move that one instead. Keeping the walking row on screen keeps its
-  /// destination within the built range, one row at a time.
-  void _followWalkTo(int index, int delta) {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || index >= _handleFocusNodes.length) return;
-      final FocusNode node = _handleFocusNodes[index];
-      final BuildContext? handle = node.context;
-      if (handle == null) return;
-      Scrollable.ensureVisible(
-        handle,
-        alignmentPolicy: delta > 0
-            ? ScrollPositionAlignmentPolicy.keepVisibleAtEnd
-            : ScrollPositionAlignmentPolicy.keepVisibleAtStart,
-      );
-      node.requestFocus();
-    });
+    _walk.followTo(
+      ReorderFocusWalk.positionAfterMove(focused, from: from, to: to),
+      to - from,
+    );
   }
 
   @override
@@ -473,7 +401,7 @@ class _UpNextListState extends ConsumerState<_UpNextList> {
     return SliverReorderableList(
       itemCount: tracks.length,
       onReorderItem: _moveByPointer,
-      proxyDecorator: _liftedRow,
+      proxyDecorator: liftedReorderProxy,
       itemBuilder: (context, index) => _UpNextTile(
         // Index-qualified so the same track queued twice never produces a
         // duplicate key (which would crash the reorderable list).
@@ -481,7 +409,7 @@ class _UpNextListState extends ConsumerState<_UpNextList> {
         track: tracks[index],
         index: index,
         count: tracks.length,
-        handleFocusNode: _focusNodeAt(index),
+        handleFocusNode: _walk.nodeAt(index),
         onPlay: () => ref.read(playbackControllerProvider).playFromQueue(index),
         onRemove: () =>
             ref.read(playbackControllerProvider).removeFromQueue(index),
@@ -489,28 +417,6 @@ class _UpNextListState extends ConsumerState<_UpNextList> {
       ),
     );
   }
-}
-
-/// The row being dragged: lifted off the list on a shadow so it reads as picked
-/// up rather than merely highlighted. Desktop pointers have no haptics and no
-/// long-press wind-up, so this elevation is the only feedback that the drag
-/// actually took.
-Widget _liftedRow(Widget child, int index, Animation<double> animation) {
-  return AnimatedBuilder(
-    animation: animation,
-    builder: (BuildContext context, Widget? child) {
-      final ColorScheme scheme = Theme.of(context).colorScheme;
-      final double t = Curves.easeInOut.transform(animation.value);
-      return Material(
-        elevation: t * 6,
-        color: Color.lerp(scheme.surface, scheme.surfaceContainerHighest, t),
-        shadowColor: scheme.shadow,
-        borderRadius: BorderRadius.circular(AppRadii.sm),
-        child: child,
-      );
-    },
-    child: child,
-  );
 }
 
 /// An upcoming track: tap to play now, an X to remove it from the queue, and a
@@ -564,145 +470,13 @@ class _UpNextTile extends StatelessWidget {
               tooltip: 'Remove from queue',
               onPressed: onRemove,
             ),
-            _ReorderHandle(
+            ReorderHandle(
               index: index,
               count: count,
               focusNode: handleFocusNode,
               onMoveBy: onMoveBy,
             ),
           ],
-        ),
-      ),
-    );
-  }
-}
-
-/// The modifier the move chord is spelled with on [platform].
-///
-/// Both modifiers stay registered everywhere — an unused activator costs
-/// nothing — but the hint has to name the one that actually works here. On
-/// macOS Ctrl+Arrow belongs to Mission Control and never reaches the app, so a
-/// hint saying Ctrl there would point people at a chord the OS eats.
-String _moveModifierLabel(TargetPlatform platform) =>
-    platform == TargetPlatform.macOS ? 'Cmd' : 'Ctrl';
-
-/// Asks for the focused queue row to move [delta] positions (-1 up, +1 down).
-class _MoveQueueItemIntent extends Intent {
-  const _MoveQueueItemIntent(this.delta);
-
-  final int delta;
-}
-
-/// The reorder affordance on an up-next row: a pointer drag target that is also
-/// a real focusable control.
-///
-/// Dragging is the fast path and stays exactly what it was. The rest is what a
-/// drag alone cannot serve: **Ctrl + ↑ / ↓** (Cmd on macOS) moves the focused
-/// row without a pointer, and the same two moves are offered as custom
-/// semantics actions so a screen reader can reorder the queue too. Both routes
-/// run through the same controller call the drag does, so there is one reorder
-/// path, not a keyboard copy of one.
-///
-/// The chord takes a modifier on purpose: a bare arrow inside a scrolling sheet
-/// belongs to focus traversal and scrolling, and stealing it would trade one
-/// accessible behaviour for another.
-class _ReorderHandle extends StatelessWidget {
-  const _ReorderHandle({
-    required this.index,
-    required this.count,
-    required this.focusNode,
-    required this.onMoveBy,
-  });
-
-  final int index;
-  final int count;
-  final FocusNode focusNode;
-  final ValueChanged<int> onMoveBy;
-
-  /// Shortcuts sit *above* the focus node, not inside it: a key event travels
-  /// up from the focused node, so a [Shortcuts] below it would never see one.
-  static const Map<ShortcutActivator, Intent> _shortcuts =
-      <ShortcutActivator, Intent>{
-    SingleActivator(LogicalKeyboardKey.arrowUp, control: true):
-        _MoveQueueItemIntent(-1),
-    SingleActivator(LogicalKeyboardKey.arrowDown, control: true):
-        _MoveQueueItemIntent(1),
-    SingleActivator(LogicalKeyboardKey.arrowUp, meta: true):
-        _MoveQueueItemIntent(-1),
-    SingleActivator(LogicalKeyboardKey.arrowDown, meta: true):
-        _MoveQueueItemIntent(1),
-  };
-
-  @override
-  Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-    final bool canMoveUp = index > 0;
-    final bool canMoveDown = index < count - 1;
-    return Shortcuts(
-      shortcuts: _shortcuts,
-      child: Actions(
-        actions: <Type, Action<Intent>>{
-          _MoveQueueItemIntent: CallbackAction<_MoveQueueItemIntent>(
-            onInvoke: (_MoveQueueItemIntent intent) {
-              onMoveBy(intent.delta);
-              return null;
-            },
-          ),
-        },
-        // Not a semantics container: the actions merge up into the row's own
-        // node, so a screen reader reads one row that happens to be movable
-        // rather than a stray control beside it. The ends of the list offer
-        // only the move that exists.
-        child: Semantics(
-          customSemanticsActions: <CustomSemanticsAction, VoidCallback>{
-            if (canMoveUp)
-              const CustomSemanticsAction(label: 'Move up'): () => onMoveBy(-1),
-            if (canMoveDown)
-              const CustomSemanticsAction(label: 'Move down'): () =>
-                  onMoveBy(1),
-          },
-          child: Focus(
-            focusNode: focusNode,
-            child: Builder(
-              builder: (BuildContext context) {
-                final bool focused = Focus.of(context).hasFocus;
-                return MouseRegion(
-                  cursor: SystemMouseCursors.grab,
-                  child: ReorderableDragStartListener(
-                    index: index,
-                    child: Tooltip(
-                      message: 'Reorder (drag, or '
-                          '${_moveModifierLabel(theme.platform)} + ↑ / ↓)',
-                      // Hover only. The default long-press trigger puts a
-                      // long-press recognizer in the arena next to the drag
-                      // listener, and on a handle the press *is* the drag: the
-                      // tooltip wins and the row never lifts. Hover is the
-                      // desktop trigger anyway, and the handle is still named
-                      // for screen readers either way.
-                      triggerMode: TooltipTriggerMode.manual,
-                      child: Container(
-                        margin: const EdgeInsets.only(left: AppSpacing.xs),
-                        padding: const EdgeInsets.all(AppSpacing.xs),
-                        decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(AppRadii.sm),
-                          border: Border.all(
-                            width: 2,
-                            color: focused
-                                ? theme.colorScheme.primary
-                                : Colors.transparent,
-                          ),
-                        ),
-                        child: const Icon(
-                          Icons.drag_handle,
-                          semanticLabel: 'Reorder',
-                        ),
-                      ),
-                    ),
-                  ),
-                );
-              },
-            ),
-          ),
         ),
       ),
     );

--- a/lib/features/playlists/playlist_detail_screen.dart
+++ b/lib/features/playlists/playlist_detail_screen.dart
@@ -11,6 +11,8 @@ import '../../data/repositories/favorites_repository_provider.dart';
 import '../../data/repositories/playlist_repository_provider.dart';
 import '../../shared/widgets/confirm_dialog.dart';
 import '../../shared/widgets/empty_state.dart';
+import '../../shared/widgets/reorder_focus_walk.dart';
+import '../../shared/widgets/reorder_handle.dart';
 import '../library/song_actions.dart';
 import '../player/favorites_providers.dart';
 import '../player/now_playing.dart';
@@ -104,6 +106,11 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
                 ],
               ),
         body: tracksAsync.when(
+          // Every edit — a reorder, a removal — re-runs the uri-to-Track
+          // resolution, and a spinner over the list on each one would both
+          // flash and tear down the reorder list's focus nodes mid-keyboard
+          // walk. Only the genuine first load shows the spinner.
+          skipLoadingOnReload: true,
           loading: () => const Center(child: CircularProgressIndicator()),
           error: (_, __) => const EmptyState(
             icon: Icons.error_outline,
@@ -220,28 +227,16 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
       return ListView.builder(
         key: _listPosition,
         itemCount: tracks.length,
-        itemBuilder: (context, index) =>
-            _trackRow(playlist, tracks, index, draggable: false),
+        itemBuilder: (context, index) => _trackRow(playlist, tracks, index),
       );
     }
 
-    return ReorderableListView.builder(
+    return _ReorderableTrackList(
       key: _listPosition,
-      buildDefaultDragHandles: false,
-      itemCount: tracks.length,
-      onReorderItem: (int oldIndex, int newIndex) {
-        // The repository still accepts the legacy pre-removal insertion index.
-        // Flutter 3.44's onReorderItem gives the final destination index, so
-        // convert only at this boundary and keep persistence behaviour stable.
-        if (oldIndex < newIndex) newIndex += 1;
-        ref.read(playlistRepositoryProvider).reorderTracks(
-              playlist.id,
-              oldIndex,
-              newIndex,
-            );
-      },
-      itemBuilder: (context, index) =>
-          _trackRow(playlist, tracks, index, draggable: true),
+      playlistId: playlist.id,
+      tracks: tracks,
+      rowBuilder: (int index, Widget handle) =>
+          _trackRow(playlist, tracks, index, handle: handle),
     );
   }
 
@@ -249,7 +244,7 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
     Playlist playlist,
     List<Track> tracks,
     int index, {
-    required bool draggable,
+    Widget? handle,
   }) {
     final Track track = tracks[index];
     final NowPlayingRowState? nowPlaying =
@@ -319,14 +314,7 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
               ),
             ],
           ),
-          if (draggable)
-            ReorderableDragStartListener(
-              index: index,
-              child: const Padding(
-                padding: EdgeInsets.only(left: AppSpacing.xs),
-                child: Icon(Icons.drag_handle),
-              ),
-            ),
+          if (handle != null) handle,
         ],
       ),
       onTap: () => _playFrom(tracks, index),
@@ -564,6 +552,124 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
     if (artist == null || artist.isEmpty) return null;
     final String? album = track.albumName;
     return (album == null || album.isEmpty) ? artist : '$artist • $album';
+  }
+}
+
+/// The playlist's drag-to-reorder list.
+///
+/// Its own widget for the same reason the queue's Up Next list is: keyboard
+/// reordering needs to know when the rows have caught up with a move, and
+/// `didUpdateWidget` on a list that is handed its tracks is the honest signal
+/// for that. Everything about *how* a row is reordered — the grab cursor, the
+/// lift, the Ctrl/Cmd + arrow chord, the screen-reader move actions — lives in
+/// the shared [ReorderHandle] and [ReorderFocusWalk], so the playlist editor
+/// and the queue cannot drift into two different gestures (#388, #389).
+///
+/// Every route (drag, chord, screen reader) lands on the same
+/// [PlaylistRepository.reorderTracks] call, so there is one persistence path
+/// rather than a keyboard copy of one. The repository writes locally first and
+/// never throws, so a server that refuses the new order leaves the local order
+/// applied and the playlist marked as failed to sync, rather than losing the
+/// edit.
+class _ReorderableTrackList extends ConsumerStatefulWidget {
+  const _ReorderableTrackList({
+    required this.playlistId,
+    required this.tracks,
+    required this.rowBuilder,
+    super.key,
+  });
+
+  final String playlistId;
+  final List<Track> tracks;
+
+  /// Builds the row at an index, handed the reorder handle to put in it.
+  final Widget Function(int index, Widget handle) rowBuilder;
+
+  @override
+  ConsumerState<_ReorderableTrackList> createState() =>
+      _ReorderableTrackListState();
+}
+
+class _ReorderableTrackListState extends ConsumerState<_ReorderableTrackList> {
+  final ReorderFocusWalk _walk =
+      ReorderFocusWalk(debugLabelPrefix: 'playlist-handle');
+
+  @override
+  void didUpdateWidget(_ReorderableTrackList oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // A reorder always resolves to a fresh list, so a changed identity means
+    // the rows now carry post-move indices and the walk has served its turn.
+    if (!identical(widget.tracks, oldWidget.tracks)) _walk.reset();
+  }
+
+  @override
+  void dispose() {
+    _walk.dispose();
+    super.dispose();
+  }
+
+  /// Moves the track at [from] to [to], both 0-based into the visible list,
+  /// [to] being the destination *after* removal.
+  ///
+  /// Out-of-range moves are dropped here as well as in the repository, so a
+  /// chord at either end of the list — or an index left stale by a playlist
+  /// that changed under the open screen — is simply harmless.
+  bool _move(int from, int to) {
+    final int count = widget.tracks.length;
+    if (from < 0 || from >= count) return false;
+    if (to < 0 || to >= count || to == from) return false;
+    // The repository still takes the legacy pre-removal insertion index, so a
+    // downward move is converted at this one boundary and persistence
+    // behaviour stays exactly what it was.
+    ref.read(playlistRepositoryProvider).reorderTracks(
+          widget.playlistId,
+          from,
+          to > from ? to + 1 : to,
+        );
+    return true;
+  }
+
+  /// The keyboard and screen-reader route: move the track the handle on row
+  /// [rowIndex] belongs to by [delta] positions.
+  void _moveBy(int rowIndex, int delta) {
+    final int from = _walk.sourceFor(rowIndex);
+    final int to = from + delta;
+    if (!_move(from, to)) return;
+    _walk.recordMove(rowIndex: rowIndex, to: to);
+    _walk.followTo(to, delta);
+  }
+
+  /// A pointer drop, carrying keyboard focus along with the row that held it.
+  /// Nothing happens when no handle has focus, so a plain mouse drag never
+  /// pulls focus into the list.
+  void _moveByPointer(int from, int to) {
+    final int focused = _walk.focusedIndex;
+    if (!_move(from, to)) return;
+    if (focused < 0) return;
+    _walk.followTo(
+      ReorderFocusWalk.positionAfterMove(focused, from: from, to: to),
+      to - from,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final List<Track> tracks = widget.tracks;
+    return ReorderableListView.builder(
+      buildDefaultDragHandles: false,
+      proxyDecorator: liftedReorderProxy,
+      itemCount: tracks.length,
+      onReorderItem: _moveByPointer,
+      itemBuilder: (BuildContext context, int index) => widget.rowBuilder(
+        index,
+        ReorderHandle(
+          index: index,
+          count: tracks.length,
+          focusNode: _walk.nodeAt(index),
+          onMoveBy: (int delta) => _moveBy(index, delta),
+        ),
+      ),
+    );
   }
 }
 

--- a/lib/shared/widgets/reorder_focus_walk.dart
+++ b/lib/shared/widgets/reorder_focus_walk.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/widgets.dart';
+
+/// Keeps keyboard focus on the row a reorder actually moved.
+///
+/// A pointer drag carries the row under the pointer, so the framework keeps the
+/// gesture aimed at the right item by itself. A keyboard move is a jump
+/// instead — the list rebuilds with the moved row a slot away — so focus has to
+/// be handed to the row it landed on, or a second Ctrl+Arrow would move
+/// whatever slid into the old position.
+///
+/// The focus nodes are per *position*, not per item, which is what makes that
+/// work: after the rebuild the node at the destination index is the moved row's
+/// handle. Keying them by item would mean a new node per edit, and a duplicate
+/// node whenever the same song appears twice.
+///
+/// Shared by the queue's Up Next list and the playlist editor (#388, #389).
+/// Pure enough to unit-test the index arithmetic without pumping a list; the
+/// focus and scroll side effects are exercised through the two screens.
+class ReorderFocusWalk {
+  ReorderFocusWalk({String debugLabelPrefix = 'reorder-handle'})
+      : _debugLabelPrefix = debugLabelPrefix;
+
+  final String _debugLabelPrefix;
+  final List<FocusNode> _nodes = <FocusNode>[];
+  bool _disposed = false;
+
+  /// Where a keyboard walk started from and where it has actually put the row,
+  /// while the list catches up.
+  ///
+  /// A move is applied to the underlying model before any frame rebuilds the
+  /// rows with it. A held chord repeats faster than that: the second press is
+  /// fired by a handle still carrying the pre-move index, and taking it at face
+  /// value would move the row back where it came from. [_walkOrigin] is that
+  /// stale index, [_walkLanded] is where the row really is, and [reset] drops
+  /// both the moment a rebuild makes the widgets truthful again.
+  int? _walkOrigin;
+  int? _walkLanded;
+
+  /// The handle focus node for row [index], grown on demand.
+  ///
+  /// The list only ever grows within one screen: a shrinking list leaves spare
+  /// nodes parked, which costs nothing and keeps the indices stable.
+  FocusNode nodeAt(int index) {
+    while (_nodes.length <= index) {
+      _nodes.add(FocusNode(debugLabel: '$_debugLabelPrefix-${_nodes.length}'));
+    }
+    return _nodes[index];
+  }
+
+  /// Forgets an in-flight walk. Hosts call this when the list identity changes,
+  /// which means the rows now carry post-move indices.
+  void reset() {
+    _walkOrigin = null;
+    _walkLanded = null;
+  }
+
+  void dispose() {
+    for (final FocusNode node in _nodes) {
+      node.dispose();
+    }
+    _nodes.clear();
+    _disposed = true;
+  }
+
+  /// The real source row for a move asked for by the handle on [rowIndex].
+  ///
+  /// [rowIndex] is only a starting point: while a walk is in flight the rows
+  /// still report their pre-move indices, so the real source comes from the
+  /// landed position. The substitution is guarded on the walk's origin, so a
+  /// press on some *other* row inside that same window is still taken at face
+  /// value.
+  int sourceFor(int rowIndex) =>
+      (_walkLanded != null && rowIndex == _walkOrigin)
+          ? _walkLanded!
+          : rowIndex;
+
+  /// Records that the row whose handle sits on [rowIndex] has landed on [to].
+  void recordMove({required int rowIndex, required int to}) {
+    _walkOrigin = rowIndex;
+    _walkLanded = to;
+  }
+
+  /// The index of the handle that currently has focus, or -1 when none does —
+  /// so a plain mouse drag never pulls focus into the list.
+  int get focusedIndex => _nodes.indexWhere((FocusNode node) => node.hasFocus);
+
+  /// Where row [index] ends up once the row at [from] is moved to [to].
+  ///
+  /// [to] is the destination *after* removal, the index a normalised
+  /// reorderable list reports.
+  static int positionAfterMove(
+    int index, {
+    required int from,
+    required int to,
+  }) {
+    if (index == from) return to;
+    if (from < index && index <= to) return index - 1;
+    if (to <= index && index < from) return index + 1;
+    return index;
+  }
+
+  /// Scrolls the moved row's handle into view and gives it focus, so a held
+  /// chord keeps walking the same row. [delta] is the direction of the move.
+  ///
+  /// The scroll is the part that makes this hold up on a long list. Focus can
+  /// only land on a row the sliver has actually built, and a walk that never
+  /// scrolls eventually pushes the row past the built range: focus would stay
+  /// behind on the row a *different* item just slid into, and the next press
+  /// would move that one instead. Keeping the walking row on screen keeps its
+  /// destination within the built range, one row at a time.
+  void followTo(int index, int delta) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_disposed || index < 0 || index >= _nodes.length) return;
+      final FocusNode node = _nodes[index];
+      final BuildContext? handle = node.context;
+      if (handle == null) return;
+      Scrollable.ensureVisible(
+        handle,
+        alignmentPolicy: delta > 0
+            ? ScrollPositionAlignmentPolicy.keepVisibleAtEnd
+            : ScrollPositionAlignmentPolicy.keepVisibleAtStart,
+      );
+      node.requestFocus();
+    });
+  }
+}

--- a/lib/shared/widgets/reorder_handle.dart
+++ b/lib/shared/widgets/reorder_handle.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter/services.dart';
+
+import '../../app/dimens.dart';
+
+/// The modifier the move chord is spelled with on [platform].
+///
+/// Both modifiers stay registered everywhere — an unused activator costs
+/// nothing — but the hint has to name the one that actually works here. On
+/// macOS Ctrl+Arrow belongs to Mission Control and never reaches the app, so a
+/// hint saying Ctrl there would point people at a chord the OS eats.
+String reorderModifierLabel(TargetPlatform platform) =>
+    platform == TargetPlatform.macOS ? 'Cmd' : 'Ctrl';
+
+/// The row being dragged: lifted off the list on a shadow so it reads as picked
+/// up rather than merely highlighted. Desktop pointers have no haptics and no
+/// long-press wind-up, so this elevation is the only feedback that the drag
+/// actually took.
+///
+/// Pass it as a reorderable list's `proxyDecorator` so every list in the app
+/// lifts a row the same way.
+Widget liftedReorderProxy(
+  Widget child,
+  int index,
+  Animation<double> animation,
+) {
+  return AnimatedBuilder(
+    animation: animation,
+    builder: (BuildContext context, Widget? child) {
+      final ColorScheme scheme = Theme.of(context).colorScheme;
+      final double t = Curves.easeInOut.transform(animation.value);
+      return Material(
+        elevation: t * 6,
+        color: Color.lerp(scheme.surface, scheme.surfaceContainerHighest, t),
+        shadowColor: scheme.shadow,
+        borderRadius: BorderRadius.circular(AppRadii.sm),
+        child: child,
+      );
+    },
+    child: child,
+  );
+}
+
+/// Asks for the focused row to move [delta] positions (-1 up, +1 down).
+class _MoveItemIntent extends Intent {
+  const _MoveItemIntent(this.delta);
+
+  final int delta;
+}
+
+/// The reorder affordance on a reorderable row: a pointer drag target that is
+/// also a real focusable control.
+///
+/// Dragging is the fast path. The rest is what a drag alone cannot serve:
+/// **Ctrl + ↑ / ↓** (Cmd on macOS) moves the focused row without a pointer, and
+/// the same two moves are offered as custom semantics actions so a screen
+/// reader can reorder the list too. Hosts run all three routes through one
+/// callback, so there is one reorder path rather than a keyboard copy of one.
+///
+/// The chord takes a modifier on purpose: a bare arrow inside a scrolling list
+/// belongs to focus traversal and scrolling, and stealing it would trade one
+/// accessible behaviour for another.
+///
+/// Shared by the queue's Up Next list and the playlist editor (#388, #389) so
+/// the two lists cannot drift into two different reorder gestures. Pair it with
+/// a [ReorderFocusWalk] on the host, which is what keeps a held chord walking
+/// one row rather than whatever slid under the focus.
+class ReorderHandle extends StatelessWidget {
+  const ReorderHandle({
+    required this.index,
+    required this.count,
+    required this.focusNode,
+    required this.onMoveBy,
+    super.key,
+  });
+
+  /// This row's position in the list, as the reorderable list numbers them.
+  final int index;
+
+  /// How many rows the list has, so the ends offer only the move that exists.
+  final int count;
+
+  final FocusNode focusNode;
+
+  /// Moves this row by the given delta (-1 up, +1 down).
+  final ValueChanged<int> onMoveBy;
+
+  /// Shortcuts sit *above* the focus node, not inside it: a key event travels
+  /// up from the focused node, so a [Shortcuts] below it would never see one.
+  static const Map<ShortcutActivator, Intent> _shortcuts =
+      <ShortcutActivator, Intent>{
+    SingleActivator(LogicalKeyboardKey.arrowUp, control: true):
+        _MoveItemIntent(-1),
+    SingleActivator(LogicalKeyboardKey.arrowDown, control: true):
+        _MoveItemIntent(1),
+    SingleActivator(LogicalKeyboardKey.arrowUp, meta: true):
+        _MoveItemIntent(-1),
+    SingleActivator(LogicalKeyboardKey.arrowDown, meta: true):
+        _MoveItemIntent(1),
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final bool canMoveUp = index > 0;
+    final bool canMoveDown = index < count - 1;
+    return Shortcuts(
+      shortcuts: _shortcuts,
+      child: Actions(
+        actions: <Type, Action<Intent>>{
+          _MoveItemIntent: CallbackAction<_MoveItemIntent>(
+            onInvoke: (_MoveItemIntent intent) {
+              onMoveBy(intent.delta);
+              return null;
+            },
+          ),
+        },
+        // Not a semantics container: the actions merge up into the row's own
+        // node, so a screen reader reads one row that happens to be movable
+        // rather than a stray control beside it. The ends of the list offer
+        // only the move that exists.
+        child: Semantics(
+          customSemanticsActions: <CustomSemanticsAction, VoidCallback>{
+            if (canMoveUp)
+              const CustomSemanticsAction(label: 'Move up'): () => onMoveBy(-1),
+            if (canMoveDown)
+              const CustomSemanticsAction(label: 'Move down'): () =>
+                  onMoveBy(1),
+          },
+          child: Focus(
+            focusNode: focusNode,
+            child: Builder(
+              builder: (BuildContext context) {
+                final bool focused = Focus.of(context).hasFocus;
+                return MouseRegion(
+                  cursor: SystemMouseCursors.grab,
+                  child: ReorderableDragStartListener(
+                    index: index,
+                    child: Tooltip(
+                      message: 'Reorder (drag, or '
+                          '${reorderModifierLabel(theme.platform)} + ↑ / ↓)',
+                      // Hover only. The default long-press trigger puts a
+                      // long-press recognizer in the arena next to the drag
+                      // listener, and on a handle the press *is* the drag: the
+                      // tooltip wins and the row never lifts. Hover is the
+                      // desktop trigger anyway, and the handle is still named
+                      // for screen readers either way.
+                      triggerMode: TooltipTriggerMode.manual,
+                      child: Container(
+                        margin: const EdgeInsets.only(left: AppSpacing.xs),
+                        padding: const EdgeInsets.all(AppSpacing.xs),
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(AppRadii.sm),
+                          border: Border.all(
+                            width: 2,
+                            color: focused
+                                ? theme.colorScheme.primary
+                                : Colors.transparent,
+                          ),
+                        ),
+                        child: const Icon(
+                          Icons.drag_handle,
+                          semanticLabel: 'Reorder',
+                        ),
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/playlists/playlist_detail_screen_test.dart
+++ b/test/features/playlists/playlist_detail_screen_test.dart
@@ -1,4 +1,7 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -51,6 +54,7 @@ Future<void> _pump(
   required InMemoryPlaylistStore store,
   required FakePlaybackController controller,
   List<Track> tracks = _tracks,
+  TargetPlatform? platform,
 }) async {
   await tester.pumpWidget(
     ProviderScope(
@@ -60,7 +64,10 @@ Future<void> _pump(
             .overrideWithValue(FakeMusicLibraryRepository(tracks: tracks)),
         playbackControllerProvider.overrideWithValue(controller),
       ],
-      child: MaterialApp.router(routerConfig: _router()),
+      child: MaterialApp.router(
+        theme: platform == null ? null : ThemeData(platform: platform),
+        routerConfig: _router(),
+      ),
     ),
   );
   await tester.pumpAndSettle();
@@ -97,6 +104,57 @@ Future<void> _dragToEnd(WidgetTester tester, {required int from}) async {
   await tester.pumpAndSettle();
   await gesture.up();
   await tester.pumpAndSettle();
+}
+
+/// Gives the reorder handle on row [index] keyboard focus, the way Tab would.
+Future<void> _focusHandle(WidgetTester tester, int index) async {
+  final Finder handles = find.byIcon(Icons.drag_handle);
+  Focus.of(tester.element(handles.at(index))).requestFocus();
+  await tester.pumpAndSettle();
+}
+
+/// Presses Ctrl + Arrow Up/Down, the chord that moves the focused row.
+Future<void> _pressMoveChord(WidgetTester tester, {required bool down}) async {
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+  await tester.sendKeyEvent(
+    down ? LogicalKeyboardKey.arrowDown : LogicalKeyboardKey.arrowUp,
+  );
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+  await tester.pumpAndSettle();
+}
+
+/// Holds Ctrl + Arrow Down for [repeats] extra auto-repeats, with no frame in
+/// between.
+///
+/// A playlist edit reaches the screen through the store's stream and an async
+/// re-resolve, so nothing has rebuilt the rows by the time the repeat arrives.
+/// This is the real shape of a held key, and the one case a press-then-pump
+/// test cannot reach.
+Future<void> _holdMoveChordDown(WidgetTester tester, {int repeats = 1}) async {
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowDown);
+  for (int i = 0; i < repeats; i++) {
+    await tester.sendKeyRepeatEvent(LogicalKeyboardKey.arrowDown);
+  }
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.arrowDown);
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+  await tester.pumpAndSettle();
+}
+
+/// The stored track order, read back from the playlist store.
+Future<List<String>> _storedOrder(InMemoryPlaylistStore store) async {
+  final List<Playlist> saved = await store.load();
+  return saved.single.trackIds;
+}
+
+/// The custom semantics actions offered on the row rendering [title].
+Set<String> _customActionsOn(WidgetTester tester, String title) {
+  return tester
+      .getSemantics(find.text(title))
+      .getSemanticsData()
+      .customSemanticsActionIds!
+      .map((int id) => CustomSemanticsAction.getAction(id)!.label!)
+      .toSet();
 }
 
 void main() {
@@ -228,5 +286,209 @@ void main() {
     await tester.tap(find.text('Song B'));
     await tester.pumpAndSettle();
     expect(find.text('2 selected'), findsOneWidget);
+  });
+
+  testWidgets('Ctrl+Arrow moves the focused track without a pointer',
+      (tester) async {
+    final InMemoryPlaylistStore store = await _seededStore(
+      trackIds: <String>['file:///a.mp3', 'file:///b.mp3', 'file:///c.mp3'],
+    );
+    await _pump(tester, store: store, controller: FakePlaybackController());
+
+    await _focusHandle(tester, 0);
+    await _pressMoveChord(tester, down: true);
+
+    expect(
+      await _storedOrder(store),
+      <String>['file:///b.mp3', 'file:///a.mp3', 'file:///c.mp3'],
+    );
+  });
+
+  testWidgets('Ctrl+Arrow up walks a track back to the top', (tester) async {
+    final InMemoryPlaylistStore store = await _seededStore(
+      trackIds: <String>['file:///a.mp3', 'file:///b.mp3', 'file:///c.mp3'],
+    );
+    await _pump(tester, store: store, controller: FakePlaybackController());
+
+    // Focus follows the moved track, so the chord can be pressed twice in a
+    // row without re-aiming at it.
+    await _focusHandle(tester, 2);
+    await _pressMoveChord(tester, down: false);
+    await _pressMoveChord(tester, down: false);
+
+    expect(
+      await _storedOrder(store),
+      <String>['file:///c.mp3', 'file:///a.mp3', 'file:///b.mp3'],
+    );
+  });
+
+  testWidgets('a move chord at either end of the playlist is a no-op',
+      (tester) async {
+    final InMemoryPlaylistStore store = await _seededStore(
+      trackIds: <String>['file:///a.mp3', 'file:///b.mp3'],
+    );
+    await _pump(tester, store: store, controller: FakePlaybackController());
+
+    await _focusHandle(tester, 0);
+    await _pressMoveChord(tester, down: false);
+    await _focusHandle(tester, 1);
+    await _pressMoveChord(tester, down: true);
+
+    expect(
+      await _storedOrder(store),
+      <String>['file:///a.mp3', 'file:///b.mp3'],
+    );
+  });
+
+  testWidgets('a held chord keeps walking the same track', (tester) async {
+    final InMemoryPlaylistStore store = await _seededStore(
+      trackIds: <String>[for (final Track track in _tracks) track.uri],
+    );
+    await _pump(tester, store: store, controller: FakePlaybackController());
+
+    await _focusHandle(tester, 0);
+    // Two presses, no frame in between. Reading the source index off the handle
+    // that fired would apply the second move to the order the first one already
+    // changed, and land Song A back where it started.
+    await _holdMoveChordDown(tester);
+
+    expect(
+      await _storedOrder(store),
+      <String>['file:///b.mp3', 'file:///c.mp3', 'file:///a.mp3'],
+    );
+  });
+
+  testWidgets('a chord after a pointer drag moves the track that was dragged',
+      (tester) async {
+    final InMemoryPlaylistStore store = await _seededStore(
+      trackIds: <String>[for (final Track track in _tracks) track.uri],
+    );
+    await _pump(tester, store: store, controller: FakePlaybackController());
+
+    // Focus row 0 (Song A), then drag it to the end. Focus is per position, so
+    // without the remap the next chord would move whatever slid into row 0.
+    await _focusHandle(tester, 0);
+    await _dragToEnd(tester, from: 0);
+    await _pressMoveChord(tester, down: false);
+
+    expect(
+      await _storedOrder(store),
+      <String>['file:///b.mp3', 'file:///a.mp3', 'file:///c.mp3'],
+    );
+  });
+
+  testWidgets('a mouse drag alone never pulls focus into the playlist',
+      (tester) async {
+    final InMemoryPlaylistStore store = await _seededStore(
+      trackIds: <String>[for (final Track track in _tracks) track.uri],
+    );
+    await _pump(tester, store: store, controller: FakePlaybackController());
+
+    await _dragToEnd(tester, from: 0);
+    await _pressMoveChord(tester, down: true);
+
+    // The drag landed; the chord that followed had nothing focused to move.
+    expect(
+      await _storedOrder(store),
+      <String>['file:///b.mp3', 'file:///c.mp3', 'file:///a.mp3'],
+    );
+  });
+
+  testWidgets('rows offer move actions, and only the ones that exist',
+      (tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    final InMemoryPlaylistStore store = await _seededStore(
+      trackIds: <String>[for (final Track track in _tracks) track.uri],
+    );
+    await _pump(tester, store: store, controller: FakePlaybackController());
+
+    // A screen reader gets the same two moves the keyboard chord does.
+    expect(
+      _customActionsOn(tester, 'Song B'),
+      <String>{'Move up', 'Move down'},
+    );
+    // The ends of the list only offer the move that goes somewhere.
+    expect(_customActionsOn(tester, 'Song A'), <String>{'Move down'});
+    expect(_customActionsOn(tester, 'Song C'), <String>{'Move up'});
+
+    handle.dispose();
+  });
+
+  testWidgets('the drag handle answers a screen reader move', (tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    final InMemoryPlaylistStore store = await _seededStore(
+      trackIds: <String>[for (final Track track in _tracks) track.uri],
+    );
+    await _pump(tester, store: store, controller: FakePlaybackController());
+
+    final int moveDown = tester
+        .getSemantics(find.text('Song A'))
+        .getSemanticsData()
+        .customSemanticsActionIds!
+        .firstWhere(
+          (int id) => CustomSemanticsAction.getAction(id)!.label == 'Move down',
+        );
+    tester.semantics.performAction(
+      find.semantics.byLabel(RegExp('Song A')),
+      SemanticsAction.customAction,
+      args: moveDown,
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      await _storedOrder(store),
+      <String>['file:///b.mp3', 'file:///a.mp3', 'file:///c.mp3'],
+    );
+
+    handle.dispose();
+  });
+
+  testWidgets('the handle shows a grab cursor and a hover hint',
+      (tester) async {
+    await _pump(
+      tester,
+      store: await _seededStore(),
+      controller: FakePlaybackController(),
+    );
+
+    final TestGesture mouse =
+        await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await mouse.addPointer();
+    addTearDown(mouse.removePointer);
+    await mouse.moveTo(tester.getCenter(find.byIcon(Icons.drag_handle).first));
+    await tester.pumpAndSettle();
+
+    // Desktop affordance: the pointer says the handle is draggable before the
+    // drag starts, and hovering spells out the keyboard alternative.
+    expect(
+      RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1),
+      SystemMouseCursors.grab,
+    );
+    expect(find.textContaining('Ctrl'), findsOneWidget);
+  });
+
+  testWidgets('mobile keeps the handle drag and the long-press selection',
+      (tester) async {
+    // The desktop affordances are additive: the handle drag a phone has always
+    // had is untouched, and so is the long-press that starts multi-select.
+    final InMemoryPlaylistStore store = await _seededStore(
+      trackIds: <String>[for (final Track track in _tracks) track.uri],
+    );
+    await _pump(
+      tester,
+      store: store,
+      controller: FakePlaybackController(),
+      platform: TargetPlatform.android,
+    );
+
+    await _dragToEnd(tester, from: 0);
+    expect(
+      await _storedOrder(store),
+      <String>['file:///b.mp3', 'file:///c.mp3', 'file:///a.mp3'],
+    );
+
+    await tester.longPress(find.text('Song B'));
+    await tester.pumpAndSettle();
+    expect(find.text('1 selected'), findsOneWidget);
   });
 }

--- a/test/shared/widgets/reorder_focus_walk_test.dart
+++ b/test/shared/widgets/reorder_focus_walk_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/shared/widgets/reorder_focus_walk.dart';
+
+void main() {
+  group('ReorderFocusWalk.positionAfterMove', () {
+    // Where an already-focused row ends up when some *other* row is dragged
+    // past it. Getting this wrong is what makes a Ctrl+Arrow after a drag move
+    // the neighbour instead of the row the user is holding.
+    test('the moved row lands on its destination', () {
+      expect(ReorderFocusWalk.positionAfterMove(2, from: 2, to: 5), 5);
+      expect(ReorderFocusWalk.positionAfterMove(5, from: 5, to: 0), 0);
+    });
+
+    test('a row the move passes downwards shifts up one', () {
+      // 0 1 [2] 3 4  ->  drag 1 to 3  ->  0 2 3 [1] 4
+      expect(ReorderFocusWalk.positionAfterMove(2, from: 1, to: 3), 1);
+      expect(ReorderFocusWalk.positionAfterMove(3, from: 1, to: 3), 2);
+    });
+
+    test('a row the move passes upwards shifts down one', () {
+      expect(ReorderFocusWalk.positionAfterMove(1, from: 3, to: 1), 2);
+      expect(ReorderFocusWalk.positionAfterMove(2, from: 3, to: 1), 3);
+    });
+
+    test('a row outside the moved span stays put', () {
+      expect(ReorderFocusWalk.positionAfterMove(0, from: 1, to: 3), 0);
+      expect(ReorderFocusWalk.positionAfterMove(4, from: 1, to: 3), 4);
+      expect(ReorderFocusWalk.positionAfterMove(0, from: 3, to: 1), 0);
+      expect(ReorderFocusWalk.positionAfterMove(4, from: 3, to: 1), 4);
+    });
+  });
+
+  group('ReorderFocusWalk in-flight walk', () {
+    test('a row index is taken at face value before any move', () {
+      final ReorderFocusWalk walk = ReorderFocusWalk();
+      addTearDown(walk.dispose);
+      expect(walk.sourceFor(3), 3);
+    });
+
+    test('a repeat from the same handle uses where the row really landed', () {
+      final ReorderFocusWalk walk = ReorderFocusWalk();
+      addTearDown(walk.dispose);
+      // A held chord: the handle still reports row 0 because no frame has
+      // rebuilt it, but the row is already at 1.
+      walk.recordMove(rowIndex: 0, to: 1);
+      expect(walk.sourceFor(0), 1);
+      walk.recordMove(rowIndex: 0, to: 2);
+      expect(walk.sourceFor(0), 2);
+    });
+
+    test('a press on another row inside the same window is not rewritten', () {
+      final ReorderFocusWalk walk = ReorderFocusWalk();
+      addTearDown(walk.dispose);
+      walk.recordMove(rowIndex: 0, to: 1);
+      expect(walk.sourceFor(4), 4);
+    });
+
+    test('a rebuild ends the walk, so indices are trusted again', () {
+      final ReorderFocusWalk walk = ReorderFocusWalk();
+      addTearDown(walk.dispose);
+      walk.recordMove(rowIndex: 0, to: 3);
+      walk.reset();
+      expect(walk.sourceFor(0), 0);
+    });
+  });
+
+  group('ReorderFocusWalk focus nodes', () {
+    test('nodes are per position and stable across lookups', () {
+      final ReorderFocusWalk walk = ReorderFocusWalk();
+      addTearDown(walk.dispose);
+      expect(identical(walk.nodeAt(2), walk.nodeAt(2)), isTrue);
+      expect(identical(walk.nodeAt(0), walk.nodeAt(1)), isFalse);
+    });
+
+    test('no focused handle reports -1, so a pointer drag stays pointer-only',
+        () {
+      final ReorderFocusWalk walk = ReorderFocusWalk();
+      addTearDown(walk.dispose);
+      walk.nodeAt(2);
+      expect(walk.focusedIndex, -1);
+    });
+  });
+}


### PR DESCRIPTION
Part of #389 (the reordering half). Drop-to-playlist is the other half and is not in this PR.

## What was missing

The playlist editor already reordered, but the handle was built for a thumb: no cursor change, no lift while dragging, and no way to move a track at all without a pointer. The queue got that treatment in #388 (PR #593). The playlist is the other ordered list in the app and had none of it.

## What changed

Rather than write a second copy of the queue's affordance, it moves into two shared pieces both lists now use:

- `lib/shared/widgets/reorder_handle.dart` — `ReorderHandle` (grab cursor, hover hint, **Ctrl + ↑ / ↓** with Cmd on macOS, and Move up / Move down semantics actions, offering only the move that goes somewhere at either end) plus `liftedReorderProxy`, the shadow a dragged row rides on.
- `lib/shared/widgets/reorder_focus_walk.dart` — `ReorderFocusWalk`, the per-position focus nodes and the stale-index compensation that keeps a held chord walking one track instead of whatever slid under the focus.

`queue_sheet.dart` loses about 150 lines to the move and behaves exactly as it did (its 27 existing tests pass untouched). The playlist detail screen gains the same four routes, all landing on the one `PlaylistRepository.reorderTracks` call the drag already used, so there is no keyboard copy of the persistence path.

Two things fell out of it:

- the reorderable list is its own widget now, so it can tell when the rows have caught up with a move (`didUpdateWidget`), the way the queue's Up Next list does;
- `playlistTracksProvider` re-resolves on every edit and `.when()` was flashing a spinner over the list each time, which also tore down the focus nodes mid-walk. `skipLoadingOnReload: true` keeps the resolved list on screen, so only a genuine first load spins.

## Behaviour notes

- Persistence is unchanged: the repository writes locally first and never throws, so a server that refuses the new order leaves the local order applied and the playlist marked `syncFailed` rather than losing the edit.
- Reordering is still offered only when every stored uri resolved. With missing entries the list stays non-reorderable, since the visible rows no longer line up 1:1 with the stored order.
- Mobile is untouched: the handle drag and the long-press into multi-select both still work, and the hover hint and grab cursor are inert without a pointer that hovers.

## Tests

`flutter analyze` clean, `dart format` clean, full suite green (4713 tests).

New:

- `test/shared/widgets/reorder_focus_walk_test.dart` — the walk arithmetic as pure unit tests: a row passed by a move in either direction, a held chord's stale index, a press on another row inside the same window, focus nodes per position, and no focused handle reporting -1.
- `test/features/playlists/playlist_detail_screen_test.dart` — the chord, focus following the moved track, no-ops at both ends, a held chord (two presses with no frame between), a chord after a pointer drag, a drag never pulling focus in, the two screen-reader actions and which rows offer them, the grab cursor and hover hint, and an Android-themed handle drag plus long-press.

## Known limitations

- No native or on-device validation ran here: everything is `flutter test` on the host. The grab cursor, the hover tooltip and the scroll-along during a keyboard walk are asserted through the widget tree, not seen on a real Linux desktop.
- Reorder of a synced **Jellyfin** playlist stays local-only, as it was before this PR (Navidrome pushes the full ordered list). Documented in `docs/playlists-and-delete.md`.
- A keyboard walk scrolls the moved row into view one row at a time. Walking a track across a very long playlist is a lot of key repeats; a "move to top/bottom" action is not part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MffeFFVaKcNCa9NZHUBJ1G

---
_Generated by [Claude Code](https://claude.ai/code/session_01MffeFFVaKcNCa9NZHUBJ1G)_