### PR TITLE
feat(library): show whether a track row still plays with its server a…

### DIFF
--- a/docs/library.md
+++ b/docs/library.md
@@ -153,6 +153,61 @@ track or surfaced in the Library — a Jellyfin track's stored reference is an
 opaque `jellyfin:<id>`, and stream URLs (which carry the access token) are minted
 only at play time.
 
+## Track status in the library
+
+Every track row carries one small, non-interactive glyph beside its overflow
+menu. It never grows into a control, and it is **silent by default**: on-device
+music has no server to be away from, and a server-backed row whose server is
+answering and which has no saved copy of its own has nothing worth saying. An
+indicator lit on every ordinary row is one nobody reads, so the interesting
+states earn their place by being the exception.
+
+The glyph answers two questions, in this order:
+
+1. **Is something being transferred?** Queued, downloading (a determinate ring
+   when the server reported a size), or failed. Transient and actionable, so it
+   wins whenever it has something to say.
+2. **Will this still play when the server is away?** Once nothing is in flight,
+   the row reports its settled availability.
+
+| What the row is | Glyph | Meaning |
+| --- | --- | --- |
+| On-device file | *(nothing)* | There is no server to be away from. |
+| Server-backed, server answering, no copy | *(nothing)* | The ordinary case. |
+| Explicitly downloaded | Download done | A copy the user asked for, and the server is answering. |
+| Pre-cached only | Outlined pin | A copy the app prefetched ahead of play ([offline-cache.md](./offline-cache.md)). Cached, but **evictable** — deliberately not shown as "Downloaded", which would promise more than it can keep. |
+| Saved copy, server away | Filled pin | The copy is no longer a convenience: it is the only reason the row still plays. |
+| Server unreachable, no copy | Cloud-off | This row will not play right now. |
+| Session rejected, no copy | Lock | The server *answered* — sign in again, rather than checking the network. |
+| Probe in flight | Cloud-sync | We do not know yet. Never shown as a failure. |
+
+A saved copy outranks the server's state on purpose: once a row plays anyway,
+whether the server is up has stopped being the interesting fact.
+
+**It is derived, never probed.** Every input already exists — the per-source
+availability the probe controller publishes
+(`core/sources/source_availability.dart`) and the live offline-cache set the
+download repository maintains. No row performs a network check of its own, and
+the state is read through Riverpod, so a server that comes back **updates every
+visible row with no restart, no reconnect and no rescan**. The glyph is scoped to
+its own row's source, so a probe of one server never rebuilds another's rows.
+
+**Nothing secret is reachable from it.** The only text the glyph announces is a
+fixed, human-readable server name — "Jellyfin", "Navidrome", "Plex" — taken from
+`PlaybackSourceLabel`, the same safe vocabulary the now-playing "Playing from …"
+indicator uses. A server URL, host, username, token, or file path is never
+formatted into it.
+
+Two things it deliberately does **not** do yet:
+
+- **Album and artist rows have no indicator.** An album mixes tracks, so
+  "available" would first have to mean something specific — every track, or the
+  primary copy — which is a design question rather than a wiring one.
+- **Only Jellyfin reports a real probe.** Every other source is treated as
+  reachable by construction, so its rows stay silent until it adopts the same
+  probe. Nothing here is Jellyfin-specific: a source that starts publishing
+  availability gets its indicators for free.
+
 ## Known limitations
 
 - **Metadata quality depends on the source.** Grouping is only as good as the

--- a/docs/offline-cache.md
+++ b/docs/offline-cache.md
@@ -122,6 +122,16 @@ only when you've allowed it, and never offline. Pre-cache is best-effort — whe
 it simply skips (it doesn't queue), and pre-cached tracks are the first to be
 evicted under the cache limit.
 
+A pre-cached track is **not** the same thing as a download, and the library rows
+say so: a copy the user asked for reads as **Downloaded**, while one the app
+prefetched ahead of play reads as **Cached for offline play**. The distinction is
+the one already recorded on the entry itself (`CachedTrack.preloaded`), and it
+matters because only the first is a promise — a pre-cached copy can be evicted
+under the cache limit at any time. When the server is away, either kind of copy
+reads as **Playing from offline copy**, because at that point the copy is the
+only reason the row still plays. See
+[library.md § Track status in the library](./library.md#track-status-in-the-library).
+
 ## Security & privacy
 
 - Track URIs and cache metadata carry only a non-secret track id, an id-derived

--- a/lib/core/catalog/track_availability.dart
+++ b/lib/core/catalog/track_availability.dart
@@ -1,0 +1,110 @@
+import '../sources/source_availability.dart';
+
+/// What a library row can honestly say about whether this track plays right
+/// now, and what it would play *from*.
+///
+/// The row already carries a download glyph — queued, downloading, a failed
+/// ring — but that describes an in-flight *task*. This is the other axis: the
+/// settled answer, once nothing is being transferred. It exists because a row
+/// backed by a server raises a question a row backed by a file never does —
+/// "will this still play when the server is away?" — and the answer differs per
+/// row: an explicitly downloaded copy, an auto-preloaded one, a server that is
+/// answering, a server that is not.
+///
+/// Two properties are deliberate:
+///
+///  * **[none] is the answer for the overwhelming majority of rows**, including
+///    every on-device track and every server-backed track whose server is
+///    answering and which has no copy of its own. An indicator that is always
+///    lit is an indicator nobody reads, and a library row is the busiest pixel
+///    in the app — so the interesting entries have to earn their place by being
+///    the exception.
+///  * **It is derived, never probed.** Every input below already exists in the
+///    app: the per-source availability the probe controller publishes and the
+///    live offline-cache set. Nothing here reaches a network, and nothing here
+///    knows what a URL, a token, or a file path is — which is what keeps the
+///    indicator safe to render on a row that may be showing a locked-down
+///    server's music.
+enum TrackAvailabilityStatus {
+  /// Nothing worth saying: on-device music, or server-backed music whose server
+  /// is answering and which has no saved copy. Renders nothing.
+  none,
+
+  /// A copy the user asked for is on this device, and its server is answering.
+  downloaded,
+
+  /// A copy is on this device only because the app prefetched it ahead of play
+  /// (see `CachedTrack.preloaded`), and its server is answering. Cached, but
+  /// evictable — which is exactly what separates it from [downloaded].
+  cached,
+
+  /// A copy is on this device and its server is *away*. This is the good news
+  /// case: it is the only reason this row still plays, so it says what the
+  /// listener is getting rather than what they are missing.
+  offlineCopy,
+
+  /// The owning server is configured and a probe is in flight, so we do not
+  /// know yet. Deliberately rendered as *checking*, not as a failure — matching
+  /// [SourceAvailability.checking], which hides nothing for the same reason.
+  checking,
+
+  /// The server could not be reached and this device has no copy, so this row
+  /// will not play right now. Recoverable: nothing was deleted, and the row
+  /// returns to [none] the moment the server answers again.
+  unreachable,
+
+  /// The server was reached but rejected the saved session, and this device has
+  /// no copy. Kept distinct from [unreachable] because the fix is signing in
+  /// again, not moving closer to the server — the same distinction
+  /// [SourceAvailability] draws for diagnostics.
+  sessionRejected,
+}
+
+/// Resolves the settled availability of one row from state that already exists.
+///
+/// Pure and total, so every combination — including the ones that are awkward to
+/// stage in a widget test — is pinned down in `track_availability_test.dart`
+/// rather than inferred from pixels.
+///
+/// [isRemote] short-circuits first: on-device music has no server to be away
+/// from, so it can never have anything to report. Everything below is about a
+/// row that came off a server.
+///
+/// A saved copy outranks the server's state on purpose. A copy that plays —
+/// [downloaded], [cached], [offlineCopy] — is a better answer than "the server
+/// is down", because the server's state has stopped being the interesting fact;
+/// whether the listener can hear the song has not. That is also why
+/// [offlineCopy] is reported even while a probe is still running.
+TrackAvailabilityStatus resolveTrackAvailability({
+  required bool isRemote,
+  required bool hasOfflineCopy,
+  required bool isExplicitDownload,
+  required SourceAvailability availability,
+}) {
+  if (!isRemote) return TrackAvailabilityStatus.none;
+
+  if (hasOfflineCopy) {
+    // The only case where the server's absence changes the sentence rather
+    // than silencing it: the copy is not a convenience any more, it is the
+    // whole reason this row works.
+    if (availability.isUnavailable) return TrackAvailabilityStatus.offlineCopy;
+    return isExplicitDownload
+        ? TrackAvailabilityStatus.downloaded
+        : TrackAvailabilityStatus.cached;
+  }
+
+  // Nothing saved locally, so the server is the only way this plays.
+  if (availability == SourceAvailability.authenticationError) {
+    return TrackAvailabilityStatus.sessionRejected;
+  }
+  if (availability == SourceAvailability.unreachable) {
+    return TrackAvailabilityStatus.unreachable;
+  }
+  if (availability.isChecking) return TrackAvailabilityStatus.checking;
+
+  // `available`, and `notConfigured` with it: an unconfigured source has no
+  // rows, and the availability map treats every source it does not list as
+  // reachable (see `sourceAvailabilityProvider`). Either way there is no
+  // server fact worth putting on the row.
+  return TrackAvailabilityStatus.none;
+}

--- a/lib/features/library/widgets/track_status_glyph.dart
+++ b/lib/features/library/widgets/track_status_glyph.dart
@@ -1,0 +1,192 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/catalog/track_availability.dart';
+import '../../../core/catalog/track_identity.dart';
+import '../../../core/models/playback_source.dart';
+import '../../../core/models/track.dart';
+import '../../../core/repositories/download_repository.dart';
+import '../../../core/repositories/download_store.dart';
+import '../../../core/services/playback_source_label.dart';
+import '../../../core/sources/source_availability.dart';
+import '../../downloads/download_providers.dart';
+import '../source_availability_providers.dart';
+
+/// The single, non-interactive status glyph a library track row shows beside its
+/// overflow menu.
+///
+/// It is the row's one status surface, and it speaks about two axes at once so
+/// they can never contradict each other or double up:
+///
+///  * the **download task** — queued, downloading (a determinate ring when the
+///    server reported a size), or failed. Transient and actionable, so it wins
+///    whenever it has something to say.
+///  * the **settled availability** — [TrackAvailabilityStatus], which answers
+///    "will this still play when the server is away?" once nothing is being
+///    transferred.
+///
+/// Splitting them across two widgets would let a row show an in-flight ring next
+/// to an availability icon for the same track, which is how a quiet row turns
+/// noisy. One widget, one glyph.
+///
+/// Nothing here is tappable and nothing is fetched: it mirrors the per-source
+/// availability the probe controller already publishes and the offline-cache set
+/// the download repository already maintains, so it costs no network and adds no
+/// subscription to an idle row. On-device tracks render nothing at all.
+///
+/// Security: the only text this ever announces is a fixed, human-readable
+/// server name ("Jellyfin", "Navidrome", "Plex") taken from
+/// [PlaybackSourceLabel]'s safe vocabulary. A server URL, host, username, token,
+/// or file path is never reachable from here.
+class TrackStatusGlyph extends ConsumerWidget {
+  const TrackStatusGlyph({
+    required this.track,
+    required this.isRemote,
+    required this.downloadStatus,
+    this.downloadProgress,
+    super.key,
+  });
+
+  final Track track;
+
+  /// Whether this track came off a server at all. On-device music is already
+  /// local, so it has no offline story to tell and shows no glyph.
+  final bool isRemote;
+
+  final DownloadStatus downloadStatus;
+
+  /// Download completion in the range 0.0–1.0 when known; `null` shows an
+  /// indeterminate (spinning) ring while downloading.
+  final double? downloadProgress;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!isRemote) return const SizedBox.shrink();
+
+    final theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.5);
+
+    // The task axis first, and before any `watch`: an in-flight download is the
+    // only thing worth saying about this row, and an idle row must not pick up
+    // subscriptions it will never read. Same reason the byte-progress watch is
+    // kept to the downloading case.
+    switch (downloadStatus) {
+      case DownloadStatus.queued:
+        return Icon(
+          Icons.schedule,
+          size: 18,
+          color: muted,
+          semanticLabel: 'Queued',
+        );
+      case DownloadStatus.downloading:
+        // The other states name themselves; this one is a bare ring.
+        return Semantics(
+          label: 'Downloading',
+          child: SizedBox.square(
+            dimension: 16,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              value: downloadProgress,
+            ),
+          ),
+        );
+      case DownloadStatus.failed:
+        return Icon(
+          Icons.error_outline,
+          size: 18,
+          color: theme.colorScheme.error,
+          semanticLabel: 'Download failed',
+        );
+      case DownloadStatus.downloaded:
+      case DownloadStatus.notDownloaded:
+        // Settled: nothing is being transferred, so the question becomes
+        // whether this row still plays when its server is away.
+        break;
+    }
+
+    // Scoped to *this* row's own source, so a probe of one server never rebuilds
+    // another's rows. An unlisted source is reachable by construction — see
+    // [sourceAvailabilityProvider].
+    final SourceAvailability availability = ref.watch(
+      sourceAvailabilityProvider.select(
+        (Map<String, SourceAvailability> bySource) =>
+            bySource[trackSourceId(track)] ?? SourceAvailability.available,
+      ),
+    );
+
+    final bool isExplicitDownload = downloadStatus == DownloadStatus.downloaded;
+    // An explicit download is a managed copy by definition, and saying so here
+    // keeps the glyph correct on a row whose cache set hasn't been read yet
+    // (and in tests that stub the download status alone).
+    final bool hasOfflineCopy = isExplicitDownload ||
+        ref.watch(
+          offlineAvailableTrackKeysProvider.select(
+            (Set<String> keys) =>
+                keys.contains(CachedTrack.cacheKeyForTrack(track)),
+          ),
+        );
+
+    final TrackAvailabilityStatus status = resolveTrackAvailability(
+      isRemote: isRemote,
+      hasOfflineCopy: hasOfflineCopy,
+      isExplicitDownload: isExplicitDownload,
+      availability: availability,
+    );
+
+    // The same safe names the now-playing "Playing from …" indicator uses, so
+    // the two can never tell the listener different stories about one server.
+    final String server = PlaybackSourceLabel.of(
+      trackUri: track.uri,
+      source: PlaybackSource.streamingDirect,
+    );
+
+    switch (status) {
+      case TrackAvailabilityStatus.none:
+        return const SizedBox.shrink();
+      case TrackAvailabilityStatus.downloaded:
+        return Icon(
+          Icons.download_done,
+          size: 18,
+          color: theme.colorScheme.primary,
+          semanticLabel: 'Downloaded',
+        );
+      case TrackAvailabilityStatus.cached:
+        return Icon(
+          Icons.offline_pin_outlined,
+          size: 18,
+          color: theme.colorScheme.primary,
+          semanticLabel: 'Cached for offline play',
+        );
+      case TrackAvailabilityStatus.offlineCopy:
+        // Filled where the cached state is outlined: this copy is not a
+        // convenience, it is the only reason the row still plays.
+        return Icon(
+          Icons.offline_pin,
+          size: 18,
+          color: theme.colorScheme.primary,
+          semanticLabel: 'Playing from offline copy',
+        );
+      case TrackAvailabilityStatus.checking:
+        return Icon(
+          Icons.cloud_sync_outlined,
+          size: 18,
+          color: muted,
+          semanticLabel: 'Checking $server',
+        );
+      case TrackAvailabilityStatus.unreachable:
+        return Icon(
+          Icons.cloud_off_outlined,
+          size: 18,
+          color: theme.colorScheme.error,
+          semanticLabel: '$server unavailable',
+        );
+      case TrackAvailabilityStatus.sessionRejected:
+        return Icon(
+          Icons.lock_outline,
+          size: 18,
+          color: theme.colorScheme.error,
+          semanticLabel: '$server sign-in needed',
+        );
+    }
+  }
+}

--- a/lib/features/library/widgets/track_tile.dart
+++ b/lib/features/library/widgets/track_tile.dart
@@ -22,6 +22,7 @@ import '../../playlists/playlist_drag.dart';
 import '../../playlists/widgets/add_to_playlist_sheet.dart';
 import '../library_browse_providers.dart';
 import '../song_actions.dart';
+import 'track_status_glyph.dart';
 
 /// The actions reachable from a track row's overflow menu. Which subset is
 /// offered is context-aware: it depends on whether the track is remote and on
@@ -45,8 +46,9 @@ enum _TrackAction {
 /// The row is deliberately calm: artwork (or a placeholder), the title, and a
 /// clean artist • album subtitle. Per-track actions live behind a trailing
 /// 3-dots overflow menu rather than a dedicated button, so the list stays
-/// uncluttered. Download state is still surfaced — but only as a subtle leading
-/// glyph next to the menu, never as a large control.
+/// uncluttered. Status is still surfaced — but only as one subtle glyph next to
+/// the menu, never as a large control: its download task and whether the row
+/// still plays with its server away, both handled by [TrackStatusGlyph].
 ///
 /// Tapping the row plays the tapped track and queues the rest of [tracks]
 /// behind it, then opens the now-playing screen — unchanged from before.
@@ -181,10 +183,11 @@ class TrackTile extends ConsumerWidget {
           : Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                _StatusGlyph(
-                  status: status,
+                TrackStatusGlyph(
+                  track: track,
                   isRemote: isRemote,
-                  progress: downloadFraction,
+                  downloadStatus: status,
+                  downloadProgress: downloadFraction,
                 ),
                 _OverflowMenu(
                   track: track,
@@ -269,64 +272,6 @@ class TrackTile extends ConsumerWidget {
   static String _subtitle(Track track) {
     final String label = track.artistAlbumLabel;
     return label.isEmpty ? track.uri : label;
-  }
-}
-
-/// The subtle, non-interactive download-state hint shown just before the
-/// overflow menu. Nothing here is tappable — it only mirrors state so the row
-/// stays quiet. Only meaningful for remote tracks; local tracks render nothing.
-class _StatusGlyph extends StatelessWidget {
-  const _StatusGlyph({
-    required this.status,
-    required this.isRemote,
-    this.progress,
-  });
-
-  final DownloadStatus status;
-  final bool isRemote;
-
-  /// Download completion in the range 0.0–1.0 when known; `null` shows an
-  /// indeterminate (spinning) ring while downloading.
-  final double? progress;
-
-  @override
-  Widget build(BuildContext context) {
-    if (!isRemote) return const SizedBox.shrink();
-    final theme = Theme.of(context);
-    switch (status) {
-      case DownloadStatus.downloaded:
-        return Icon(
-          Icons.download_done,
-          size: 18,
-          color: theme.colorScheme.primary,
-          semanticLabel: 'Downloaded',
-        );
-      case DownloadStatus.downloading:
-        // The other three states name themselves; this one is a bare ring.
-        return Semantics(
-          label: 'Downloading',
-          child: SizedBox.square(
-            dimension: 16,
-            child: CircularProgressIndicator(strokeWidth: 2, value: progress),
-          ),
-        );
-      case DownloadStatus.queued:
-        return Icon(
-          Icons.schedule,
-          size: 18,
-          color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
-          semanticLabel: 'Queued',
-        );
-      case DownloadStatus.failed:
-        return Icon(
-          Icons.error_outline,
-          size: 18,
-          color: theme.colorScheme.error,
-          semanticLabel: 'Download failed',
-        );
-      case DownloadStatus.notDownloaded:
-        return const SizedBox.shrink();
-    }
   }
 }
 

--- a/test/core/catalog/track_availability_test.dart
+++ b/test/core/catalog/track_availability_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/catalog/track_availability.dart';
+import 'package:linthra/core/sources/source_availability.dart';
+
+/// The resolver is where every combination of "what this device has" and "what
+/// the server is doing" becomes one answer, including the combinations that are
+/// hard to stage on screen (a rejected session with no copy, a probe still in
+/// flight over a row that is already saved). Pinning them here keeps the widget
+/// tests about pixels and the a11y labels rather than about state algebra.
+void main() {
+  TrackAvailabilityStatus resolve({
+    bool isRemote = true,
+    bool hasOfflineCopy = false,
+    bool isExplicitDownload = false,
+    SourceAvailability availability = SourceAvailability.available,
+  }) {
+    return resolveTrackAvailability(
+      isRemote: isRemote,
+      hasOfflineCopy: hasOfflineCopy,
+      isExplicitDownload: isExplicitDownload,
+      availability: availability,
+    );
+  }
+
+  group('resolveTrackAvailability: on-device music', () {
+    test('never has anything to report, whatever a server is doing', () {
+      for (final SourceAvailability availability in SourceAvailability.values) {
+        expect(
+          resolve(isRemote: false, availability: availability),
+          TrackAvailabilityStatus.none,
+          reason: 'a file on this device has no server to be away from, so a '
+              'server elsewhere has no business putting a glyph on its row',
+        );
+      }
+    });
+  });
+
+  group('resolveTrackAvailability: the ordinary case stays quiet', () {
+    test('a server-backed track on an answering server says nothing', () {
+      expect(
+        resolve(),
+        TrackAvailabilityStatus.none,
+        reason: 'an indicator lit on every ordinary row is one nobody reads',
+      );
+    });
+
+    test('an unconfigured source is not a fault', () {
+      expect(
+        resolve(availability: SourceAvailability.notConfigured),
+        TrackAvailabilityStatus.none,
+        reason:
+            'no server configured means no tracks from it, not a broken one',
+      );
+    });
+  });
+
+  group('resolveTrackAvailability: saved copies', () {
+    test('an explicit download on an answering server reads as downloaded', () {
+      expect(
+        resolve(hasOfflineCopy: true, isExplicitDownload: true),
+        TrackAvailabilityStatus.downloaded,
+      );
+    });
+
+    test('a prefetched copy reads as cached, never as a download', () {
+      expect(
+        resolve(hasOfflineCopy: true),
+        TrackAvailabilityStatus.cached,
+        reason: 'the user never asked for it, and it can be evicted underneath '
+            'them — calling it "Downloaded" would promise more than it can keep',
+      );
+    });
+
+    test('a saved copy outranks a server that is away', () {
+      for (final bool explicit in <bool>[true, false]) {
+        for (final SourceAvailability down in <SourceAvailability>[
+          SourceAvailability.unreachable,
+          SourceAvailability.authenticationError,
+        ]) {
+          expect(
+            resolve(
+              hasOfflineCopy: true,
+              isExplicitDownload: explicit,
+              availability: down,
+            ),
+            TrackAvailabilityStatus.offlineCopy,
+            reason: 'the server being down stops being the interesting fact '
+                'once the row plays anyway; what matters is that it does',
+          );
+        }
+      }
+    });
+
+    test('a saved copy outranks a probe still in flight', () {
+      expect(
+        resolve(
+          hasOfflineCopy: true,
+          isExplicitDownload: true,
+          availability: SourceAvailability.checking,
+        ),
+        TrackAvailabilityStatus.downloaded,
+        reason: 'we already know this plays; a pending probe adds nothing',
+      );
+    });
+  });
+
+  group('resolveTrackAvailability: no copy, so the server is the only way', () {
+    test('an unreachable server reads as unavailable', () {
+      expect(
+        resolve(availability: SourceAvailability.unreachable),
+        TrackAvailabilityStatus.unreachable,
+      );
+    });
+
+    test('a rejected session reads differently from an unreachable server', () {
+      expect(
+        resolve(availability: SourceAvailability.authenticationError),
+        TrackAvailabilityStatus.sessionRejected,
+        reason: 'the fix is signing in again, not moving closer to the server',
+      );
+    });
+
+    test('a probe in flight reads as checking, never as a failure', () {
+      expect(
+        resolve(availability: SourceAvailability.checking),
+        TrackAvailabilityStatus.checking,
+        reason: 'a slow answer is not a negative one, and the library is shown '
+            'optimistically while we wait',
+      );
+    });
+  });
+}

--- a/test/features/library/track_status_glyph_test.dart
+++ b/test/features/library/track_status_glyph_test.dart
@@ -1,0 +1,241 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/download_repository.dart';
+import 'package:linthra/core/repositories/download_store.dart';
+import 'package:linthra/core/sources/music_provider.dart';
+import 'package:linthra/core/sources/source_availability.dart';
+import 'package:linthra/features/downloads/download_providers.dart';
+import 'package:linthra/features/library/source_availability_providers.dart';
+import 'package:linthra/features/library/widgets/track_status_glyph.dart';
+
+/// A row's status glyph is the only place a listener is told whether the music
+/// in front of them will still play when the server is away. These tests hold it
+/// to the two things that are easy to get wrong: saying something when there is
+/// nothing to say (which teaches people to ignore it), and saying the wrong
+/// thing about *why* a row will not play (a rejected session is not a dead
+/// server, and the fix is different).
+const Track _remote = Track(
+  id: 'a',
+  title: 'Careful',
+  uri: 'jellyfin:a',
+  artistName: 'NF',
+  albumName: 'Perception',
+);
+
+const Track _local = Track(
+  id: 'b',
+  title: 'Something Local',
+  uri: 'file:///b.mp3',
+);
+
+/// The server's state, as the availability probe would publish it. Held as a
+/// provider so a test can move it while the glyph is on screen — the reconnect
+/// case, which must not need an app restart.
+final StateProvider<SourceAvailability> _serverState =
+    StateProvider<SourceAvailability>((ref) => SourceAvailability.available);
+
+/// Pumps one row's glyph. Returns the container so a test can move the server
+/// state afterwards without rebuilding the widget tree.
+Future<ProviderContainer> _pump(
+  WidgetTester tester, {
+  Track track = _remote,
+  bool isRemote = true,
+  SourceAvailability availability = SourceAvailability.available,
+  DownloadStatus status = DownloadStatus.notDownloaded,
+  bool hasOfflineCopy = false,
+}) async {
+  final ProviderContainer container = ProviderContainer(
+    overrides: <Override>[
+      _serverState.overrideWith((ref) => availability),
+      sourceAvailabilityProvider.overrideWith(
+        (ref) => <String, SourceAvailability>{
+          MusicProviders.jellyfin.sourceId: ref.watch(_serverState),
+        },
+      ),
+      offlineAvailableTrackKeysProvider.overrideWithValue(
+        hasOfflineCopy
+            ? <String>{CachedTrack.cacheKeyForTrack(track)}
+            : const <String>{},
+      ),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: TrackStatusGlyph(
+              track: track,
+              isRemote: isRemote,
+              downloadStatus: status,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+  return container;
+}
+
+/// Nothing rendered at all — the answer for the overwhelming majority of rows.
+void _expectSilent(WidgetTester tester) {
+  expect(find.byType(Icon), findsNothing);
+  expect(find.byType(CircularProgressIndicator), findsNothing);
+}
+
+void main() {
+  group('TrackStatusGlyph stays quiet when there is nothing to say', () {
+    testWidgets('an on-device track shows no glyph', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(
+        tester,
+        track: _local,
+        isRemote: false,
+        availability: SourceAvailability.unreachable,
+      );
+
+      _expectSilent(tester);
+      handle.dispose();
+    });
+
+    testWidgets('an ordinary server-backed row shows no glyph', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(tester);
+
+      _expectSilent(tester);
+      handle.dispose();
+    });
+  });
+
+  group('TrackStatusGlyph reports saved copies', () {
+    testWidgets('an explicit download says downloaded', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(tester, status: DownloadStatus.downloaded);
+
+      expect(find.bySemanticsLabel('Downloaded'), findsOneWidget);
+      handle.dispose();
+    });
+
+    testWidgets('a prefetched copy says cached, not downloaded',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(tester, hasOfflineCopy: true);
+
+      expect(find.bySemanticsLabel('Cached for offline play'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('Downloaded'),
+        findsNothing,
+        reason: 'the user never asked for this copy and it can be evicted, so '
+            'it must not read as one they own',
+      );
+      handle.dispose();
+    });
+
+    testWidgets('a saved copy says so when its server is away', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(
+        tester,
+        hasOfflineCopy: true,
+        availability: SourceAvailability.unreachable,
+      );
+
+      expect(
+          find.bySemanticsLabel('Playing from offline copy'), findsOneWidget);
+      handle.dispose();
+    });
+  });
+
+  group('TrackStatusGlyph reports a server that cannot serve this row', () {
+    testWidgets('an unreachable server reads as unavailable', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(tester, availability: SourceAvailability.unreachable);
+
+      expect(find.bySemanticsLabel('Jellyfin unavailable'), findsOneWidget);
+      handle.dispose();
+    });
+
+    testWidgets('a rejected session asks for a sign-in, not for the network',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(tester, availability: SourceAvailability.authenticationError);
+
+      expect(find.bySemanticsLabel('Jellyfin sign-in needed'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('Jellyfin unavailable'),
+        findsNothing,
+        reason: 'the server answered — telling the user to check their '
+            'connection would send them looking in the wrong place',
+      );
+      handle.dispose();
+    });
+
+    testWidgets('a probe still in flight reads as checking, not as failed',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(tester, availability: SourceAvailability.checking);
+
+      expect(find.bySemanticsLabel('Checking Jellyfin'), findsOneWidget);
+      handle.dispose();
+    });
+  });
+
+  group('TrackStatusGlyph shows one glyph, never two', () {
+    testWidgets('an in-flight download outranks the server state',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(
+        tester,
+        status: DownloadStatus.queued,
+        availability: SourceAvailability.unreachable,
+      );
+
+      expect(find.bySemanticsLabel('Queued'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('Jellyfin unavailable'),
+        findsNothing,
+        reason: 'two glyphs for one row is how a calm list turns noisy',
+      );
+      handle.dispose();
+    });
+  });
+
+  group('TrackStatusGlyph follows the server without a restart', () {
+    testWidgets('the glyph clears when the server answers again',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      final ProviderContainer container = await _pump(
+        tester,
+        availability: SourceAvailability.unreachable,
+      );
+      expect(find.bySemanticsLabel('Jellyfin unavailable'), findsOneWidget);
+
+      // The probe comes back. Same widget tree, same screen, no re-pump of the
+      // app — exactly what walking back onto the home network does.
+      container.read(_serverState.notifier).state =
+          SourceAvailability.available;
+      await tester.pump();
+
+      _expectSilent(tester);
+      handle.dispose();
+    });
+
+    testWidgets('the glyph appears when the server goes away', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      final ProviderContainer container = await _pump(tester);
+      _expectSilent(tester);
+
+      container.read(_serverState.notifier).state =
+          SourceAvailability.unreachable;
+      await tester.pump();
+
+      expect(find.bySemanticsLabel('Jellyfin unavailable'), findsOneWidget);
+      handle.dispose();
+    });
+  });
+}

--- a/test/features/library/track_tile_semantics_test.dart
+++ b/test/features/library/track_tile_semantics_test.dart
@@ -7,8 +7,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/download_progress.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/repositories/download_repository.dart';
+import 'package:linthra/core/repositories/download_store.dart';
+import 'package:linthra/core/sources/music_provider.dart';
+import 'package:linthra/core/sources/source_availability.dart';
 import 'package:linthra/data/repositories/download_repository_provider.dart';
 import 'package:linthra/features/downloads/download_providers.dart';
+import 'package:linthra/features/library/source_availability_providers.dart';
 import 'package:linthra/features/library/widgets/track_tile.dart';
 import 'package:linthra/features/player/now_playing.dart';
 
@@ -32,6 +36,8 @@ Future<void> _pump(
   DownloadStatus status = DownloadStatus.notDownloaded,
   bool selectionActive = false,
   bool selected = false,
+  SourceAvailability availability = SourceAvailability.available,
+  bool offlineCopy = false,
 }) async {
   await tester.pumpWidget(
     ProviderScope(
@@ -40,6 +46,15 @@ Future<void> _pump(
             .overrideWithValue(FakeRemoteTrackDownloader()),
         if (nowPlaying != null)
           nowPlayingProvider.overrideWithValue(nowPlaying),
+        sourceAvailabilityProvider.overrideWith(
+          (ref) => <String, SourceAvailability>{
+            MusicProviders.jellyfin.sourceId: availability,
+          },
+        ),
+        if (offlineCopy)
+          offlineAvailableTrackKeysProvider.overrideWithValue(
+            <String>{CachedTrack.cacheKeyForTrack(_remote)},
+          ),
         trackDownloadStatusProvider.overrideWith(
           (ref, String key) => Stream<DownloadStatus>.value(status),
         ),
@@ -164,6 +179,38 @@ void main() {
 
       // Exactly the visible text, nothing invented on top of it.
       expect(_row(tester).label, 'Careful\nNF • Perception');
+      handle.dispose();
+    });
+
+    testWidgets('a row whose server is away says so', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(tester, availability: SourceAvailability.unreachable);
+
+      expect(_row(tester).label, contains('Jellyfin unavailable'));
+      handle.dispose();
+    });
+
+    testWidgets('a row saved offline says the server being away is survivable',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(
+        tester,
+        offlineCopy: true,
+        availability: SourceAvailability.unreachable,
+      );
+
+      expect(_row(tester).label, contains('Playing from offline copy'));
+      // The row still plays, so it must not also be announced as broken.
+      expect(_row(tester).label, isNot(contains('unavailable')));
+      handle.dispose();
+    });
+
+    testWidgets('a rejected session asks for a sign-in instead of the network',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(tester, availability: SourceAvailability.authenticationError);
+
+      expect(_row(tester).label, contains('Jellyfin sign-in needed'));
       handle.dispose();
     });
 


### PR DESCRIPTION
…way (#431)

A library row already carried a download glyph, but that only describes an in-flight *task*. It said nothing about the question a server-backed row raises and a local one never does: will this still play when the server is away? The availability state needed to answer it already exists (#536) — the per-source probe controller publishes it, and the download repository maintains the offline cache set — but no library surface read it, so a row whose server had just gone away looked exactly like a row whose server was fine.

This adds the missing presentation layer, deliberately quietly:

* `TrackAvailabilityStatus` + `resolveTrackAvailability` (pure, total): every combination of "what this device has" and "what the server is doing" resolves to one answer, including the ones that are awkward to stage on screen.
* `TrackStatusGlyph` owns the row's single status glyph across both axes — the download task and the settled availability — so a row can never show an in-flight ring next to a contradictory availability icon.
* The row stays silent by default: on-device music, and server-backed music whose server is answering and which has no saved copy, render nothing at all.

Guarantees:

* Derived, never probed. The inputs are the existing `sourceAvailabilityProvider` and `offlineAvailableTrackKeysProvider`; no row performs a network check.
* Live. State is read through Riverpod, so a server that comes back updates every visible row with no restart, no reconnect and no rescan.
* Secret-free. The only text announced is a fixed server name from `PlaybackSourceLabel` ("Jellyfin", "Navidrome", "Plex"); a URL, host, username, token or path is unreachable from the glyph.
* Explicit downloads, auto-prefetched copies and streamable-only rows are distinguished, reusing the distinction the records already keep (`CachedTrack.preloaded`) rather than inventing one.
* Scoped per source, so a probe of one server never rebuilds another's rows, and an idle row adds no subscription.

Untouched: no probe, resolver, playback path or download-policy change — a source that starts publishing availability gets its indicators for free, and every unlisted source is still treated as reachable. Album and artist rows are deliberately not covered yet: an album mixes tracks, so "available" would first have to mean something specific.

Tests: the resolver's full state table, the glyph's states and a11y labels, the no-noise guarantee, the one-glyph-never-two rule, and a reconnect that updates an on-screen row without a restart.