### PR TITLE
chore(tooling): make the 200k benchmark output easier to read (#338)

### DIFF
--- a/test/tooling/large_library_benchmark_test.py
+++ b/test/tooling/large_library_benchmark_test.py
@@ -3,11 +3,10 @@
 
     python3 test/tooling/large_library_benchmark_test.py
 
-`tools/large_library/benchmark_sqlite.py` prints a small summary after the
-per-query lines, and that block is what a contributor (or a CI log reader)
-actually looks at. These tests pin the two things that make it useful: the
-numbers are the ones the labels claim, and the block stays aligned and
-deterministic.
+`tools/large_library/benchmark_sqlite.py` prints a line per query and then a
+small summary, and those are what a contributor (or a CI log reader) actually
+looks at. These tests pin the two things that make them useful: the numbers are
+the ones the labels claim, and both stay aligned and deterministic.
 
 The plan checks are here for the same reason: they are the part of the
 benchmark that decides pass or fail, and getting them wrong is either a green
@@ -45,6 +44,10 @@ def _load():
 
 benchmark_sqlite = _load()
 
+# The --database argument as main() passes it on: the summary prints the path
+# it was given, so a test path stands in for the 200k fixture.
+DATABASE = Path("/tmp/linthra-200k.sqlite")
+
 # (name, average ms, p95 ms, max ms): the shape main() collects per query.
 RESULTS = (
     ("title prefix", 1.5, 2.0, 4.25),
@@ -54,12 +57,78 @@ RESULTS = (
 )
 
 
-class SummaryLinesTest(unittest.TestCase):
-    def summary(self, results=RESULTS, track_count=200_000, iterations=200):
-        return benchmark_sqlite.summary_lines(track_count, results, iterations)
+# Where the summary's values start, once the two-space indent and the label
+# column are out of the way.
+VALUE_COLUMN = 2 + benchmark_sqlite.SUMMARY_LABEL_WIDTH
 
-    def labelled(self, label: str) -> str:
-        matches = [line for line in self.summary() if line.strip().startswith(label)]
+
+class QueryLineTest(unittest.TestCase):
+    """The per-query line printed above each plan."""
+
+    def line(self, name="album exact", average_ms=0.113, p95_ms=0.177, max_ms=2.845):
+        return benchmark_sqlite.query_line(name, average_ms, p95_ms, max_ms)
+
+    def test_it_reports_the_average_the_p95_and_the_max(self):
+        line = self.line()
+        self.assertIn("avg=   0.113 ms", line)
+        self.assertIn("p95=   0.177 ms", line)
+        self.assertIn("max=   2.845 ms", line)
+
+    def test_the_max_is_the_number_the_summary_singles_out(self):
+        # "slowest single run" is one query's max, so printing the max on every
+        # query's line is what lets a reader see where that number came from
+        # and which query was next.
+        name, average_ms, p95_ms, max_ms = "provider album", 2.0, 3.0, 9.5
+        summary = benchmark_sqlite.summary_lines(DATABASE, 200_000, RESULTS, 200, 50.0)
+        slowest = [line for line in summary if "slowest single run:" in line][0]
+        self.assertIn("9.500 ms", slowest)
+        self.assertIn(f"({name})", slowest)
+        self.assertIn("max=   9.500 ms", self.line(name, average_ms, p95_ms, max_ms))
+
+    def test_columns_line_up_whatever_the_query_is_called(self):
+        lines = [self.line(name=name) for name in ("a", "provider identity")]
+        for marker in ("avg=", "p95=", "max="):
+            with self.subTest(marker=marker):
+                self.assertEqual(len({line.index(marker) for line in lines}), 1)
+
+    def test_a_long_name_still_fits_a_narrow_terminal(self):
+        # Query names are capped at QUERY_NAME_WIDTH by a test below; at that
+        # width the line has to stay inside 80 columns or it wraps in a CI log
+        # and takes its plan with it.
+        longest = "x" * benchmark_sqlite.QUERY_NAME_WIDTH
+        self.assertLessEqual(len(self.line(name=longest)), 80)
+
+    def test_it_is_deterministic_and_free_of_tabs(self):
+        self.assertEqual(self.line(), self.line())
+        self.assertNotIn("\t", self.line())
+
+
+class SummaryLinesTest(unittest.TestCase):
+    def summary(
+        self,
+        results=RESULTS,
+        track_count=200_000,
+        iterations=200,
+        database=DATABASE,
+        max_average_ms=50.0,
+    ):
+        return benchmark_sqlite.summary_lines(
+            database, track_count, results, iterations, max_average_ms
+        )
+
+    def rows(self, **kwargs) -> list[str]:
+        return [line for line in self.summary(**kwargs) if line.startswith("  ")]
+
+    def numeric_rows(self, **kwargs) -> list[str]:
+        return [
+            line
+            for line in self.rows(**kwargs)
+            if not line.strip().startswith("database:")
+        ]
+
+    def labelled(self, label: str, lines=None) -> str:
+        lines = self.summary() if lines is None else lines
+        matches = [line for line in lines if line.strip().startswith(label)]
         self.assertEqual(len(matches), 1, f"expected exactly one {label!r} line")
         return matches[0]
 
@@ -68,6 +137,10 @@ class SummaryLinesTest(unittest.TestCase):
         self.assertIn("4", self.labelled("queries:"))
         self.assertIn("200", self.labelled("iterations per query:"))
 
+    def test_the_database_says_which_fixture_was_measured(self):
+        # 200k and 5k runs are otherwise indistinguishable in a log.
+        self.assertIn(str(DATABASE), self.labelled("database:"))
+
     def test_summed_averages_add_up_the_per_query_averages(self):
         # 1.5 + 0.5 + 2.0 + 0.25, not the wall-clock time of 200 iterations.
         self.assertIn("4.250 ms", self.labelled("sum of query averages:"))
@@ -75,24 +148,63 @@ class SummaryLinesTest(unittest.TestCase):
     def test_average_per_query_is_the_mean_of_those_averages(self):
         self.assertIn("1.062 ms", self.labelled("average per query:"))
 
+    def test_total_time_in_queries_adds_up_every_sample(self):
+        # Each query is timed `iterations` times and reported as a mean, so
+        # iterations x mean is that query's samples added back up: 200 x 4.25.
+        self.assertIn("850.000 ms", self.labelled("total time in queries:"))
+
+    def test_total_time_in_queries_scales_with_iterations(self):
+        # The distinction from the two averages, which do not move: this is the
+        # time the run really spent querying, so doubling the iterations
+        # doubles it.
+        doubled = self.summary(iterations=400)
+        self.assertIn("1700.000 ms", self.labelled("total time in queries:", doubled))
+
     def test_slowest_single_run_reports_the_max_sample_and_its_query(self):
         line = self.labelled("slowest single run:")
         self.assertIn("9.500 ms", line)
         self.assertIn("(provider album)", line)
 
+    def test_the_budget_every_average_had_to_clear_is_shown(self):
+        # A red run says which query missed it; without this, a green run never
+        # says how much headroom it had.
+        self.assertIn("50.000 ms", self.labelled("average-query budget:"))
+
     def test_no_label_claims_a_total_the_benchmark_never_measures(self):
         # The old "total query time" label read as wall-clock time while the
-        # value was the sum of the per-query averages (#338).
+        # value was the sum of the per-query averages (#338). The total below
+        # it is a different number with a label that says which one it is.
         joined = "\n".join(self.summary())
         self.assertNotIn("total query time", joined)
 
     def test_values_line_up_in_one_column(self):
-        rows = [line for line in self.summary() if line.startswith("  ")]
-        self.assertEqual(len(rows), 6)
+        rows = self.numeric_rows()
+        self.assertEqual(len(rows), 8)
         # Counts have no unit and end the line; timings are followed by " ms".
         # Both end their value in the same column, which is what makes the
         # block scannable in a CI log.
         ends = {len(line) if " ms" not in line else line.index(" ms") for line in rows}
+        self.assertEqual(len(ends), 1, f"values end at {ends}")
+
+    def test_every_label_fits_its_column(self):
+        # A label wider than the column would push its own value out of line
+        # and break the column above for that one row.
+        for line in self.rows():
+            with self.subTest(line=line):
+                self.assertIn(":", line[:VALUE_COLUMN])
+
+    def test_a_text_value_starts_where_the_numbers_do(self):
+        # A path has no right edge worth aligning to, so it is left-aligned
+        # from the value column rather than pushed around by its own length.
+        line = self.labelled("database:")
+        self.assertEqual(line[VALUE_COLUMN:], str(DATABASE))
+
+    def test_a_long_path_does_not_disturb_the_numbers(self):
+        long_path = Path("/tmp") / ("nested/" * 12) / "linthra-200k.sqlite"
+        ends = {
+            len(line) if " ms" not in line else line.index(" ms")
+            for line in self.numeric_rows(database=long_path)
+        }
         self.assertEqual(len(ends), 1, f"values end at {ends}")
 
     def test_no_tabs_anywhere(self):
@@ -101,6 +213,23 @@ class SummaryLinesTest(unittest.TestCase):
 
     def test_output_is_deterministic(self):
         self.assertEqual(self.summary(), self.summary())
+
+    def test_only_the_numbers_move_between_runs(self):
+        # Nothing in the block is keyed off the clock, the environment or the
+        # order the queries happened to finish in, which is what makes it
+        # diffable between two CI runs.
+        labels = [line[:VALUE_COLUMN] for line in self.rows()]
+        other = [
+            line[:VALUE_COLUMN]
+            for line in self.rows(
+                results=(("title prefix", 1.0, 1.2, 1.5),),
+                track_count=5_000,
+                iterations=10,
+                database=Path("/tmp/other.sqlite"),
+                max_average_ms=25.0,
+            )
+        ]
+        self.assertEqual(labels, other)
 
     def test_single_query_run_still_renders(self):
         lines = self.summary(results=(("title prefix", 1.0, 1.2, 1.5),))
@@ -633,7 +762,7 @@ class QueryCatalogueTest(unittest.TestCase):
         names = [query.name for query in benchmark_sqlite.QUERIES]
         self.assertEqual(len(names), len(set(names)))
         for name in names:
-            self.assertLessEqual(len(name), 18, name)
+            self.assertLessEqual(len(name), benchmark_sqlite.QUERY_NAME_WIDTH, name)
 
     def test_every_schema_index_is_exercised_by_some_query(self):
         # #341 is about showing the indexes are used. An index nothing

--- a/tools/large_library/README.md
+++ b/tools/large_library/README.md
@@ -20,9 +20,9 @@ python3 tools/large_library/benchmark_sqlite.py \
 Each query prints its timings, then its query plan indented underneath:
 
 ```
-title prefix       avg=   0.051 ms  p95=   0.102 ms
+title prefix       avg=   0.027 ms  p95=   0.040 ms  max=   0.104 ms
     SEARCH tracks USING INDEX idx_tracks_title (normalized_title>? AND normalized_title<?)
-album exact        avg=   0.113 ms  p95=   0.177 ms
+album exact        avg=   0.058 ms  p95=   0.072 ms  max=   0.357 ms
     SEARCH tracks USING INDEX idx_tracks_album (normalized_album=?)
     USE TEMP B-TREE FOR ORDER BY
 ```
@@ -31,18 +31,33 @@ then a summary block:
 
 ```
 benchmark summary
+  database:               /tmp/linthra-200k.sqlite
   tracks:                   200,000
   queries:                        8
   iterations per query:         200
-  sum of query averages:      2.166 ms
-  average per query:          0.271 ms
-  slowest single run:         2.845 ms (track count)
+  total time in queries:    269.751 ms
+  sum of query averages:      1.349 ms
+  average per query:          0.169 ms
+  slowest single run:         2.128 ms (track count)
+  average-query budget:      50.000 ms
 ```
 
-Every query is timed the same number of times and reported as a mean, so
-`sum of query averages` adds up those per-query means rather than the
-wall-clock time the run spent querying, and `slowest single run` is the single
-slowest timed iteration, not the slowest query on average.
+Every query is timed the same number of times and reported as a mean, so the
+three totals are three different numbers and the labels say which is which:
+
+- `total time in queries` is every timed sample added up, so it is the time the
+  run really spent executing queries (and the only one that moves when you
+  change `--iterations`). Building the fixture, collecting the plans and
+  printing all happen outside it.
+- `sum of query averages` adds up the per-query means instead, which is what
+  keeps two runs at different iteration counts comparable.
+- `slowest single run` is the single slowest timed iteration, not the slowest
+  query on average: it is the outlier worth looking at when a run is spiky, and
+  the `max=` on each query line is where it comes from.
+
+`average-query budget` is the `--max-average-ms` this run was checked against,
+so a green run shows how much headroom it had rather than only a red one
+showing the miss, and `database` says which fixture produced all of it.
 
 ## Memory: large-library profiling (#463)
 

--- a/tools/large_library/benchmark_sqlite.py
+++ b/tools/large_library/benchmark_sqlite.py
@@ -351,30 +351,79 @@ def query_plan(
     return rows
 
 
+#: The width of the query-name column in the per-query timing lines. Names are
+#: padded to it so the timings of every query start in the same place; the
+#: query catalogue is kept inside it by a unit test.
+QUERY_NAME_WIDTH = 18
+
+#: The summary's label column, and the column its numbers are right-aligned in.
+#: Both are fixed so counts and timings end in the same place whatever their
+#: magnitude, which is what makes the block scannable in a CI log.
+SUMMARY_LABEL_WIDTH = 24
+SUMMARY_VALUE_WIDTH = 9
+
+
+def query_line(name: str, average_ms: float, p95_ms: float, max_ms: float) -> str:
+    """One query's timings, as printed on the line above its plan.
+
+    The maximum is here because the summary's "slowest single run" is drawn
+    from it: without it, the one number a spiky run gets read for appears out of
+    nowhere, and there is no way to see which other query was close behind.
+    """
+    return (
+        f"{name:{QUERY_NAME_WIDTH}} avg={average_ms:8.3f} ms"
+        f"  p95={p95_ms:8.3f} ms  max={max_ms:8.3f} ms"
+    )
+
+
 def summary_lines(
+    database: Path,
     track_count: int,
     results: Sequence[tuple[str, float, float, float]],
     iterations: int,
+    max_average_ms: float,
 ) -> list[str]:
     """Render the summary block printed after the per-query lines.
 
     Separate from `main` so the wording, the numbers and the alignment can be
-    checked without a database: everything here is derived from `results`.
+    checked without a database: everything here is derived from its arguments.
     """
     summed_average_ms = sum(average_ms for _, average_ms, _, _ in results)
     average_query_ms = summed_average_ms / len(results)
+    # Every query is timed the same number of times and reported as a mean, so
+    # iterations x mean adds that query's samples back up, and the sum over the
+    # queries is the time the run actually spent executing them. Nothing else
+    # is inside it: building the fixture, collecting the plans and printing all
+    # happen outside the timed section.
+    total_query_ms = summed_average_ms * iterations
     slowest_name, _, _, slowest_max_ms = max(results, key=lambda result: result[3])
 
     # Labels are padded to a fixed width and values are right-aligned inside
     # one column, so counts and timings line up whatever their magnitude.
     def row(label: str, value: str, unit: str = "") -> str:
-        return f"  {label + ':':<24}{value:>9}{unit}"
+        return (
+            f"  {label + ':':<{SUMMARY_LABEL_WIDTH}}"
+            f"{value:>{SUMMARY_VALUE_WIDTH}}{unit}"
+        )
+
+    def text_row(label: str, value: str) -> str:
+        # A path has no right edge worth aligning to, and one longer than the
+        # value column would push the numbers out of line, so text starts where
+        # the number column starts and runs on from there.
+        return f"  {label + ':':<{SUMMARY_LABEL_WIDTH}}{value}"
 
     return [
         "benchmark summary",
+        # Which fixture this was: the numbers below mean nothing without it,
+        # and a 200k run and a 5k run otherwise look identical in a log.
+        text_row("database", str(database)),
         row("tracks", f"{track_count:,}"),
         row("queries", f"{len(results)}"),
         row("iterations per query", f"{iterations:,}"),
+        # The time the run spent inside the timed queries: every sample of
+        # every query, added up. It scales with --iterations, which is exactly
+        # what the two averages below do not do.
+        row("total time in queries", f"{total_query_ms:.3f}", " ms"),
         # Each query is timed the same number of times and reported as a mean,
         # so this is the sum of those per-query averages, not the wall-clock
         # time the benchmark spent querying. Saying so keeps the number
@@ -384,6 +433,10 @@ def summary_lines(
         # The slowest single timed run, not the slowest query on average: it is
         # the outlier worth looking at when a run is unexpectedly spiky.
         row("slowest single run", f"{slowest_max_ms:.3f}", f" ms ({slowest_name})"),
+        # The bar every per-query average had to clear. A red run says which
+        # query missed it; this says what it missed, and a green run says how
+        # much headroom there was.
+        row("average-query budget", f"{max_average_ms:.3f}", " ms"),
     ]
 
 
@@ -430,7 +483,7 @@ def main() -> None:
             # per line and indented by its depth. The plan used to be joined
             # onto the end of the timing line, where it wrapped and stopped
             # being read.
-            print(f"{query.name:18} avg={average_ms:8.3f} ms  p95={p95_ms:8.3f} ms")
+            print(query_line(query.name, average_ms, p95_ms, max_ms))
             for row in plan:
                 print(f"    {row.rendered()}")
 
@@ -486,13 +539,15 @@ def main() -> None:
                 failed = True
             if average_ms > args.max_average_ms:
                 print(
-                    f"ERROR: {query.name} exceeded the {args.max_average_ms:.1f} ms "
+                    f"ERROR: {query.name} exceeded the {args.max_average_ms:.3f} ms "
                     "average-query budget"
                 )
                 failed = True
 
         print()
-        for line in summary_lines(count, results, args.iterations):
+        for line in summary_lines(
+            args.database, count, results, args.iterations, args.max_average_ms
+        ):
             print(line)
         if failed:
             raise SystemExit(1)


### PR DESCRIPTION
Closes #338

Follow-up polish on the benchmark summary, picking up the loose ends from the last round on this issue. Output only: no query, index, threshold, fixture or app code changed.

## What the summary looks like now

```
title prefix       avg=   0.027 ms  p95=   0.040 ms  max=   0.104 ms
    SEARCH tracks USING INDEX idx_tracks_title (normalized_title>? AND normalized_title<?)
...

benchmark summary
  database:               /tmp/linthra-200k.sqlite
  tracks:                   200,000
  queries:                        8
  iterations per query:         200
  total time in queries:    269.751 ms
  sum of query averages:      1.349 ms
  average per query:          0.169 ms
  slowest single run:         2.128 ms (track count)
  average-query budget:      50.000 ms
```

(real output from a 200k fixture, not a mockup)

## What changed

Three new summary lines:

- `total time in queries` is every timed sample added up (iterations × the per-query mean, summed), so it is the time the run really spent executing queries, and the only number that moves with `--iterations`. It sits next to `sum of query averages` rather than replacing it, because that one is what stays comparable between runs at different iteration counts. Both labels say which is which, so nothing claims a wall-clock total the benchmark does not measure.
- `database` says which fixture produced the numbers. A 200k run and a 5k run otherwise look identical in a log.
- `average-query budget` echoes `--max-average-ms`, so a green run shows its headroom instead of only a red one showing the miss.

Each query line also prints `max=` now. That is where the summary's `slowest single run` comes from, and without it the one number a spiky run gets read for appeared out of nowhere. At the 18-column name cap the line still fits inside 80 columns, so it does not wrap in a CI log and drag its plan with it.

Small related fix: the "exceeded the budget" error printed `--max-average-ms` at one decimal, so a sub-millisecond budget read as `exceeded the 0.0 ms average-query budget`. It now prints at the same precision as the summary.

## Formatting

Unchanged in shape: labels padded to one column, numbers right-aligned in the next, no tabs, no colour, no ANSI, stdlib only, and nothing keyed off the clock, the environment or the order queries finished in. The path is the one text value, so it is left-aligned from the value column rather than right-aligned, which keeps a long path from pushing the numbers out of line (there is a test for exactly that).

## Tests

`query_line()` is now pulled out of `main()` next to `summary_lines()`, and both are unit-tested in `test/tooling/large_library_benchmark_test.py`: the new numbers, the alignment of every row, the text value, a long path, the 80-column fit, no tabs, and determinism. No database needed.

```bash
python3 test/tooling/large_library_benchmark_test.py   # 71 tests, OK
ruff check scripts tool tools
ruff format --check scripts tool tools
```

Also ran the real thing end to end against a freshly generated 200k fixture (green), and against a deliberately impossible `--max-average-ms` to check the failure path still reads well.
