### PR TITLE
feat(desktop): drag tracks onto a playlist (#389)

### DIFF
--- a/docs/playlists-and-delete.md
+++ b/docs/playlists-and-delete.md
@@ -69,11 +69,21 @@ the Playlists tab. Dragging a row that is part of a multi-selection carries the
 whole selection; dragging any other row carries just that row, which is what a
 desktop list is expected to do.
 
-The library and the playlist list are different tabs, so the navigation rail is
+The library and the playlist list are different tabs, so Linthra's navigation is
 **spring-loaded**: rest a drag on it for a moment and it opens Playlists, with
 the Playlists destination highlighted so you can see where the drag is heading.
-The rail never takes the drop itself, it only gets you to the rows. Crossing it
-quickly on the way somewhere else does nothing.
+Navigation never takes the drop itself, it only gets you to the rows. Crossing
+it quickly on the way somewhere else does nothing.
+
+This works on the rail of a wide window and on the bottom bar of a narrow one.
+A mouse is still a mouse below the desktop breakpoint, so a drag that could
+start there needs somewhere to go.
+
+The spring always opens the **playlist list**, not whatever that tab had open
+last. Favorites and the smart mixes live inside the Playlists tab and are not
+playlists you can drop onto, so restoring one of those would leave a drag on a
+page it could not finish on. Starting a drag from Favorites and resting it on
+the navigation gets you back to the list for the same reason.
 
 Only sideways drags pick a row up, so a vertical drag still scrolls the list.
 None of this exists on mobile, where a long press already starts multi-select.

--- a/docs/playlists-and-delete.md
+++ b/docs/playlists-and-delete.md
@@ -23,7 +23,8 @@ What you can do:
   detail screen).
 - **Delete** a playlist (always behind a confirmation).
 - **Add tracks** from a track's overflow menu ("Add to playlist"), from the Now
-  Playing actions, or via multi-select.
+  Playing actions, via multi-select, or, on desktop, by dragging tracks onto a
+  playlist row (see [Dragging tracks into a playlist](#dragging-tracks-into-a-playlist)).
 - **Remove tracks** from a playlist (per-row, with an Undo snackbar, or via
   multi-select).
 - **Reorder tracks** by dragging the handle on a row — see
@@ -60,6 +61,36 @@ see.
 Playlists persist locally via `shared_preferences` (the same lightweight,
 plugin-only storage used for favourites and the offline-download set) — no
 secrets are ever written to playlist metadata.
+
+### Dragging tracks into a playlist
+
+On desktop, pull a track row sideways to pick it up and drop it on a playlist in
+the Playlists tab. Dragging a row that is part of a multi-selection carries the
+whole selection; dragging any other row carries just that row, which is what a
+desktop list is expected to do.
+
+The library and the playlist list are different tabs, so the navigation rail is
+**spring-loaded**: rest a drag on it for a moment and it opens Playlists, with
+the Playlists destination highlighted so you can see where the drag is heading.
+The rail never takes the drop itself, it only gets you to the rows. Crossing it
+quickly on the way somewhere else does nothing.
+
+Only sideways drags pick a row up, so a vertical drag still scrolls the list.
+None of this exists on mobile, where a long press already starts multi-select.
+
+A drop goes through exactly the same rules as the "Add to playlist" sheet
+(`PlaylistAddPlan`), so it can never put a track somewhere the sheet would have
+refused:
+
+- a synced playlist takes only its own server's tracks, and a drop of a mixed
+  selection adds the supported half and says how many it skipped
+- a drop a playlist cannot take at all writes nothing and explains why, rather
+  than silently bouncing back
+- tracks already in the playlist are skipped, and the confirmation counts only
+  what genuinely landed
+
+Drag-and-drop is an addition, never the only way in. Every playlist edit is
+still reachable from the keyboard and the row menus.
 
 ### Sync state
 

--- a/lib/features/library/album_detail_screen.dart
+++ b/lib/features/library/album_detail_screen.dart
@@ -236,6 +236,7 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
       onSelectStart: () => _enterSelection(track),
       onSelectToggle: () => _toggle(track),
       onSelectRange: _extendSelection,
+      dragSelection: () => _selection.resolve(tracks),
     );
   }
 

--- a/lib/features/library/artist_detail_screen.dart
+++ b/lib/features/library/artist_detail_screen.dart
@@ -209,6 +209,7 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
             onSelectStart: () => _enterSelection(track),
             onSelectToggle: () => _toggle(track),
             onSelectRange: _extendSelection,
+            dragSelection: () => _selection.resolve(tracks),
           );
         },
       ),

--- a/lib/features/library/widgets/alphabet_track_list.dart
+++ b/lib/features/library/widgets/alphabet_track_list.dart
@@ -227,6 +227,13 @@ class _AlphabetTrackListState extends State<AlphabetTrackList> {
                   ? null
                   : () => widget.onSelectStart!(track),
               onSelectRange: widget.onSelectRange,
+              // Resolved from the sorted list the rows are drawn from, so a
+              // drag carries the selection in the order the user sees it.
+              // Only runs when a drag actually starts.
+              dragSelection: () => <Track>[
+                for (final Track candidate in _sorted)
+                  if (widget.selectedUris.contains(candidate.uri)) candidate,
+              ],
             );
           },
         ),

--- a/lib/features/library/widgets/track_tile.dart
+++ b/lib/features/library/widgets/track_tile.dart
@@ -18,6 +18,7 @@ import '../../player/favorites_providers.dart';
 import '../../player/now_playing.dart';
 import '../../player/player_providers.dart';
 import '../../player/widgets/track_artwork.dart';
+import '../../playlists/playlist_drag.dart';
 import '../../playlists/widgets/add_to_playlist_sheet.dart';
 import '../library_browse_providers.dart';
 import '../song_actions.dart';
@@ -62,6 +63,13 @@ enum _TrackAction {
 /// hardware keyboard at tap time rather than gated on a platform, so a keyboard
 /// case on a tablet gets them for free and a bare touch tap is unchanged.
 ///
+/// On desktop the row is also a drag source for playlists (#389): pulling it
+/// sideways picks up this track, or the whole selection when this row is part
+/// of one, and dropping it on a playlist adds it. A vertical drag still
+/// scrolls the list, and nothing about this exists on mobile. The keyboard and
+/// menu route to the same operation, "Add to playlist", is unchanged and stays
+/// the accessible path.
+///
 /// Source-awareness: offline/download actions only appear for *remote* tracks
 /// (resolved through [remoteTrackDownloaderProvider], the same seam the
 /// download repository uses). On-device tracks are already local, so showing
@@ -77,6 +85,7 @@ class TrackTile extends ConsumerWidget {
     this.onSelectToggle,
     this.onSelectStart,
     this.onSelectRange,
+    this.dragSelection,
     super.key,
   });
 
@@ -102,6 +111,14 @@ class TrackTile extends ConsumerWidget {
   /// user sees it, so a range can never span rows that are not on screen
   /// between its two ends.
   final void Function(List<Track> tracks, int index)? onSelectRange;
+
+  /// The host's current selection, for a drag that starts on a selected row.
+  ///
+  /// A callback rather than a list because it is only ever called if a drag
+  /// actually starts: resolving the selection eagerly would be an O(n) walk
+  /// per row on every rebuild, which a 200k-track library cannot afford.
+  /// Hosts without selection leave it null and a drag carries this row alone.
+  final List<Track> Function()? dragSelection;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -209,7 +226,7 @@ class TrackTile extends ConsumerWidget {
     // favourite and download state as it is then rather than as it was when the
     // row was laid out. Withheld while selecting: the app bar is acting on the
     // whole selection there, and a per-row menu would be acting on one row.
-    return ContextMenuRegion<_TrackAction>(
+    final Widget menu = ContextMenuRegion<_TrackAction>(
       enabled: !selectionActive,
       itemBuilder: (BuildContext context) => _trackMenuItems(
         track: track,
@@ -222,6 +239,16 @@ class TrackTile extends ConsumerWidget {
       onSelected: (_TrackAction action) =>
           _runTrackAction(context, ref, track, action),
       child: row,
+    );
+
+    return PlaylistTrackDraggable(
+      tracks: () => dragPayloadFor(
+        track: track,
+        selectionActive: selectionActive,
+        selected: selected,
+        selection: dragSelection,
+      ),
+      child: menu,
     );
   }
 

--- a/lib/features/playlists/playlist_add.dart
+++ b/lib/features/playlists/playlist_add.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/foundation.dart';
+
+import '../../core/models/playlist.dart';
+import '../../core/models/track.dart';
+import '../../core/repositories/playlist_repository.dart';
+import '../../core/sources/jellyfin/jellyfin_track_mapper.dart';
+import '../../core/sources/subsonic/subsonic_track_mapper.dart';
+
+/// What adding a set of tracks to a playlist would actually do.
+///
+/// Two rules decide it, and both were previously private to the "Add to
+/// playlist" sheet:
+///
+///  * a synced playlist only takes its own server's tracks, so it stays
+///    consistent with the server (a Jellyfin playlist holds only `jellyfin:`
+///    uris, a Navidrome playlist only `subsonic:` ones)
+///  * the repository skips uris already in the playlist, so the count a user is
+///    told must be the genuinely-new ones
+///
+/// It lives here because drag-and-drop (#389) is a second way into the same
+/// operation, and a drop that used its own rules could put a Jellyfin track in
+/// a Navidrome playlist by going around the sheet. One plan, both paths.
+///
+/// Pure and free of Flutter, so every awkward case (a mixed selection onto a
+/// synced playlist, a drop of tracks that are all already there, an empty
+/// selection) is unit-testable without pumping a widget.
+@immutable
+class PlaylistAddPlan {
+  const PlaylistAddPlan._({
+    required this.playlist,
+    required this.requested,
+    required this.addable,
+    required this.newTracks,
+  });
+
+  /// Works out what adding [tracks] to [playlist] would do.
+  factory PlaylistAddPlan.of({
+    required Playlist playlist,
+    required List<Track> tracks,
+  }) {
+    final String? scheme = _schemeFor(playlist.source);
+    final List<Track> addable = scheme == null
+        ? List<Track>.unmodifiable(tracks)
+        : List<Track>.unmodifiable(<Track>[
+            for (final Track track in tracks)
+              if (track.uri.startsWith(scheme)) track,
+          ]);
+    // Keyed by the provider-namespaced uri, so adding `subsonic:101` to a
+    // playlist holding `jellyfin:101` is a real add rather than a no-op.
+    final Set<String> existing = playlist.trackIds.toSet();
+    return PlaylistAddPlan._(
+      playlist: playlist,
+      requested: tracks.length,
+      addable: addable,
+      newTracks: List<Track>.unmodifiable(<Track>[
+        for (final Track track in addable)
+          if (!existing.contains(track.uri)) track,
+      ]),
+    );
+  }
+
+  final Playlist playlist;
+
+  /// How many tracks were offered, including ones this playlist cannot take.
+  final int requested;
+
+  /// The offered tracks this playlist's source allows.
+  final List<Track> addable;
+
+  /// The subset of [addable] not already in the playlist: what an add changes.
+  final List<Track> newTracks;
+
+  /// Whether this playlist can take *any* of the offered tracks.
+  ///
+  /// This is the question a drop target asks while a drag hovers, so it is
+  /// deliberately about the source rule alone. Tracks that are already in the
+  /// playlist still count as acceptable: dropping them is a harmless no-op, and
+  /// refusing the whole drop because one song is already there would be a
+  /// worse answer than saying so afterwards.
+  bool get accepts => addable.isNotEmpty;
+
+  /// Whether performing this add would change the playlist at all.
+  bool get changesAnything => newTracks.isNotEmpty;
+
+  /// The uris to hand the repository.
+  List<String> get uris =>
+      <String>[for (final Track track in addable) track.uri];
+
+  /// Why a drop was refused outright, or `null` when something can be added.
+  ///
+  /// Only a synced playlist can refuse: a local playlist takes anything, so an
+  /// empty [addable] there means an empty selection, which has nothing to say.
+  String? get refusalMessage {
+    if (accepts) return null;
+    final String? label = playlist.source.serverLabel;
+    if (label == null) return null;
+    return 'Only $label tracks can be added to ${playlist.name}.';
+  }
+
+  /// The line to show once the add has run. Never claims more than landed.
+  String get resultMessage {
+    final int added = newTracks.length;
+    if (added == 0) {
+      // Nothing new landed. Either the whole selection was unsupported, or
+      // every track was already in the playlist.
+      final String? refusal = refusalMessage;
+      if (refusal != null) return refusal;
+      return requested == 1
+          ? "That song's already in ${playlist.name}."
+          : 'Those songs are already in ${playlist.name}.';
+    }
+    final int skipped = requested - added;
+    final String base = added == 1
+        ? 'Added to ${playlist.name}.'
+        : 'Added $added songs to ${playlist.name}.';
+    if (skipped > 0) {
+      return '$base $skipped skipped (already added or not supported).';
+    }
+    return base;
+  }
+
+  /// The track-uri scheme a synced playlist of [source] accepts, or `null` for
+  /// a local playlist (which accepts any source's tracks).
+  static String? _schemeFor(PlaylistSource source) {
+    switch (source) {
+      case PlaylistSource.local:
+        return null;
+      case PlaylistSource.jellyfin:
+        return JellyfinTrackMapper.uriScheme;
+      case PlaylistSource.subsonic:
+        return SubsonicTrackMapper.uriScheme;
+    }
+  }
+}
+
+/// Adds [tracks] to [playlist] through [repository] and returns what happened.
+///
+/// The repository is passed in rather than read from a provider so this stays
+/// testable with a fake, and so both entry points, the sheet and a drop,
+/// persist through the same path the rest of the app uses.
+///
+/// A plan with nothing addable performs no write at all: an unsupported drop
+/// should not touch the playlist's `updatedAt`, let alone queue a sync.
+Future<PlaylistAddPlan> addTracksToPlaylist({
+  required PlaylistRepository repository,
+  required Playlist playlist,
+  required List<Track> tracks,
+}) async {
+  final PlaylistAddPlan plan =
+      PlaylistAddPlan.of(playlist: playlist, tracks: tracks);
+  if (plan.accepts) {
+    await repository.addTracks(playlist.id, plan.uris);
+  }
+  return plan;
+}

--- a/lib/features/playlists/playlist_detail_screen.dart
+++ b/lib/features/playlists/playlist_detail_screen.dart
@@ -21,6 +21,8 @@ import '../player/now_playing.dart';
 import '../player/player_providers.dart';
 import '../player/widgets/album_artwork.dart';
 import '../player/widgets/track_artwork.dart';
+import 'playlist_add.dart';
+import 'playlist_drag.dart';
 import 'playlist_providers.dart';
 import 'widgets/add_to_playlist_sheet.dart';
 import 'widgets/create_playlist_dialog.dart';
@@ -126,21 +128,55 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
                   ),
                 ],
               ),
-        body: tracksAsync.when(
-          // Every edit — a reorder, a removal — re-runs the uri-to-Track
-          // resolution, and a spinner over the list on each one would both
-          // flash and tear down the reorder list's focus nodes mid-keyboard
-          // walk. Only the genuine first load shows the spinner.
-          skipLoadingOnReload: true,
-          loading: () => const Center(child: CircularProgressIndicator()),
-          error: (_, __) => const EmptyState(
-            icon: Icons.error_outline,
-            title: "Couldn't load this playlist",
-            message: 'Try again in a moment.',
-          ),
-          data: (PlaylistTracks data) => _content(playlist, data),
+        // The whole page takes a dropped track (#389), not just the list: the
+        // rail's spring can land a drag here rather than on the Playlists tab
+        // when this playlist was already open, and an empty playlist is
+        // exactly the one somebody wants to drag songs into.
+        body: PlaylistDropRegion(
+          playlist: playlist,
+          onDrop: (List<Track> tracks) => _addDropped(playlist, tracks),
+          onRefused: _say,
+          builder: (BuildContext context, PlaylistDropState state) {
+            return PlaylistDropHighlight(
+              state: state,
+              child: tracksAsync.when(
+                // Every edit — a reorder, a removal — re-runs the uri-to-Track
+                // resolution, and a spinner over the list on each one would
+                // both flash and tear down the reorder list's focus nodes
+                // mid-keyboard walk. Only the genuine first load shows the
+                // spinner.
+                skipLoadingOnReload: true,
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (_, __) => const EmptyState(
+                  icon: Icons.error_outline,
+                  title: "Couldn't load this playlist",
+                  message: 'Try again in a moment.',
+                ),
+                data: (PlaylistTracks data) => _content(playlist, data),
+              ),
+            );
+          },
         ),
       ),
+    );
+  }
+
+  /// Adds dropped tracks to the open playlist, through the same plan the
+  /// "Add to playlist" sheet and the Playlists tab both use.
+  Future<void> _addDropped(Playlist playlist, List<Track> tracks) async {
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    final PlaylistAddPlan plan = await addTracksToPlaylist(
+      repository: ref.read(playlistRepositoryProvider),
+      playlist: playlist,
+      tracks: tracks,
+    );
+    if (!mounted) return;
+    messenger.showSnackBar(SnackBar(content: Text(plan.resultMessage)));
+  }
+
+  void _say(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
     );
   }
 

--- a/lib/features/playlists/playlist_drag.dart
+++ b/lib/features/playlists/playlist_drag.dart
@@ -1,0 +1,291 @@
+import 'package:flutter/material.dart';
+
+import '../../core/models/playlist.dart';
+import '../../core/models/track.dart';
+import 'playlist_add.dart';
+
+/// The tracks a drag is carrying.
+///
+/// Resolved lazily, and once. A row cannot work out "the current selection"
+/// eagerly at build time: with a 200k-track library that is an O(n) walk per
+/// row on every rebuild, so the list would resolve the selection a hundred
+/// thousand times to draw one screen. The closure runs when a drop target
+/// first asks, which is at most once per drag.
+class PlaylistDragPayload {
+  PlaylistDragPayload(this._resolve);
+
+  final List<Track> Function() _resolve;
+  List<Track>? _resolved;
+
+  List<Track> get tracks => _resolved ??= List<Track>.unmodifiable(_resolve());
+}
+
+/// What a drag starting on [track] should carry.
+///
+/// The whole selection when the row is part of one, otherwise the row alone.
+/// Dragging an *unselected* row while a selection is running carries that row
+/// by itself, which is what every desktop list does: the drag is about the row
+/// under the pointer, not about what happens to be ticked elsewhere.
+///
+/// [selection] is a callback because a row must not resolve "the current
+/// selection" on every build. It is called at most once, when a drag starts.
+List<Track> dragPayloadFor({
+  required Track track,
+  required bool selectionActive,
+  required bool selected,
+  required List<Track> Function()? selection,
+}) {
+  if (selectionActive && selected && selection != null) {
+    final List<Track> tracks = selection();
+    // An empty answer means the selection no longer holds this row (it was
+    // filtered out, or removed). Dragging nothing would be worse than dragging
+    // the row the pointer is actually on.
+    if (tracks.isNotEmpty) return tracks;
+  }
+  return <Track>[track];
+}
+
+/// How a drop target should draw itself while a drag is over it.
+enum PlaylistDropState {
+  /// Nothing is hovering.
+  idle,
+
+  /// A drop here would add something.
+  accepted,
+
+  /// A drop here would be refused, because the playlist cannot take these
+  /// tracks. Drawn differently rather than not drawn at all: a target that
+  /// simply stays inert leaves the user to guess why nothing happened.
+  refused,
+}
+
+/// Makes [child] draggable onto a playlist, on desktop only.
+///
+/// Mobile is untouched (#389 is a desktop issue, and the acceptance criteria
+/// ask for mobile playlist behaviour to stay as it is). On a phone the row's
+/// long-press already starts multi-select, and a second long-press gesture
+/// competing for it would break that.
+///
+/// The drag is horizontally-affine: a vertical drag still scrolls the list, and
+/// only a sideways pull starts a drag. That is both what keeps a long track
+/// list usable with a mouse and, conveniently, the direction the navigation
+/// rail is in.
+class PlaylistTrackDraggable extends StatelessWidget {
+  const PlaylistTrackDraggable({
+    required this.tracks,
+    required this.child,
+    super.key,
+  });
+
+  /// The tracks this drag carries, resolved only if a drag actually starts.
+  final List<Track> Function() tracks;
+
+  final Widget child;
+
+  /// Whether a pointer drag should start a playlist drag on this platform.
+  static bool isSupported(BuildContext context) {
+    switch (Theme.of(context).platform) {
+      case TargetPlatform.linux:
+      case TargetPlatform.macOS:
+      case TargetPlatform.windows:
+        return true;
+      case TargetPlatform.android:
+      case TargetPlatform.iOS:
+      case TargetPlatform.fuchsia:
+        return false;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!isSupported(context)) return child;
+    // One payload for the drag, shared with the feedback card, so the whole
+    // gesture resolves the selection exactly once.
+    final PlaylistDragPayload payload = PlaylistDragPayload(tracks);
+    return Draggable<PlaylistDragPayload>(
+      data: payload,
+      affinity: Axis.horizontal,
+      dragAnchorStrategy: pointerDragAnchorStrategy,
+      feedback: _DragFeedback(payload: payload),
+      childWhenDragging: Opacity(opacity: 0.4, child: child),
+      child: child,
+    );
+  }
+}
+
+/// The little card that follows the cursor during a drag.
+class _DragFeedback extends StatelessWidget {
+  const _DragFeedback({required this.payload});
+
+  final PlaylistDragPayload payload;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    // Built once, when the drag starts, and reading the same cached payload
+    // the drop targets read.
+    final List<Track> dragged = payload.tracks;
+    final String label =
+        dragged.length == 1 ? dragged.single.title : '${dragged.length} songs';
+    return Material(
+      elevation: 6,
+      borderRadius: BorderRadius.circular(8),
+      color: theme.colorScheme.surfaceContainerHighest,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            const Icon(Icons.playlist_add, size: 18),
+            const SizedBox(width: 8),
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 220),
+              child: Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodyMedium,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A region that takes tracks dropped on it and adds them to [playlist].
+///
+/// It always accepts the drop, even when the playlist cannot take the tracks,
+/// and then says why. Refusing at `onWillAccept` would make the drag bounce
+/// back with no explanation at all, which is a worse answer than "only
+/// Jellyfin tracks can be added to this playlist".
+///
+/// Nothing is written for a refused drop: [onDrop] is only called with tracks
+/// the playlist accepts, so an unsupported drop cannot touch the playlist's
+/// `updatedAt` or queue a sync.
+class PlaylistDropRegion extends StatelessWidget {
+  const PlaylistDropRegion({
+    required this.playlist,
+    required this.onDrop,
+    required this.builder,
+    this.onRefused,
+    super.key,
+  });
+
+  final Playlist playlist;
+
+  /// Called with the whole dropped selection when the playlist accepts some of
+  /// it. Working out which tracks are new is [PlaylistAddPlan]'s job, not the
+  /// caller's.
+  final void Function(List<Track> tracks) onDrop;
+
+  /// Called instead of [onDrop] when the playlist can take none of them, with
+  /// the reason to show.
+  final void Function(String message)? onRefused;
+
+  final Widget Function(BuildContext context, PlaylistDropState state) builder;
+
+  @override
+  Widget build(BuildContext context) {
+    return DragTarget<PlaylistDragPayload>(
+      onWillAcceptWithDetails: (_) => true,
+      onAcceptWithDetails: (DragTargetDetails<PlaylistDragPayload> details) {
+        final List<Track> dropped = details.data.tracks;
+        final PlaylistAddPlan plan =
+            PlaylistAddPlan.of(playlist: playlist, tracks: dropped);
+        if (!plan.accepts) {
+          final String? message = plan.refusalMessage;
+          if (message != null) onRefused?.call(message);
+          return;
+        }
+        onDrop(dropped);
+      },
+      builder: (
+        BuildContext context,
+        List<PlaylistDragPayload?> candidate,
+        List<dynamic> rejected,
+      ) {
+        return builder(context, _stateFor(candidate));
+      },
+    );
+  }
+
+  /// Which of the three states the hovering payload (if any) puts this target
+  /// in. `candidate` holds the payloads `onWillAccept` said yes to, which is
+  /// all of them, so the accept/refuse split happens here.
+  PlaylistDropState _stateFor(List<PlaylistDragPayload?> candidate) {
+    if (candidate.isEmpty) return PlaylistDropState.idle;
+    for (final PlaylistDragPayload? payload in candidate) {
+      if (payload == null) continue;
+      final PlaylistAddPlan plan =
+          PlaylistAddPlan.of(playlist: playlist, tracks: payload.tracks);
+      if (plan.accepts) return PlaylistDropState.accepted;
+    }
+    return PlaylistDropState.refused;
+  }
+}
+
+/// The standard highlight for a playlist drop target: a tinted, outlined box
+/// while a drop would land, an error-tinted one while it would be refused.
+///
+/// Shared so every playlist target looks the same to a user mid-drag, rather
+/// than each inventing its own hint.
+///
+/// Drawn with a foreground painter rather than a `DecoratedBox`. A decorated
+/// ancestor between a `Material` and a `ListTile` hides the tile's background
+/// and swallows its ink splashes, and Flutter asserts about it either way
+/// round; a painter adds no ancestor and no layout at all, so a highlighted
+/// row is the same row it was.
+class PlaylistDropHighlight extends StatelessWidget {
+  const PlaylistDropHighlight({
+    required this.state,
+    required this.child,
+    super.key,
+  });
+
+  final PlaylistDropState state;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    if (state == PlaylistDropState.idle) return child;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    return CustomPaint(
+      foregroundPainter: _DropHighlightPainter(
+        accent:
+            state == PlaylistDropState.accepted ? colors.primary : colors.error,
+      ),
+      child: child,
+    );
+  }
+}
+
+class _DropHighlightPainter extends CustomPainter {
+  const _DropHighlightPainter({required this.accent});
+
+  final Color accent;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final RRect box = RRect.fromRectAndRadius(
+      // Inset by the stroke so the outline sits inside the row rather than
+      // half over its neighbour.
+      Rect.fromLTWH(1, 1, size.width - 2, size.height - 2),
+      const Radius.circular(8),
+    );
+    canvas
+      ..drawRRect(box, Paint()..color = accent.withValues(alpha: 0.10))
+      ..drawRRect(
+        box,
+        Paint()
+          ..color = accent
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 2,
+      );
+  }
+
+  @override
+  bool shouldRepaint(_DropHighlightPainter oldDelegate) =>
+      oldDelegate.accent != accent;
+}

--- a/lib/features/playlists/playlist_drag.dart
+++ b/lib/features/playlists/playlist_drag.dart
@@ -106,6 +106,12 @@ class PlaylistTrackDraggable extends StatelessWidget {
       data: payload,
       affinity: Axis.horizontal,
       dragAnchorStrategy: pointerDragAnchorStrategy,
+      // The feedback belongs to the root overlay, not the one the drag started
+      // in. Each navigation branch has its own overlay, and the spring's whole
+      // job is to switch branches mid-drag: the source branch then goes
+      // offstage and takes a branch-owned feedback card with it, leaving the
+      // pointer carrying an invisible drag to a target it cannot see.
+      rootOverlay: true,
       feedback: _DragFeedback(payload: payload),
       childWhenDragging: Opacity(opacity: 0.4, child: child),
       child: child,

--- a/lib/features/playlists/playlists_screen.dart
+++ b/lib/features/playlists/playlists_screen.dart
@@ -4,12 +4,15 @@ import 'package:go_router/go_router.dart';
 
 import '../../app/routes.dart';
 import '../../core/models/playlist.dart';
+import '../../core/models/track.dart';
 import '../../data/repositories/playlist_repository_provider.dart';
 import '../../shared/layout/adaptive_layout.dart';
 import '../../shared/widgets/confirm_dialog.dart';
 import '../../shared/widgets/context_menu_region.dart';
 import '../../shared/widgets/empty_state.dart';
 import '../library/remote_library_refresher.dart';
+import 'playlist_add.dart';
+import 'playlist_drag.dart';
 import 'playlist_providers.dart';
 import 'widgets/create_playlist_dialog.dart';
 
@@ -128,7 +131,7 @@ class _PlaylistTile extends ConsumerWidget {
     // The same two actions the trailing button offers, on right-click and on
     // the keyboard's menu key (#386). Rename and delete are all the domain
     // layer supports for a playlist from here, so that is all the menu claims.
-    return ContextMenuRegion<_PlaylistMenuAction>(
+    final Widget row = ContextMenuRegion<_PlaylistMenuAction>(
       itemBuilder: (BuildContext context) => _menuItems(),
       onSelected: (action) => _run(context, ref, action),
       child: ListTile(
@@ -153,6 +156,38 @@ class _PlaylistTile extends ConsumerWidget {
         ),
         onTap: () => context.push(AppRoutes.playlistDetailPath(playlist.id)),
       ),
+    );
+    // Dropping tracks here adds them (#389). The row is the clear target the
+    // issue asks for: it is the playlist, named, with its song count.
+    return PlaylistDropRegion(
+      playlist: playlist,
+      onDrop: (List<Track> tracks) => _addDropped(context, ref, tracks),
+      onRefused: (String message) => _say(context, message),
+      builder: (BuildContext context, PlaylistDropState state) =>
+          PlaylistDropHighlight(state: state, child: row),
+    );
+  }
+
+  /// Adds dropped tracks through the same plan the "Add to playlist" sheet
+  /// uses, so a drop can never put a track in a playlist the sheet would have
+  /// refused, and reports what actually landed.
+  Future<void> _addDropped(
+    BuildContext context,
+    WidgetRef ref,
+    List<Track> tracks,
+  ) async {
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    final PlaylistAddPlan plan = await addTracksToPlaylist(
+      repository: ref.read(playlistRepositoryProvider),
+      playlist: playlist,
+      tracks: tracks,
+    );
+    messenger.showSnackBar(SnackBar(content: Text(plan.resultMessage)));
+  }
+
+  void _say(BuildContext context, String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
     );
   }
 

--- a/lib/features/playlists/widgets/add_to_playlist_sheet.dart
+++ b/lib/features/playlists/widgets/add_to_playlist_sheet.dart
@@ -4,10 +4,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../app/dimens.dart';
 import '../../../core/models/playlist.dart';
 import '../../../core/models/track.dart';
-import '../../../core/sources/jellyfin/jellyfin_track_mapper.dart';
-import '../../../core/sources/subsonic/subsonic_track_mapper.dart';
 import '../../../data/repositories/playlist_repository_provider.dart';
 import '../../../shared/widgets/empty_state.dart';
+import '../playlist_add.dart';
 import '../playlist_providers.dart';
 import 'create_playlist_dialog.dart';
 
@@ -119,38 +118,13 @@ class _AddToPlaylistSheet extends ConsumerWidget {
   ) async {
     final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     final NavigatorState navigator = Navigator.of(context);
-    final List<Track> addable = _addableFor(playlist);
-    if (addable.isEmpty) {
-      navigator.pop();
-      final String label = playlist.source.serverLabel ?? 'this server';
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(
-            'Only $label tracks can be added to a $label playlist.',
-          ),
-        ),
-      );
-      return;
-    }
-    // The repository skips uris already in the playlist, so the count the user
-    // sees must be the genuinely-new ones — not the whole addable list. Keyed by
-    // the provider-namespaced uri, so adding `subsonic:101` to a playlist that
-    // holds `jellyfin:101` is a real add, not a no-op "already there".
-    final Set<String> existing = playlist.trackIds.toSet();
-    final int added =
-        addable.where((Track t) => !existing.contains(t.uri)).length;
-    await ref.read(playlistRepositoryProvider).addTracks(
-      playlist.id,
-      <String>[for (final Track track in addable) track.uri],
+    final PlaylistAddPlan plan = await addTracksToPlaylist(
+      repository: ref.read(playlistRepositoryProvider),
+      playlist: playlist,
+      tracks: tracks,
     );
     navigator.pop();
-    messenger.showSnackBar(
-      SnackBar(
-        content: Text(
-          _resultMessage(playlist, addableCount: addable.length, added: added),
-        ),
-      ),
-    );
+    messenger.showSnackBar(SnackBar(content: Text(plan.resultMessage)));
   }
 
   Future<void> _createAndAdd(BuildContext context, WidgetRef ref) async {
@@ -169,80 +143,14 @@ class _AddToPlaylistSheet extends ConsumerWidget {
       description: edit.description,
       source: edit.source,
     );
-    final List<Track> addable = _addableFor(created);
-    if (addable.isNotEmpty) {
-      await repository.addTracks(
-        created.id,
-        <String>[for (final Track track in addable) track.uri],
-      );
-    }
-    navigator.pop();
     // A freshly created playlist is empty, so every addable track is genuinely
     // added; the skipped remainder (if any) was filtered as a different source.
-    messenger.showSnackBar(
-      SnackBar(
-        content: Text(
-          _resultMessage(created,
-              addableCount: addable.length, added: addable.length),
-        ),
-      ),
+    final PlaylistAddPlan plan = await addTracksToPlaylist(
+      repository: repository,
+      playlist: created,
+      tracks: tracks,
     );
-  }
-
-  /// The subset of [tracks] that can be added to [playlist]: every track for a
-  /// local playlist, only same-provider tracks for a synced playlist (so it
-  /// stays consistent with the server — a Jellyfin playlist holds only
-  /// `jellyfin:` tracks, a Navidrome playlist only `subsonic:` tracks).
-  List<Track> _addableFor(Playlist playlist) {
-    final String? scheme = _schemeFor(playlist.source);
-    if (scheme == null) return tracks;
-    return <Track>[
-      for (final Track track in tracks)
-        if (track.uri.startsWith(scheme)) track,
-    ];
-  }
-
-  /// The track-uri scheme a synced playlist of [source] accepts, or `null` for a
-  /// local playlist (which accepts any source's tracks).
-  static String? _schemeFor(PlaylistSource source) {
-    switch (source) {
-      case PlaylistSource.local:
-        return null;
-      case PlaylistSource.jellyfin:
-        return JellyfinTrackMapper.uriScheme;
-      case PlaylistSource.subsonic:
-        return SubsonicTrackMapper.uriScheme;
-    }
-  }
-
-  /// A snackbar line reflecting what actually changed. [added] is the number of
-  /// tracks genuinely appended (the repository skips ids already present, and
-  /// [addableCount] excludes tracks the playlist can't take — e.g. a different
-  /// source's tracks for a synced playlist), so this never claims more than was
-  /// added.
-  String _resultMessage(
-    Playlist playlist, {
-    required int addableCount,
-    required int added,
-  }) {
-    if (added == 0) {
-      // Nothing new landed. Either the whole selection was unsupported, or
-      // every track was already in the playlist.
-      if (addableCount == 0 && playlist.source != PlaylistSource.local) {
-        final String label = playlist.source.serverLabel ?? 'this server';
-        return 'Only $label tracks can be added to ${playlist.name}.';
-      }
-      return tracks.length == 1
-          ? "That song's already in ${playlist.name}."
-          : 'Those songs are already in ${playlist.name}.';
-    }
-    final int skipped = tracks.length - added;
-    final String base = added == 1
-        ? 'Added to ${playlist.name}.'
-        : 'Added $added songs to ${playlist.name}.';
-    if (skipped > 0) {
-      return '$base $skipped skipped (already added or not supported).';
-    }
-    return base;
+    navigator.pop();
+    messenger.showSnackBar(SnackBar(content: Text(plan.resultMessage)));
   }
 }

--- a/lib/features/shell/home_shell.dart
+++ b/lib/features/shell/home_shell.dart
@@ -97,9 +97,18 @@ class HomeShell extends StatelessWidget {
         constraints.maxWidth >= desktopNavigationBreakpoint;
   }
 
+  /// Opens the Playlists tab at its root for a drag (#389).
+  ///
+  /// Always the branch's initial location, unlike a tap, which restores
+  /// whatever that branch had on top. Favorites and the smart mixes live
+  /// inside this branch and take no drop, so restoring one of those would put
+  /// the drag on a page it cannot finish on. The playlist list always can.
+  void _springToPlaylists() {
+    navigationShell.goBranch(playlistsBranchIndex, initialLocation: true);
+  }
+
   /// The rail, wrapped in the drag spring so a track dragged out of the
-  /// library can reach the Playlists tab (#389). The spring is off while
-  /// Playlists is already showing, since there is nowhere to go.
+  /// library can reach the Playlists tab (#389).
   Widget _buildNavigationRail() {
     return FocusTraversalOrder(
       order: const NumericFocusOrder(2),
@@ -107,8 +116,7 @@ class HomeShell extends StatelessWidget {
         child: SafeArea(
           right: false,
           child: PlaylistDragSpring(
-            enabled: navigationShell.currentIndex != playlistsBranchIndex,
-            onSpring: () => _onDestinationSelected(playlistsBranchIndex),
+            onSpring: _springToPlaylists,
             builder: (BuildContext context, bool dragHovering) {
               return NavigationRail(
                 selectedIndex: navigationShell.currentIndex,
@@ -154,11 +162,44 @@ class HomeShell extends StatelessWidget {
     );
   }
 
-  NavigationBar _buildNavigationBar() {
-    return NavigationBar(
-      selectedIndex: navigationShell.currentIndex,
-      onDestinationSelected: _onDestinationSelected,
-      destinations: _destinations,
+  /// The bottom bar, wrapped in the same drag spring as the rail.
+  ///
+  /// A Linux window narrower than [desktopNavigationBreakpoint] shows this
+  /// instead of the rail, and a mouse is still a mouse there: the drag starts
+  /// whatever the width, so without a spring here it would pick a row up and
+  /// have nowhere in the app to put it. On a phone no drag ever reaches this,
+  /// because the drag source is desktop-only.
+  Widget _buildNavigationBar() {
+    return PlaylistDragSpring(
+      onSpring: _springToPlaylists,
+      builder: (BuildContext context, bool dragHovering) {
+        return NavigationBar(
+          selectedIndex: navigationShell.currentIndex,
+          onDestinationSelected: _onDestinationSelected,
+          destinations: <Widget>[
+            for (int i = 0; i < _destinations.length; i++)
+              _barDestination(context, i, dragHovering: dragHovering),
+          ],
+        );
+      },
+    );
+  }
+
+  /// One bottom-bar destination, marked the same way the rail's is while a
+  /// track drag is over the bar.
+  NavigationDestination _barDestination(
+    BuildContext context,
+    int index, {
+    required bool dragHovering,
+  }) {
+    final NavigationDestination destination = _destinations[index];
+    if (!(dragHovering && index == playlistsBranchIndex)) return destination;
+    final Color accent = Theme.of(context).colorScheme.primary;
+    final Icon marker = Icon(Icons.playlist_add, color: accent);
+    return NavigationDestination(
+      icon: marker,
+      selectedIcon: marker,
+      label: destination.label,
     );
   }
 

--- a/lib/features/shell/home_shell.dart
+++ b/lib/features/shell/home_shell.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import '../player/mini_player.dart';
+import 'playlist_drag_spring.dart';
 
 /// The persistent app frame: hosts the active tab and the app's primary
 /// navigation. Tab state is owned by go_router's [StatefulNavigationShell], so
@@ -23,6 +24,19 @@ class HomeShell extends StatelessWidget {
   /// gives the shell one reusable presentation seam instead of scattering
   /// platform checks through feature screens.
   static const double desktopNavigationBreakpoint = 900;
+
+  /// Which branch the Playlists tab is, so the drag spring and the destination
+  /// list can never disagree about it. A const constructor cannot assert
+  /// against a destination's label, so a test pins the two together instead;
+  /// [destinationLabels] is what it reads.
+  static const int playlistsBranchIndex = 2;
+
+  /// The destination labels, in branch order, for tests that need to know
+  /// which index is which without reaching into private state.
+  static List<String> get destinationLabels => <String>[
+        for (final NavigationDestination destination in _destinations)
+          destination.label,
+      ];
 
   static const _destinations = <NavigationDestination>[
     NavigationDestination(
@@ -83,28 +97,60 @@ class HomeShell extends StatelessWidget {
         constraints.maxWidth >= desktopNavigationBreakpoint;
   }
 
+  /// The rail, wrapped in the drag spring so a track dragged out of the
+  /// library can reach the Playlists tab (#389). The spring is off while
+  /// Playlists is already showing, since there is nowhere to go.
   Widget _buildNavigationRail() {
     return FocusTraversalOrder(
       order: const NumericFocusOrder(2),
       child: FocusTraversalGroup(
         child: SafeArea(
           right: false,
-          child: NavigationRail(
-            selectedIndex: navigationShell.currentIndex,
-            onDestinationSelected: _onDestinationSelected,
-            labelType: NavigationRailLabelType.all,
-            groupAlignment: -1,
-            destinations: [
-              for (final NavigationDestination destination in _destinations)
-                NavigationRailDestination(
-                  icon: destination.icon,
-                  selectedIcon: destination.selectedIcon,
-                  label: Text(destination.label),
-                ),
-            ],
+          child: PlaylistDragSpring(
+            enabled: navigationShell.currentIndex != playlistsBranchIndex,
+            onSpring: () => _onDestinationSelected(playlistsBranchIndex),
+            builder: (BuildContext context, bool dragHovering) {
+              return NavigationRail(
+                selectedIndex: navigationShell.currentIndex,
+                onDestinationSelected: _onDestinationSelected,
+                labelType: NavigationRailLabelType.all,
+                groupAlignment: -1,
+                destinations: <NavigationRailDestination>[
+                  for (int i = 0; i < _destinations.length; i++)
+                    _railDestination(context, i, dragHovering: dragHovering),
+                ],
+              );
+            },
           ),
         ),
       ),
+    );
+  }
+
+  /// One rail destination. While a track drag is over the rail, Playlists
+  /// swaps to an "add to playlist" glyph in the accent colour, so the tab the
+  /// spring is about to open announces itself instead of the page simply
+  /// changing under the drag.
+  NavigationRailDestination _railDestination(
+    BuildContext context,
+    int index, {
+    required bool dragHovering,
+  }) {
+    final NavigationDestination destination = _destinations[index];
+    final bool marked = dragHovering && index == playlistsBranchIndex;
+    if (!marked) {
+      return NavigationRailDestination(
+        icon: destination.icon,
+        selectedIcon: destination.selectedIcon,
+        label: Text(destination.label),
+      );
+    }
+    final Color accent = Theme.of(context).colorScheme.primary;
+    final Icon marker = Icon(Icons.playlist_add, color: accent);
+    return NavigationRailDestination(
+      icon: marker,
+      selectedIcon: marker,
+      label: Text(destination.label, style: TextStyle(color: accent)),
     );
   }
 

--- a/lib/features/shell/playlist_drag_spring.dart
+++ b/lib/features/shell/playlist_drag_spring.dart
@@ -26,7 +26,6 @@ class PlaylistDragSpring extends StatefulWidget {
   const PlaylistDragSpring({
     required this.onSpring,
     required this.builder,
-    this.enabled = true,
     super.key,
   });
 
@@ -38,11 +37,11 @@ class PlaylistDragSpring extends StatefulWidget {
   static const Duration dwell = Duration(milliseconds: 600);
 
   /// Called once per hover, when the dwell elapses.
+  ///
+  /// It fires even when the Playlists tab is already the selected one: that
+  /// branch can be showing Favorites or a smart mix, neither of which takes a
+  /// drop, and springing is what puts the drag back on the playlist list.
   final VoidCallback onSpring;
-
-  /// False when the spring has nothing to do, e.g. the Playlists tab is
-  /// already showing.
-  final bool enabled;
 
   /// Builds the navigation region. [hovering] is true while a track drag is
   /// over it, so the destination it would spring to can say so.
@@ -65,7 +64,6 @@ class _PlaylistDragSpringState extends State<PlaylistDragSpring> {
   void _onEnter() {
     if (_hovering) return;
     setState(() => _hovering = true);
-    if (!widget.enabled) return;
     _timer?.cancel();
     _timer = Timer(PlaylistDragSpring.dwell, () {
       // The drag can end, or the widget go away, inside the dwell.

--- a/lib/features/shell/playlist_drag_spring.dart
+++ b/lib/features/shell/playlist_drag_spring.dart
@@ -1,0 +1,104 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../playlists/playlist_drag.dart';
+
+/// Switches to the Playlists tab when a track drag rests over the navigation
+/// rail, so a song dragged out of the library can reach a playlist row.
+///
+/// Without this there is nowhere to drop. The library and the playlist list
+/// live in different tabs, and a drag cannot press a navigation button on its
+/// way past, which is why every desktop file manager spring-loads its
+/// sidebar. Linthra's is the same idea with one destination that means
+/// anything mid-drag.
+///
+/// The whole rail springs, not the Playlists destination alone. Measured, the
+/// destination's icon slot is 24x24 inside a 128 px rail: a target that small
+/// is a poor thing to ask someone to hit while holding a drag, and the two
+/// stray destinations they might cross on the way are not somewhere a track
+/// drag could have meant to go anyway. The rail highlights Playlists while a
+/// drag is over it, so where the drop is heading is never a guess.
+///
+/// Nothing is accepted here. The rail reports every payload as refused, so the
+/// drag passes straight through to the playlist rows the spring just revealed.
+class PlaylistDragSpring extends StatefulWidget {
+  const PlaylistDragSpring({
+    required this.onSpring,
+    required this.builder,
+    this.enabled = true,
+    super.key,
+  });
+
+  /// How long a drag has to rest on the rail before the tab changes.
+  ///
+  /// Long enough that crossing the rail on the way somewhere else does not
+  /// yank the page out from under the drag; short enough that a deliberate
+  /// hover does not feel stuck.
+  static const Duration dwell = Duration(milliseconds: 600);
+
+  /// Called once per hover, when the dwell elapses.
+  final VoidCallback onSpring;
+
+  /// False when the spring has nothing to do, e.g. the Playlists tab is
+  /// already showing.
+  final bool enabled;
+
+  /// Builds the navigation region. [hovering] is true while a track drag is
+  /// over it, so the destination it would spring to can say so.
+  final Widget Function(BuildContext context, bool hovering) builder;
+
+  @override
+  State<PlaylistDragSpring> createState() => _PlaylistDragSpringState();
+}
+
+class _PlaylistDragSpringState extends State<PlaylistDragSpring> {
+  Timer? _timer;
+  bool _hovering = false;
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  void _onEnter() {
+    if (_hovering) return;
+    setState(() => _hovering = true);
+    if (!widget.enabled) return;
+    _timer?.cancel();
+    _timer = Timer(PlaylistDragSpring.dwell, () {
+      // The drag can end, or the widget go away, inside the dwell.
+      if (!mounted || !_hovering) return;
+      widget.onSpring();
+    });
+  }
+
+  void _onLeave() {
+    _timer?.cancel();
+    _timer = null;
+    if (!_hovering) return;
+    setState(() => _hovering = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DragTarget<PlaylistDragPayload>(
+      // Never takes the drop: the rail is a route to the playlists, not a
+      // destination. Reporting the payload as rejected still enters and leaves
+      // this target, which is all the dwell needs.
+      onWillAcceptWithDetails: (_) {
+        _onEnter();
+        return false;
+      },
+      onLeave: (_) => _onLeave(),
+      builder: (
+        BuildContext context,
+        List<PlaylistDragPayload?> candidate,
+        List<dynamic> rejected,
+      ) {
+        return widget.builder(context, _hovering);
+      },
+    );
+  }
+}

--- a/test/features/playlists/playlist_add_test.dart
+++ b/test/features/playlists/playlist_add_test.dart
@@ -1,0 +1,189 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playlist.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/playlist_repository.dart';
+import 'package:linthra/features/playlists/playlist_add.dart';
+
+Track _local(String id) => Track(id: id, title: id, uri: 'file:///$id.mp3');
+
+Track _jellyfin(String id) => Track(id: id, title: id, uri: 'jellyfin:$id');
+
+Track _subsonic(String id) => Track(id: id, title: id, uri: 'subsonic:$id');
+
+Playlist _playlist({
+  PlaylistSource source = PlaylistSource.local,
+  List<String> trackIds = const <String>[],
+  String name = 'My Mix',
+}) {
+  return Playlist(id: 'p1', name: name, source: source, trackIds: trackIds);
+}
+
+/// Records what reached the repository, so a test can tell "wrote nothing"
+/// apart from "wrote an empty list".
+class _RecordingRepository implements PlaylistRepository {
+  final List<(String, List<String>)> calls = <(String, List<String>)>[];
+
+  @override
+  Future<void> addTracks(String playlistId, List<String> trackUris) async {
+    calls.add((playlistId, trackUris));
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName} is not used here');
+}
+
+void main() {
+  group('PlaylistAddPlan', () {
+    test('a local playlist takes tracks from every source', () {
+      final PlaylistAddPlan plan = PlaylistAddPlan.of(
+        playlist: _playlist(),
+        tracks: <Track>[_local('a'), _jellyfin('1'), _subsonic('2')],
+      );
+
+      expect(plan.accepts, isTrue);
+      expect(plan.addable, hasLength(3));
+      expect(plan.newTracks, hasLength(3));
+      expect(plan.refusalMessage, isNull);
+    });
+
+    test('a synced playlist keeps only its own server\'s tracks', () {
+      final PlaylistAddPlan plan = PlaylistAddPlan.of(
+        playlist: _playlist(source: PlaylistSource.jellyfin),
+        tracks: <Track>[_local('a'), _jellyfin('1'), _subsonic('2')],
+      );
+
+      expect(plan.uris, <String>['jellyfin:1']);
+      expect(plan.accepts, isTrue);
+      // The two it could not take are still counted, so the message can own up
+      // to them rather than quietly reporting a clean add.
+      expect(plan.requested, 3);
+      expect(
+        plan.resultMessage,
+        'Added to My Mix. 2 skipped (already added or not supported).',
+      );
+    });
+
+    test('a synced playlist refuses a selection with none of its tracks', () {
+      final PlaylistAddPlan plan = PlaylistAddPlan.of(
+        playlist: _playlist(source: PlaylistSource.subsonic),
+        tracks: <Track>[_local('a'), _jellyfin('1')],
+      );
+
+      expect(plan.accepts, isFalse);
+      expect(
+        plan.refusalMessage,
+        'Only Navidrome tracks can be added to My Mix.',
+      );
+      expect(plan.resultMessage, plan.refusalMessage);
+    });
+
+    test('an empty drop on a local playlist has nothing to refuse', () {
+      // A local playlist never refuses on source, so "nothing addable" here
+      // only means "nothing was offered", which has no message to give.
+      final PlaylistAddPlan plan =
+          PlaylistAddPlan.of(playlist: _playlist(), tracks: <Track>[]);
+
+      expect(plan.accepts, isFalse);
+      expect(plan.refusalMessage, isNull);
+      expect(plan.changesAnything, isFalse);
+    });
+
+    test('tracks already in the playlist are addable but not new', () {
+      final PlaylistAddPlan plan = PlaylistAddPlan.of(
+        playlist: _playlist(trackIds: <String>['file:///a.mp3']),
+        tracks: <Track>[_local('a'), _local('b')],
+      );
+
+      // Accepting the drop is the right answer even for a song already there:
+      // it is a harmless no-op, and refusing the whole drop over one duplicate
+      // would be worse than saying so afterwards.
+      expect(plan.accepts, isTrue);
+      expect(plan.addable, hasLength(2));
+      expect(plan.newTracks.single.uri, 'file:///b.mp3');
+      expect(
+        plan.resultMessage,
+        'Added to My Mix. 1 skipped (already added or not supported).',
+      );
+    });
+
+    test('a drop of nothing but duplicates says so, in the plural it was', () {
+      final PlaylistAddPlan one = PlaylistAddPlan.of(
+        playlist: _playlist(trackIds: <String>['file:///a.mp3']),
+        tracks: <Track>[_local('a')],
+      );
+      final PlaylistAddPlan many = PlaylistAddPlan.of(
+        playlist: _playlist(
+          trackIds: <String>['file:///a.mp3', 'file:///b.mp3'],
+        ),
+        tracks: <Track>[_local('a'), _local('b')],
+      );
+
+      expect(one.resultMessage, "That song's already in My Mix.");
+      expect(many.resultMessage, 'Those songs are already in My Mix.');
+    });
+
+    test('membership is by namespaced uri, not by bare id', () {
+      // `jellyfin:101` in the playlist must not make `subsonic:101` look like a
+      // duplicate: they are different songs on different servers.
+      final PlaylistAddPlan plan = PlaylistAddPlan.of(
+        playlist: _playlist(trackIds: <String>['jellyfin:101']),
+        tracks: <Track>[_subsonic('101')],
+      );
+
+      expect(plan.newTracks.single.uri, 'subsonic:101');
+      expect(plan.resultMessage, 'Added to My Mix.');
+    });
+
+    test('a clean multi-track add claims exactly what it added', () {
+      final PlaylistAddPlan plan = PlaylistAddPlan.of(
+        playlist: _playlist(),
+        tracks: <Track>[_local('a'), _local('b'), _local('c')],
+      );
+
+      expect(plan.resultMessage, 'Added 3 songs to My Mix.');
+    });
+  });
+
+  group('addTracksToPlaylist', () {
+    test('writes the addable uris and reports the plan', () async {
+      final repository = _RecordingRepository();
+      final PlaylistAddPlan plan = await addTracksToPlaylist(
+        repository: repository,
+        playlist: _playlist(source: PlaylistSource.jellyfin),
+        tracks: <Track>[_jellyfin('1'), _local('a')],
+      );
+
+      expect(repository.calls.single.$1, 'p1');
+      expect(repository.calls.single.$2, <String>['jellyfin:1']);
+      expect(plan.resultMessage, contains('1 skipped'));
+    });
+
+    test('a refused add never touches the repository', () async {
+      // Not a detail: an add of nothing would still bump `updatedAt` and queue
+      // a sync for a playlist the user never actually changed.
+      final repository = _RecordingRepository();
+      await addTracksToPlaylist(
+        repository: repository,
+        playlist: _playlist(source: PlaylistSource.jellyfin),
+        tracks: <Track>[_local('a')],
+      );
+
+      expect(repository.calls, isEmpty);
+    });
+
+    test('an all-duplicates add still goes through, and is a no-op', () async {
+      // The repository is what knows about duplicates, so the call is made and
+      // it skips them. The plan is what keeps the *message* honest.
+      final repository = _RecordingRepository();
+      final PlaylistAddPlan plan = await addTracksToPlaylist(
+        repository: repository,
+        playlist: _playlist(trackIds: <String>['file:///a.mp3']),
+        tracks: <Track>[_local('a')],
+      );
+
+      expect(repository.calls.single.$2, <String>['file:///a.mp3']);
+      expect(plan.resultMessage, "That song's already in My Mix.");
+    });
+  });
+}

--- a/test/features/playlists/playlist_detail_drop_test.dart
+++ b/test/features/playlists/playlist_detail_drop_test.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playlist.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/in_memory_playlist_store.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/data/repositories/playlist_repository_provider.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/playlists/playlist_detail_screen.dart';
+import 'package:linthra/features/playlists/playlist_drag.dart';
+
+import '../library/fake_music_library_repository.dart';
+import '../player/fake_playback_controller.dart';
+
+const List<Track> _catalog = <Track>[
+  Track(id: 'a', title: 'Song A', uri: 'file:///a.mp3'),
+  Track(id: 'b', title: 'Song B', uri: 'file:///b.mp3'),
+  Track(id: 'j', title: 'Server Song', uri: 'jellyfin:1'),
+];
+
+/// The open playlist beside a draggable strip standing in for the library.
+Future<void> _pump(
+  WidgetTester tester,
+  InMemoryPlaylistStore store,
+  List<Track> dragged,
+) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        playlistStoreProvider.overrideWithValue(store),
+        musicLibraryRepositoryProvider
+            .overrideWithValue(FakeMusicLibraryRepository(tracks: _catalog)),
+        playbackControllerProvider.overrideWithValue(FakePlaybackController()),
+      ],
+      child: MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.linux),
+        home: Row(
+          children: <Widget>[
+            const Expanded(child: PlaylistDetailScreen(playlistId: 'p1')),
+            SizedBox(
+              width: 200,
+              height: 600,
+              child: Material(
+                child: PlaylistTrackDraggable(
+                  tracks: () => dragged,
+                  child: const Center(child: Text('source row')),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> _dropOnPage(WidgetTester tester) async {
+  final TestGesture gesture =
+      await tester.startGesture(tester.getCenter(find.text('source row')));
+  await gesture.moveBy(const Offset(-40, 0));
+  await tester.pump();
+  await gesture.moveTo(tester.getCenter(find.byType(PlaylistDropRegion)));
+  await tester.pump();
+  await gesture.up();
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('dropping tracks on the open playlist (#389)', () {
+    testWidgets('an empty playlist takes the drop', (tester) async {
+      // The case that matters most: the page is nothing but an empty state,
+      // and it is exactly the playlist somebody wants to drag songs into.
+      final InMemoryPlaylistStore store = InMemoryPlaylistStore();
+      await store.save(<Playlist>[
+        const Playlist(id: 'p1', name: 'Road Trip'),
+      ]);
+      await _pump(tester, store, <Track>[_catalog[0]]);
+      expect(find.text('No songs yet'), findsOneWidget);
+
+      await _dropOnPage(tester);
+
+      final List<Playlist> saved = await store.load();
+      expect(saved.single.trackIds, <String>['file:///a.mp3']);
+      expect(find.text('Added to Road Trip.'), findsOneWidget);
+    });
+
+    testWidgets('a playlist with songs appends to it', (tester) async {
+      final InMemoryPlaylistStore store = InMemoryPlaylistStore();
+      await store.save(<Playlist>[
+        const Playlist(
+          id: 'p1',
+          name: 'Road Trip',
+          trackIds: <String>['file:///a.mp3'],
+        ),
+      ]);
+      await _pump(tester, store, <Track>[_catalog[1]]);
+
+      await _dropOnPage(tester);
+
+      final List<Playlist> saved = await store.load();
+      expect(saved.single.trackIds, <String>['file:///a.mp3', 'file:///b.mp3']);
+    });
+
+    testWidgets('a synced playlist refuses another source, and says why',
+        (tester) async {
+      final InMemoryPlaylistStore store = InMemoryPlaylistStore();
+      await store.save(<Playlist>[
+        const Playlist(
+          id: 'p1',
+          name: 'Server Mix',
+          source: PlaylistSource.jellyfin,
+        ),
+      ]);
+      await _pump(tester, store, <Track>[_catalog[0]]);
+
+      await _dropOnPage(tester);
+
+      final List<Playlist> saved = await store.load();
+      expect(saved.single.trackIds, isEmpty);
+      expect(
+        find.text('Only Jellyfin tracks can be added to Server Mix.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('a duplicate drop leaves the playlist alone', (tester) async {
+      final InMemoryPlaylistStore store = InMemoryPlaylistStore();
+      await store.save(<Playlist>[
+        const Playlist(
+          id: 'p1',
+          name: 'Road Trip',
+          trackIds: <String>['file:///a.mp3'],
+        ),
+      ]);
+      await _pump(tester, store, <Track>[_catalog[0]]);
+
+      await _dropOnPage(tester);
+
+      final List<Playlist> saved = await store.load();
+      expect(saved.single.trackIds, <String>['file:///a.mp3']);
+      expect(find.text("That song's already in Road Trip."), findsOneWidget);
+    });
+  });
+}

--- a/test/features/playlists/playlist_drag_test.dart
+++ b/test/features/playlists/playlist_drag_test.dart
@@ -1,0 +1,363 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playlist.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/features/playlists/playlist_drag.dart';
+
+Track _local(String id) => Track(id: id, title: id, uri: 'file:///$id.mp3');
+
+Track _jellyfin(String id) => Track(id: id, title: id, uri: 'jellyfin:$id');
+
+/// A source row on the left and a playlist row on the right, far enough apart
+/// that a drag between them is unambiguously horizontal.
+class _Harness extends StatelessWidget {
+  const _Harness({
+    required this.playlist,
+    required this.tracks,
+    required this.dropped,
+    required this.refusals,
+    this.platform = TargetPlatform.linux,
+    this.onResolve,
+  });
+
+  final Playlist playlist;
+  final List<Track> tracks;
+  final List<List<Track>> dropped;
+  final List<String> refusals;
+  final TargetPlatform platform;
+
+  /// Counts how many times the payload closure ran, so a test can pin that it
+  /// is not walked on every rebuild.
+  final VoidCallback? onResolve;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: ThemeData(platform: platform),
+      home: Scaffold(
+        body: Row(
+          children: <Widget>[
+            SizedBox(
+              width: 200,
+              height: 80,
+              child: PlaylistTrackDraggable(
+                tracks: () {
+                  onResolve?.call();
+                  return tracks;
+                },
+                child: const ColoredBox(
+                  color: Color(0xFF2196F3),
+                  child: Center(child: Text('source row')),
+                ),
+              ),
+            ),
+            const Spacer(),
+            SizedBox(
+              width: 200,
+              height: 80,
+              child: PlaylistDropRegion(
+                playlist: playlist,
+                onDrop: dropped.add,
+                onRefused: refusals.add,
+                builder: (BuildContext context, PlaylistDropState state) {
+                  return PlaylistDropHighlight(
+                    state: state,
+                    child: Center(child: Text('drop: ${state.name}')),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Drags the source row onto the drop region and releases, in the small steps
+/// a real pointer moves in so the target enters and leaves properly.
+Future<void> _dragSourceToTarget(WidgetTester tester) async {
+  final TestGesture gesture =
+      await tester.startGesture(tester.getCenter(find.text('source row')));
+  // Horizontal first: the draggable is horizontally-affine, so this is what
+  // wins the gesture arena and starts the drag.
+  await gesture.moveBy(const Offset(40, 0));
+  await tester.pump();
+  await gesture.moveTo(tester.getCenter(find.byType(PlaylistDropRegion)));
+  await tester.pump();
+  await gesture.up();
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('what a drag picks up', () {
+    test('an unselected row drags itself', () {
+      expect(
+        dragPayloadFor(
+          track: _local('a'),
+          selectionActive: false,
+          selected: false,
+          selection: () => <Track>[_local('x'), _local('y')],
+        ).map((Track t) => t.uri),
+        <String>['file:///a.mp3'],
+      );
+    });
+
+    test('a selected row drags the whole selection', () {
+      expect(
+        dragPayloadFor(
+          track: _local('a'),
+          selectionActive: true,
+          selected: true,
+          selection: () => <Track>[_local('a'), _local('b')],
+        ).map((Track t) => t.uri),
+        <String>['file:///a.mp3', 'file:///b.mp3'],
+      );
+    });
+
+    test('an unselected row inside a live selection still drags itself', () {
+      // What every desktop list does: the drag is about the row under the
+      // pointer, not about what happens to be ticked elsewhere.
+      expect(
+        dragPayloadFor(
+          track: _local('c'),
+          selectionActive: true,
+          selected: false,
+          selection: () => <Track>[_local('a'), _local('b')],
+        ).map((Track t) => t.uri),
+        <String>['file:///c.mp3'],
+      );
+    });
+
+    test('a selection that no longer holds this row falls back to it', () {
+      // The row was filtered out or removed from under the selection.
+      // Dragging nothing would be worse than dragging what the pointer is on.
+      expect(
+        dragPayloadFor(
+          track: _local('a'),
+          selectionActive: true,
+          selected: true,
+          selection: () => <Track>[],
+        ).map((Track t) => t.uri),
+        <String>['file:///a.mp3'],
+      );
+    });
+
+    test('a host with no selection at all drags the row', () {
+      expect(
+        dragPayloadFor(
+          track: _local('a'),
+          selectionActive: true,
+          selected: true,
+          selection: null,
+        ).map((Track t) => t.uri),
+        <String>['file:///a.mp3'],
+      );
+    });
+  });
+
+  group('drag a track onto a playlist', () {
+    testWidgets('a drop hands the target every dragged track', (tester) async {
+      final dropped = <List<Track>>[];
+      await tester.pumpWidget(_Harness(
+        playlist: const Playlist(id: 'p1', name: 'My Mix'),
+        tracks: <Track>[_local('a'), _local('b')],
+        dropped: dropped,
+        refusals: <String>[],
+      ));
+
+      await _dragSourceToTarget(tester);
+
+      expect(dropped.single.map((Track t) => t.uri).toList(),
+          <String>['file:///a.mp3', 'file:///b.mp3']);
+    });
+
+    testWidgets('a playlist that can take nothing refuses, and says why',
+        (tester) async {
+      final dropped = <List<Track>>[];
+      final refusals = <String>[];
+      await tester.pumpWidget(_Harness(
+        playlist: const Playlist(
+          id: 'p1',
+          name: 'Server Mix',
+          source: PlaylistSource.jellyfin,
+        ),
+        tracks: <Track>[_local('a')],
+        dropped: dropped,
+        refusals: refusals,
+      ));
+
+      await _dragSourceToTarget(tester);
+
+      // Nothing written, and the user is told rather than left watching the
+      // drag bounce back with no explanation.
+      expect(dropped, isEmpty);
+      expect(
+          refusals.single, 'Only Jellyfin tracks can be added to Server Mix.');
+    });
+
+    testWidgets('a mixed selection lands its supported half', (tester) async {
+      final dropped = <List<Track>>[];
+      final refusals = <String>[];
+      await tester.pumpWidget(_Harness(
+        playlist: const Playlist(
+          id: 'p1',
+          name: 'Server Mix',
+          source: PlaylistSource.jellyfin,
+        ),
+        tracks: <Track>[_local('a'), _jellyfin('1')],
+        dropped: dropped,
+        refusals: refusals,
+      ));
+
+      await _dragSourceToTarget(tester);
+
+      // The whole selection is handed over; deciding which half is addable is
+      // the plan's job, not the drop region's.
+      expect(dropped.single, hasLength(2));
+      expect(refusals, isEmpty);
+    });
+  });
+
+  group('the target says what a drop would do before it happens', () {
+    testWidgets('an acceptable payload highlights it', (tester) async {
+      await tester.pumpWidget(_Harness(
+        playlist: const Playlist(id: 'p1', name: 'My Mix'),
+        tracks: <Track>[_local('a')],
+        dropped: <List<Track>>[],
+        refusals: <String>[],
+      ));
+      expect(find.text('drop: idle'), findsOneWidget);
+
+      final TestGesture gesture =
+          await tester.startGesture(tester.getCenter(find.text('source row')));
+      await gesture.moveBy(const Offset(40, 0));
+      await tester.pump();
+      await gesture.moveTo(tester.getCenter(find.byType(PlaylistDropRegion)));
+      await tester.pump();
+
+      expect(find.text('drop: accepted'), findsOneWidget);
+
+      // ...and it goes back to idle once the drag leaves again.
+      await gesture.moveTo(tester.getCenter(find.text('source row')));
+      await tester.pump();
+      expect(find.text('drop: idle'), findsOneWidget);
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('a payload it cannot take shows as refused, not as idle',
+        (tester) async {
+      await tester.pumpWidget(_Harness(
+        playlist: const Playlist(
+          id: 'p1',
+          name: 'Server Mix',
+          source: PlaylistSource.jellyfin,
+        ),
+        tracks: <Track>[_local('a')],
+        dropped: <List<Track>>[],
+        refusals: <String>[],
+      ));
+
+      final TestGesture gesture =
+          await tester.startGesture(tester.getCenter(find.text('source row')));
+      await gesture.moveBy(const Offset(40, 0));
+      await tester.pump();
+      await gesture.moveTo(tester.getCenter(find.byType(PlaylistDropRegion)));
+      await tester.pump();
+
+      // A target that stayed inert would leave the user guessing why the drop
+      // did nothing.
+      expect(find.text('drop: refused'), findsOneWidget);
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+  });
+
+  group('the drag is desktop-only, and does not fight the list', () {
+    testWidgets('mobile has no draggable at all', (tester) async {
+      final dropped = <List<Track>>[];
+      await tester.pumpWidget(_Harness(
+        platform: TargetPlatform.android,
+        playlist: const Playlist(id: 'p1', name: 'My Mix'),
+        tracks: <Track>[_local('a')],
+        dropped: dropped,
+        refusals: <String>[],
+      ));
+
+      expect(find.byType(Draggable<PlaylistDragPayload>), findsNothing);
+      await _dragSourceToTarget(tester);
+      expect(dropped, isEmpty);
+    });
+
+    testWidgets('a vertical pull is left to the scroller', (tester) async {
+      // The rows live in a scrollable here, which is the situation that
+      // matters: if the drag won a vertical pull, a long track list would stop
+      // scrolling with a mouse.
+      final dropped = <List<Track>>[];
+      final ScrollController controller = ScrollController();
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.linux),
+        home: Scaffold(
+          body: ListView(
+            controller: controller,
+            children: <Widget>[
+              for (int i = 0; i < 30; i++)
+                SizedBox(
+                  height: 80,
+                  child: PlaylistTrackDraggable(
+                    tracks: () => <Track>[_local('$i')],
+                    child: Center(child: Text('row $i')),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ));
+
+      await tester.drag(find.text('row 0'), const Offset(0, -200));
+      await tester.pumpAndSettle();
+
+      // The list scrolled the whole pull, less the slop `drag` spends getting
+      // the gesture recognised. Nothing was picked up.
+      expect(controller.offset, 200 - kDragSlopDefault);
+      expect(dropped, isEmpty);
+    });
+  });
+
+  group('the payload is resolved lazily', () {
+    testWidgets('no drag means the selection is never walked', (tester) async {
+      int resolved = 0;
+      await tester.pumpWidget(_Harness(
+        playlist: const Playlist(id: 'p1', name: 'My Mix'),
+        tracks: <Track>[_local('a')],
+        dropped: <List<Track>>[],
+        refusals: <String>[],
+        onResolve: () => resolved++,
+      ));
+      await tester.pump();
+
+      // A row cannot afford to resolve "the current selection" on every build:
+      // with a 200k-track library that is an O(n) walk per row per frame.
+      expect(resolved, 0);
+    });
+
+    testWidgets('a whole drag resolves it once', (tester) async {
+      int resolved = 0;
+      await tester.pumpWidget(_Harness(
+        playlist: const Playlist(id: 'p1', name: 'My Mix'),
+        tracks: <Track>[_local('a')],
+        dropped: <List<Track>>[],
+        refusals: <String>[],
+        onResolve: () => resolved++,
+      ));
+
+      await _dragSourceToTarget(tester);
+
+      // The feedback card asks once when the drag starts; every hover and the
+      // drop itself read the payload's cached answer.
+      expect(resolved, 1);
+    });
+  });
+}

--- a/test/features/playlists/playlists_screen_drop_test.dart
+++ b/test/features/playlists/playlists_screen_drop_test.dart
@@ -1,0 +1,192 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playlist.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/in_memory_playlist_store.dart';
+import 'package:linthra/data/repositories/playlist_repository_provider.dart';
+import 'package:linthra/features/playlists/playlist_drag.dart';
+import 'package:linthra/features/playlists/playlists_screen.dart';
+
+Track _local(String id) => Track(id: id, title: id, uri: 'file:///$id.mp3');
+
+Track _jellyfin(String id) => Track(id: id, title: id, uri: 'jellyfin:$id');
+
+/// The Playlists screen with a draggable strip beside it, standing in for the
+/// library tab a drag would really have come from.
+Future<void> _pump(
+  WidgetTester tester,
+  InMemoryPlaylistStore store,
+  List<Track> dragged,
+) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        playlistStoreProvider.overrideWithValue(store),
+      ],
+      child: MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.linux),
+        home: Row(
+          children: <Widget>[
+            const Expanded(child: PlaylistsScreen()),
+            SizedBox(
+              width: 200,
+              height: 600,
+              child: Material(
+                child: PlaylistTrackDraggable(
+                  tracks: () => dragged,
+                  child: const Center(child: Text('source row')),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// Drags the source row onto the named playlist and lets go.
+Future<void> _dropOn(WidgetTester tester, String playlistName) async {
+  final TestGesture gesture =
+      await tester.startGesture(tester.getCenter(find.text('source row')));
+  await gesture.moveBy(const Offset(-40, 0));
+  await tester.pump();
+  await gesture.moveTo(tester.getCenter(find.text(playlistName)));
+  await tester.pump();
+  await gesture.up();
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('dropping tracks on a playlist row (#389)', () {
+    testWidgets('adds them, and says what landed', (tester) async {
+      final InMemoryPlaylistStore store = InMemoryPlaylistStore();
+      await store.save(<Playlist>[
+        const Playlist(id: 'p1', name: 'Road Trip'),
+      ]);
+      await _pump(tester, store, <Track>[_local('a'), _local('b')]);
+
+      await _dropOn(tester, 'Road Trip');
+
+      final List<Playlist> saved = await store.load();
+      expect(saved.single.trackIds, <String>['file:///a.mp3', 'file:///b.mp3']);
+      expect(find.text('Added 2 songs to Road Trip.'), findsOneWidget);
+    });
+
+    testWidgets('the add survives a reload of the playlist', (tester) async {
+      // "Persist through the existing repository path", from the issue: the
+      // drop writes through the store, not into screen state.
+      final InMemoryPlaylistStore store = InMemoryPlaylistStore();
+      await store.save(<Playlist>[
+        const Playlist(id: 'p1', name: 'Road Trip'),
+      ]);
+      await _pump(tester, store, <Track>[_local('a')]);
+      await _dropOn(tester, 'Road Trip');
+
+      // The row's own count is read back from the repository stream.
+      expect(find.text('1 song'), findsOneWidget);
+    });
+
+    testWidgets('a duplicate drop changes nothing and owns up to it',
+        (tester) async {
+      final InMemoryPlaylistStore store = InMemoryPlaylistStore();
+      await store.save(<Playlist>[
+        const Playlist(
+          id: 'p1',
+          name: 'Road Trip',
+          trackIds: <String>['file:///a.mp3'],
+        ),
+      ]);
+      await _pump(tester, store, <Track>[_local('a')]);
+
+      await _dropOn(tester, 'Road Trip');
+
+      final List<Playlist> saved = await store.load();
+      expect(saved.single.trackIds, <String>['file:///a.mp3']);
+      expect(find.text("That song's already in Road Trip."), findsOneWidget);
+    });
+
+    testWidgets('a synced playlist refuses another server\'s track',
+        (tester) async {
+      final InMemoryPlaylistStore store = InMemoryPlaylistStore();
+      await store.save(<Playlist>[
+        const Playlist(
+          id: 'p1',
+          name: 'Server Mix',
+          source: PlaylistSource.jellyfin,
+        ),
+      ]);
+      await _pump(tester, store, <Track>[_local('a')]);
+
+      await _dropOn(tester, 'Server Mix');
+
+      final List<Playlist> saved = await store.load();
+      expect(saved.single.trackIds, isEmpty);
+      expect(
+        find.text('Only Jellyfin tracks can be added to Server Mix.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('a synced playlist keeps the half it can take', (tester) async {
+      final InMemoryPlaylistStore store = InMemoryPlaylistStore();
+      await store.save(<Playlist>[
+        const Playlist(
+          id: 'p1',
+          name: 'Server Mix',
+          source: PlaylistSource.jellyfin,
+        ),
+      ]);
+      await _pump(tester, store, <Track>[_local('a'), _jellyfin('1')]);
+
+      await _dropOn(tester, 'Server Mix');
+
+      final List<Playlist> saved = await store.load();
+      expect(saved.single.trackIds, <String>['jellyfin:1']);
+      expect(find.textContaining('1 skipped'), findsOneWidget);
+    });
+
+    testWidgets('a drop lands on the row it was released over', (tester) async {
+      // Two playlists, one drop: the wrong one must stay empty.
+      final InMemoryPlaylistStore store = InMemoryPlaylistStore();
+      await store.save(<Playlist>[
+        const Playlist(id: 'p1', name: 'Road Trip'),
+        const Playlist(id: 'p2', name: 'Late Night'),
+      ]);
+      await _pump(tester, store, <Track>[_local('a')]);
+
+      await _dropOn(tester, 'Late Night');
+
+      final List<Playlist> saved = await store.load();
+      final Playlist roadTrip = saved.firstWhere((Playlist p) => p.id == 'p1');
+      final Playlist lateNight = saved.firstWhere((Playlist p) => p.id == 'p2');
+      expect(roadTrip.trackIds, isEmpty);
+      expect(lateNight.trackIds, <String>['file:///a.mp3']);
+    });
+
+    testWidgets('tapping a row still opens the playlist, not a drag',
+        (tester) async {
+      // The row keeps every job it had: the drag is an addition, not a
+      // replacement for the tap.
+      final InMemoryPlaylistStore store = InMemoryPlaylistStore();
+      await store.save(<Playlist>[
+        const Playlist(id: 'p1', name: 'Road Trip'),
+      ]);
+      await _pump(tester, store, <Track>[_local('a')]);
+
+      expect(find.widgetWithText(ListTile, 'Road Trip'), findsOneWidget);
+      expect(find.text('Playlist actions'), findsNothing);
+      // The overflow menu is still reachable, which is the non-drag route the
+      // issue asks to keep.
+      expect(
+        find.descendant(
+          of: find.widgetWithText(ListTile, 'Road Trip'),
+          matching: find.byIcon(Icons.more_vert),
+        ),
+        findsOneWidget,
+      );
+    });
+  });
+}

--- a/test/features/shell/playlist_drag_spring_shell_test.dart
+++ b/test/features/shell/playlist_drag_spring_shell_test.dart
@@ -1,0 +1,270 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/playlists/playlist_drag.dart';
+import 'package:linthra/features/shell/home_shell.dart';
+import 'package:linthra/features/shell/playlist_drag_spring.dart';
+
+import '../player/fake_playback_controller.dart';
+
+const Track _song = Track(id: 'a', title: 'Dragged Song', uri: 'file:///a.mp3');
+
+/// The Library tab, with a draggable row standing in for a track list.
+class _LibraryScreen extends StatelessWidget {
+  const _LibraryScreen();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: SizedBox(
+          width: 200,
+          height: 80,
+          child: PlaylistTrackDraggable(
+            tracks: () => const <Track>[_song],
+            child: const Center(child: Text('library row')),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A plain branch page.
+class _BranchScreen extends StatelessWidget {
+  const _BranchScreen(this.label);
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(body: Center(child: Text('$label screen')));
+  }
+}
+
+/// Favorites: a nested page inside the Playlists branch that is *not* a drop
+/// target, but does have a draggable row of its own.
+class _FavoritesScreen extends StatelessWidget {
+  const _FavoritesScreen();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: SizedBox(
+          width: 200,
+          height: 80,
+          child: PlaylistTrackDraggable(
+            tracks: () => const <Track>[_song],
+            child: const Center(child: Text('favorites row')),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+GoRouter _router(
+  GlobalKey<NavigatorState> rootKey,
+  List<GlobalKey<NavigatorState>> branchKeys,
+) {
+  const List<String> paths = <String>[
+    '/library',
+    '/folders',
+    '/playlists',
+    '/downloads',
+    '/settings',
+  ];
+  const List<String> labels = <String>[
+    'Library',
+    'Folders',
+    'Playlists',
+    'Downloads',
+    'Settings',
+  ];
+
+  return GoRouter(
+    navigatorKey: rootKey,
+    initialLocation: paths.first,
+    routes: <RouteBase>[
+      StatefulShellRoute.indexedStack(
+        builder: (_, __, StatefulNavigationShell shell) => HomeShell(
+          navigationShell: shell,
+          rootNavigatorKey: rootKey,
+          branchNavigatorKeys: branchKeys,
+        ),
+        branches: <StatefulShellBranch>[
+          for (int i = 0; i < paths.length; i++)
+            StatefulShellBranch(
+              navigatorKey: branchKeys[i],
+              routes: <RouteBase>[
+                GoRoute(
+                  path: paths[i],
+                  builder: (_, __) => i == 0
+                      ? const _LibraryScreen()
+                      : _BranchScreen(labels[i]),
+                  routes: <RouteBase>[
+                    // Only the Playlists branch gets the nested pages that
+                    // matter here.
+                    if (i == 2)
+                      GoRoute(
+                        path: 'favorites',
+                        builder: (_, __) => const _FavoritesScreen(),
+                      ),
+                  ],
+                ),
+              ],
+            ),
+        ],
+      ),
+    ],
+  );
+}
+
+Future<void> _pumpShell(WidgetTester tester, {required Size size}) async {
+  tester.view.devicePixelRatio = 1;
+  tester.view.physicalSize = size;
+  addTearDown(tester.view.resetDevicePixelRatio);
+  addTearDown(tester.view.resetPhysicalSize);
+
+  final GlobalKey<NavigatorState> rootKey = GlobalKey<NavigatorState>();
+  final List<GlobalKey<NavigatorState>> branchKeys =
+      <GlobalKey<NavigatorState>>[
+    for (int i = 0; i < 5; i++) GlobalKey<NavigatorState>(),
+  ];
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        playbackControllerProvider.overrideWithValue(FakePlaybackController()),
+      ],
+      child: MaterialApp.router(
+        theme: ThemeData(platform: TargetPlatform.linux),
+        routerConfig: _router(rootKey, branchKeys),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// Picks the named row up and holds it over the navigation region until the
+/// spring has had time to fire.
+Future<TestGesture> _dragOntoNavigation(
+  WidgetTester tester,
+  String rowLabel,
+) async {
+  final TestGesture gesture =
+      await tester.startGesture(tester.getCenter(find.text(rowLabel)));
+  await gesture.moveBy(const Offset(-40, 0));
+  await tester.pump();
+  await gesture.moveTo(tester.getCenter(find.byType(PlaylistDragSpring)));
+  await tester.pump();
+  await tester.pump(PlaylistDragSpring.dwell);
+  await tester.pumpAndSettle();
+  return gesture;
+}
+
+void main() {
+  group('the spring reaches the playlists from anywhere a drag can start', () {
+    testWidgets('a narrow Linux window springs its bottom bar', (tester) async {
+      // The drag is enabled by platform, but the rail only exists above the
+      // 900 px breakpoint. Without a spring on the bottom bar, a sideways pull
+      // in a narrow window picks a row up and has nowhere at all to put it.
+      await _pumpShell(tester, size: const Size(700, 800));
+      expect(find.byType(NavigationBar), findsOneWidget);
+      expect(find.byType(NavigationRail), findsNothing);
+
+      final TestGesture gesture =
+          await _dragOntoNavigation(tester, 'library row');
+
+      expect(find.text('Playlists screen'), findsOneWidget);
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('a wide window springs its rail', (tester) async {
+      await _pumpShell(tester, size: const Size(1280, 800));
+      expect(find.byType(NavigationRail), findsOneWidget);
+
+      final TestGesture gesture =
+          await _dragOntoNavigation(tester, 'library row');
+
+      expect(find.text('Playlists screen'), findsOneWidget);
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+  });
+
+  group('the spring lands on a page that can take the drop', () {
+    testWidgets('a nested page in the branch is not restored under the drag',
+        (tester) async {
+      // Favorites lives inside the Playlists branch and takes no drop.
+      // Restoring whatever the branch had on top leaves the drag stranded.
+      await _pumpShell(tester, size: const Size(1280, 800));
+      await tester.tap(find.text('Playlists'));
+      await tester.pumpAndSettle();
+      final BuildContext context =
+          tester.element(find.text('Playlists screen'));
+      unawaited(GoRouter.of(context).push('/playlists/favorites'));
+      await tester.pumpAndSettle();
+      expect(find.text('favorites row'), findsOneWidget);
+
+      await tester.tap(find.text('Library'));
+      await tester.pumpAndSettle();
+      final TestGesture gesture =
+          await _dragOntoNavigation(tester, 'library row');
+
+      expect(find.text('Playlists screen'), findsOneWidget);
+      expect(find.text('favorites row'), findsNothing);
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('a drag starting on a nested page can still spring',
+        (tester) async {
+      // The Playlists branch is already selected here, so a spring gated on
+      // "not already on this tab" never fires and the drag is stuck on a page
+      // with no drop target.
+      await _pumpShell(tester, size: const Size(1280, 800));
+      await tester.tap(find.text('Playlists'));
+      await tester.pumpAndSettle();
+      final BuildContext context =
+          tester.element(find.text('Playlists screen'));
+      unawaited(GoRouter.of(context).push('/playlists/favorites'));
+      await tester.pumpAndSettle();
+
+      final TestGesture gesture =
+          await _dragOntoNavigation(tester, 'favorites row');
+
+      expect(find.text('Playlists screen'), findsOneWidget);
+      expect(find.text('favorites row'), findsNothing);
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+  });
+
+  group('the drag stays visible across the tab it just opened', () {
+    testWidgets('the feedback card survives the branch switch', (tester) async {
+      // The draggable's default overlay belongs to the branch it started in.
+      // Once the spring switches branches that branch goes offstage, taking
+      // the feedback with it, and the pointer carries an invisible drag.
+      await _pumpShell(tester, size: const Size(1280, 800));
+
+      final TestGesture gesture =
+          await _dragOntoNavigation(tester, 'library row');
+
+      // The source row is offstage now (its branch is), so the only onstage
+      // copy of this title is the feedback card following the pointer.
+      expect(find.text('library row'), findsNothing);
+      expect(find.text(_song.title), findsOneWidget);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+  });
+}

--- a/test/features/shell/playlist_drag_spring_test.dart
+++ b/test/features/shell/playlist_drag_spring_test.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/features/playlists/playlist_drag.dart';
+import 'package:linthra/features/shell/home_shell.dart';
+import 'package:linthra/features/shell/playlist_drag_spring.dart';
+
+Track _local(String id) => Track(id: id, title: id, uri: 'file:///$id.mp3');
+
+/// A stand-in for the shell: a draggable row on the right, and the spring
+/// wrapping a rail-shaped strip on the left.
+class _Harness extends StatelessWidget {
+  const _Harness({required this.sprung, this.enabled = true});
+
+  final List<int> sprung;
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: ThemeData(platform: TargetPlatform.linux),
+      home: Scaffold(
+        body: Row(
+          children: <Widget>[
+            SizedBox(
+              width: 128,
+              height: 600,
+              child: PlaylistDragSpring(
+                enabled: enabled,
+                onSpring: () => sprung.add(sprung.length),
+                builder: (BuildContext context, bool hovering) {
+                  return ColoredBox(
+                    color: const Color(0xFFEEEEEE),
+                    child: Center(
+                      child: Text(hovering ? 'rail: hovering' : 'rail: idle'),
+                    ),
+                  );
+                },
+              ),
+            ),
+            Expanded(
+              child: SizedBox(
+                height: 600,
+                child: PlaylistTrackDraggable(
+                  tracks: () => <Track>[_local('a')],
+                  child: const Center(child: Text('source row')),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Picks up the source row and holds the pointer over the rail.
+Future<TestGesture> _dragOntoRail(WidgetTester tester) async {
+  final TestGesture gesture =
+      await tester.startGesture(tester.getCenter(find.text('source row')));
+  await gesture.moveBy(const Offset(-40, 0));
+  await tester.pump();
+  await gesture.moveTo(tester.getCenter(find.byType(PlaylistDragSpring)));
+  await tester.pump();
+  return gesture;
+}
+
+void main() {
+  group('the rail springs to Playlists mid-drag', () {
+    testWidgets('a drag resting on the rail switches tab', (tester) async {
+      final sprung = <int>[];
+      await tester.pumpWidget(_Harness(sprung: sprung));
+
+      final TestGesture gesture = await _dragOntoRail(tester);
+      expect(sprung, isEmpty, reason: 'not before the dwell elapses');
+
+      await tester.pump(PlaylistDragSpring.dwell);
+      expect(sprung, hasLength(1));
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('crossing the rail on the way past does not', (tester) async {
+      // The whole point of the dwell: a drag that sweeps over the rail towards
+      // something else must not yank the page out from under it.
+      final sprung = <int>[];
+      await tester.pumpWidget(_Harness(sprung: sprung));
+
+      final TestGesture gesture = await _dragOntoRail(tester);
+      await tester.pump(const Duration(milliseconds: 100));
+      await gesture.moveTo(tester.getCenter(find.text('source row')));
+      await tester.pump(PlaylistDragSpring.dwell * 2);
+
+      expect(sprung, isEmpty);
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('the rail says where the drag is headed', (tester) async {
+      // Growable: the spring appends to this when it fires, so a const literal
+      // here would throw rather than record.
+      final sprung = <int>[];
+      await tester.pumpWidget(_Harness(sprung: sprung));
+      expect(find.text('rail: idle'), findsOneWidget);
+
+      final TestGesture gesture = await _dragOntoRail(tester);
+      expect(find.text('rail: hovering'), findsOneWidget);
+
+      await gesture.moveTo(tester.getCenter(find.text('source row')));
+      await tester.pump();
+      expect(find.text('rail: idle'), findsOneWidget);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('it springs once per hover, not once per pointer move',
+        (tester) async {
+      final sprung = <int>[];
+      await tester.pumpWidget(_Harness(sprung: sprung));
+
+      final TestGesture gesture = await _dragOntoRail(tester);
+      await tester.pump(PlaylistDragSpring.dwell);
+      // Keep wandering around inside the rail well past a second dwell.
+      await gesture.moveBy(const Offset(0, 40));
+      await tester.pump(PlaylistDragSpring.dwell);
+      await gesture.moveBy(const Offset(0, -80));
+      await tester.pump(PlaylistDragSpring.dwell);
+
+      expect(sprung, hasLength(1));
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('disabled, it still highlights but never fires',
+        (tester) async {
+      // The state the Playlists tab is already showing in: there is nowhere to
+      // spring to, and re-selecting the branch would pop the user's stack.
+      final sprung = <int>[];
+      await tester.pumpWidget(_Harness(sprung: sprung, enabled: false));
+
+      final TestGesture gesture = await _dragOntoRail(tester);
+      await tester.pump(PlaylistDragSpring.dwell * 2);
+
+      expect(sprung, isEmpty);
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('the rail never swallows the drop', (tester) async {
+      // The spring is a route to the playlists, not a destination. If it took
+      // the drop, the drag would end on the rail and never reach a playlist.
+      final sprung = <int>[];
+      await tester.pumpWidget(_Harness(sprung: sprung));
+
+      final TestGesture gesture = await _dragOntoRail(tester);
+      await tester.pump(PlaylistDragSpring.dwell);
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      final DragTarget<PlaylistDragPayload> target = tester.widget(
+        find.byType(DragTarget<PlaylistDragPayload>),
+      );
+      expect(
+        target.onWillAcceptWithDetails!(
+          DragTargetDetails<PlaylistDragPayload>(
+            data: PlaylistDragPayload(() => <Track>[_local('a')]),
+            offset: Offset.zero,
+          ),
+        ),
+        isFalse,
+      );
+    });
+
+    testWidgets('a drag that ends inside the dwell springs nothing',
+        (tester) async {
+      final sprung = <int>[];
+      await tester.pumpWidget(_Harness(sprung: sprung));
+
+      final TestGesture gesture = await _dragOntoRail(tester);
+      await gesture.up();
+      await tester.pumpAndSettle();
+      await tester.pump(PlaylistDragSpring.dwell * 2);
+
+      expect(sprung, isEmpty);
+    });
+  });
+
+  group('the shell agrees with the spring about which branch is which', () {
+    test('playlistsBranchIndex points at the Playlists destination', () {
+      // A const constructor cannot assert this, and getting it wrong would
+      // spring a drag to Downloads.
+      expect(
+        HomeShell.destinationLabels[HomeShell.playlistsBranchIndex],
+        'Playlists',
+      );
+    });
+  });
+}

--- a/test/features/shell/playlist_drag_spring_test.dart
+++ b/test/features/shell/playlist_drag_spring_test.dart
@@ -10,10 +10,9 @@ Track _local(String id) => Track(id: id, title: id, uri: 'file:///$id.mp3');
 /// A stand-in for the shell: a draggable row on the right, and the spring
 /// wrapping a rail-shaped strip on the left.
 class _Harness extends StatelessWidget {
-  const _Harness({required this.sprung, this.enabled = true});
+  const _Harness({required this.sprung});
 
   final List<int> sprung;
-  final bool enabled;
 
   @override
   Widget build(BuildContext context) {
@@ -26,7 +25,6 @@ class _Harness extends StatelessWidget {
               width: 128,
               height: 600,
               child: PlaylistDragSpring(
-                enabled: enabled,
                 onSpring: () => sprung.add(sprung.length),
                 builder: (BuildContext context, bool hovering) {
                   return ColoredBox(
@@ -129,21 +127,6 @@ void main() {
       await tester.pump(PlaylistDragSpring.dwell);
 
       expect(sprung, hasLength(1));
-      await gesture.up();
-      await tester.pumpAndSettle();
-    });
-
-    testWidgets('disabled, it still highlights but never fires',
-        (tester) async {
-      // The state the Playlists tab is already showing in: there is nowhere to
-      // spring to, and re-selecting the branch would pop the user's stack.
-      final sprung = <int>[];
-      await tester.pumpWidget(_Harness(sprung: sprung, enabled: false));
-
-      final TestGesture gesture = await _dragOntoRail(tester);
-      await tester.pump(PlaylistDragSpring.dwell * 2);
-
-      expect(sprung, isEmpty);
       await gesture.up();
       await tester.pumpAndSettle();
     });


### PR DESCRIPTION
Closes #389.

The other half of the issue. #601 covered reordering inside a playlist; this is getting a song in there in the first place.

## What you can do now

Drag a track row sideways on desktop and drop it on a playlist. Dragging a row that is part of a multi-selection carries the whole selection; dragging any other row carries just that row, which is what a desktop list is expected to do. Only sideways drags pick a row up, so a vertical drag still scrolls the list. None of it exists on mobile, where a long press already starts multi-select.

Two things take a drop: a playlist row on the Playlists tab, and the open playlist's whole page.

## Getting the drag somewhere it can land

The library and the playlist list are in different tabs, and a drag cannot press a navigation button on its way past, so without help there is nowhere to drop. Navigation is spring-loaded: rest a drag on it for ~600 ms and it opens Playlists, with that destination swapped to an accent-coloured "add to playlist" glyph so the drag says where it is heading. Crossing it quickly on the way somewhere else does nothing. Navigation never takes the drop itself, it only gets you to the rows.

Three things had to be true for that to actually work, and only the first was true in the original draft:

**The whole navigation region springs, not one destination.** I measured it: the rail's destination icon slot is 24x24 inside a 128 px rail, which is a poor thing to ask someone to hit while holding a drag, and the destinations they might cross on the way are not somewhere a track drag could have meant to go.

**Both layouts spring.** The rail only exists above the 900 px breakpoint; below it the shell shows a bottom bar. The drag is gated on platform, so a Linux window narrower than that made every row draggable with nowhere in the app to put it. The bottom bar springs identically now. A phone never reaches it, since the drag source stays desktop-only.

**The spring opens the playlist list, not the tab's last page.** Favorites and the smart mixes live inside the Playlists branch and take no drop, so restoring whatever that branch had on top could strand a drag, and a drag *starting* from one of those pages could not spring at all while the gate was "not already on this tab". It now always opens the branch's initial location, which always takes a drop, and is what you want mid-drag anyway: you have not picked a playlist yet.

## Modules

**`lib/features/playlists/playlist_add.dart`** is the rule for what adding a set of tracks to a playlist would do. Two rules decide it, and both were private to the "Add to playlist" sheet:

- a synced playlist takes only its own server's tracks, so it stays consistent with the server
- the repository skips uris already present, so the count a user is told must be the genuinely-new ones

That privacy is the actual problem being fixed. A drop with its own rules could have put a Jellyfin track in a Navidrome playlist by going around the sheet. The sheet now goes through the same plan, so there is one rule and both paths follow it. Pure, no Flutter, so a mixed selection onto a synced playlist and a drop of nothing but duplicates are unit-testable without pumping a widget.

**`lib/features/playlists/playlist_drag.dart`** holds the payload, the drag source, the drop region and the shared highlight.

**`lib/features/shell/playlist_drag_spring.dart`** is the navigation dwell.

Nothing new touches persistence: every drop goes through `PlaylistRepository.addTracks`, the same call the sheet makes.

## Invalid and duplicate drops

The issue asks for invalid drops to be prevented "according to current playlist semantics", and they are, but the target still accepts the gesture and then explains itself. Refusing at `onWillAccept` makes the drag bounce back with no explanation at all, which is a worse answer than "only Jellyfin tracks can be added to Server Mix".

- a playlist that can take none of the dropped tracks writes nothing and says why
- a mixed selection onto a synced playlist adds the supported half and reports how many it skipped
- tracks already there are skipped, and the message never claims more than landed
- a refused drop performs **no repository call at all**, so it cannot bump `updatedAt` or queue a sync for a playlist nobody changed

## Accessibility

Drag-and-drop is an addition, never the only way in. "Add to playlist" is still on every track row's overflow menu and right-click menu, still reachable from the keyboard, and now runs through the same plan the drop does.

## Tests

36 new, 4881 passing overall. `flutter analyze` and `dart format --set-exit-if-changed` both clean.

Three found real bugs rather than confirming what I had already written:

- a decorated ancestor between a `Material` and a `ListTile` hides the tile's background and swallows its ink splashes. Flutter asserts about it, foreground or background, so the highlight is a `CustomPaint` foreground painter instead, which has the side benefit of adding no layout at all.
- the drag feedback card resolved the selection separately from the payload, so one drag walked it twice. They share one payload now.
- the feedback card belonged to the source branch's overlay, so the spring's own branch switch put it offstage and the pointer carried an invisible drag. `rootOverlay: true` keeps it. The test is behavioural: after the spring, the source row is offstage with its branch, so the only onstage copy of the title is the card following the pointer.

Every assertion was checked against a deliberate mutation:

| Mutation | Failed |
| --- | --- |
| the source rule dropped (a synced playlist takes anything) | 8 tests across the plan, the drop region and both screens |
| a refused add writes anyway | `a refused add never touches the repository` |
| the drag is no longer horizontally-affine | `a vertical pull is left to the scroller` |
| the drag is enabled on mobile too | `mobile has no draggable at all` |
| every target looks acceptable | `a payload it cannot take shows as refused, not as idle` |
| the payload ignores the selection | `a selected row drags the whole selection` |
| the spring fires with no dwell | `crossing the rail on the way past does not` |
| the rail swallows the drop | `the rail never swallows the drop` |
| the bottom bar loses its spring | `a narrow Linux window springs its bottom bar` |
| the spring restores the branch's top page | the two nested-page tests |
| the feedback drops back to the nearest overlay | `the feedback card survives the branch switch` |

The last five tests run against a real `StatefulShellRoute.indexedStack` with five branches and a nested Favorites route, because the bugs they cover only exist once branches and overlays are real.

## Review rounds

Three findings, all the same shape: a drag that starts fine and then has no reachable target. Details on the threads.

| Finding | Why it mattered |
| --- | --- |
| No spring below the desktop breakpoint | Two gates disagreed about what "desktop" means: the drag asked the platform, the spring asked whether the rail existed |
| The spring restored the branch's top page | Favorites and the smart mixes are in that branch and take no drop, so a drag could be stranded on one, or could not spring off one at all |
| Feedback in the branch overlay | The drag kept working and went invisible halfway through, which is the kind of thing that only shows up on a real screen |

## Known limitations

- **No on-device or real-desktop validation.** Everything here is `flutter test` on the host, including the rail geometry the spring was sized against. The third finding above is a good illustration of what that misses.
- The 600 ms dwell is a judgement call, not a measured one. It wants a few minutes with a real mouse.
- **The open-playlist drop target is currently unreachable.** It was written to catch the spring landing on a playlist detail page; now that the spring always opens the list, nothing lands there, and that page has no drag source of its own. It is kept because "a playlist on screen takes a drop" is correct behaviour for the page and costs four tests and no runtime, but say the word and I will drop it.
- The Now Playing queue is not a drag source. Only track rows built through `TrackTile` are, which covers the library, album, artist, folder and smart-mix lists.
- Reordering a playlist by dropping a track *between* two rows is not part of this. A drop appends, and reordering stays the handle-and-keyboard job #601 built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MffeFFVaKcNCa9NZHUBJ1G