### PR TITLE
feat(desktop): choose Compact or Comfortable density (#395)

### DIFF
--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -384,6 +384,7 @@ undeclared network access to an isolated `flatpak-builder` build.
 | Volume control | Supported | A mute and a slider on Now Playing and the wide mini-player bar, plus MPRIS `Volume`, driven through `PlaybackController` and remembered across launches ([issue #394](https://github.com/TheZupZup/Linthra/issues/394)). See [Volume](#volume). |
 | Desktop layout | Supported | The shell swaps its bottom bar for a navigation rail at 900 px, and feature screens adapt on the width they are given — including a third pane for the Library grids and for Now Playing's queue. See [How the desktop layout adapts](#how-the-desktop-layout-adapts). |
 | Window geometry | Supported | Size and maximized state survive a restart; position too, on X11. A saved position is re-checked against the monitors attached now. See [Window state](#window-state). |
+| Content density | Supported | Compact by default, switchable to Comfortable in Settings → Appearance and remembered across restarts ([issue #395](https://github.com/thezupzup/linthra/issues/395)). Both are Material `VisualDensity` values, so the choice reaches every list row, grid and control at once. Touch builds are unaffected. See [Density (Compact / Comfortable)](#density-compact--comfortable). |
 | Pointer affordances | Supported | Compact content density, visible hover feedback, right-click context menus with a keyboard equivalent, and Ctrl/Shift multi-select in track lists — all keyed on the input rather than the window width. See [Pointer, not width](#pointer-not-width). |
 | Keyboard shortcuts | Partial | Quick search is bound to **Ctrl+K** / **Ctrl+F** ([issue #393](https://github.com/TheZupZup/Linthra/issues/393)) — see [Quick search](#quick-search-ctrlk). The volume control takes the wheel and arrow keys when focused; global transport and volume shortcuts are still later work in #376. |
 
@@ -495,6 +496,45 @@ window and is still driven by a thumb.
   number follow it rather than ignoring it — the songs list's fixed row extent
   (which the A–Z index measures its scroll offsets in) and the artist grid's
   cell floor — and both only give back padding, never room the words need.
+  On desktop the value is also a **preference**: see
+  [Density (Compact / Comfortable)](#density-compact--comfortable).
+### Density (Compact / Comfortable)
+
+Settings → Appearance → **Density** offers two desktop densities
+([issue #395](https://github.com/thezupzup/linthra/issues/395)):
+
+| Mode | Material value | Effect |
+| --- | --- | --- |
+| **Compact** (default) | `VisualDensity.compact` | What a desktop build has always looked like. Fits the most of a library per screen. |
+| **Comfortable** | `VisualDensity.comfortable` | One step back towards the touch layout: roomier rows and grids, still denser than a phone. |
+
+The preference is *only* a choice between two of Material's own
+`VisualDensity` values — there is no second spacing scale. That is what makes
+it reach the whole app for free: every widget that already reads
+`Theme.of(context).visualDensity` (list rows, buttons, popup menus, the songs
+list's row extent, the artist grid's cell floor) follows it with no change of
+its own, and Material's minimum tap targets still apply on top, so neither
+setting can shrink a control below a real click target.
+
+| Piece | File |
+| --- | --- |
+| The preference | `lib/core/models/desktop_density.dart` |
+| Store seam | `lib/core/repositories/desktop_density_store.dart` |
+| Persistence | `lib/data/repositories/shared_preferences_desktop_density_store.dart` |
+| Controller + `VisualDensity` mapping | `lib/features/appearance/desktop_density_controller.dart` |
+| The card | `lib/features/appearance/desktop_density_card.dart` |
+
+Two rules keep touch out of it. The card renders nothing off desktop, and
+`LinthraApp` passes a density to `AppTheme` **only** on a desktop host — off
+desktop the parameter is null and the theme keeps
+`VisualDensity.adaptivePlatformDensity` exactly as before. An Android build can
+therefore never inherit a desktop density, which
+`test/features/appearance/desktop_density_widget_test.dart` pins.
+
+Like the theme mode, the stored value is read before `runApp` so the first
+frame already lays out at the chosen density; changing it afterwards rebuilds
+both themes and relayouts every screen at once, with no restart.
+
 * **Hover** — `hoverColor` carries enough weight to be seen on a black-first
   theme, and every ink surface picks it up at once: list rows, buttons, grid
   cards, rail destinations, menu items. It is neutral rather than brand-tinted,

--- a/lib/app/application_container.dart
+++ b/lib/app/application_container.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../core/models/desktop_density.dart';
 import '../core/models/theme_mode_preference.dart';
 import '../core/platform/host_platform.dart';
 import '../data/repositories/app_icon_variant_store_provider.dart';
@@ -7,6 +8,7 @@ import '../data/repositories/audio_output_device_service_provider.dart';
 import '../data/repositories/audiobookshelf_session_store_provider.dart';
 import '../data/repositories/cast_receiver_pin_store_provider.dart';
 import '../data/repositories/default_provider_store_provider.dart';
+import '../data/repositories/desktop_density_store_provider.dart';
 import '../data/repositories/desktop_window_controller_provider.dart';
 import '../data/repositories/desktop_window_preferences_provider.dart';
 import '../data/repositories/download_repository_provider.dart';
@@ -30,6 +32,7 @@ import '../data/repositories/share_service_provider.dart';
 import '../data/repositories/subsonic_auto_sync_store_provider.dart';
 import '../data/repositories/subsonic_session_store_provider.dart';
 import '../data/repositories/theme_mode_store_provider.dart';
+import '../features/appearance/desktop_density_controller.dart';
 import '../features/appearance/theme_mode_controller.dart';
 import '../features/downloads/download_providers.dart';
 import '../features/library/playback_candidates_provider.dart';
@@ -45,6 +48,7 @@ import '../features/settings/jellyfin/jellyfin_availability_controller.dart';
 /// without calling `runApp`.
 List<Override> productionApplicationOverrides({
   required ThemeModePreference storedThemeMode,
+  DesktopDensity storedDesktopDensity = DesktopDensity.fallback,
   HostPlatform? host,
 }) {
   final HostPlatform resolvedHost = host ?? HostPlatform.current;
@@ -92,6 +96,8 @@ List<Override> productionApplicationOverrides({
     sharedPreferencesAppIconVariantStoreOverride,
     sharedPreferencesThemeModeStoreOverride,
     initialThemeModeProvider.overrideWithValue(storedThemeMode),
+    sharedPreferencesDesktopDensityStoreOverride,
+    initialDesktopDensityProvider.overrideWithValue(storedDesktopDensity),
     platformLauncherIconServiceOverride,
     platformShareServiceOverride,
     platformAudioOutputDeviceServiceOverride,

--- a/lib/app/linthra_app.dart
+++ b/lib/app/linthra_app.dart
@@ -14,6 +14,7 @@ import '../data/repositories/host_platform_provider.dart';
 import '../features/appearance/app_icon_controller.dart';
 import '../features/appearance/custom_brand_palette.dart';
 import '../features/appearance/custom_theme_controller.dart';
+import '../features/appearance/desktop_density_controller.dart';
 import '../features/appearance/selected_logo_mark.dart';
 import '../features/appearance/theme_mode_controller.dart';
 import '../features/library/remote_library_refresher.dart';
@@ -175,8 +176,23 @@ class _LinthraAppState extends ConsumerState<LinthraApp>
       return BrandPalettes.byId(variant.id, brightness: brightness);
     }
 
-    final ThemeData lightTheme = AppTheme.light(paletteFor(Brightness.light));
-    final ThemeData darkTheme = AppTheme.dark(paletteFor(Brightness.dark));
+    // Desktop density (#395). Watched here rather than read deeper down so a
+    // change repaints and relaids out every screen at once, the same way the
+    // theme mode does — no restart, and no widget needing to know the
+    // preference exists.
+    //
+    // Resolved to null off desktop: a touch build keeps
+    // `VisualDensity.adaptivePlatformDensity` exactly as before, so an Android
+    // phone can never inherit a density someone picked for a Linux window (the
+    // preference is per-install, and Android does not show the picker at all).
+    final VisualDensity? density = ref.watch(hostPlatformProvider).isDesktop
+        ? ref.watch(desktopDensityControllerProvider).visualDensity
+        : null;
+
+    final ThemeData lightTheme =
+        AppTheme.light(paletteFor(Brightness.light), density: density);
+    final ThemeData darkTheme =
+        AppTheme.dark(paletteFor(Brightness.dark), density: density);
 
     // Do not construct the router until first-install/update state is known.
     // This tiny branded launch surface prevents both a library→welcome flash and

--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -17,8 +17,10 @@ import 'dimens.dart';
 /// Reach for these instead of hard-coding colours, so retuning the brand stays
 /// a one-file change.
 abstract final class AppTheme {
-  static ThemeData dark(BrandPalette palette) => _build(
+  static ThemeData dark(BrandPalette palette, {VisualDensity? density}) =>
+      _build(
         palette: palette,
+        density: density,
         brightness: Brightness.dark,
         background: AppColors.darkBackground,
         surface: AppColors.darkSurface,
@@ -33,8 +35,10 @@ abstract final class AppTheme {
         error: AppColors.error,
       );
 
-  static ThemeData light(BrandPalette palette) => _build(
+  static ThemeData light(BrandPalette palette, {VisualDensity? density}) =>
+      _build(
         palette: palette,
+        density: density,
         brightness: Brightness.light,
         background: AppColors.lightBackground,
         surface: AppColors.lightSurface,
@@ -52,6 +56,7 @@ abstract final class AppTheme {
   static ThemeData _build({
     required BrandPalette palette,
     required Brightness brightness,
+    VisualDensity? density,
     required Color background,
     required Color surface,
     required Color surfaceHigh,
@@ -105,7 +110,12 @@ abstract final class AppTheme {
       // navigation rail keys off, rather than shrinking on width: density is
       // about what is pointing at the row, and an Android tablet in landscape
       // is as wide as a desktop window and still driven by a thumb.
-      visualDensity: VisualDensity.adaptivePlatformDensity,
+      //
+      // [density] overrides it with the user's Compact/Comfortable choice
+      // (#395). `LinthraApp` passes one only on a desktop host, so a touch
+      // build can never inherit a desktop density: off desktop the parameter is
+      // null and this stays exactly the adaptive value it has always been.
+      visualDensity: density ?? VisualDensity.adaptivePlatformDensity,
       // Hover feedback (#385). Material's default is a 4% white/black veil,
       // which on a black-first theme is close to invisible — so a mouse user
       // could not tell a row apart from the page it sits on.

--- a/lib/core/models/desktop_density.dart
+++ b/lib/core/models/desktop_density.dart
@@ -1,0 +1,59 @@
+/// How much vertical room desktop rows, grids and controls are given.
+///
+/// Desktop content density has existed since #384, but as a *fixed* value:
+/// `AppTheme` hands Material `VisualDensity.adaptivePlatformDensity`, which
+/// resolves to [VisualDensity.compact] on Linux/macOS/Windows and
+/// [VisualDensity.standard] on anything touch-first. That is the right default —
+/// a mouse hits a smaller row happily and a thumb does not — but it is not a
+/// choice, and "fit more of my library on screen" and "stop making me aim" are
+/// both reasonable things to want from the same app.
+///
+/// This enum is that choice, and only that: it selects between two of Material's
+/// own [VisualDensity] values rather than introducing a second spacing scale.
+/// Every widget that already reads `Theme.of(context).visualDensity` — list
+/// rows, the artist grid's tile extent, the alphabet list's row extent, buttons,
+/// popup menus — follows it with no change of its own, which is the whole reason
+/// the preference is expressed this way.
+///
+/// Deliberately Flutter-free (like `ThemeModePreference`) so a lightweight
+/// key/value store can persist it as one short string. The mapping onto
+/// [VisualDensity] lives with the appearance feature that renders it.
+///
+/// The stored value is a non-secret display preference: no account, server,
+/// library, or playback data is involved.
+enum DesktopDensity {
+  /// The tighter of the two, and what a desktop build has always looked like:
+  /// Material's [VisualDensity.compact]. Fits materially more of a library per
+  /// screen.
+  compact('compact'),
+
+  /// Roomier rows for people who would rather read than scroll: Material's
+  /// [VisualDensity.comfortable]. Still denser than the touch layout, so a
+  /// desktop window never turns into a stretched phone.
+  comfortable('comfortable');
+
+  const DesktopDensity(this.storageId);
+
+  /// The stable string written to storage. Never shown to users, and never
+  /// renamed — a stored value must keep resolving across app updates.
+  final String storageId;
+
+  /// What an absent, empty, or unrecognised stored value resolves to.
+  ///
+  /// [compact] on purpose: it is exactly what `adaptivePlatformDensity` already
+  /// gave every desktop build, so adding this preference moves nothing for
+  /// anyone who never opens it.
+  static const DesktopDensity fallback = DesktopDensity.compact;
+
+  /// Resolves a stored [storageId] back to its density, falling back to
+  /// [fallback] for anything unrecognised — the same "unknown → default" rule
+  /// the theme mode and branding variants use, so a corrupted or downgraded
+  /// preference can never leave the app without a density.
+  static DesktopDensity fromStorageId(String? storageId) {
+    if (storageId == null || storageId.isEmpty) return fallback;
+    for (final DesktopDensity density in values) {
+      if (density.storageId == storageId) return density;
+    }
+    return fallback;
+  }
+}

--- a/lib/core/repositories/desktop_density_store.dart
+++ b/lib/core/repositories/desktop_density_store.dart
@@ -1,0 +1,14 @@
+import '../models/desktop_density.dart';
+
+/// Persists the user's desktop Compact / Comfortable choice.
+///
+/// The value is a non-secret display preference only. No account, server,
+/// library, or playback data is stored here.
+abstract interface class DesktopDensityStore {
+  /// Returns the stored density, or `null` when the user has never chosen one —
+  /// which the caller resolves to [DesktopDensity.fallback].
+  Future<DesktopDensity?> read();
+
+  /// Persists [density].
+  Future<void> write(DesktopDensity density);
+}

--- a/lib/data/repositories/desktop_density_store_provider.dart
+++ b/lib/data/repositories/desktop_density_store_provider.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/desktop_density.dart';
+import '../../core/repositories/desktop_density_store.dart';
+import 'in_memory_desktop_density_store.dart';
+import 'shared_preferences_desktop_density_store.dart';
+
+/// The single [DesktopDensityStore] the app reads/writes the Compact /
+/// Comfortable choice through.
+///
+/// Defaults to the in-memory implementation so widget and unit tests stay free
+/// of platform plugins. The running app overrides this with
+/// [sharedPreferencesDesktopDensityStoreOverride] so the choice persists across
+/// restarts.
+final desktopDensityStoreProvider = Provider<DesktopDensityStore>((ref) {
+  return InMemoryDesktopDensityStore();
+});
+
+/// Production binding: persists the desktop density via `shared_preferences`.
+/// Applied in `main`.
+final sharedPreferencesDesktopDensityStoreOverride =
+    desktopDensityStoreProvider.overrideWithValue(
+  const SharedPreferencesDesktopDensityStore(),
+);
+
+/// Reads the stored desktop density before the first frame is built.
+///
+/// `main` awaits this and seeds `initialDesktopDensityProvider` with the
+/// result, for the same reason the theme mode is read there: density decides
+/// every row height in the app, and resolving it after startup would draw the
+/// library once at one size and immediately relayout it at another.
+///
+/// Defensive by design: a store that throws (a plugin hiccup, unreadable
+/// preferences) resolves to [DesktopDensity.fallback] rather than taking
+/// startup down. A display preference must never be able to stop the app
+/// booting.
+Future<DesktopDensity> readStoredDesktopDensity([
+  DesktopDensityStore store = const SharedPreferencesDesktopDensityStore(),
+]) async {
+  try {
+    return await store.read() ?? DesktopDensity.fallback;
+  } catch (_) {
+    return DesktopDensity.fallback;
+  }
+}

--- a/lib/data/repositories/in_memory_desktop_density_store.dart
+++ b/lib/data/repositories/in_memory_desktop_density_store.dart
@@ -1,0 +1,20 @@
+import '../../core/models/desktop_density.dart';
+import '../../core/repositories/desktop_density_store.dart';
+
+/// Test-friendly [DesktopDensityStore] that keeps one value in memory.
+class InMemoryDesktopDensityStore implements DesktopDensityStore {
+  InMemoryDesktopDensityStore([this._density]);
+
+  DesktopDensity? _density;
+
+  /// The last written value, for assertions.
+  DesktopDensity? get density => _density;
+
+  @override
+  Future<DesktopDensity?> read() async => _density;
+
+  @override
+  Future<void> write(DesktopDensity density) async {
+    _density = density;
+  }
+}

--- a/lib/data/repositories/shared_preferences_desktop_density_store.dart
+++ b/lib/data/repositories/shared_preferences_desktop_density_store.dart
@@ -1,0 +1,27 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/models/desktop_density.dart';
+import '../../core/repositories/desktop_density_store.dart';
+
+/// Persists the desktop density choice as a single non-secret string.
+class SharedPreferencesDesktopDensityStore implements DesktopDensityStore {
+  const SharedPreferencesDesktopDensityStore();
+
+  static const String _key = 'desktop_density_v1';
+
+  @override
+  Future<DesktopDensity?> read() async {
+    final SharedPreferences preferences = await SharedPreferences.getInstance();
+    final String? stored = preferences.getString(_key);
+    if (stored == null) return null;
+    // An unrecognised value (a downgrade, or a hand-edited preference file)
+    // resolves to the default rather than throwing.
+    return DesktopDensity.fromStorageId(stored);
+  }
+
+  @override
+  Future<void> write(DesktopDensity density) async {
+    final SharedPreferences preferences = await SharedPreferences.getInstance();
+    await preferences.setString(_key, density.storageId);
+  }
+}

--- a/lib/features/appearance/appearance_settings_screen.dart
+++ b/lib/features/appearance/appearance_settings_screen.dart
@@ -3,11 +3,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../app/colors.dart';
 import '../../app/dimens.dart';
+import '../../data/repositories/host_platform_provider.dart';
 import '../../data/repositories/launcher_icon_service_provider.dart';
 import '../support/support_actions_provider.dart';
 import 'app_icon_controller.dart';
 import 'app_icon_variant.dart';
 import 'custom_theme_card.dart';
+import 'desktop_density_card.dart';
 import 'linthra_logo_mark.dart';
 import 'theme_mode_card.dart';
 
@@ -38,6 +40,13 @@ class AppearanceSettingsScreen extends ConsumerWidget {
         children: <Widget>[
           const ThemeModeCard(),
           const SizedBox(height: AppSpacing.lg),
+          // Desktop only — the card renders nothing elsewhere, so the spacing
+          // below it would be a stray gap on a phone. Both live inside the same
+          // conditional list entry for that reason.
+          if (ref.watch(hostPlatformProvider).isDesktop) ...<Widget>[
+            const DesktopDensityCard(),
+            const SizedBox(height: AppSpacing.lg),
+          ],
           _IntroCard(showCustomPalette: showCustomPalette),
           const SizedBox(height: AppSpacing.md),
           _VariantGrid(

--- a/lib/features/appearance/desktop_density_card.dart
+++ b/lib/features/appearance/desktop_density_card.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../app/dimens.dart';
+import '../../core/models/desktop_density.dart';
+import '../../data/repositories/host_platform_provider.dart';
+import 'desktop_density_controller.dart';
+
+/// The Compact / Comfortable picker, shown in Settings → Appearance on desktop.
+///
+/// Renders nothing off desktop, the same way the Audio output card does: on a
+/// phone the density is the platform's business (a thumb needs the touch
+/// layout), so offering the control there would be offering a way to make the
+/// app harder to use. Android therefore never sees this card *and* never reads
+/// the preference — `LinthraApp` only applies it on a desktop host.
+class DesktopDensityCard extends ConsumerWidget {
+  const DesktopDensityCard({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!ref.watch(hostPlatformProvider).isDesktop) {
+      return const SizedBox.shrink();
+    }
+
+    final ThemeData theme = Theme.of(context);
+    final DesktopDensity selected = ref.watch(desktopDensityControllerProvider);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Icon(Icons.view_agenda_outlined,
+                    color: theme.colorScheme.primary),
+                const SizedBox(width: AppSpacing.sm),
+                Expanded(
+                  child: Text(
+                    'Density',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              selected.description,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            // Same control as the theme-mode picker: one clear selected state
+            // and the right semantics for screen readers for free.
+            SizedBox(
+              width: double.infinity,
+              child: SegmentedButton<DesktopDensity>(
+                segments: <ButtonSegment<DesktopDensity>>[
+                  for (final DesktopDensity density in DesktopDensity.values)
+                    ButtonSegment<DesktopDensity>(
+                      value: density,
+                      label: Text(density.label),
+                      icon: Icon(density.icon),
+                      tooltip: density.label,
+                    ),
+                ],
+                selected: <DesktopDensity>{selected},
+                showSelectedIcon: false,
+                onSelectionChanged: (Set<DesktopDensity> selection) {
+                  ref
+                      .read(desktopDensityControllerProvider.notifier)
+                      .select(selection.first);
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/appearance/desktop_density_controller.dart
+++ b/lib/features/appearance/desktop_density_controller.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/desktop_density.dart';
+import '../../data/repositories/desktop_density_store_provider.dart';
+
+/// The desktop density the controller starts from on its very first build.
+///
+/// Defaults to [DesktopDensity.fallback]. `main` overrides it with the value
+/// read from storage *before* `runApp`, so the first frame already lays out at
+/// the chosen density and the library is not drawn once at one row height and
+/// immediately relaid out at another.
+///
+/// This seam is why the controller has no async load of its own: the value is
+/// known before any frame exists, which also removes the race where a stored
+/// value lands after the user has already tapped a different option.
+final initialDesktopDensityProvider = Provider<DesktopDensity>((ref) {
+  return DesktopDensity.fallback;
+});
+
+/// Holds the user's Compact / Comfortable choice and persists every change.
+///
+/// Mirrors [ThemeModeController] deliberately: same seam, same optimistic
+/// write, same "a failed preference write never surfaces as an error" rule.
+class DesktopDensityController extends Notifier<DesktopDensity> {
+  @override
+  DesktopDensity build() => ref.read(initialDesktopDensityProvider);
+
+  /// Applies [density] immediately and persists it best-effort.
+  ///
+  /// The UI relayouts from [state] rather than from the write completing, so
+  /// rows resize on tap even if storage is slow or unavailable.
+  Future<void> select(DesktopDensity density) async {
+    if (density == state) return;
+    state = density;
+    try {
+      await ref.read(desktopDensityStoreProvider).write(density);
+    } catch (_) {
+      // A failed preference write must never surface as an error or undo the
+      // user's visible choice; it just will not survive the next restart.
+    }
+  }
+}
+
+/// The app's desktop density. `LinthraApp` watches this and rebuilds both
+/// themes from it, so a change relayouts every screen at once — no restart.
+final desktopDensityControllerProvider =
+    NotifierProvider<DesktopDensityController, DesktopDensity>(
+  DesktopDensityController.new,
+);
+
+/// Maps the persisted preference onto Material's [VisualDensity].
+///
+/// Kept out of the model itself so `DesktopDensity` stays Flutter-free and
+/// storable by a plain key/value store.
+///
+/// Both values are Material's own, not Linthra numbers: Compact is the
+/// [VisualDensity.compact] a desktop build already used, Comfortable is
+/// [VisualDensity.comfortable], one step back towards the touch layout. Neither
+/// touches horizontal padding enough to shrink a control below its minimum tap
+/// target — Material's own `IconButton`/`ListTile` minimums still apply on top
+/// — which is why the preference is expressed as a density rather than as a
+/// second set of spacing constants.
+extension DesktopDensityMaterial on DesktopDensity {
+  VisualDensity get visualDensity => switch (this) {
+        DesktopDensity.compact => VisualDensity.compact,
+        DesktopDensity.comfortable => VisualDensity.comfortable,
+      };
+
+  /// The user-facing option label.
+  String get label => switch (this) {
+        DesktopDensity.compact => 'Compact',
+        DesktopDensity.comfortable => 'Comfortable',
+      };
+
+  /// The icon shown beside [label] in the picker.
+  IconData get icon => switch (this) {
+        DesktopDensity.compact => Icons.density_small,
+        DesktopDensity.comfortable => Icons.density_medium,
+      };
+
+  /// The one-line explanation under the picker.
+  String get description => switch (this) {
+        DesktopDensity.compact =>
+          'Tighter rows and grids, so more of your library fits on screen.',
+        DesktopDensity.comfortable =>
+          'Roomier rows and grids, easier to read and to aim at.',
+      };
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app/application_lifecycle.dart';
 import 'app/linthra_app.dart';
+import 'core/models/desktop_density.dart';
 import 'core/models/theme_mode_preference.dart';
+import 'data/repositories/desktop_density_store_provider.dart';
 import 'data/repositories/theme_mode_store_provider.dart';
 
 Future<void> main() async {
@@ -12,6 +14,10 @@ Future<void> main() async {
   // Read the saved theme mode before the container exists so the first frame
   // paints in the user's chosen mode.
   final ThemeModePreference storedThemeMode = await readStoredThemeMode();
+
+  // Same reason, one frame later would be one relayout too many: density
+  // decides every row height, so it is resolved before the first frame too.
+  final DesktopDensity storedDesktopDensity = await readStoredDesktopDensity();
 
   // One container backs the whole app so the *same* PlaybackController and
   // MusicLibraryRepository instances drive both the UI (through providers) and
@@ -24,6 +30,7 @@ Future<void> main() async {
   final container = ProviderContainer(
     overrides: productionApplicationOverrides(
       storedThemeMode: storedThemeMode,
+      storedDesktopDensity: storedDesktopDensity,
     ),
   );
 

--- a/test/features/appearance/desktop_density_controller_test.dart
+++ b/test/features/appearance/desktop_density_controller_test.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/desktop_density.dart';
+import 'package:linthra/core/repositories/desktop_density_store.dart';
+import 'package:linthra/data/repositories/desktop_density_store_provider.dart';
+import 'package:linthra/data/repositories/in_memory_desktop_density_store.dart';
+import 'package:linthra/features/appearance/desktop_density_controller.dart';
+
+/// A store whose reads and writes always fail, standing in for a plugin hiccup
+/// or unreadable preferences.
+class _ThrowingDesktopDensityStore implements DesktopDensityStore {
+  @override
+  Future<DesktopDensity?> read() async => throw StateError('read failed');
+
+  @override
+  Future<void> write(DesktopDensity density) async =>
+      throw StateError('write failed');
+}
+
+void main() {
+  group('DesktopDensity', () {
+    test('defaults to compact, which is what desktop already looked like', () {
+      expect(DesktopDensity.fallback, DesktopDensity.compact);
+    });
+
+    test('round-trips every value through its storage id', () {
+      for (final DesktopDensity density in DesktopDensity.values) {
+        expect(
+          DesktopDensity.fromStorageId(density.storageId),
+          density,
+          reason: '${density.name} must survive a storage round-trip',
+        );
+      }
+    });
+
+    test('storage ids are stable strings, not enum indices', () {
+      // Indices would silently remap if the enum is ever reordered, turning a
+      // stored "compact" into "comfortable" on update.
+      expect(DesktopDensity.compact.storageId, 'compact');
+      expect(DesktopDensity.comfortable.storageId, 'comfortable');
+    });
+
+    test('an unknown, empty, or absent id falls back to compact', () {
+      expect(DesktopDensity.fromStorageId(null), DesktopDensity.compact);
+      expect(DesktopDensity.fromStorageId(''), DesktopDensity.compact);
+      expect(DesktopDensity.fromStorageId('roomy'), DesktopDensity.compact);
+    });
+
+    test('maps onto Material densities, not Linthra numbers', () {
+      expect(DesktopDensity.compact.visualDensity, VisualDensity.compact);
+      expect(
+        DesktopDensity.comfortable.visualDensity,
+        VisualDensity.comfortable,
+      );
+    });
+
+    test('comfortable is roomier than compact but still under touch', () {
+      final double compact =
+          DesktopDensity.compact.visualDensity.baseSizeAdjustment.dy;
+      final double comfortable =
+          DesktopDensity.comfortable.visualDensity.baseSizeAdjustment.dy;
+      expect(comfortable, greaterThan(compact));
+      expect(
+        comfortable,
+        lessThan(VisualDensity.standard.baseSizeAdjustment.dy),
+        reason: 'a desktop window must never become a stretched phone',
+      );
+    });
+
+    test('every value has a label, an icon and an explanation', () {
+      for (final DesktopDensity density in DesktopDensity.values) {
+        expect(density.label, isNotEmpty);
+        expect(density.description, isNotEmpty);
+        expect(density.icon, isNotNull);
+      }
+    });
+  });
+
+  group('DesktopDensityController', () {
+    ProviderContainer containerWith({
+      DesktopDensityStore? store,
+      DesktopDensity? seed,
+    }) {
+      final ProviderContainer container = ProviderContainer(
+        overrides: <Override>[
+          if (store != null)
+            desktopDensityStoreProvider.overrideWithValue(store),
+          if (seed != null)
+            initialDesktopDensityProvider.overrideWithValue(seed),
+        ],
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
+
+    test('starts on compact when nothing has been seeded', () {
+      expect(
+        containerWith().read(desktopDensityControllerProvider),
+        DesktopDensity.compact,
+      );
+    });
+
+    test('starts on the density read from storage before the first frame', () {
+      final ProviderContainer container =
+          containerWith(seed: DesktopDensity.comfortable);
+      expect(
+        container.read(desktopDensityControllerProvider),
+        DesktopDensity.comfortable,
+      );
+    });
+
+    test('a choice is applied immediately and persisted', () async {
+      final InMemoryDesktopDensityStore store = InMemoryDesktopDensityStore();
+      final ProviderContainer container = containerWith(store: store);
+
+      await container
+          .read(desktopDensityControllerProvider.notifier)
+          .select(DesktopDensity.comfortable);
+
+      expect(
+        container.read(desktopDensityControllerProvider),
+        DesktopDensity.comfortable,
+      );
+      expect(store.density, DesktopDensity.comfortable);
+    });
+
+    test('re-picking the current density writes nothing', () async {
+      final InMemoryDesktopDensityStore store = InMemoryDesktopDensityStore();
+      final ProviderContainer container = containerWith(store: store);
+
+      await container
+          .read(desktopDensityControllerProvider.notifier)
+          .select(DesktopDensity.compact);
+
+      expect(store.density, isNull);
+    });
+
+    test('a storage failure never undoes the visible choice', () async {
+      final ProviderContainer container =
+          containerWith(store: _ThrowingDesktopDensityStore());
+
+      await container
+          .read(desktopDensityControllerProvider.notifier)
+          .select(DesktopDensity.comfortable);
+
+      expect(
+        container.read(desktopDensityControllerProvider),
+        DesktopDensity.comfortable,
+      );
+    });
+
+    test('a store that throws on read still boots on the default', () async {
+      expect(
+        await readStoredDesktopDensity(_ThrowingDesktopDensityStore()),
+        DesktopDensity.fallback,
+      );
+    });
+
+    test('an empty store reads as the default rather than null', () async {
+      expect(
+        await readStoredDesktopDensity(InMemoryDesktopDensityStore()),
+        DesktopDensity.fallback,
+      );
+    });
+
+    test('a stored density is read back before the first frame', () async {
+      expect(
+        await readStoredDesktopDensity(
+          InMemoryDesktopDensityStore(DesktopDensity.comfortable),
+        ),
+        DesktopDensity.comfortable,
+      );
+    });
+  });
+}

--- a/test/features/appearance/desktop_density_widget_test.dart
+++ b/test/features/appearance/desktop_density_widget_test.dart
@@ -1,0 +1,256 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/app/brand_theme.dart';
+import 'package:linthra/app/theme.dart';
+import 'package:linthra/core/models/artist.dart';
+import 'package:linthra/core/models/desktop_density.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/data/repositories/desktop_density_store_provider.dart';
+import 'package:linthra/data/repositories/host_platform_provider.dart';
+import 'package:linthra/data/repositories/in_memory_desktop_density_store.dart';
+import 'package:linthra/features/appearance/desktop_density_card.dart';
+import 'package:linthra/features/appearance/desktop_density_controller.dart';
+import 'package:linthra/features/library/widgets/artist_grid.dart';
+import 'package:linthra/features/library/widgets/artist_tile.dart';
+
+/// Desktop density (#395): the Compact/Comfortable preference selects one of
+/// Material's own [VisualDensity] values, so every widget that already reads
+/// `Theme.of(context).visualDensity` follows it without a change of its own.
+
+final List<Artist> _artists = <Artist>[
+  for (int i = 0; i < 12; i++)
+    Artist(id: '$i', name: 'Artist $i', albumCount: 2, trackCount: 9),
+];
+
+/// Runs [body] as if Linthra were on [platform].
+///
+/// The override has to be cleared inside the test body rather than in a
+/// tearDown: the framework asserts that no foundation debug variable is still
+/// set when the body returns.
+Future<void> _onPlatform(
+  TargetPlatform platform,
+  Future<void> Function() body,
+) async {
+  debugDefaultTargetPlatformOverride = platform;
+  try {
+    await body();
+  } finally {
+    debugDefaultTargetPlatformOverride = null;
+  }
+}
+
+/// A miniature of what `LinthraApp` does: watch the density and rebuild the
+/// theme from it, so a change relayouts without a restart.
+class _DensityHost extends ConsumerWidget {
+  const _DensityHost({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final VisualDensity? density = ref.watch(hostPlatformProvider).isDesktop
+        ? ref.watch(desktopDensityControllerProvider).visualDensity
+        : null;
+    return MaterialApp(
+      theme: AppTheme.dark(BrandPalettes.classic, density: density),
+      home: Scaffold(body: child),
+    );
+  }
+}
+
+Future<ProviderContainer> _pumpHost(
+  WidgetTester tester, {
+  required HostPlatform host,
+  required Widget child,
+  DesktopDensity? seed,
+  InMemoryDesktopDensityStore? store,
+}) async {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = const Size(1280, 900);
+  addTearDown(tester.view.reset);
+
+  final ProviderContainer container = ProviderContainer(
+    overrides: <Override>[
+      hostPlatformProvider.overrideWithValue(host),
+      if (seed != null) initialDesktopDensityProvider.overrideWithValue(seed),
+      if (store != null) desktopDensityStoreProvider.overrideWithValue(store),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: _DensityHost(child: child),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return container;
+}
+
+double _rowHeight(WidgetTester tester) =>
+    tester.getRect(find.byType(ArtistTile).first).height;
+
+void main() {
+  group('the theme carries the density', () {
+    test('no override keeps the adaptive value #384 shipped', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      expect(
+        AppTheme.dark(BrandPalettes.classic).visualDensity,
+        VisualDensity.compact,
+      );
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      expect(
+        AppTheme.dark(BrandPalettes.classic).visualDensity,
+        VisualDensity.standard,
+      );
+    });
+
+    test('an override wins in both light and dark', () {
+      for (final DesktopDensity density in DesktopDensity.values) {
+        expect(
+          AppTheme.dark(BrandPalettes.classic, density: density.visualDensity)
+              .visualDensity,
+          density.visualDensity,
+        );
+        expect(
+          AppTheme.light(BrandPalettes.classic, density: density.visualDensity)
+              .visualDensity,
+          density.visualDensity,
+        );
+      }
+    });
+  });
+
+  group('library rows follow the preference', () {
+    testWidgets('comfortable gives a taller row than compact', (tester) async {
+      await _onPlatform(TargetPlatform.linux, () async {
+        await _pumpHost(
+          tester,
+          host: HostPlatform.linux,
+          seed: DesktopDensity.compact,
+          child: ArtistGrid(artists: _artists, onOpen: (_) {}),
+        );
+        final double compact = _rowHeight(tester);
+
+        await _pumpHost(
+          tester,
+          host: HostPlatform.linux,
+          seed: DesktopDensity.comfortable,
+          child: ArtistGrid(artists: _artists, onOpen: (_) {}),
+        );
+        final double comfortable = _rowHeight(tester);
+
+        expect(comfortable, greaterThan(compact));
+        // Density buys back padding, never the row: still clickable at either
+        // setting.
+        expect(compact, greaterThanOrEqualTo(48));
+      });
+    });
+
+    testWidgets('changing the preference relayouts without a restart',
+        (tester) async {
+      await _onPlatform(TargetPlatform.linux, () async {
+        final ProviderContainer container = await _pumpHost(
+          tester,
+          host: HostPlatform.linux,
+          seed: DesktopDensity.compact,
+          child: ArtistGrid(artists: _artists, onOpen: (_) {}),
+        );
+        final double before = _rowHeight(tester);
+
+        await container
+            .read(desktopDensityControllerProvider.notifier)
+            .select(DesktopDensity.comfortable);
+        await tester.pumpAndSettle();
+
+        expect(_rowHeight(tester), greaterThan(before));
+      });
+    });
+
+    testWidgets('a touch build ignores the preference entirely',
+        (tester) async {
+      await _onPlatform(TargetPlatform.android, () async {
+        await _pumpHost(
+          tester,
+          host: HostPlatform.android,
+          seed: DesktopDensity.compact,
+          child: ArtistGrid(artists: _artists, onOpen: (_) {}),
+        );
+        // 72 is the two-line ListTile height touch has always had. A desktop
+        // "compact" preference must not reach it.
+        expect(_rowHeight(tester), 72);
+      });
+    });
+  });
+
+  group('hit targets survive both densities', () {
+    for (final DesktopDensity density in DesktopDensity.values) {
+      testWidgets('a row control stays clickable when ${density.name}',
+          (tester) async {
+        await _onPlatform(TargetPlatform.linux, () async {
+          await _pumpHost(
+            tester,
+            host: HostPlatform.linux,
+            seed: density,
+            child: ListTile(
+              title: const Text('Song One'),
+              trailing: IconButton(
+                onPressed: () {},
+                icon: const Icon(Icons.more_vert),
+              ),
+            ),
+          );
+
+          final Size button = tester.getSize(find.byType(IconButton));
+          expect(button.width, greaterThanOrEqualTo(40));
+          expect(button.height, greaterThanOrEqualTo(40));
+          expect(
+            tester.getSize(find.byType(ListTile)).height,
+            greaterThanOrEqualTo(48),
+          );
+        });
+      });
+    }
+  });
+
+  group('the settings card', () {
+    testWidgets('is offered on desktop and writes the choice', (tester) async {
+      final InMemoryDesktopDensityStore store = InMemoryDesktopDensityStore();
+      await _onPlatform(TargetPlatform.linux, () async {
+        final ProviderContainer container = await _pumpHost(
+          tester,
+          host: HostPlatform.linux,
+          store: store,
+          child: const SingleChildScrollView(child: DesktopDensityCard()),
+        );
+
+        expect(find.text('Density'), findsOneWidget);
+        await tester.tap(find.text('Comfortable'));
+        await tester.pumpAndSettle();
+
+        expect(
+          container.read(desktopDensityControllerProvider),
+          DesktopDensity.comfortable,
+        );
+        expect(store.density, DesktopDensity.comfortable);
+      });
+    });
+
+    testWidgets('is not shown on a touch build', (tester) async {
+      await _onPlatform(TargetPlatform.android, () async {
+        await _pumpHost(
+          tester,
+          host: HostPlatform.android,
+          child: const SingleChildScrollView(child: DesktopDensityCard()),
+        );
+        expect(find.text('Density'), findsNothing);
+        expect(find.byType(SegmentedButton<DesktopDensity>), findsNothing);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Closes #395.

## What this is

Desktop content density has been fixed since #384: `AppTheme` hands Material `VisualDensity.adaptivePlatformDensity`, which resolves to compact on Linux/macOS/Windows and standard on anything touch-first. That is the right default, but it is not a choice, and "fit more of my library on screen" and "stop making me aim" are both fair things to want from the same app.

This adds Settings → Appearance → **Density** with Compact and Comfortable, and nothing else.

## Architecture

The whole point is that this is *not* a new spacing system.

`DesktopDensity` selects between two of Material's own `VisualDensity` values:

| Mode | Material value |
| --- | --- |
| Compact (default) | `VisualDensity.compact` |
| Comfortable | `VisualDensity.comfortable` |

Because the preference is expressed that way, every widget that already reads `Theme.of(context).visualDensity` follows it with no change of its own — list rows, buttons, popup menus, plus the two places that size rows by hand and already consult density: the songs list's fixed row extent (`alphabet_track_list.dart`) and the artist grid's cell floor (`artist_grid.dart`). No spacing constant was duplicated, and no widget had to learn that the preference exists.

The seam mirrors `ThemeModePreference`/`ThemeModeController` exactly:

| Piece | File |
| --- | --- |
| The preference (Flutter-free) | `lib/core/models/desktop_density.dart` |
| Store seam | `lib/core/repositories/desktop_density_store.dart` |
| Persistence / in-memory | `lib/data/repositories/shared_preferences_desktop_density_store.dart`, `in_memory_desktop_density_store.dart` |
| Provider + pre-frame read | `lib/data/repositories/desktop_density_store_provider.dart` |
| Controller + `VisualDensity` mapping | `lib/features/appearance/desktop_density_controller.dart` |
| The card | `lib/features/appearance/desktop_density_card.dart` |

`AppTheme.dark`/`light` take an optional `VisualDensity`; `LinthraApp` watches the controller and passes one **only on a desktop host**.

## The rules it keeps

- **Persists.** One short string, read before `runApp` (same reason as the theme mode: density decides every row height, and resolving it after startup would draw the library at one size and immediately relayout it at another).
- **Live.** Changing it rebuilds both themes and relayouts every screen — no restart.
- **Compact is the default**, so nothing moves for anyone who never opens the card.
- **Touch is untouched.** The card renders nothing off desktop, *and* `LinthraApp` passes `null` off desktop, so the theme keeps `adaptivePlatformDensity`. Android can never inherit a desktop density even if a preference somehow got written.
- **Accessibility.** Both values are above the touch layout's floor and Material's own minimum tap targets still apply on top; the tests assert a row control stays ≥40×40 and a row ≥48 at both settings.

## Tests

`test/features/appearance/desktop_density_controller_test.dart`
- storage-id round-trip, stable ids (not enum indices), unknown/empty/absent → compact
- comfortable is roomier than compact and still tighter than touch
- controller: seeded start, optimistic apply, no write on a re-pick, a failing store never undoing the visible choice, a throwing read still booting on the default

`test/features/appearance/desktop_density_widget_test.dart`
- no override keeps the adaptive value #384 shipped (linux → compact, android → standard)
- an override wins in light and dark
- artist grid rows: comfortable > compact, both still clickable
- changing the preference relayouts with no restart
- an Android build keeps the 72 px touch row regardless of the preference
- hit targets at both densities
- the card is offered on desktop (and writes) and absent on touch

## Checks

- `dart format --set-exit-if-changed lib test` — clean
- `flutter analyze lib test` — no issues
- `flutter test` — full suite, 4905 tests, all passing

## Linux validation

Nothing here needs a real Linux box: the preference is pure Dart and the density is a Material theme value, both exercised in widget tests. `docs/linux-desktop.md` gains a **Density (Compact / Comfortable)** section and a row in the support table.

## Not in this PR

No queue, playback, audio-output or Cast code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLUbVqJ6e9qfW5GTEFm1gN

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLUbVqJ6e9qfW5GTEFm1gN)_