### PR TITLE
fix(flatpak): the audio and local-library smokes delete only what they made (#629)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,18 @@ jobs:
       - name: Test the Flatpak permission checker
         run: python3 test/tooling/check_flatpak_permissions_test.py
 
+      # A smoke borrows a contributor's machine: it may remove what it
+      # installed, and nothing else (#629). The audio and local-library smokes
+      # used to end with `uninstall --delete-data`, which deletes
+      # ~/.var/app/<app id>/ and the app's permission-store grants whether or
+      # not the run created them. These tests run the real harnesses against
+      # stub flatpak binaries in a throwaway HOME, so the rule is checked on
+      # every PR rather than only on a runner with flatpak-builder, where it
+      # never bites because the runner starts clean. Local twin:
+      # `python3 test/tooling/flatpak_smoke_cleanup_test.py`.
+      - name: Test what a Flatpak smoke may delete
+        run: python3 test/tooling/flatpak_smoke_cleanup_test.py
+
   release-bump-guard:
     name: Release bump touches only version files
     runs-on: ubuntu-latest

--- a/docs/flatpak-audio-smoke.md
+++ b/docs/flatpak-audio-smoke.md
@@ -159,8 +159,23 @@ bash ../scripts/flatpak_audio_smoke.sh repo-sandbox-smoke
 ```
 
 The harness refuses to run if Linthra is already installed, so it can never
-uninstall or test a build you care about. Everything it does install, it
-removes on exit, app data included.
+uninstall or test a build you care about.
+
+It also never runs `flatpak uninstall --delete-data`. That flag would take
+`~/.var/app/io.github.thezupzup.linthra/` with it (library database, settings,
+offline audio, credentials) and clear the app's entries in Flatpak's permission
+store, where the document-portal grants for the music folders you picked live.
+Neither of those is necessarily something the run created: an install you
+removed earlier *without* `--delete-data` leaves both behind, while
+`flatpak info` reports nothing installed at all.
+
+So what the harness cleans up is what it owns. On exit it removes the temporary
+remote, the install, and the app-data tree **only if that tree was not already
+there** when it started. If it was, the tree stays, and the one thing inside it
+this run made, the negative control's shadow directory under `cache/`, is
+removed by name instead. Your permission-store grants are never touched either
+way. A run does leave the packaged app's own settings and cache written into a
+tree you already had, the same as launching the app would.
 
 Every sandbox run is time-bounded (`LINTHRA_FLATPAK_SMOKE_TIMEOUT`, 300s by
 default), including the probe that checks the smoke binary is installed. The

--- a/docs/flatpak-ci.md
+++ b/docs/flatpak-ci.md
@@ -124,6 +124,30 @@ is already installed for the current user or system-wide, so a local smoke can
 never launch or remove a contributor's existing installation. Use a clean test
 user/environment for this final step when Linthra is already installed.
 
+### What a smoke may delete on your machine
+
+CI runners start clean, so none of this matters there. It matters locally, and
+the rule is the same for every smoke in `scripts/`: each removes what it
+created, and nothing else.
+
+None of them uses `flatpak uninstall --delete-data`. That flag deletes
+`~/.var/app/io.github.thezupzup.linthra/` (library database, settings, offline
+audio, credentials) and clears the app's Flatpak permission-store entries, the
+document-portal grants for the music folders you picked, and it reaches both
+whether or not the run put them there. An ordinary uninstall leaves a data tree
+behind, so "Linthra is not installed" says nothing about whether one exists.
+
+The three smokes that install the app themselves (`flatpak_audio_smoke.sh`,
+`flatpak_local_library_smoke.sh`, `flatpak_filesystem_smoke.sh`) therefore
+look for
+`~/.var/app/io.github.thezupzup.linthra/` *before* they install anything,
+uninstall plainly on the way out, and remove that directory only when it was
+not already there. `flatpak_launch_smoke.sh` never removes app data at all. So
+a data tree you already had, and your permission-store grants, are never
+removed by a smoke. For the commands that *do* delete that data, when you want
+it gone, see
+[flatpak-development.md § Clean and uninstall](./flatpak-development.md#clean-and-uninstall).
+
 ## The audio smoke job beside it
 
 The same workflow runs a second job, `Audio lifecycle smoke in the sandbox`,

--- a/docs/flatpak-development.md
+++ b/docs/flatpak-development.md
@@ -231,7 +231,7 @@ Ordered least to most destructive. Nothing here needs `sudo`.
 | `rm -rf flatpak/flatpak-builder-build flatpak/repo` | build tree + local repo | Safe; both are recreated by the next build. Delete the remote too, or it dangles |
 | `flatpak --user uninstall --unused` | runtimes nothing installed needs any more | Safe, but re-downloads them next time you build |
 | `rm -rf flatpak/.flatpak-builder` | downloaded sources + every cached module build | **Expensive.** The next build recompiles ffmpeg/libplacebo/libass/mpv and re-downloads the Flutter SDK |
-| `flatpak --user uninstall --delete-data io.github.thezupzup.linthra` | the app **and** `~/.var/app/io.github.thezupzup.linthra/` | **Destructive.** Wipes the Flatpak install's settings, library database and cache. Your native build's data under `~/.local/share`/`~/.config` is untouched |
+| `flatpak --user uninstall --delete-data io.github.thezupzup.linthra` | the app, `~/.var/app/io.github.thezupzup.linthra/` **and** the app's entries in Flatpak's permission store | **Destructive.** Wipes the Flatpak install's settings, library database and cache, and clears the document-portal grants for folders you picked through a file chooser. Your native build's data under `~/.local/share`/`~/.config` is untouched |
 | `rm -rf .tool/flatpak-flutter .tool/flatpak-flutter-venv` | the source-regeneration tool checkout | Safe; refetched by `regenerate_flatpak_sources.sh` |
 
 The audio/network testing in

--- a/docs/flatpak-local-library-smoke.md
+++ b/docs/flatpak-local-library-smoke.md
@@ -124,8 +124,16 @@ bash ../scripts/flatpak_local_library_smoke.sh repo-sandbox-smoke
 
 The harness refuses to run when Linthra is already installed, or when any user
 or system override already grants filesystem access, since an override would decide
-the isolation result before the test started. Everything it creates (the music
-folder, the probes, the installed app and its data) is removed on exit.
+the isolation result before the test started.
+
+What it removes on exit is what it created: the music folder, the host probes,
+the temporary remote, the install, and the app-data tree at
+`~/.var/app/io.github.thezupzup.linthra/` **only if that tree was not already
+there** when it started. It never runs `flatpak uninstall --delete-data`, so a
+tree an earlier install left behind (your library database, settings, offline
+audio and credentials) survives a run, and so do your Flatpak permission-store
+grants, the document-portal grants for the folders you picked included. Those
+grants matter here more than anywhere: they are the thing this smoke is about.
 
 Every mode is time-bounded (`LINTHRA_FLATPAK_SMOKE_TIMEOUT`, 300s by default)
 and hitting the bound fails the run. The Dart side bounds each step it waits

--- a/scripts/flatpak_audio_smoke.sh
+++ b/scripts/flatpak_audio_smoke.sh
@@ -61,16 +61,56 @@ if flatpak --user info "$APP_ID" >/dev/null 2>&1 ||
   fail "$APP_ID is already installed; remove it or run this smoke in a clean user environment"
 fi
 
+# That guard is about an *installation*. The data tree is a different question,
+# and it outlives an ordinary uninstall: somebody who removed an older Linthra
+# build without deleting its data still has ~/.var/app/<app id>/ with their
+# library database, settings, offline audio and credentials in it, while
+# `flatpak info` reports nothing installed at all. So the guard above cannot
+# speak for the tree, and whether this script may take the tree with it depends
+# entirely on whether the tree was here first. Asked before anything is
+# installed, because afterwards there is no way to tell.
+[[ -n "${HOME:-}" ]] || fail "HOME is not set"
+APP_DATA_DIR="$HOME/.var/app/$APP_ID"
+APP_DATA_EXISTED=0
+[[ -e "$APP_DATA_DIR" ]] && APP_DATA_EXISTED=1
+
+# The negative control writes its shadow libmpv into the sandbox's own cache
+# directory, which is $APP_DATA_DIR/cache on the host. That used to be cleaned
+# up as a side effect of deleting the whole tree; now that a pre-existing tree
+# stays, the one directory this run creates inside it is removed by name.
+SHADOW_DIR_NAME="linthra-audio-smoke-shadow-libmpv"
+SHADOW_HOST_DIR="$APP_DATA_DIR/cache/$SHADOW_DIR_NAME"
+SHADOW_CREATED=0
+
 LOG_FILE="$(mktemp)"
 
 cleanup() {
   rm -f -- "$LOG_FILE"
   flatpak kill "$APP_ID" >/dev/null 2>&1 || true
-  # --delete-data takes the sandbox's own XDG tree with it, including the
-  # negative control's shadow directory. Safe because this script refused to
-  # start against an installation it did not make.
-  flatpak --user uninstall -y --delete-data "$APP_ID" >/dev/null 2>&1 || true
+
+  # A plain uninstall, never `--delete-data`. docs/flatpak-development.md calls
+  # that flag Destructive because it is: it wipes ~/.var/app/<app id>/ with the
+  # library database, settings and offline audio in it, and it also drops the
+  # app's entries from Flatpak's permission store, which lives outside
+  # ~/.var/app and holds the document-portal grants for the music folders a
+  # user picked. A script that borrows the machine for a few minutes has no
+  # business reaching either of those.
+  flatpak --user uninstall -y "$APP_ID" >/dev/null 2>&1 || true
+
+  # So the cleanup is scoped to what this run actually created.
+  if (( ! APP_DATA_EXISTED )); then
+    # No tree before the install, so the install made this one: it goes, and
+    # with it the shadow directory that lives inside it.
+    [[ -d "$APP_DATA_DIR" ]] && rm -rf -- "$APP_DATA_DIR"
+  elif (( SHADOW_CREATED )); then
+    # The tree was here first, so it stays. The negative control's shadow
+    # directory is the one thing inside it this run put there, and it is
+    # removed on its own rather than by emptying somebody's library.
+    [[ -d "$SHADOW_HOST_DIR" ]] && rm -rf -- "$SHADOW_HOST_DIR"
+  fi
+
   flatpak --user remote-delete "$REMOTE_NAME" >/dev/null 2>&1 || true
+  return 0
 }
 trap cleanup EXIT
 
@@ -268,10 +308,24 @@ expect_failure() {
 # LD_LIBRARY_PATH points at it, so /app is untouched and the next run is
 # unaffected.
 printf 'Negative control: shadowing the packaged libmpv...\n'
+# From here on there is a directory inside the app's cache that this run made,
+# and cleanup has to account for it whether or not the control gets as far as
+# writing anything into it.
+SHADOW_CREATED=1
 expect_failure "a libmpv that carries none of mpv's symbols" 'libmpv' bounded \
   flatpak run --command=sh "$APP_ID" -c '
     set -eu
-    shadow="${XDG_CACHE_HOME:-$HOME/.cache}/linthra-audio-smoke-shadow-libmpv"
+    # $2 is the directory name the host-side cleanup removes, and the cache
+    # directory of the sandbox is where it has to land: Flatpak maps that to
+    # $APP_DATA_DIR/cache on the host, so the two halves meet. A shadow
+    # anywhere else would outlive a run that found the data tree already there
+    # and therefore left it alone. 3 is the "could not set this control up"
+    # exit, which fails the job rather than guessing at a path.
+    if [ -z "${XDG_CACHE_HOME:-}" ]; then
+      printf "XDG_CACHE_HOME is not set inside the sandbox\n" >&2
+      exit 3
+    fi
+    shadow="$XDG_CACHE_HOME/$2"
     rm -rf -- "$shadow"
     mkdir -p -- "$shadow"
 
@@ -302,7 +356,7 @@ expect_failure "a libmpv that carries none of mpv's symbols" 'libmpv' bounded \
     LINTHRA_AUDIO_SMOKE_REQUIRE_LIBMPV_PREFIX=/app/ \
     LD_LIBRARY_PATH="$shadow${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
       exec "$1"
-  ' sh "$SMOKE_COMMAND"
+  ' sh "$SMOKE_COMMAND" "$SHADOW_DIR_NAME"
 
 # 2. The identity check itself.
 #

--- a/scripts/flatpak_local_library_smoke.sh
+++ b/scripts/flatpak_local_library_smoke.sh
@@ -80,6 +80,18 @@ for scope in "--user" "--system"; do
 done
 
 [[ -n "${HOME:-}" ]] || fail "HOME is not set"
+
+# The installed check above is about an *installation*. The app's data tree is
+# a separate question, and it outlives an ordinary uninstall: somebody who
+# removed an older Linthra build without deleting its data still has
+# ~/.var/app/<app id>/ with their library database, settings, offline audio and
+# credentials in it, while `flatpak info` reports nothing installed. Whether
+# this script may take that tree with it depends entirely on whether the tree
+# was here first, which can only be asked before anything is installed.
+APP_DATA_DIR="$HOME/.var/app/$APP_ID"
+APP_DATA_EXISTED=0
+[[ -e "$APP_DATA_DIR" ]] && APP_DATA_EXISTED=1
+
 LOG_FILE="$(mktemp)"
 
 cleanup() {
@@ -87,7 +99,22 @@ cleanup() {
   [[ -n "$MUSIC_DIR" && -d "$MUSIC_DIR" ]] && rm -rf -- "$MUSIC_DIR"
   [[ -n "$SIBLING_DIR" && -d "$SIBLING_DIR" ]] && rm -rf -- "$SIBLING_DIR"
   flatpak kill "$APP_ID" >/dev/null 2>&1 || true
-  flatpak --user uninstall -y --delete-data "$APP_ID" >/dev/null 2>&1 || true
+
+  # A plain uninstall, never `--delete-data`. docs/flatpak-development.md calls
+  # that flag Destructive because it is: it wipes ~/.var/app/<app id>/ with the
+  # library database, settings and offline audio in it, and it also drops the
+  # app's entries from Flatpak's permission store, which lives outside
+  # ~/.var/app and holds the document-portal grants for the music folders a
+  # user picked. This smoke is about proving those grants work. Clearing them
+  # on the way out would be a poor way to say so.
+  flatpak --user uninstall -y "$APP_ID" >/dev/null 2>&1 || true
+
+  # And only ever the app data this run created. A tree that was here first
+  # belongs to the contributor, not to the test that borrowed their machine.
+  if (( ! APP_DATA_EXISTED )) && [[ -d "$APP_DATA_DIR" ]]; then
+    rm -rf -- "$APP_DATA_DIR"
+  fi
+
   flatpak --user remote-delete "$REMOTE_NAME" >/dev/null 2>&1 || true
   return 0
 }

--- a/test/tooling/flatpak_audio_smoke_test.dart
+++ b/test/tooling/flatpak_audio_smoke_test.dart
@@ -11,11 +11,22 @@ import 'package:flutter_test/flutter_test.dart';
 /// dropped in a PR that never triggers the heavy build.
 void main() {
   late String harness;
+
+  /// The harness with its comments stripped.
+  ///
+  /// It explains at length which flag it deliberately does *not* use, so a
+  /// check for `--delete-data` has to read the commands rather than the prose
+  /// about them.
+  late String harnessCommands;
   late String lifecycle;
   late String workflow;
 
   setUpAll(() {
     harness = File('scripts/flatpak_audio_smoke.sh').readAsStringSync();
+    harnessCommands = harness
+        .split('\n')
+        .where((String line) => !line.trimLeft().startsWith('#'))
+        .join('\n');
     lifecycle = File('tool/linux_audio_backend_smoke.dart').readAsStringSync();
     workflow = File('.github/workflows/flatpak-build.yml').readAsStringSync();
   });
@@ -102,7 +113,59 @@ void main() {
       expect(harness, contains(r'flatpak --system info "$APP_ID"'));
       expect(harness, contains(r'$APP_ID is already installed'));
       expect(harness, contains('trap cleanup EXIT'));
-      expect(harness, contains('--delete-data'));
+      expect(harness, contains(r'flatpak --user uninstall -y "$APP_ID"'));
+    });
+
+    // An installed build and an app-data tree are two different questions
+    // (#629). The refusal above answers the first. `uninstall --delete-data`
+    // reached past it: an ordinary uninstall leaves ~/.var/app/<app id>/ in
+    // place, so a contributor who removed an older build still has their
+    // library database, settings, offline audio and credentials there while
+    // nothing is installed, and the flag also drops the app's Flatpak
+    // permission-store entries, where the document-portal grants for their
+    // music folders live.
+    test('deletes app data only when this run created it', () {
+      expect(
+        harnessCommands,
+        isNot(contains('--delete-data')),
+        reason: 'a guard about the data tree cannot authorise an action that '
+            'also clears the permission store',
+      );
+      expect(harness, contains(r'APP_DATA_DIR="$HOME/.var/app/$APP_ID"'));
+      expect(
+        harness,
+        contains(r'[[ -e "$APP_DATA_DIR" ]] && APP_DATA_EXISTED=1'),
+      );
+      expect(harness, contains('(( ! APP_DATA_EXISTED ))'));
+      expect(harness, contains(r'rm -rf -- "$APP_DATA_DIR"'));
+      // Asked before installing, because after the install the answer is
+      // always yes.
+      expect(
+        harness.indexOf('APP_DATA_EXISTED=1'),
+        lessThan(harness.indexOf('flatpak --user install')),
+      );
+    });
+
+    // The shadow library used to be cleaned up as a side effect of deleting
+    // the whole tree. When the tree is somebody else's and stays, the one
+    // directory this run put inside it has to go by name.
+    test('removes the shadow directory even when the data tree stays', () {
+      expect(
+        harness,
+        contains(r'SHADOW_HOST_DIR="$APP_DATA_DIR/cache/$SHADOW_DIR_NAME"'),
+      );
+      // One name, passed into the sandbox rather than written twice.
+      expect(harness, contains(r'sh "$SMOKE_COMMAND" "$SHADOW_DIR_NAME"'));
+      // The sandbox's own cache directory, which Flatpak maps to the `cache/`
+      // subdirectory of the host tree the cleanup reads.
+      expect(harness, contains(r'shadow="$XDG_CACHE_HOME/$2"'));
+      expect(harness, contains(r'rm -rf -- "$SHADOW_HOST_DIR"'));
+      // Marked before the control runs: a control that died halfway still
+      // left a directory behind.
+      expect(
+        harness.indexOf('SHADOW_CREATED=1'),
+        lessThan(harness.indexOf('expect_failure "a libmpv that carries')),
+      );
     });
 
     test('requires the packaged libmpv', () {

--- a/test/tooling/flatpak_local_library_smoke_test.dart
+++ b/test/tooling/flatpak_local_library_smoke_test.dart
@@ -170,11 +170,41 @@ void main() {
       expect(harness, contains(r'fail "checking for $SMOKE_COMMAND hung'));
     });
 
-    test('the harness leaves nothing behind', () {
+    test('the harness leaves nothing of its own behind', () {
       expect(harness, contains('trap cleanup EXIT'));
       expect(harness, contains(r'rm -rf -- "$MUSIC_DIR"'));
       expect(harness, contains(r'rm -rf -- "$SIBLING_DIR"'));
-      expect(harness, contains('--delete-data'));
+      expect(harness, contains(r'flatpak --user uninstall -y "$APP_ID"'));
+      expect(harness, contains(r'rm -rf -- "$APP_DATA_DIR"'));
+    });
+
+    // ...and nothing of anyone else's (#629). Refusing to run against an
+    // installed Linthra said nothing about the app-data tree, which survives an
+    // ordinary uninstall: a contributor who removed an older build still has
+    // their library database, settings, offline audio and credentials in
+    // ~/.var/app/<app id>/ with nothing installed. `--delete-data` took that,
+    // and the app's Flatpak permission-store entries with it, which in this
+    // smoke's case means the document-portal grants for the music folders it
+    // exists to prove work.
+    test('deletes app data only when this run created it', () {
+      expect(
+        harnessCommands,
+        isNot(contains('--delete-data')),
+        reason: 'a guard about the data tree cannot authorise an action that '
+            'also clears the permission store',
+      );
+      expect(harness, contains(r'APP_DATA_DIR="$HOME/.var/app/$APP_ID"'));
+      expect(
+        harness,
+        contains(r'[[ -e "$APP_DATA_DIR" ]] && APP_DATA_EXISTED=1'),
+      );
+      expect(harness, contains('(( ! APP_DATA_EXISTED ))'));
+      // Asked before installing, because after the install the answer is
+      // always yes.
+      expect(
+        harness.indexOf('APP_DATA_EXISTED=1'),
+        lessThan(harness.indexOf('flatpak --user install')),
+      );
     });
 
     test('CI runs it against the packaged app', () {

--- a/test/tooling/flatpak_smoke_cleanup_test.py
+++ b/test/tooling/flatpak_smoke_cleanup_test.py
@@ -1,0 +1,559 @@
+#!/usr/bin/env python3
+"""The Flatpak smokes clean up what they created, and nothing else (#629).
+
+    python3 test/tooling/flatpak_smoke_cleanup_test.py
+
+A smoke borrows a contributor's machine for a few minutes. What it installed it
+may remove; what it found there it may not. The audio and local-library smokes
+used to end with `flatpak uninstall -y --delete-data`, which deletes
+`~/.var/app/io.github.thezupzup.linthra/` (library database, settings, offline
+audio, credentials) and drops the app's entries from Flatpak's permission store,
+where the document-portal grants for a user's music folders live.
+
+Both scripts refuse to start when Linthra is already installed, and that was
+read as permission for the flag. It is not: an ordinary uninstall removes the
+installation and leaves the data tree and the grants behind, so a contributor
+who removed an older build has both while `flatpak info` reports nothing
+installed. The guard was about the installation; the flag reached past it.
+
+Two kinds of test here:
+
+  * text rules over the smoke scripts, so the flag cannot come back and the
+    "was this tree here first" question cannot drift to after the install;
+  * the real scripts run end to end against stub `flatpak`, `xvfb-run` and
+    `dbus-run-session` binaries in a throwaway HOME, which is how "a
+    pre-existing tree survives" gets proven rather than asserted. The stub
+    honours `--delete-data` the way flatpak does, so a script that reaches for
+    it again fails these tests rather than passing them quietly, and it maps
+    the sandbox's XDG directories the way Flatpak does (`XDG_CACHE_HOME` is
+    `~/.var/app/<app id>/cache`), which is what makes the in-sandbox negative
+    control and the host-side cleanup of its shadow directory meet.
+
+Nothing here needs flatpak, a built package, a display or the network.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[2]
+APP_ID = "io.github.thezupzup.linthra"
+
+# The smokes that remove app data, and so have to know whose it is.
+# flatpak_launch_smoke.sh installs the package too but removes no app data, and
+# flatpak_offline_build_smoke.sh installs nothing at all.
+SMOKES_THAT_REMOVE_APP_DATA = (
+    "flatpak_audio_smoke.sh",
+    "flatpak_local_library_smoke.sh",
+    "flatpak_filesystem_smoke.sh",
+)
+
+DOC_CLAIMS = {
+    "flatpak-audio-smoke.md": (
+        "never runs `flatpak uninstall --delete-data`",
+        "only if that tree was not already there",
+        "permission-store grants are never touched",
+    ),
+    "flatpak-local-library-smoke.md": (
+        "never runs `flatpak uninstall --delete-data`",
+        "only if that tree was not already there",
+        "Flatpak permission-store grants",
+    ),
+    "flatpak-ci.md": (
+        "None of them uses `flatpak uninstall --delete-data`",
+        "removes what it created, and nothing else",
+        "only when it was not already there",
+    ),
+}
+
+# Claims the docs used to make, which were wrong in exactly the way #629
+# describes. Named here so a revert of the prose is as loud as a revert of the
+# code.
+RETIRED_DOC_CLAIMS = {
+    "flatpak-audio-smoke.md": "removes on exit, app data included",
+    "flatpak-local-library-smoke.md": (
+        "the installed app and its data) is removed on exit"
+    ),
+}
+
+
+def script_text(name: str) -> str:
+    return (ROOT / "scripts" / name).read_text(encoding="utf-8")
+
+
+def squashed(path: Path) -> str:
+    """One-line form of a document, so a wrapped sentence still matches."""
+    return " ".join(path.read_text(encoding="utf-8").split())
+
+
+def commands_only(text: str) -> str:
+    """`text` without its whole-line comments.
+
+    The scripts explain at length which flag they deliberately do not use, so a
+    search for the flag has to read what they run rather than the prose about
+    it.
+    """
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+class DestructiveDeletionIsGone(unittest.TestCase):
+    def test_nothing_under_scripts_or_workflows_passes_delete_data(self) -> None:
+        offenders = []
+        searched = 0
+        for directory in (ROOT / "scripts", ROOT / ".github" / "workflows"):
+            for path in sorted(directory.rglob("*")):
+                if not path.is_file():
+                    continue
+                try:
+                    text = path.read_text(encoding="utf-8")
+                except (UnicodeDecodeError, OSError):
+                    continue
+                searched += 1
+                if "--delete-data" in commands_only(text):
+                    offenders.append(str(path.relative_to(ROOT)))
+        self.assertGreater(searched, 0, msg="nothing was searched")
+        self.assertEqual(
+            offenders,
+            [],
+            msg=(
+                "`flatpak uninstall --delete-data` deletes ~/.var/app/<app id>/ "
+                "and the app's Flatpak permission-store grants whether or not "
+                "the run created them (#629). Remove the tree directly, and "
+                "only when the run made it."
+            ),
+        )
+
+
+class CleanupOwnership(unittest.TestCase):
+    """The guard and the deletion have to be about the same thing."""
+
+    def test_the_data_tree_is_checked_before_anything_is_installed(self) -> None:
+        for name in SMOKES_THAT_REMOVE_APP_DATA:
+            with self.subTest(script=name):
+                text = script_text(name)
+                self.assertIn('APP_DATA_DIR="$HOME/.var/app/$APP_ID"', text)
+                self.assertIn('[[ -e "$APP_DATA_DIR" ]] && APP_DATA_EXISTED=1', text)
+                self.assertLess(
+                    text.index("APP_DATA_EXISTED=1"),
+                    text.index("flatpak --user install"),
+                    msg=(
+                        "after the install there is no way to tell whose tree "
+                        "it is, so the question has to be asked before it"
+                    ),
+                )
+
+    def test_the_uninstall_is_plain_and_the_tree_is_still_cleaned_in_ci(
+        self,
+    ) -> None:
+        for name in SMOKES_THAT_REMOVE_APP_DATA:
+            with self.subTest(script=name):
+                text = script_text(name)
+                self.assertIn('flatpak --user uninstall -y "$APP_ID"', text)
+                self.assertIn('rm -rf -- "$APP_DATA_DIR"', text)
+
+    def test_every_removal_of_the_tree_sits_behind_the_ownership_guard(
+        self,
+    ) -> None:
+        for name in SMOKES_THAT_REMOVE_APP_DATA:
+            with self.subTest(script=name):
+                lines = script_text(name).splitlines()
+                removals = [
+                    index
+                    for index, line in enumerate(lines)
+                    if 'rm -rf -- "$APP_DATA_DIR"' in line
+                ]
+                self.assertTrue(removals, msg="the tree is never removed at all")
+                for index in removals:
+                    guard = self._enclosing_condition(lines, index)
+                    self.assertIsNotNone(
+                        guard, msg="line {} removes the tree unguarded".format(index + 1)
+                    )
+                    self.assertIn("! APP_DATA_EXISTED", guard)
+
+    @staticmethod
+    def _enclosing_condition(lines: list[str], index: int) -> str | None:
+        """The `if`/`elif` line the statement at `index` is governed by."""
+        for line in reversed(lines[: index + 1]):
+            if re.match(r"\s*(if|elif)\b", line):
+                return line
+        return None
+
+
+class TheAudioShadowDirectory(unittest.TestCase):
+    """The negative control's own leftovers, now that the tree may stay."""
+
+    def setUp(self) -> None:
+        self.text = script_text("flatpak_audio_smoke.sh")
+
+    def test_the_control_and_the_cleanup_agree_on_one_name(self) -> None:
+        self.assertIn(
+            'SHADOW_DIR_NAME="linthra-audio-smoke-shadow-libmpv"', self.text
+        )
+        self.assertIn(
+            'SHADOW_HOST_DIR="$APP_DATA_DIR/cache/$SHADOW_DIR_NAME"', self.text
+        )
+        # The in-sandbox control is told the name rather than repeating it,
+        # and writes it where Flatpak maps $APP_DATA_DIR/cache.
+        self.assertIn('shadow="$XDG_CACHE_HOME/$2"', self.text)
+        self.assertIn('sh "$SMOKE_COMMAND" "$SHADOW_DIR_NAME"', self.text)
+
+    def test_it_is_removed_on_its_own_when_the_tree_stays(self) -> None:
+        self.assertIn('rm -rf -- "$SHADOW_HOST_DIR"', self.text)
+        # Marked before the control runs: a control that died halfway still
+        # left a directory behind.
+        self.assertLess(
+            self.text.index("SHADOW_CREATED=1"),
+            self.text.index('expect_failure "a libmpv that carries'),
+        )
+
+    def test_the_control_itself_is_unchanged(self) -> None:
+        # The cleanup rewrite must not have softened what the control proves.
+        self.assertIn("for soname in libmpv.so libmpv.so.2 libmpv.so.1", self.text)
+        self.assertIn('cp -L "$donor" "$shadow/$soname"', self.text)
+        self.assertIn('LD_LIBRARY_PATH="$shadow', self.text)
+
+
+class DocumentedLocalBehaviour(unittest.TestCase):
+    """The docs that tell contributors to run these locally."""
+
+    def test_each_one_says_what_a_run_may_delete(self) -> None:
+        for name, claims in DOC_CLAIMS.items():
+            with self.subTest(doc=name):
+                text = squashed(ROOT / "docs" / name)
+                self.assertIn("~/.var/app/io.github.thezupzup.linthra/", text)
+                for claim in claims:
+                    self.assertIn(claim, text)
+
+    def test_the_old_promise_to_delete_app_data_is_gone(self) -> None:
+        for name, claim in RETIRED_DOC_CLAIMS.items():
+            with self.subTest(doc=name):
+                self.assertNotIn(claim, squashed(ROOT / "docs" / name))
+
+    def test_the_uninstall_table_names_the_permission_store(self) -> None:
+        # The flag's second reach is the one a data-directory check cannot
+        # cover, so the table that documents it has to say so.
+        text = squashed(ROOT / "docs" / "flatpak-development.md")
+        self.assertIn("entries in Flatpak's permission store", text)
+        self.assertIn("document-portal grants", text)
+
+
+FLATPAK_STUB = '''#!/usr/bin/env python3
+"""A `flatpak` just real enough to exercise a smoke harness's cleanup path."""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+APP_DIR = os.environ["LINTHRA_STUB_APP_DIR"]
+PERMISSION_STORE = os.environ["LINTHRA_STUB_PERMISSION_STORE"]
+SCENARIO = os.environ["LINTHRA_STUB_SCENARIO"]
+LOG = os.environ["LINTHRA_STUB_LOG"]
+INSTALLED_MARKER = os.path.join(APP_DIR, ".stub-installed")
+
+args = sys.argv[1:]
+
+
+def record(event):
+    with open(LOG, "a", encoding="utf-8") as handle:
+        print(json.dumps(event), file=handle)
+
+
+record({"argv": args})
+positional = [a for a in args if not a.startswith("-")]
+command = positional[0] if positional else ""
+
+if command == "info":
+    sys.exit(0 if os.path.exists(INSTALLED_MARKER) else 1)
+
+if command == "install":
+    # Real flatpak creates the app's private tree when it installs the app.
+    for name in ("cache", "config", "data"):
+        os.makedirs(os.path.join(APP_DIR, name), exist_ok=True)
+    open(INSTALLED_MARKER, "w").close()
+    sys.exit(0)
+
+if command == "uninstall":
+    if os.path.exists(INSTALLED_MARKER):
+        os.remove(INSTALLED_MARKER)
+    # A plain uninstall leaves ~/.var/app and the permission store alone.
+    # --delete-data is what #629 is about, so the stub performs it: a script
+    # that reaches for the flag again fails the tests instead of passing them.
+    if "--delete-data" in args:
+        shutil.rmtree(APP_DIR, ignore_errors=True)
+        if os.path.exists(PERMISSION_STORE):
+            os.remove(PERMISSION_STORE)
+    sys.exit(0)
+
+if command != "run":
+    # kill, remote-add, remote-delete, override --show, and anything else a
+    # harness asks for on the way past.
+    sys.exit(0)
+
+script = None
+rest = []
+if "-c" in args:
+    index = args.index("-c")
+    script = args[index + 1]
+    rest = args[index + 2 :]
+
+if script is not None and '[ -x "$1" ]' in script:
+    sys.exit(0)
+
+if script is not None and "shadow=" in script:
+    # The negative control. Run it for real, with the sandbox's XDG paths
+    # mapped the way Flatpak maps them, so the directory it writes lands where
+    # the harness's cleanup looks for it.
+    shadow_name = rest[2] if len(rest) > 2 else ""
+    env = dict(os.environ)
+    env["HOME"] = APP_DIR
+    env["XDG_CACHE_HOME"] = os.path.join(APP_DIR, "cache")
+    env["XDG_CONFIG_HOME"] = os.path.join(APP_DIR, "config")
+    env["XDG_DATA_HOME"] = os.path.join(APP_DIR, "data")
+    status = subprocess.run(["sh", "-c", script, *rest], env=env).returncode
+    record(
+        {
+            "shadow_dir_after_control": os.path.isdir(
+                os.path.join(APP_DIR, "cache", shadow_name)
+            )
+        }
+    )
+    if status == 3:
+        # "I could not set this control up" travels back unchanged.
+        sys.exit(3)
+    print("error: the library opened as libmpv exports none of mpv's symbols")
+    sys.exit(1)
+
+if SCENARIO == "audio":
+    if "--env=LINTHRA_AUDIO_SMOKE_REQUIRE_LIBMPV_PREFIX=/app/" in args:
+        print("libmpv in use: /app/lib/libmpv.so.2")
+        print("PASS: Linux native audio lifecycle smoke passed.")
+        sys.exit(0)
+    print("error: libmpv in use: /usr/lib/libmpv.so.2, outside the required prefix")
+    sys.exit(1)
+
+mode = ""
+for arg in args:
+    if arg.startswith("--env=LINTHRA_LOCAL_LIBRARY_SMOKE_MODE="):
+        mode = arg.split("=", 2)[2]
+print("PASS: local-library smoke ({}) passed.".format(mode))
+sys.exit(0)
+'''
+
+XVFB_RUN_STUB = '''#!/usr/bin/env python3
+"""`xvfb-run` without an X server: run the command, drop the display flags."""
+
+import os
+import sys
+
+args = [
+    a
+    for a in sys.argv[1:]
+    if not a.startswith("--auto-servernum") and not a.startswith("--server-args")
+]
+os.execvp(args[0], args)
+'''
+
+DBUS_RUN_SESSION_STUB = '''#!/usr/bin/env python3
+"""`dbus-run-session` without a bus: run the command after the `--`."""
+
+import os
+import sys
+
+args = sys.argv[1:]
+if args and args[0] == "--":
+    args = args[1:]
+os.execvp(args[0], args)
+'''
+
+
+class RunAgainstStubs(unittest.TestCase):
+    """The scripts themselves, run end to end in a throwaway HOME."""
+
+    maxDiff = None
+
+    def _run(self, script: str, scenario: str, *, preexisting: bool) -> SimpleNamespace:
+        tmp = Path(tempfile.mkdtemp(prefix="linthra-smoke-cleanup-"))
+        self.addCleanup(shutil.rmtree, tmp, True)
+
+        home = tmp / "home"
+        bin_dir = tmp / "bin"
+        repo = tmp / "repo"
+        for path in (home, bin_dir, repo):
+            path.mkdir(parents=True)
+        (repo / "config").write_text("[core]\n", encoding="utf-8")
+
+        app_dir = home / ".var" / "app" / APP_ID
+        # Flatpak's permission store lives outside ~/.var/app entirely, which is
+        # the whole reason a check on the data tree cannot authorise
+        # --delete-data.
+        store = home / ".local" / "share" / "flatpak" / "db" / "documents"
+        store.parent.mkdir(parents=True)
+        store.write_bytes(b"a document-portal grant for a music folder\n")
+
+        library = app_dir / "data" / "linthra" / "library.sqlite"
+        settings = app_dir / "config" / "settings.json"
+        if preexisting:
+            library.parent.mkdir(parents=True)
+            library.write_text("a contributor's library\n", encoding="utf-8")
+            settings.parent.mkdir(parents=True)
+            settings.write_text('{"volume": 0.4}\n', encoding="utf-8")
+
+        log = tmp / "flatpak-calls.jsonl"
+        for name, source in (
+            ("flatpak", FLATPAK_STUB),
+            ("xvfb-run", XVFB_RUN_STUB),
+            ("dbus-run-session", DBUS_RUN_SESSION_STUB),
+        ):
+            stub = bin_dir / name
+            stub.write_text(source, encoding="utf-8")
+            stub.chmod(0o755)
+
+        env = {
+            "PATH": "{}:{}".format(bin_dir, os.environ.get("PATH", "")),
+            "HOME": str(home),
+            "TMPDIR": str(tmp),
+            "USER": "smoke-user",
+            "LINTHRA_FLATPAK_SMOKE_TIMEOUT": "120",
+            "LINTHRA_STUB_APP_DIR": str(app_dir),
+            "LINTHRA_STUB_PERMISSION_STORE": str(store),
+            "LINTHRA_STUB_SCENARIO": scenario,
+            "LINTHRA_STUB_LOG": str(log),
+        }
+        process = subprocess.run(
+            ["bash", str(ROOT / "scripts" / script), str(repo)],
+            cwd=str(ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=600,
+            check=False,
+        )
+        calls = []
+        if log.exists():
+            calls = [json.loads(line) for line in log.read_text().splitlines() if line]
+        return SimpleNamespace(
+            process=process,
+            output=process.stdout + process.stderr,
+            calls=calls,
+            home=home,
+            app_dir=app_dir,
+            store=store,
+            library=library,
+            settings=settings,
+            shadow=app_dir / "cache" / "linthra-audio-smoke-shadow-libmpv",
+        )
+
+    def assertRanToCompletion(self, run: SimpleNamespace, banner: str) -> None:
+        self.assertEqual(run.process.returncode, 0, msg=run.output)
+        self.assertIn(banner, run.output)
+
+    def assertPreexistingDataSurvived(self, run: SimpleNamespace) -> None:
+        for path, expected in (
+            (run.library, "a contributor's library\n"),
+            (run.settings, '{"volume": 0.4}\n'),
+        ):
+            self.assertTrue(
+                path.exists(),
+                msg="the smoke deleted {}, which was here before it ran".format(
+                    path.name
+                ),
+            )
+            self.assertEqual(path.read_text(), expected)
+
+    def assertCleanupWasNotDestructive(self, run: SimpleNamespace) -> None:
+        uninstalls = [c["argv"] for c in run.calls if "uninstall" in c.get("argv", [])]
+        self.assertTrue(uninstalls, msg="the run never uninstalled anything")
+        for argv in uninstalls:
+            self.assertNotIn("--delete-data", argv)
+        self.assertTrue(
+            run.store.exists(),
+            msg="a permission-store grant was removed by a smoke run",
+        )
+
+    # --- the audio smoke ---------------------------------------------------
+
+    def test_audio_smoke_removes_the_tree_its_own_install_created(self) -> None:
+        run = self._run("flatpak_audio_smoke.sh", "audio", preexisting=False)
+        self.assertRanToCompletion(run, "PASS: Flatpak audio playback smoke complete.")
+        self.assertShadowWasWritten(run)
+        self.assertFalse(
+            run.app_dir.exists(),
+            msg="a tree this run created was left on the machine",
+        )
+        self.assertCleanupWasNotDestructive(run)
+
+    def test_audio_smoke_keeps_a_tree_it_found(self) -> None:
+        run = self._run("flatpak_audio_smoke.sh", "audio", preexisting=True)
+        self.assertRanToCompletion(run, "PASS: Flatpak audio playback smoke complete.")
+        self.assertPreexistingDataSurvived(run)
+        self.assertCleanupWasNotDestructive(run)
+        # The tree stays, so the negative control's shadow directory inside it
+        # has to be removed on its own.
+        self.assertShadowWasWritten(run)
+        self.assertFalse(
+            run.shadow.exists(),
+            msg="the negative control's shadow directory outlived the run",
+        )
+
+    def assertShadowWasWritten(self, run: SimpleNamespace) -> None:
+        self.assertTrue(
+            any(call.get("shadow_dir_after_control") for call in run.calls),
+            msg=(
+                "the negative control never created its shadow directory, so "
+                "this test proves nothing about cleaning it up"
+            ),
+        )
+
+    # --- the local-library smoke ------------------------------------------
+
+    def test_local_library_smoke_removes_the_tree_its_own_install_created(
+        self,
+    ) -> None:
+        run = self._run(
+            "flatpak_local_library_smoke.sh", "local-library", preexisting=False
+        )
+        self.assertRanToCompletion(
+            run, "PASS: Flatpak local-library sandbox smoke complete."
+        )
+        self.assertFalse(
+            run.app_dir.exists(),
+            msg="a tree this run created was left on the machine",
+        )
+        self.assertCleanupWasNotDestructive(run)
+        self.assertFixtureFoldersAreGone(run)
+
+    def test_local_library_smoke_keeps_a_tree_it_found(self) -> None:
+        run = self._run(
+            "flatpak_local_library_smoke.sh", "local-library", preexisting=True
+        )
+        self.assertRanToCompletion(
+            run, "PASS: Flatpak local-library sandbox smoke complete."
+        )
+        self.assertPreexistingDataSurvived(run)
+        self.assertCleanupWasNotDestructive(run)
+        self.assertFixtureFoldersAreGone(run)
+
+    def assertFixtureFoldersAreGone(self, run: SimpleNamespace) -> None:
+        leftovers = sorted(
+            str(path.name)
+            for path in run.home.iterdir()
+            if path.name.startswith(".linthra-local-library-sentinel")
+            or path.name.startswith("linthra-local-library-")
+        )
+        self.assertEqual(leftovers, [], msg="the fixture library was left behind")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #629

## The failure mode

Both harnesses ended their cleanup with:

```bash
flatpak --user uninstall -y --delete-data "$APP_ID"
```

Run either one on a machine that has `~/.var/app/io.github.thezupzup.linthra/`, and the tree goes: library database, settings, offline audio, credentials. CI never noticed because runners start clean. Locally it only takes one contributor reproducing a packaging failure.

## Why "is Linthra installed?" was not enough

Both scripts refuse to start against an installed Linthra, and the audio smoke's comment leaned on that ("Safe because this script refused to start against an installation it did not make"). Two holes:

1. **The data tree outlives an ordinary uninstall.** Somebody who removed an older build without `--delete-data` still has the whole tree, and `flatpak info` reports nothing installed, so the guard passes and the cleanup wipes it.
2. **`--delete-data` reaches past the tree.** It also drops the app's entries from Flatpak's permission store, which lives outside `~/.var/app` and holds the document-portal grants for the music folders a user picked. A check on the data directory could not have authorised that even if it had existed. Those grants are what the local-library smoke exists to prove work.

So the guard was about the installation, and the action reached into data and grants the run never created.

## The cleanup ownership model

Same shape `scripts/flatpak_filesystem_smoke.sh` has had since #615:

- before installing anything, record whether `$HOME/.var/app/$APP_ID` exists (`APP_DATA_EXISTED`). It has to be asked first, because after the install the answer is always yes;
- on exit, always `flatpak --user uninstall -y "$APP_ID"`, never `--delete-data`;
- `rm -rf` the tree directly, and only when this run created it;
- the permission store is never touched by either script.

The audio smoke needed one more thing, as the issue called out. Its negative control writes a shadow libmpv into the sandbox's cache, which the old flag cleaned up as a side effect of deleting the whole tree. The directory name is now a single constant (`SHADOW_DIR_NAME`), passed into the sandbox and read by the host cleanup as `$APP_DATA_DIR/cache/$SHADOW_DIR_NAME`, so a run that leaves a pre-existing tree alone still removes that directory by name. The control now requires `XDG_CACHE_HOME` instead of falling back to `$HOME/.cache`, so the path the sandbox writes and the path the host cleans are provably the same one; a sandbox without it exits 3, which is the existing "could not set this control up" failure.

Nothing about what the controls prove changed: all three sonames are still shadowed with a library that loads, the shadow control is still `bounded`, the identity control is still `named`, and an exit-0 control still fails the job.

## What stops it coming back

New: `test/tooling/flatpak_smoke_cleanup_test.py`, wired into `ci.yml` (cheap, offline, so it runs on every PR rather than only in the 90-minute Flatpak job where this never bites).

It runs **both real harnesses end to end** against stub `flatpak`, `xvfb-run` and `dbus-run-session` binaries in a throwaway `HOME`, so these are behavioural, not textual:

- a tree the run created is gone afterwards (CI behaviour is unchanged);
- a tree that was there first survives, with its library file intact, and so does a stand-in permission-store entry under `~/.local/share/flatpak/db/`;
- the negative control's shadow directory is created inside that tree and then removed on its own;
- the fixture music folder, sibling folder and sentinel are cleaned up;
- every `uninstall` the run issued carried no `--delete-data`.

The stub honours `--delete-data` the way flatpak does (tree plus permission store), so putting the flag back fails these tests rather than passing them quietly. I checked that by reintroducing it and by no-oping the shadow removal: four tests fail on the first, one on the second.

Alongside them, text rules:

- nothing under `scripts/` or `.github/workflows/` passes `--delete-data` (comments about the flag are excluded, commands are not);
- for each smoke that removes app data, every `rm -rf -- "$APP_DATA_DIR"` sits inside an `if`/`elif` carrying `! APP_DATA_EXISTED`;
- the guard is read before the first `flatpak --user install`;
- the docs that tell contributors to run these locally still describe what a run may delete.

`flatpak_audio_smoke_test.dart` and `flatpak_local_library_smoke_test.dart` both asserted `--delete-data` was present. They now assert the opposite, plus the new cleanup shape and the shadow-directory handling.

## Docs

- `flatpak-audio-smoke.md` and `flatpak-local-library-smoke.md` both promised a run removes app data unconditionally. They now say what it actually removes, and that a pre-existing tree and your portal grants are left alone.
- `flatpak-ci.md` said nothing about it, and it is the page that tells people to run the smokes locally. It gets a short "What a smoke may delete on your machine" section.
- `flatpak-development.md`'s uninstall table now names the permission store on the `--delete-data` row, which was the half of the flag it did not mention.

## Checks

`flutter test` (5309 tests, all passing), `flutter analyze`, `dart format --set-exit-if-changed`, `ruff check`/`ruff format --check`, `python3 test/tooling/flatpak_smoke_cleanup_test.py`, `scripts/check_flatpak_permissions.py`, `scripts/check_linux_runner.py`, `scripts/check_secrets.sh`. `shellcheck` on both scripts reports only the pre-existing SC2016 infos that `main` already has (the in-sandbox scripts are deliberately single-quoted).

CI on this head is green, including `Sandbox smokes on the packaged app`, which runs both changed harnesses against a real built package.

## One thing I left alone

`docs/linux-desktop.md` says "Uninstalling removes the application and its sandboxed data" two lines above explaining that `--delete-data` removes the data. That is the same misunderstanding in user-facing docs, but it is not smoke tooling, so it is out of this PR's scope. Happy to fix it in a one-line follow-up if you want.