### PR TITLE
feat(linux): keep embedded local artwork correct across changes (#408)

### DIFF
--- a/lib/core/services/local_artwork_cache.dart
+++ b/lib/core/services/local_artwork_cache.dart
@@ -7,6 +7,8 @@ import 'package:crypto/crypto.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
+import '../models/local_file_stamp.dart';
+
 /// Persists a local file's embedded cover art (ID3 `APIC`, a FLAC `PICTURE`
 /// block, an MP4 `covr` atom, …) into Linthra's private, OS-reclaimable cache
 /// and hands back a `file:` URI that [Track.artworkUri] can point at directly
@@ -15,12 +17,12 @@ import 'package:path_provider/path_provider.dart';
 /// tags rather than a server.
 ///
 /// Mirrors the Android SAF walk's own embedded-artwork cache
-/// (`SafDocumentScanner.cacheEmbeddedArtwork`): extract once, key by a hash of
-/// the *source file's path* (never the path itself, see [_key]) so a rescan
-/// reuses what an earlier one already extracted, write through a temp sibling
-/// then rename so a crash mid-write can never leave a half-written cover that
-/// fails to decode forever, and treat every failure as "no artwork" rather
-/// than a failed scan or a dropped track.
+/// (`SafDocumentScanner.cacheEmbeddedArtwork`): extract once, key by a hash
+/// (never the path itself, see [_key]) so a rescan reuses what an earlier one
+/// already extracted, write through a temp sibling then rename so a crash
+/// mid-write can never leave a half-written cover that fails to decode
+/// forever, and treat every failure as "no artwork" rather than a failed scan
+/// or a dropped track.
 ///
 /// Distinct from [ArtworkDiskCache] (remote covers, keyed by URL, never
 /// resized — a server already serves a sane size) and [MediaArtworkCache] (a
@@ -28,11 +30,24 @@ import 'package:path_provider/path_provider.dart';
 /// the one path from a local file's own embedded picture to something
 /// Linthra's UI can render.
 ///
-/// A cover wider or taller than [_maxDimension] is downsampled before it ever
-/// reaches disk. An embedded scan can be a multi-megapixel JPEG nobody asked
-/// to see at full resolution, and every track row in a scrolling list would
-/// otherwise decode it in full just to paint a thumbnail a hundred pixels
-/// wide.
+/// ## Bounds
+///
+/// Two of them, because an embedded picture is unvalidated input in the mild
+/// sense that nobody ever checked it: it is whatever bytes some tagger wrote
+/// into a frame years ago.
+///
+///  * [_maxSourceBytes] caps what is worth decoding at all, so a malformed
+///    picture frame claiming a preposterous length is dropped before it costs
+///    a decode, a re-encode and a disk write.
+///  * [_maxDimension] caps what reaches disk. An embedded scan can be a
+///    multi-megapixel JPEG nobody asked to see at full resolution, and every
+///    track row in a scrolling list would otherwise decode it in full just to
+///    paint a thumbnail a hundred pixels wide.
+///
+/// The downsample never materialises the full-size bitmap: the dimensions come
+/// from [ui.ImageDescriptor.encoded], which reads the header only, and the
+/// decode itself is asked for the *target* size, so a 12000x12000 cover costs
+/// a 1024 px bitmap rather than 576 MB of pixels.
 class LocalArtworkCache {
   LocalArtworkCache({Future<Directory> Function()? directory})
       : _directory = directory ?? _defaultDirectory;
@@ -45,11 +60,38 @@ class LocalArtworkCache {
   /// sits in memory or on disk at full size just for a list thumbnail.
   static const int _maxDimension = 1024;
 
-  /// The already-cached cover for [path]'s source file, or `null` on a miss —
-  /// including a missing, empty, or otherwise unreadable cache entry, which is
-  /// treated exactly like a miss so a later [store] regenerates it safely.
-  Future<File?> cachedFile(String path) async {
-    final File file = await _fileFor(path);
+  /// The largest embedded picture worth decoding, in bytes.
+  ///
+  /// Deliberately generous rather than tight: a genuine lossless cover scan
+  /// stored as PNG runs into the low tens of megabytes, and rejecting one
+  /// would show a placeholder for a file that really does have art, which is
+  /// the worse failure. What this rules out is the pathological end — a
+  /// truncated or hostile frame whose declared length is nothing a cover could
+  /// legitimately be — before it reaches the decoder.
+  ///
+  /// Peak cost for an accepted picture is therefore this plus one 1024 px
+  /// bitmap (4 MB) plus its re-encode, once, for one file at a time; scans are
+  /// sequential, so a large library never multiplies it.
+  static const int _maxSourceBytes = 16 * 1024 * 1024;
+
+  /// The extension every finished cache entry carries, and the only thing
+  /// [retainOnly] will ever delete besides an abandoned [_tempSuffix] write.
+  static const String _entrySuffix = '.img';
+
+  /// The extension of an in-flight write, renamed onto [_entrySuffix] once the
+  /// bytes are on disk.
+  static const String _tempSuffix = '.tmp';
+
+  /// The already-cached cover for the file at [path] as it currently looks on
+  /// disk ([stamp]), or `null` on a miss — including a missing, empty, or
+  /// otherwise unreadable cache entry, which is treated exactly like a miss so
+  /// a later [store] regenerates it safely.
+  ///
+  /// A file whose size or mtime moved since its cover was extracted misses by
+  /// construction (see [_key]), so a re-tagged album shows its *new* cover
+  /// rather than the one cached before the edit.
+  Future<File?> cachedFile(String path, LocalFileStamp stamp) async {
+    final File file = await _fileFor(path, stamp);
     try {
       if (await file.length() > 0) return file;
     } on FileSystemException {
@@ -59,21 +101,24 @@ class LocalArtworkCache {
   }
 
   /// Bounds a just-extracted embedded picture's [bytes] and writes it to the
-  /// private cache for [path]'s source file, returning a `file:` URI to it.
-  /// Returns `null` — and writes nothing — when [bytes] is empty or the image
-  /// can't be decoded at all (a corrupt or unsupported embedded picture);
-  /// never throws.
-  Future<Uri?> store(String path, Uint8List bytes) async {
-    if (bytes.isEmpty) return null;
+  /// private cache for the file at [path] as stamped by [stamp], returning a
+  /// `file:` URI to it.
+  ///
+  /// Returns `null` — and writes nothing — when [bytes] is empty, larger than
+  /// [_maxSourceBytes], or can't be decoded at all (a corrupt or unsupported
+  /// embedded picture). Never throws: the caller's track keeps its text tags
+  /// and simply renders the normal placeholder.
+  Future<Uri?> store(String path, LocalFileStamp stamp, Uint8List bytes) async {
+    if (bytes.isEmpty || bytes.length > _maxSourceBytes) return null;
     try {
       final Uint8List? bounded = await _bound(bytes);
       if (bounded == null) return null;
-      final File file = await _fileFor(path);
+      final File file = await _fileFor(path, stamp);
       final Directory dir = file.parent;
       if (!await dir.exists()) await dir.create(recursive: true);
       // Temp sibling then rename: an interrupted write can never leave a
       // truncated cover that then fails to decode forever.
-      final File tmp = File('${file.path}.tmp');
+      final File tmp = File('${file.path}$_tempSuffix');
       await tmp.writeAsBytes(bounded, flush: true);
       await tmp.rename(file.path);
       return Uri.file(file.path);
@@ -82,18 +127,102 @@ class LocalArtworkCache {
     }
   }
 
-  Future<File> _fileFor(String path) async {
-    final Directory dir = await _directory();
-    return File(p.join(dir.path, '${_key(path)}.img'));
+  /// Deletes every cache entry [live] does not reference: the covers of files
+  /// the library no longer holds (deleted, moved, or renamed) and the
+  /// superseded entries of files that were re-tagged since.
+  ///
+  /// Without this the cache only ever grows. Every re-tag mints a new entry
+  /// (the stamp is part of the key) and orphans the old one, and a library
+  /// reorganised once a year would keep a cover for every path a track ever
+  /// sat at.
+  ///
+  /// **Why this cannot touch the user's music.** It never leaves its own
+  /// directory: the listing is non-recursive and `followLinks: false`, so a
+  /// symlink planted in the cache is reported as a [Link] and skipped rather
+  /// than followed to whatever it points at; and of what remains it deletes
+  /// only plain files whose name ends in [_entrySuffix] or [_tempSuffix],
+  /// neither of which is an audio extension. A source file is not reachable
+  /// from here even in principle, which is the property worth having — the
+  /// user's audio is read-only to all of Linthra, and a cache sweep is exactly
+  /// where that would be easiest to get wrong.
+  ///
+  /// Abandoned `.tmp` writes are always swept: by construction they are never
+  /// a finished cover, so the worst case is that a sweep racing a concurrent
+  /// [store] costs that one cover a regeneration on the next scan.
+  ///
+  /// Never throws, and never gives up part-way: an entry that cannot be
+  /// deleted (a permission change, a file that vanished under us) is skipped
+  /// and the sweep continues.
+  Future<void> retainOnly(Set<Uri> live) async {
+    try {
+      final Directory dir = await _directory();
+      if (!await dir.exists()) return;
+      final Set<String> keep = <String>{
+        for (final Uri uri in live)
+          if (uri.isScheme('file')) _canonical(uri.toFilePath()),
+      };
+      await for (final FileSystemEntity entity
+          in dir.list(followLinks: false)) {
+        // A Link (symlink) and a Directory are both skipped here: only a plain
+        // file this cache itself wrote is ever a deletion candidate.
+        if (entity is! File) continue;
+        final String name = p.basename(entity.path);
+        final bool isEntry = name.endsWith(_entrySuffix);
+        final bool isTemp = name.endsWith(_tempSuffix);
+        if (!isEntry && !isTemp) continue;
+        if (isEntry && keep.contains(_canonical(entity.path))) continue;
+        try {
+          await entity.delete();
+        } catch (_) {
+          // Busy, vanished, or read-only. Nothing here is load-bearing.
+        }
+      }
+    } catch (_) {
+      // A cache that cannot be swept is a cache that grows, not a failed scan.
+    }
   }
 
-  /// A stable, path-free cache key: the SHA-256 of the source file's own path.
-  /// Hashing keeps a user's real file path (private — see CONTRIBUTING,
-  /// Privacy) out of both the file name and the cache directory listing,
-  /// mirroring the SHA-1-of-content-URI key the Android SAF walk uses for the
-  /// same purpose.
-  static String _key(String path) =>
-      sha256.convert(utf8.encode(path)).toString();
+  Future<File> _fileFor(String path, LocalFileStamp stamp) async {
+    final Directory dir = await _directory();
+    return File(p.join(dir.path, '${_key(path, stamp)}$_entrySuffix'));
+  }
+
+  /// A stable, path-free cache key: the SHA-256 of the source file's path
+  /// *together with the size and mtime it had when its cover was extracted*.
+  ///
+  /// **Why the path.** Two unrelated files can easily share a size and an
+  /// mtime (see [LocalFileStamp], which says so outright), so the stamp alone
+  /// would hand one track's cover to another. Hashing keeps a user's real file
+  /// path (private — see CONTRIBUTING, Privacy) out of both the file name and
+  /// the cache directory listing, mirroring the SHA-1-of-content-URI key the
+  /// Android SAF walk uses for the same purpose.
+  ///
+  /// **Why the stamp.** It is what makes the entry describe *these bytes*
+  /// rather than *this location*. A path-only key is wrong in both directions
+  /// that matter: re-tag an album with new art and the old cover is served
+  /// forever (the scan re-reads the file, finds a cache hit, and never looks
+  /// at the new picture), and delete a track then drop a different one at the
+  /// same path and it inherits the previous song's cover. Folding in the stamp
+  /// turns both into an ordinary miss, and [retainOnly] reaps what they
+  /// superseded.
+  ///
+  /// The cost is that a *moved* file re-extracts once at its new path. That is
+  /// the right side to be wrong on: an extraction is cheap and self-correcting,
+  /// a cover silently belonging to another song is neither.
+  ///
+  /// The three parts are joined with NUL, which cannot occur in a path, so no
+  /// two distinct (path, size, mtime) triples can spell the same input.
+  static String _key(String path, LocalFileStamp stamp) => sha256
+      .convert(
+        utf8.encode(
+          '$path\u0000${stamp.sizeBytes}\u0000${stamp.modifiedAtMs}',
+        ),
+      )
+      .toString();
+
+  /// Compares cache paths the way the filesystem does, so an entry is not
+  /// swept merely because the live URI spelled the same file differently.
+  static String _canonical(String path) => p.canonicalize(path);
 
   /// Downsamples [bytes] to at most [_maxDimension] on its long edge,
   /// preserving aspect ratio, or returns it unchanged when already within

--- a/lib/core/sources/local/filesystem_local_metadata_reader.dart
+++ b/lib/core/sources/local/filesystem_local_metadata_reader.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:audio_metadata_reader/audio_metadata_reader.dart';
 
+import '../../models/local_file_stamp.dart';
 import '../../services/local_artwork_cache.dart';
 import 'local_audio_metadata.dart';
 import 'local_metadata_reader.dart';
@@ -28,17 +29,21 @@ import 'vorbis_comment_fields.dart';
 /// unsupported container, a truncated tag or a format the package has no parser
 /// for all return `null`, so the track still appears with its filename-derived
 /// metadata instead of vanishing from the library.
-class FilesystemLocalMetadataReader implements LocalMetadataReader {
+class FilesystemLocalMetadataReader
+    implements LocalMetadataReader, LocalArtworkMaintainer {
   FilesystemLocalMetadataReader({LocalArtworkCache? artworkCache})
       : _artworkCache = artworkCache ?? LocalArtworkCache();
 
   final LocalArtworkCache _artworkCache;
 
   @override
+  Future<void> retainArtwork(Set<Uri> live) => _artworkCache.retainOnly(live);
+
+  @override
   Future<LocalAudioMetadata?> readFromPath(String path) async {
     try {
       final File file = File(path);
-      // `await`, and asynchronous `exists()` rather than `existsSync()`, is
+      // `await`, and an asynchronous `stat()` rather than `statSync()`, is
       // load-bearing: it is the only point in this method that reaches the
       // event loop. `readAllMetadata` below is synchronous, so without a real
       // asynchronous call first, this method would do all its work before
@@ -48,14 +53,29 @@ class FilesystemLocalMetadataReader implements LocalMetadataReader {
       // unbroken chain with no frame rendered and no input handled from the
       // first file to the last. Measured on a 2000-iteration stand-in: zero
       // event-loop ticks with the synchronous check, one per file with this.
-      // Switching this back to existsSync() re-freezes the desktop UI for the
-      // length of the scan, silently (see the test that asserts the yield).
-      if (!await file.exists()) return null;
+      // Switching this back to a synchronous check re-freezes the desktop UI
+      // for the length of the scan, silently (see the test that asserts the
+      // yield).
+      //
+      // `stat` rather than `exists` because it is the same one syscall and
+      // answers strictly more: whether this is a regular file (a *directory*
+      // named `Album.mp3` used to read as "exists" and then fail deeper in),
+      // and the size and mtime that identify which bytes any cached cover was
+      // extracted from.
+      final FileStat stat = await file.stat();
+      if (stat.type != FileSystemEntityType.file) return null;
+      final LocalFileStamp stamp = LocalFileStamp(
+        sizeBytes: stat.size,
+        modifiedAtMs: stat.modified.millisecondsSinceEpoch,
+      );
 
       // A cover cached from an earlier scan needs no re-extraction: checking
       // first means a hit costs nothing beyond this stat, and only a genuine
-      // miss asks the parser for the (possibly large) embedded picture.
-      final File? cachedArtwork = await _artworkCache.cachedFile(path);
+      // miss asks the parser for the (possibly large) embedded picture. The
+      // lookup is keyed by the stamp too, so a file re-tagged with new art
+      // misses here and re-extracts rather than serving the cover from before
+      // the edit.
+      final File? cachedArtwork = await _artworkCache.cachedFile(path, stamp);
       final bool needsArtwork = cachedArtwork == null;
 
       // Format-specific rather than the package's unified `readMetadata`: that
@@ -77,7 +97,7 @@ class FilesystemLocalMetadataReader implements LocalMetadataReader {
       if (needsArtwork) {
         final Picture? cover = _bestCover(_picturesOf(tag));
         if (cover != null) {
-          artworkUri = await _artworkCache.store(path, cover.bytes);
+          artworkUri = await _artworkCache.store(path, stamp, cover.bytes);
         }
       }
 

--- a/lib/core/sources/local/local_metadata_reader.dart
+++ b/lib/core/sources/local/local_metadata_reader.dart
@@ -20,6 +20,34 @@ abstract interface class LocalMetadataReader {
   Future<LocalAudioMetadata?> readFromPath(String path);
 }
 
+/// The optional half of [LocalMetadataReader]: a reader that also owns an
+/// on-disk artwork cache, and can be asked to drop what the library no longer
+/// references.
+///
+/// Kept as a *separate* interface, and reached through a `is` check at the one
+/// call site (`LibraryController._scanLocal`), for the same reason
+/// `StampedCatalogWriter` is: it lets the capability exist without every
+/// `LocalMetadataReader` — the Android one, and the fakes in six test files —
+/// having to answer a question that is meaningless for them.
+///
+/// It is also the platform seam. Android's tags and artwork come from the
+/// native SAF walk, which manages its own cache; its
+/// [UnsupportedLocalMetadataReader] is deliberately not a
+/// [LocalArtworkMaintainer], so the sweep simply does not happen there and no
+/// caller needs a platform conditional to arrange that.
+abstract interface class LocalArtworkMaintainer {
+  /// Drops every cached cover this reader owns that [live] does not reference.
+  ///
+  /// [live] is the complete set of artwork URIs the catalog holds after a
+  /// scan; anything else in the reader's own cache is a cover for a file that
+  /// was deleted, moved, or re-tagged since, and is dead weight.
+  ///
+  /// Must never throw, and must never touch anything outside the cache it
+  /// owns — emphatically including the user's audio files, which Linthra only
+  /// ever reads.
+  Future<void> retainArtwork(Set<Uri> live);
+}
+
 /// The [LocalMetadataReader] for anywhere a filesystem tag read is not wanted:
 /// Android, whose tags come from the native SAF walk, and tests. It reads
 /// nothing, so the mapper falls back to filename/folder metadata.

--- a/lib/features/library/library_controller.dart
+++ b/lib/features/library/library_controller.dart
@@ -11,6 +11,7 @@ import '../../core/repositories/stamped_catalog_writer.dart';
 import '../../core/services/local_track_move_applier.dart';
 import '../../core/sources/local/folder_location.dart';
 import '../../core/sources/local/local_library_scanner.dart';
+import '../../core/sources/local/local_metadata_reader.dart';
 import '../../core/sources/local/local_music_roots.dart';
 import '../../core/sources/local/local_music_source.dart';
 import '../../core/sources/local/local_scan_report.dart';
@@ -168,13 +169,18 @@ class LibraryController extends Notifier<LibraryState> {
                 stamped.track.uri: stamped,
             };
 
+      // Hoisted so the post-write artwork sweep below asks the *same* reader
+      // that just populated the cache, rather than assuming which one the
+      // provider hands out.
+      final LocalMetadataReader metadataReader =
+          ref.read(localMetadataReaderProvider);
       final scanner = LocalLibraryScanner((String root) {
         return LocalMusicSource(
           folderPath: root,
           scanner: ref.read(audioFileScannerProvider),
           safDocumentLister: ref.read(safDocumentListerProvider),
           androidMediaLibrary: ref.read(androidMediaLibraryProvider),
-          metadataReader: ref.read(localMetadataReaderProvider),
+          metadataReader: metadataReader,
           statReader: ref.read(localFileStatReaderProvider),
           alreadyIndexed: alreadyIndexed,
         ).scanTracks();
@@ -226,6 +232,26 @@ class LibraryController extends Notifier<LibraryState> {
         // A newer action may have started while the write was awaiting I/O.
         // Its queued write will run after this one; do not publish stale status.
         if (generation != _scanGeneration) return null;
+
+        // The catalog just written *is* the live set, so anything else in the
+        // local artwork cache belongs to a file that has since been deleted,
+        // moved, or re-tagged. Swept here and nowhere else, for two reasons:
+        // this is the only point where the set is both complete (a folder that
+        // could not be read contributed its retained tracks, and a scan that
+        // lost even those never reaches here — see `scan.isWritable`) and
+        // current (a superseded scan returned at the check above rather than
+        // deleting covers a newer one had already written).
+        //
+        // Android's reader is not a LocalArtworkMaintainer, so this is a
+        // no-op there and its SAF-side artwork cache is left entirely alone.
+        if (metadataReader is LocalArtworkMaintainer) {
+          await (metadataReader as LocalArtworkMaintainer).retainArtwork(
+            <Uri>{
+              for (final Track track in tracks)
+                if (track.artworkUri != null) track.artworkUri!,
+            },
+          );
+        }
         ref.read(localScanReportProvider.notifier).record(scan.report);
         await _load();
         return generation == _scanGeneration ? scan.report : null;

--- a/test/core/services/local_artwork_cache_test.dart
+++ b/test/core/services/local_artwork_cache_test.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/local_file_stamp.dart';
 import 'package:linthra/core/services/local_artwork_cache.dart';
 
 /// A real, decodable solid-colour PNG of [width]x[height] — a corrupt/garbage
@@ -35,6 +36,12 @@ Future<ui.Size> _decodedSize(Uint8List bytes) async {
   return size;
 }
 
+/// What a file looked like on disk when its cover was extracted. The cache
+/// never stats anything itself — the reader hands it the stamp — so a test can
+/// describe a re-tag simply by passing a different one.
+LocalFileStamp _stamp({int size = 4096, int mtime = 1700000000000}) =>
+    LocalFileStamp(sizeBytes: size, modifiedAtMs: mtime);
+
 void main() {
   late Directory dir;
   late LocalArtworkCache cache;
@@ -49,17 +56,17 @@ void main() {
   });
 
   test('a fresh path has no cached file', () async {
-    expect(await cache.cachedFile('/music/song.flac'), isNull);
+    expect(await cache.cachedFile('/music/song.flac', _stamp()), isNull);
   });
 
   test('store writes the image and cachedFile then finds it', () async {
     final Uint8List cover = await _solidPng(32, 32);
 
-    final Uri? uri = await cache.store('/music/song.flac', cover);
+    final Uri? uri = await cache.store('/music/song.flac', _stamp(), cover);
 
     expect(uri, isNotNull);
     expect(uri!.isScheme('file'), isTrue);
-    final File? found = await cache.cachedFile('/music/song.flac');
+    final File? found = await cache.cachedFile('/music/song.flac', _stamp());
     expect(found, isNotNull);
     expect(found!.path, uri.toFilePath());
     expect(found.lengthSync(), greaterThan(0));
@@ -67,17 +74,48 @@ void main() {
 
   test('different source paths cache to different files', () async {
     final Uint8List cover = await _solidPng(16, 16);
-    final Uri? a = await cache.store('/music/a.flac', cover);
-    final Uri? b = await cache.store('/music/b.flac', cover);
+    final Uri? a = await cache.store('/music/a.flac', _stamp(), cover);
+    final Uri? b = await cache.store('/music/b.flac', _stamp(), cover);
 
     expect(a, isNotNull);
     expect(b, isNotNull);
     expect(a, isNot(b));
   });
 
+  test('two different files sharing a size and mtime do not collide', () async {
+    // A stamp is explicitly not an identity (see LocalFileStamp): a rip that
+    // wrote a whole album in one pass leaves plenty of files agreeing on both.
+    // Only the path keeps their covers apart.
+    final LocalFileStamp shared = _stamp(size: 5_242_880, mtime: 1699999999000);
+    final Uri a = (await cache.store(
+      '/music/album/01.flac',
+      shared,
+      await _solidPng(16, 16),
+    ))!;
+    final Uri b = (await cache.store(
+      '/music/album/02.flac',
+      shared,
+      await _solidPng(24, 24),
+    ))!;
+
+    expect(a, isNot(b));
+    expect(
+      await _decodedSize(File(a.toFilePath()).readAsBytesSync()),
+      const ui.Size(16, 16),
+    );
+    expect(
+      await _decodedSize(File(b.toFilePath()).readAsBytesSync()),
+      const ui.Size(24, 24),
+    );
+  });
+
   test('the cache key never contains the source path', () async {
     final Uint8List cover = await _solidPng(16, 16);
-    await cache.store('/home/alice/Music/Private Folder/song.flac', cover);
+    await cache.store(
+      '/home/alice/Music/Private Folder/song.flac',
+      _stamp(),
+      cover,
+    );
 
     final List<FileSystemEntity> written = dir.listSync();
     expect(written, hasLength(1));
@@ -86,7 +124,11 @@ void main() {
   });
 
   test('store returns null and writes nothing for empty bytes', () async {
-    final Uri? uri = await cache.store('/music/song.flac', Uint8List(0));
+    final Uri? uri = await cache.store(
+      '/music/song.flac',
+      _stamp(),
+      Uint8List(0),
+    );
 
     expect(uri, isNull);
     expect(dir.listSync(), isEmpty);
@@ -95,25 +137,40 @@ void main() {
   test('store returns null for bytes that are not a decodable image', () async {
     final Uri? uri = await cache.store(
       '/music/song.flac',
+      _stamp(),
       Uint8List.fromList('definitely not an image'.codeUnits),
     );
 
     expect(uri, isNull);
-    expect(await cache.cachedFile('/music/song.flac'), isNull);
+    expect(await cache.cachedFile('/music/song.flac', _stamp()), isNull);
+  });
+
+  test('a picture larger than the source cap is dropped before any decode',
+      () async {
+    // 17 MiB of plausible-looking PNG header plus noise: a frame whose declared
+    // length is nothing a cover legitimately is. The point is that it costs no
+    // decode and reaches no disk, not that it happens to be undecodable.
+    final Uint8List oversized = Uint8List(17 * 1024 * 1024);
+    oversized.setRange(0, 8, await _solidPng(1, 1));
+
+    final Uri? uri = await cache.store('/music/song.flac', _stamp(), oversized);
+
+    expect(uri, isNull);
+    expect(dir.listSync(), isEmpty);
   });
 
   test('a corrupt (0-byte) cache entry is treated as a miss', () async {
     final Uint8List cover = await _solidPng(16, 16);
-    final Uri uri = (await cache.store('/music/song.flac', cover))!;
+    final Uri uri = (await cache.store('/music/song.flac', _stamp(), cover))!;
     File(uri.toFilePath()).writeAsBytesSync(<int>[]);
 
-    expect(await cache.cachedFile('/music/song.flac'), isNull);
+    expect(await cache.cachedFile('/music/song.flac', _stamp()), isNull);
   });
 
   test('an image within the bound is stored at its original size', () async {
     final Uint8List cover = await _solidPng(300, 150);
 
-    final Uri uri = (await cache.store('/music/song.flac', cover))!;
+    final Uri uri = (await cache.store('/music/song.flac', _stamp(), cover))!;
 
     final ui.Size size = await _decodedSize(
       File(uri.toFilePath()).readAsBytesSync(),
@@ -125,7 +182,7 @@ void main() {
   test('an image over the bound is downsampled, aspect ratio kept', () async {
     final Uint8List cover = await _solidPng(4000, 2000);
 
-    final Uri uri = (await cache.store('/music/song.flac', cover))!;
+    final Uri uri = (await cache.store('/music/song.flac', _stamp(), cover))!;
 
     final ui.Size size = await _decodedSize(
       File(uri.toFilePath()).readAsBytesSync(),
@@ -135,17 +192,200 @@ void main() {
     expect(size.width / size.height, closeTo(2.0, 0.05));
   });
 
-  test('storing again for the same path overwrites the same cache entry',
+  test('storing again for the same path and stamp reuses the same entry',
       () async {
     final Uint8List small = await _solidPng(16, 16);
     final Uint8List big = await _solidPng(64, 64);
-    final Uri first = (await cache.store('/music/song.flac', small))!;
-    final Uri second = (await cache.store('/music/song.flac', big))!;
+    final Uri first = (await cache.store('/music/song.flac', _stamp(), small))!;
+    final Uri second = (await cache.store('/music/song.flac', _stamp(), big))!;
 
     expect(second, first);
     final ui.Size size = await _decodedSize(
       File(second.toFilePath()).readAsBytesSync(),
     );
     expect(size.width, 64);
+  });
+
+  group('a changed file invalidates its own entry', () {
+    test('a new mtime misses, so the re-tagged cover is re-extracted',
+        () async {
+      await cache.store(
+        '/music/song.flac',
+        _stamp(mtime: 1700000000000),
+        await _solidPng(16, 16),
+      );
+
+      expect(
+        await cache.cachedFile(
+          '/music/song.flac',
+          _stamp(mtime: 1700000009000),
+        ),
+        isNull,
+      );
+    });
+
+    test('a new size misses too', () async {
+      await cache.store(
+        '/music/song.flac',
+        _stamp(size: 4096),
+        await _solidPng(16, 16),
+      );
+
+      expect(
+        await cache.cachedFile('/music/song.flac', _stamp(size: 8192)),
+        isNull,
+      );
+    });
+
+    test(
+        'the superseded entry survives until it is swept, and the new cover '
+        'is what the current stamp reads back', () async {
+      final Uri old = (await cache.store(
+        '/music/song.flac',
+        _stamp(mtime: 1),
+        await _solidPng(16, 16),
+      ))!;
+      final Uri fresh = (await cache.store(
+        '/music/song.flac',
+        _stamp(mtime: 2),
+        await _solidPng(48, 48),
+      ))!;
+
+      expect(fresh, isNot(old));
+      final File? current = await cache.cachedFile(
+        '/music/song.flac',
+        _stamp(mtime: 2),
+      );
+      expect(current!.path, fresh.toFilePath());
+
+      await cache.retainOnly(<Uri>{fresh});
+      expect(File(old.toFilePath()).existsSync(), isFalse);
+      expect(File(fresh.toFilePath()).existsSync(), isTrue);
+    });
+  });
+
+  group('retainOnly', () {
+    test('keeps referenced entries and drops the rest', () async {
+      final Uri kept = (await cache.store(
+        '/music/kept.flac',
+        _stamp(),
+        await _solidPng(16, 16),
+      ))!;
+      final Uri orphan = (await cache.store(
+        '/music/deleted.flac',
+        _stamp(),
+        await _solidPng(16, 16),
+      ))!;
+
+      await cache.retainOnly(<Uri>{kept});
+
+      expect(File(kept.toFilePath()).existsSync(), isTrue);
+      expect(File(orphan.toFilePath()).existsSync(), isFalse);
+      expect(
+        await cache.cachedFile('/music/kept.flac', _stamp()),
+        isNotNull,
+      );
+    });
+
+    test('an empty live set empties the cache', () async {
+      await cache.store('/music/a.flac', _stamp(), await _solidPng(16, 16));
+      await cache.store('/music/b.flac', _stamp(), await _solidPng(16, 16));
+
+      await cache.retainOnly(const <Uri>{});
+
+      expect(dir.listSync(), isEmpty);
+    });
+
+    test('abandoned .tmp writes are swept', () async {
+      final File abandoned = File('${dir.path}/deadbeef.img.tmp')
+        ..writeAsBytesSync(await _solidPng(8, 8));
+
+      await cache.retainOnly(const <Uri>{});
+
+      expect(abandoned.existsSync(), isFalse);
+    });
+
+    test('files this cache did not write are left alone', () async {
+      final File foreign = File('${dir.path}/notes.txt')
+        ..writeAsStringSync('someone else put this here');
+
+      await cache.retainOnly(const <Uri>{});
+
+      expect(foreign.existsSync(), isTrue);
+    });
+
+    test('a missing cache directory is a no-op, not a failure', () async {
+      await dir.delete(recursive: true);
+
+      await expectLater(cache.retainOnly(const <Uri>{}), completes);
+    });
+
+    test('a non-file live URI does not keep anything alive', () async {
+      final Uri orphan = (await cache.store(
+        '/music/song.flac',
+        _stamp(),
+        await _solidPng(16, 16),
+      ))!;
+
+      // Remote covers are https: and belong to a different cache entirely;
+      // they must not be mistaken for a reference into this one.
+      await cache
+          .retainOnly(<Uri>{Uri.parse('https://example.test/cover.jpg')});
+
+      expect(File(orphan.toFilePath()).existsSync(), isFalse);
+    });
+
+    group('never touches the user’s source audio', () {
+      late Directory music;
+      late File song;
+      late Uint8List original;
+
+      setUp(() async {
+        music = await Directory.systemTemp.createTemp('local_artwork_source');
+        original = Uint8List.fromList(
+          List<int>.generate(2048, (int i) => i % 251),
+        );
+        song = File('${music.path}/song.flac')..writeAsBytesSync(original);
+      });
+
+      tearDown(() async {
+        if (await music.exists()) await music.delete(recursive: true);
+      });
+
+      test('a sweep that empties the cache leaves the file byte-identical',
+          () async {
+        await cache.store(song.path, _stamp(), await _solidPng(16, 16));
+
+        await cache.retainOnly(const <Uri>{});
+
+        expect(song.existsSync(), isTrue);
+        expect(song.readAsBytesSync(), original);
+        expect(music.listSync(), hasLength(1));
+      });
+
+      test('a symlink planted in the cache is not followed to the audio file',
+          () async {
+        // The one way a sweep confined to its own directory could still reach
+        // a source file. `followLinks: false` reports this as a Link, which is
+        // not a File, so it is skipped before any delete is even considered.
+        Link('${dir.path}/deadbeef.img').createSync(song.path);
+
+        await cache.retainOnly(const <Uri>{});
+
+        expect(song.existsSync(), isTrue);
+        expect(song.readAsBytesSync(), original);
+      });
+
+      test('a live entry pointing outside the cache is still never deleted',
+          () async {
+        // Belt and braces: even handed the source file as a "live" URI, the
+        // sweep only ever iterates its own directory, so nothing outside it is
+        // a candidate either way.
+        await cache.retainOnly(<Uri>{Uri.file(song.path)});
+
+        expect(song.existsSync(), isTrue);
+        expect(song.readAsBytesSync(), original);
+      });
+    });
   });
 }

--- a/test/core/sources/local/filesystem_local_metadata_reader_test.dart
+++ b/test/core/sources/local/filesystem_local_metadata_reader_test.dart
@@ -605,5 +605,76 @@ void main() {
       expect(second, isNotNull);
       expect(File(second!.toFilePath()).existsSync(), isTrue);
     });
+
+    test('re-tagging a file with new art replaces the cover it shows',
+        () async {
+      // The stale-cache case that matters in practice: the user fixes an
+      // album's artwork in a tagger. The scan sees a changed stamp and
+      // re-reads the file, and the cover must follow the tags rather than
+      // being served from the entry cached before the edit.
+      final String path = write(
+        'retagged.mp3',
+        AudioTagFixtures.mp3(title: 'Song', coverImage: await solidPng(32, 32)),
+      );
+      final Uri before = (await reader.readFromPath(path))!.artworkUri!;
+      expect(
+          await decodedSize(File(before.toFilePath())), const ui.Size(32, 32));
+
+      // A real re-tag rewrites the bytes and moves the mtime; writing a
+      // different cover does both.
+      File(path).writeAsBytesSync(
+        AudioTagFixtures.mp3(title: 'Song', coverImage: await solidPng(96, 96)),
+        flush: true,
+      );
+      File(path).setLastModifiedSync(
+        DateTime.now().add(const Duration(seconds: 5)),
+      );
+
+      final Uri after = (await reader.readFromPath(path))!.artworkUri!;
+
+      expect(after, isNot(before));
+      expect(
+          await decodedSize(File(after.toFilePath())), const ui.Size(96, 96));
+    });
+
+    test('retainArtwork drops covers the library no longer references',
+        () async {
+      final String kept = write(
+        'kept.mp3',
+        AudioTagFixtures.mp3(title: 'Kept', coverImage: await solidPng(24, 24)),
+      );
+      final String removed = write(
+        'removed.mp3',
+        AudioTagFixtures.mp3(title: 'Gone', coverImage: await solidPng(24, 24)),
+      );
+      final Uri keptCover = (await reader.readFromPath(kept))!.artworkUri!;
+      final Uri removedCover =
+          (await reader.readFromPath(removed))!.artworkUri!;
+
+      await reader.retainArtwork(<Uri>{keptCover});
+
+      expect(File(keptCover.toFilePath()).existsSync(), isTrue);
+      expect(File(removedCover.toFilePath()).existsSync(), isFalse);
+    });
+
+    test('retainArtwork never touches the source audio files', () async {
+      final Uint8List songBytes = AudioTagFixtures.mp3(
+        title: 'Song',
+        coverImage: await solidPng(24, 24),
+      );
+      final String path = write('source.mp3', songBytes);
+      await reader.readFromPath(path);
+
+      // The most aggressive sweep there is: nothing at all is live.
+      await reader.retainArtwork(const <Uri>{});
+
+      expect(File(path).existsSync(), isTrue);
+      expect(File(path).readAsBytesSync(), songBytes);
+      expect(root.listSync(), hasLength(1));
+      // …and the track is still perfectly readable afterwards, cover included.
+      final LocalAudioMetadata? again = await reader.readFromPath(path);
+      expect(again!.title, 'Song');
+      expect(File(again.artworkUri!.toFilePath()).existsSync(), isTrue);
+    });
   });
 }

--- a/test/features/library/local_artwork_cache_sweep_test.dart
+++ b/test/features/library/local_artwork_cache_sweep_test.dart
@@ -1,0 +1,212 @@
+// The artwork half of a local scan's commit (#408), wired the way the app
+// wires it: a scan writes the catalog, then tells the reader that owns the
+// local artwork cache which covers are still referenced, so the entries left
+// behind by deleted, moved and re-tagged files stop accumulating.
+//
+// The cache's own safety rules are covered in
+// test/core/services/local_artwork_cache_test.dart; what is under test here is
+// that the sweep is asked for at all, with the right set, and only on the
+// platforms whose covers this cache holds.
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/core/sources/local/local_audio_metadata.dart';
+import 'package:linthra/core/sources/local/local_metadata_reader.dart';
+import 'package:linthra/core/sources/local/local_scan_diagnostics.dart';
+import 'package:linthra/data/repositories/host_platform_provider.dart';
+import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
+import 'package:linthra/data/repositories/in_memory_selected_music_folder_repository.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/data/repositories/selected_music_folder_repository_provider.dart';
+import 'package:linthra/features/library/library_providers.dart';
+import 'package:linthra/features/library/selected_folder_controller.dart';
+import 'package:linthra/features/settings/source/local_music_controller.dart';
+
+import 'fake_audio_file_scanner.dart';
+import 'fake_folder_picker_service.dart';
+
+/// A desktop-shaped reader: tags keyed by path, and an artwork cache it owns,
+/// recorded rather than written to disk.
+class _MaintainingMetadataReader
+    implements LocalMetadataReader, LocalArtworkMaintainer {
+  _MaintainingMetadataReader(this.byPath);
+
+  Map<String, LocalAudioMetadata> byPath;
+
+  /// One entry per sweep, so a test can tell "never asked" from "asked with
+  /// the wrong set" — and can see a superseded scan not sweeping at all.
+  final List<Set<Uri>> sweeps = <Set<Uri>>[];
+
+  @override
+  Future<LocalAudioMetadata?> readFromPath(String path) async => byPath[path];
+
+  @override
+  Future<void> retainArtwork(Set<Uri> live) async => sweeps.add(live);
+}
+
+LocalAudioMetadata _tagged(String title, {Uri? artwork}) => LocalAudioMetadata(
+      title: title,
+      artist: 'Someone',
+      album: 'An Album',
+      duration: const Duration(seconds: 180),
+      artworkUri: artwork,
+    );
+
+void main() {
+  setUp(LocalScanDiagnostics.reset);
+  tearDown(LocalScanDiagnostics.reset);
+
+  late InMemoryMusicLibraryRepository catalog;
+  late FakeAudioFileScanner scanner;
+  late _MaintainingMetadataReader reader;
+
+  ProviderContainer container({HostPlatform platform = HostPlatform.linux}) {
+    final ProviderContainer c = ProviderContainer(
+      overrides: <Override>[
+        folderPickerServiceProvider
+            .overrideWithValue(FakeFolderPickerService()),
+        selectedMusicFolderRepositoryProvider.overrideWithValue(
+          InMemorySelectedMusicFolderRepository(
+            initialFolders: const <String>['/music'],
+          ),
+        ),
+        musicLibraryRepositoryProvider.overrideWithValue(catalog),
+        audioFileScannerProvider.overrideWithValue(scanner),
+        localMetadataReaderProvider.overrideWithValue(reader),
+        hostPlatformProvider.overrideWithValue(platform),
+      ],
+    );
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  setUp(() {
+    catalog = InMemoryMusicLibraryRepository();
+    scanner = FakeAudioFileScanner();
+    reader = _MaintainingMetadataReader(<String, LocalAudioMetadata>{});
+  });
+
+  Future<void> rescan(ProviderContainer c) =>
+      c.read(localMusicControllerProvider.notifier).rescan();
+
+  test('a scan sweeps with exactly the covers the catalog now references',
+      () async {
+    final Uri coverA = Uri.file('/cache/local_artwork/aaa.img');
+    final Uri coverB = Uri.file('/cache/local_artwork/bbb.img');
+    scanner = FakeAudioFileScanner(filesByFolder: <String, List<String>>{
+      '/music': <String>['/music/a.mp3', '/music/b.mp3', '/music/c.mp3'],
+    });
+    reader = _MaintainingMetadataReader(<String, LocalAudioMetadata>{
+      '/music/a.mp3': _tagged('A', artwork: coverA),
+      '/music/b.mp3': _tagged('B', artwork: coverB),
+      // c.mp3 has no embedded art at all: it contributes nothing to keep, and
+      // must not contribute a null either.
+      '/music/c.mp3': _tagged('C'),
+    });
+    final ProviderContainer c = container();
+    await c.read(selectedFolderControllerProvider.future);
+
+    await rescan(c);
+
+    expect(reader.sweeps, hasLength(1));
+    expect(reader.sweeps.single, <Uri>{coverA, coverB});
+  });
+
+  test('a file that left the library stops keeping its cover alive', () async {
+    final Uri coverA = Uri.file('/cache/local_artwork/aaa.img');
+    final Uri coverB = Uri.file('/cache/local_artwork/bbb.img');
+    scanner = FakeAudioFileScanner(filesByFolder: <String, List<String>>{
+      '/music': <String>['/music/a.mp3', '/music/b.mp3'],
+    });
+    reader = _MaintainingMetadataReader(<String, LocalAudioMetadata>{
+      '/music/a.mp3': _tagged('A', artwork: coverA),
+      '/music/b.mp3': _tagged('B', artwork: coverB),
+    });
+    final ProviderContainer c = container();
+    await c.read(selectedFolderControllerProvider.future);
+    await rescan(c);
+
+    // b.mp3 is deleted from disk.
+    scanner.filesByFolder = <String, List<String>>{
+      '/music': <String>['/music/a.mp3'],
+    };
+    await rescan(c);
+
+    expect(reader.sweeps, hasLength(2));
+    expect(reader.sweeps.last, <Uri>{coverA});
+  });
+
+  test('an unreadable folder sweeps with its retained covers still kept',
+      () async {
+    // The dangerous case for a live-set sweep: an unplugged drive's tracks are
+    // retained rather than deleted, so their covers must be retained too, or
+    // plugging the drive back in would mean re-extracting the whole thing.
+    final Uri onDisk = Uri.file('/cache/local_artwork/aaa.img');
+    final Uri onUsb = Uri.file('/cache/local_artwork/bbb.img');
+    scanner = FakeAudioFileScanner(filesByFolder: <String, List<String>>{
+      '/music': <String>['/music/a.mp3'],
+      '/media/usb': <String>['/media/usb/b.mp3'],
+    });
+    reader = _MaintainingMetadataReader(<String, LocalAudioMetadata>{
+      '/music/a.mp3': _tagged('A', artwork: onDisk),
+      '/media/usb/b.mp3': _tagged('B', artwork: onUsb),
+    });
+    final ProviderContainer c = ProviderContainer(
+      overrides: <Override>[
+        folderPickerServiceProvider
+            .overrideWithValue(FakeFolderPickerService()),
+        selectedMusicFolderRepositoryProvider.overrideWithValue(
+          InMemorySelectedMusicFolderRepository(
+            initialFolders: const <String>['/music', '/media/usb'],
+          ),
+        ),
+        musicLibraryRepositoryProvider.overrideWithValue(catalog),
+        audioFileScannerProvider.overrideWithValue(scanner),
+        localMetadataReaderProvider.overrideWithValue(reader),
+        hostPlatformProvider.overrideWithValue(HostPlatform.linux),
+      ],
+    );
+    addTearDown(c.dispose);
+    await c.read(selectedFolderControllerProvider.future);
+    await rescan(c);
+
+    scanner.unavailable = <String>{'/media/usb'};
+    await rescan(c);
+
+    expect(reader.sweeps.last, <Uri>{onDisk, onUsb});
+  });
+
+  test('a scan that wrote nothing sweeps nothing', () async {
+    // Every folder failed, so the catalog was not rewritten and the live set
+    // would be empty: sweeping on it would delete every cover in the cache.
+    scanner = FakeAudioFileScanner(filesByFolder: <String, List<String>>{
+      '/music': <String>['/music/a.mp3'],
+    });
+    reader = _MaintainingMetadataReader(<String, LocalAudioMetadata>{
+      '/music/a.mp3': _tagged(
+        'A',
+        artwork: Uri.file('/cache/local_artwork/aaa.img'),
+      ),
+    });
+    final ProviderContainer c = container();
+    await c.read(selectedFolderControllerProvider.future);
+    await rescan(c);
+    expect(reader.sweeps, hasLength(1));
+
+    scanner.unavailable = <String>{'/music'};
+    await rescan(c);
+
+    expect(reader.sweeps, hasLength(1));
+  });
+
+  test('Android sweeps nothing: its reader owns no artwork cache', () {
+    // The platform seam, spelled out. Android's tags and covers come from the
+    // native SAF walk, which manages its own cache; the `is` check at the
+    // scan's commit is therefore false there and nothing on that side is
+    // touched by any of this.
+    expect(
+      const UnsupportedLocalMetadataReader(),
+      isNot(isA<LocalArtworkMaintainer>()),
+    );
+  });
+}


### PR DESCRIPTION
Finishes #408. Extraction itself landed in #590; this closes the two gaps that were left, plus a memory bound.

## What was wrong

The cache key was `SHA-256(path)`. That is wrong in both directions that matter:

- **Re-tag an album with new art** and the cover never updates. The incremental scan notices the changed stamp and re-reads the file, but `readFromPath` checks the artwork cache first, hits the entry from before the edit, and never asks the parser for the new picture. Stale forever.
- **Delete a track and drop a different one at the same path** and it inherits the previous song's cover.

And nothing ever cleaned the cache up, so every deleted, moved or renamed file left an entry behind permanently.

## How artwork is extracted

Unchanged from #590, and still through the existing seam. `FilesystemLocalMetadataReader` parses tags with `audio_metadata_reader` (MIT, pure Dart, already a dependency) and asks for the embedded picture with `getImage: true` **only on a cache miss**, so a cover already extracted costs exactly what a tags-only read costs. ID3 `APIC`, FLAC `PICTURE`, APEv2, RIFF and MP4 `covr` are all covered; when a file carries several pictures the one tagged front-cover wins, otherwise the first.

Nothing new renders anything: the extracted cover becomes a `file:` URI on `Track.artworkUri`, and `artworkImageProvider` already loads those through `FileImage`. Track rows, album views, artist/library views and Now Playing pick it up because they all go through that one seam.

The one change here is that the reader now `stat`s instead of `exists` — the same single syscall, still the load-bearing `await` that keeps a scan off the UI thread, but it also answers whether this is a regular file and gives the size and mtime the cache key needs.

## Where it is cached

`getApplicationCacheDirectory()/local_artwork_cache`, Linthra-owned and OS-reclaimable. Only a `file:` URI to it is persisted; no artwork bytes go into app state, and the user's real path never appears in a filename or in the directory listing. The source audio file is opened read-only and is never written, moved or deleted.

## Cache identity and invalidation

The key is now `SHA-256(path \0 sizeBytes \0 modifiedAtMs)` using the same `LocalFileStamp` the incremental scan already computes.

- **Stamp** makes the entry describe *these bytes* rather than *this location*, so a re-tag is an ordinary miss and re-extracts.
- **Path** stays because a stamp is explicitly not an identity (`LocalFileStamp` says so outright) — a rip that wrote an album in one pass leaves plenty of files agreeing on size and mtime, and they must not share a cover.
- A **moved** file re-extracts once at its new path. That is the right side to be wrong on: an extraction is cheap and self-correcting, a cover silently belonging to another song is neither.
- A **missing, empty or unreadable** entry reads as a miss, so it regenerates. Writes still go through a temp sibling then rename, so an interrupted write can't leave a cover that fails to decode forever.

Cleanup is new: `LocalArtworkCache.retainOnly`, called once at the scan's commit with exactly the artwork URIs the catalog now holds. It runs only where that set is both complete and current — a scan that couldn't read back an offline folder's tracks writes nothing and sweeps nothing, a superseded scan returns before it, and an unplugged drive's *retained* tracks keep their covers alive (there's a test for that one specifically).

**It cannot touch the user's music.** It never leaves its own directory: the listing is non-recursive and `followLinks: false`, so a symlink planted in the cache is reported as a `Link` and skipped rather than followed; and of what remains it deletes only plain files ending in `.img` or `.tmp`, neither of which is an audio extension. A source file is not reachable from it even in principle.

## Memory bounds

- Embedded pictures over **16 MiB** are dropped before any decode, so a malformed frame costs no decode, no re-encode and no disk write. Deliberately generous rather than tight: a genuine lossless cover scan runs into the low tens of MB, and showing a placeholder for a file that really does have art is the worse failure.
- Covers over **1024 px** on the long edge are downsampled before reaching disk (unchanged), and the downsample never materialises the full-size bitmap — dimensions come from `ImageDescriptor.encoded` (header only) and the decode is asked for the target size, so a 12000x12000 cover costs a 1024 px bitmap, not 576 MB of pixels.
- Peak is therefore one picture plus one 1024 px bitmap at a time. Scans are sequential, so a large library doesn't multiply it, and the sweep keeps the on-disk side from growing without bound.
- Extraction failure is never fatal: corrupt, oversized and undecodable pictures all yield no artwork, the track keeps its text tags, and the normal placeholder renders.

## Why Android is unaffected

Android's tags and covers come from the native SAF walk, which manages its own cache; `localMetadataReaderProvider` gives it `UnsupportedLocalMetadataReader`, so none of this code runs there.

The sweep is reached through a new `LocalArtworkMaintainer` interface — separate from `LocalMetadataReader` and reached by an `is` check at the one call site, the same shape as `StampedCatalogWriter` nearby. `UnsupportedLocalMetadataReader` deliberately isn't a `LocalArtworkMaintainer`, so the sweep is a no-op on Android with no platform conditional at the call site and nothing scattered through UI code. A test asserts that seam directly. F-Droid is unaffected for the same reason: no new dependency, no telemetry, no network lookup.

## Tests

`test/core/services/local_artwork_cache_test.dart` (24), `test/core/sources/local/filesystem_local_metadata_reader_test.dart` (35) and a new `test/features/library/local_artwork_cache_sweep_test.dart` (5) cover:

1. artwork present (MP3 `APIC`, FLAC `PICTURE`, picture-only files)
2. no artwork, and no text tags either
3. corrupt picture bytes, and a corrupt (0-byte) cache entry
4. oversized: over the pixel bound, and over the 16 MiB byte cap
5. cache reuse across a restart-equivalent reader, asserted by mtime so it proves extraction was skipped
6. regeneration after a deleted entry, after a corrupt entry, and after a re-tag end to end
7. source audio untouched by cleanup: byte-identical after the most aggressive sweep, and a symlink planted in the cache is not followed to it

Plus non-collision for two files sharing a size and mtime, the sweep's live set, the offline-folder retention case, and the Android seam.

`dart format`, `flutter analyze` (no issues) and the full `flutter test` suite (5328 tests) all pass locally on the pinned SDK.

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019M7EjiBVNryd4jDmeuRgAp

---
_Generated by [Claude Code](https://claude.ai/code/session_019M7EjiBVNryd4jDmeuRgAp)_