### PR TITLE
feat(desktop): keep the queue beside the page on wide windows (#416)

### DIFF
--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -558,7 +558,7 @@ loaded:
 | Chromecast | Android/iOS only | Already gated in `cast_providers.dart`; Linux keeps the honest "cast unavailable" service. |
 | Share sheet, launcher-icon switching | Android-only, by design | No desktop equivalent; the UI simply omits them. |
 | Volume control | Supported | A mute and a slider on Now Playing and the wide mini-player bar, plus MPRIS `Volume`, driven through `PlaybackController` and remembered across launches ([issue #394](https://github.com/TheZupZup/Linthra/issues/394)). See [Volume](#volume). |
-| Desktop layout | Supported | The shell swaps its bottom bar for a navigation rail at 900 px, and feature screens adapt on the width they are given — including a third pane for the Library grids and for Now Playing's queue. See [How the desktop layout adapts](#how-the-desktop-layout-adapts). |
+| Desktop layout | Supported | The shell swaps its bottom bar for a navigation rail at 900 px, and feature screens adapt on the width they are given, including a third pane for the Library grids and for Now Playing's queue. On a wide enough window the shell can also keep the queue as a column beside the page ([issue #416](https://github.com/TheZupZup/Linthra/issues/416)). See [How the desktop layout adapts](#how-the-desktop-layout-adapts). |
 | Window geometry | Supported | Size and maximized state survive a restart; position too, on X11. A saved position is re-checked against the monitors attached now. See [Window state](#window-state). |
 | Content density | Supported | Compact by default, switchable to Comfortable in Settings → Appearance and remembered across restarts ([issue #395](https://github.com/thezupzup/linthra/issues/395)). Both are Material `VisualDensity` values, so the choice reaches every list row, grid and control at once. Touch builds are unaffected. See [Density (Compact / Comfortable)](#density-compact--comfortable). |
 | Pointer affordances | Supported | Compact content density, visible hover feedback, right-click context menus with a keyboard equivalent, and Ctrl/Shift multi-select in track lists — all keyed on the input rather than the window width. See [Pointer, not width](#pointer-not-width). |
@@ -650,6 +650,15 @@ What it buys, per surface:
   still, the queue joins them as a third column instead of a sheet over the top,
   so lyrics and up-next are readable at once; the action row's queue button
   becomes the pane toggle, and narrower windows keep the sheet.
+* **The queue, beside the page**: past `queueSidePanelMinWindowWidth` the
+  frame itself can hold the queue as a column on the right, so up-next stays
+  readable while you browse the library. The now-playing bar's queue button is
+  its toggle there (and still opens the sheet at every narrower width), the
+  column is closed until asked for, and it is the same `QueueSheet` the phone
+  opens as a sheet: one queue, three hosts. The threshold is what it takes for
+  all three columns to be worth having: the panel's 340 px, the rail beside it,
+  and a page still wide enough to split into list and detail. Narrow the window
+  and the column goes; widen it and it comes back where you left it.
 * **The now-playing bar** — on a desktop host the progress line along its top
   edge is a seek control, not a readout: the same `PlaybackProgressBar` the full
   player uses, at its compact density and without the time caption. Width alone

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -6,9 +6,10 @@ how it behaves with shuffle/repeat/Cast/Android Auto, and the known limits.
 
 The queue is owned by a single `PlaybackController` (see
 [docs/architecture.md](./architecture.md) and
-[docs/background-playback.md](./background-playback.md)). Every surface —
-mini-player, Now Playing, the Queue sheet, Cast, and the Android Auto media
-session — reads from and edits the **same** queue. There is never a second copy.
+[docs/background-playback.md](./background-playback.md)). Every surface reads
+from and edits the **same** queue: mini-player, Now Playing, the Queue sheet,
+the desktop queue column, Cast, and the Android Auto media session. There is
+never a second copy.
 
 ## Opening the Queue
 
@@ -32,6 +33,37 @@ On a wide **desktop** window the same manager opens as a pane beside Now
 Playing, and its history section is a different thing — see
 [Recently played (desktop)](#recently-played-desktop).
 
+## The desktop queue column
+
+On a wide desktop window the queue can also stay open beside whatever you are
+browsing, instead of only beside Now Playing
+([issue #416](https://github.com/TheZupZup/Linthra/issues/416)). The
+now-playing bar's **queue** button is the toggle: it lights up while the column
+is open, and the column has its own close button in the header.
+
+It is the same Queue manager, so everything above applies unchanged: current
+track, up next, reorder, remove, play now, Save and Clear. There is no separate
+desktop queue: the column reads and edits the one `PlaybackController` queue, so
+a reorder made here, a skip from the media keys and a track queued from the
+library all land in the same place and every surface sees it at once.
+
+What is specific to the column:
+
+- **It is the frame's, not a screen's.** It sits between the page and the
+  now-playing bar, so switching tabs, opening an album or pushing a detail route
+  leaves it exactly where it was.
+- **Width decides whether it exists.** It needs room for its own 340 px, the
+  navigation rail, and a page still wide enough to keep its own detail pane,
+  so a narrower window simply does not offer it, and the queue button opens the
+  sheet there as it always has. Narrowing a window with the column open takes it
+  away without touching playback; widening finds it open again.
+- **Closed until you ask.** It costs the page real width, so it never opens
+  itself.
+- **Long queues stay cheap.** Up next is a lazily built list: a thousand queued
+  songs cost a screenful of rows, not a thousand.
+- **Android is untouched.** The column is part of the desktop frame, so a wide
+  Android tablet keeps the phone layout and the sheet at every width.
+
 ## Recently played (desktop)
 
 There are two kinds of "what already played", and the desktop pane shows the
@@ -44,6 +76,10 @@ second one ([issue #419](https://github.com/thezupzup/linthra/issues/419)).
 | Bound | the queue's own length | **50 tracks**, hard cap |
 | Order | queue order, above Now playing | newest first, below Up next |
 | Tapping a row | steps back inside the queue | replays the track (see below) |
+
+"Desktop pane" here means both desktop hosts of the manager: Now Playing's
+queue pane and the shell's [queue column](#the-desktop-queue-column). They are
+the same widget, so they show the same history.
 
 Android keeps the sheet and its queue-derived history at **every** window
 width. The pane's history is chosen on the host, not on the width, so a wide
@@ -269,3 +305,13 @@ when you save the queue as a playlist (only stable track ids are saved).
 - [ ] With repeat one on, let a song finish, then skip it partway through the
       next pass — the row reads as skipped.
 - [ ] Restart the app — Recently played is empty again (memory only).
+- [ ] On a wide window, press the queue button in the now-playing bar: the
+      queue opens as a column beside the library, and the library still shows
+      its detail pane.
+- [ ] Reorder, remove and play a song from the column, then open Now Playing.
+      The queue matches what the column shows.
+- [ ] Narrow the window until the column goes, then widen it again. Playback
+      never stops and the column comes back open.
+- [ ] Switch tabs and open an album with the column open. It stays put.
+- [ ] Tab from the page: focus reaches the column before the navigation rail,
+      and Ctrl + ↑ / ↓ moves the focused row there too.

--- a/lib/features/player/mini_player.dart
+++ b/lib/features/player/mini_player.dart
@@ -19,6 +19,7 @@ import 'player_providers.dart';
 import 'widgets/album_artwork.dart';
 import 'widgets/playback_progress_bar.dart';
 import 'widgets/queue_sheet.dart';
+import 'widgets/queue_side_panel.dart';
 import 'widgets/volume_controls.dart';
 import 'widgets/wavy_seek_bar.dart';
 
@@ -484,17 +485,37 @@ class _SkipButton extends ConsumerWidget {
 
 /// Opens the up-next list. Desktop windows only: it is the one control here
 /// that has somewhere better to live on a phone (the full player's action row).
+///
+/// Two shapes, decided by the frame rather than by the button. Where the shell
+/// can host the queue as a column beside the page (#416) this is the toggle for
+/// it, lit while the column is open. Everywhere else it opens the sheet, as it
+/// always has, so the queue is reachable at every window size, and the button
+/// never offers a panel that has nowhere to go.
 class _QueueButton extends StatelessWidget {
   const _QueueButton();
 
   @override
   Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.7);
+    final QueueSidePanelScope? panel = QueueSidePanelScope.maybeOf(context);
+    if (panel == null || !panel.available) {
+      return IconButton(
+        onPressed: () => showQueueSheet(context),
+        icon: const Icon(Icons.queue_music_outlined),
+        iconSize: 22,
+        color: muted,
+        tooltip: 'Queue',
+      );
+    }
     return IconButton(
-      onPressed: () => showQueueSheet(context),
+      onPressed: panel.onToggle,
+      isSelected: panel.visible,
       icon: const Icon(Icons.queue_music_outlined),
+      selectedIcon: const Icon(Icons.queue_music),
       iconSize: 22,
-      color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
-      tooltip: 'Queue',
+      color: panel.visible ? theme.colorScheme.primary : muted,
+      tooltip: panel.visible ? 'Hide queue' : 'Show queue',
     );
   }
 }

--- a/lib/features/player/widgets/queue_sheet.dart
+++ b/lib/features/player/widgets/queue_sheet.dart
@@ -34,12 +34,14 @@ Future<void> showQueueSheet(BuildContext context) {
 
 /// The Queue / Up Next manager.
 ///
-/// Hosted two ways. As a modal sheet ([showQueueSheet]) it keeps its own height
-/// budget and safe-area inset, the way a sheet has to. As an [embedded] pane —
-/// what a desktop-width Now Playing does with it — it fills whatever box the
-/// host gives it instead: the pane is already inside the screen's padding, and
-/// a sheet's 85%-of-the-window ceiling in a column that is the full window tall
-/// would leave a band of dead space under the list.
+/// Hosted three ways. As a modal sheet ([showQueueSheet]) it keeps its own
+/// height budget and safe-area inset, the way a sheet has to. As an [embedded]
+/// pane (what a desktop-width Now Playing does with it, and what the shell's
+/// desktop queue column, `QueueSidePanel`, does with it in #416) it fills
+/// whatever box the host gives it instead: the pane is already inside the
+/// host's padding, and a sheet's 85%-of-the-window ceiling in a column that is
+/// the full window tall would leave a band of dead space under the list. Only
+/// a host that can collapse passes [onClose].
 ///
 /// Reads the live [PlaybackState] (so it stays current while open) and shows,
 /// top to bottom: a header with Save/Clear actions, the played history, the
@@ -60,10 +62,16 @@ Future<void> showQueueSheet(BuildContext context) {
 /// semantics are therefore untouched: the recorder that fills that history does
 /// not even run there.
 class QueueSheet extends ConsumerWidget {
-  const QueueSheet({this.embedded = false, super.key});
+  const QueueSheet({this.embedded = false, this.onClose, super.key});
 
   /// Whether the host lays this out as a pane rather than a modal sheet.
   final bool embedded;
+
+  /// Collapses the host pane, when it is one that can be collapsed (the shell's
+  /// desktop queue column). Null everywhere else, because a modal sheet is
+  /// dismissed the way every sheet is and Now Playing's pane has its own toggle
+  /// in the action row beside it, and then no close control is drawn at all.
+  final VoidCallback? onClose;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -117,8 +125,17 @@ class QueueSheet extends ConsumerWidget {
             children: <Widget>[
               Icon(Icons.queue_music, color: theme.colorScheme.primary),
               const SizedBox(width: AppSpacing.sm),
-              Text('Queue', style: theme.textTheme.titleMedium),
-              const Spacer(),
+              // Takes the slack, and gives it back: in a fixed-width column at
+              // a large text scale the actions beside it are what has to stay
+              // reachable, so the title is the part that yields.
+              Expanded(
+                child: Text(
+                  'Queue',
+                  style: theme.textTheme.titleMedium,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
               IconButton(
                 onPressed: canSave ? () => _saveAsPlaylist(context, ref) : null,
                 icon: const Icon(Icons.playlist_add),
@@ -139,6 +156,12 @@ class QueueSheet extends ConsumerWidget {
                     : null,
                 child: const Text('Clear'),
               ),
+              if (onClose != null)
+                IconButton(
+                  onPressed: onClose,
+                  icon: const Icon(Icons.close),
+                  tooltip: 'Close queue',
+                ),
             ],
           ),
         ),

--- a/lib/features/player/widgets/queue_side_panel.dart
+++ b/lib/features/player/widgets/queue_side_panel.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+
+import '../../../app/dimens.dart';
+import '../../../shared/layout/pane_layout.dart';
+import 'queue_sheet.dart';
+
+/// Width of the persistent desktop queue column.
+///
+/// The same number the Now Playing pane uses: the queue is a list of song rows
+/// wherever it is drawn, and rows have a width that reads well. A flex share
+/// would only pull each title away from its handle as the window grows.
+const double queueSidePanelWidth = 340;
+
+/// What the desktop navigation rail and the two hairline dividers take out of
+/// the window before either column gets a pixel.
+///
+/// Measured rather than derived: a labelled [NavigationRail] is as wide as its
+/// longest destination, which is a text measurement and not a constant anyone
+/// can look up. A shell test pins the budget this number is standing in for,
+/// so a wider rail is caught there instead of quietly eating the page.
+const double _desktopShellChromeWidth = 132;
+
+/// The narrowest window that may host the queue beside the page.
+///
+/// Deliberately not "the panel fits": the panel's own column, the shell chrome
+/// beside it, *and* a page still wide enough to split into list and detail
+/// ([listDetailMinWidth]). A queue that costs the library its detail pane has
+/// taken more than it gave, and the queue is one click away as a sheet at any
+/// width.
+const double queueSidePanelMinWindowWidth =
+    queueSidePanelWidth + _desktopShellChromeWidth + listDetailMinWidth;
+
+/// The playback queue as a persistent column beside the page (#416).
+///
+/// It is the same [QueueSheet] the phone opens as a bottom sheet and Now
+/// Playing opens as a pane: the same current/up-next rows, the same reorder,
+/// remove and jump actions, all going through the one [PlaybackController].
+/// There is no desktop queue model: this widget is a host, not a second copy of
+/// the queue, so a change made here, in the sheet, from the media session or by
+/// playback itself lands in exactly one place and every surface sees it at
+/// once.
+///
+/// Whether it exists at all is the shell's call (see `HomeShell`), from the
+/// width of the window rather than from anything this widget knows.
+class QueueSidePanel extends StatelessWidget {
+  const QueueSidePanel({required this.onClose, super.key});
+
+  /// Collapses the panel. The queue stays exactly as it is; only the column
+  /// goes away.
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return SizedBox(
+      width: queueSidePanelWidth,
+      child: Material(
+        // A shade off the page beside it, so the column reads as chrome that
+        // belongs to the frame rather than as more content.
+        color: theme.colorScheme.surfaceContainerLow,
+        // A named region rather than a loose stack of rows: a screen reader
+        // lands on "Queue" and can walk out of it again, instead of having to
+        // guess which list it is in. Child nodes stay explicit so the rows keep
+        // their own labels and move actions.
+        child: Semantics(
+          container: true,
+          explicitChildNodes: true,
+          label: 'Queue',
+          child: Padding(
+            padding: const EdgeInsets.only(top: AppSpacing.md),
+            child: QueueSheet(embedded: true, onClose: onClose),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// What the shell tells the rest of the frame about the queue column: whether
+/// this window is wide enough to host one, whether it is open, and how to flip
+/// that.
+///
+/// The visibility lives in the shell because the *layout* owns it, the same
+/// place the rail and the bottom bar are chosen. Anything that wants to offer
+/// the toggle (the mini-player's queue button) reads it from here instead of
+/// re-deriving the breakpoint, so there is one answer to "is there a queue
+/// column right now" rather than two that can disagree.
+///
+/// Queue *state* is not in here, and must not be: that stays in the shared
+/// [PlaybackController] every surface already reads.
+class QueueSidePanelScope extends InheritedWidget {
+  const QueueSidePanelScope({
+    required this.available,
+    required this.visible,
+    required this.onToggle,
+    required super.child,
+    super.key,
+  });
+
+  /// Whether the frame is wide enough to draw the panel at all. False on a
+  /// phone, on Android at any width, and on a desktop window narrower than
+  /// [queueSidePanelMinWindowWidth].
+  final bool available;
+
+  /// Whether the panel is currently open. Always false while [available] is.
+  final bool visible;
+
+  /// Opens the panel, or closes it again.
+  final VoidCallback onToggle;
+
+  /// The nearest scope, or null when nothing above hosts a queue column: a
+  /// phone, or any surface outside the shell (the full Now Playing route,
+  /// which draws its own pane).
+  static QueueSidePanelScope? maybeOf(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<QueueSidePanelScope>();
+  }
+
+  @override
+  bool updateShouldNotify(QueueSidePanelScope oldWidget) {
+    return available != oldWidget.available ||
+        visible != oldWidget.visible ||
+        onToggle != oldWidget.onToggle;
+  }
+}

--- a/lib/features/shell/home_shell.dart
+++ b/lib/features/shell/home_shell.dart
@@ -2,12 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import '../player/mini_player.dart';
+import '../player/widgets/queue_side_panel.dart';
 import 'playlist_drag_spring.dart';
 
 /// The persistent app frame: hosts the active tab and the app's primary
 /// navigation. Tab state is owned by go_router's [StatefulNavigationShell], so
 /// each tab keeps its own stack and scroll position across switches.
-class HomeShell extends StatelessWidget {
+class HomeShell extends StatefulWidget {
   const HomeShell({
     required this.navigationShell,
     required this.rootNavigatorKey,
@@ -18,6 +19,9 @@ class HomeShell extends StatelessWidget {
   final StatefulNavigationShell navigationShell;
   final GlobalKey<NavigatorState> rootNavigatorKey;
   final List<GlobalKey<NavigatorState>> branchNavigatorKeys;
+
+  @override
+  State<HomeShell> createState() => _HomeShellState();
 
   /// Wide Linux windows get a persistent desktop navigation region instead of
   /// the phone-oriented bottom navigation bar. Keeping the breakpoint here
@@ -68,24 +72,43 @@ class HomeShell extends StatelessWidget {
       label: 'Settings',
     ),
   ];
+}
+
+/// The frame's own state: which tab is showing is go_router's, but whether the
+/// desktop queue column is open is the frame's, and nothing below it needs to
+/// know.
+class _HomeShellState extends State<HomeShell> {
+  /// Whether the queue column is open, when the window is wide enough to draw
+  /// one.
+  ///
+  /// Remembered even while the window is too narrow for the column, so dragging
+  /// a window down to a phone width and back finds the queue where it was left
+  /// rather than closed, the same promise Now Playing's pane makes. Starts
+  /// closed: the column costs the page a whole column's width, and that is the
+  /// listener's call to make, not a default to wake up to.
+  bool _queuePanelOpen = false;
+
+  void _toggleQueuePanel() {
+    setState(() => _queuePanelOpen = !_queuePanelOpen);
+  }
 
   void _onDestinationSelected(int index) {
-    navigationShell.goBranch(
+    widget.navigationShell.goBranch(
       index,
-      initialLocation: index == navigationShell.currentIndex,
+      initialLocation: index == widget.navigationShell.currentIndex,
     );
   }
 
   Future<bool> _handleSystemBack() async {
-    if (rootNavigatorKey.currentState?.canPop() ?? false) return false;
+    if (widget.rootNavigatorKey.currentState?.canPop() ?? false) return false;
 
-    final int currentIndex = navigationShell.currentIndex;
+    final int currentIndex = widget.navigationShell.currentIndex;
     final NavigatorState? activeBranch =
-        branchNavigatorKeys[currentIndex].currentState;
+        widget.branchNavigatorKeys[currentIndex].currentState;
     if (activeBranch?.canPop() ?? false) return false;
 
     if (currentIndex == 0) return false;
-    navigationShell.goBranch(0);
+    widget.navigationShell.goBranch(0);
     return true;
   }
 
@@ -94,7 +117,7 @@ class HomeShell extends StatelessWidget {
     BoxConstraints constraints,
   ) {
     return Theme.of(context).platform == TargetPlatform.linux &&
-        constraints.maxWidth >= desktopNavigationBreakpoint;
+        constraints.maxWidth >= HomeShell.desktopNavigationBreakpoint;
   }
 
   /// Opens the Playlists tab at its root for a drag (#389).
@@ -104,14 +127,15 @@ class HomeShell extends StatelessWidget {
   /// inside this branch and take no drop, so restoring one of those would put
   /// the drag on a page it cannot finish on. The playlist list always can.
   void _springToPlaylists() {
-    navigationShell.goBranch(playlistsBranchIndex, initialLocation: true);
+    widget.navigationShell
+        .goBranch(HomeShell.playlistsBranchIndex, initialLocation: true);
   }
 
   /// The rail, wrapped in the drag spring so a track dragged out of the
   /// library can reach the Playlists tab (#389).
   Widget _buildNavigationRail() {
     return FocusTraversalOrder(
-      order: const NumericFocusOrder(2),
+      order: const NumericFocusOrder(3),
       child: FocusTraversalGroup(
         child: SafeArea(
           right: false,
@@ -119,12 +143,12 @@ class HomeShell extends StatelessWidget {
             onSpring: _springToPlaylists,
             builder: (BuildContext context, bool dragHovering) {
               return NavigationRail(
-                selectedIndex: navigationShell.currentIndex,
+                selectedIndex: widget.navigationShell.currentIndex,
                 onDestinationSelected: _onDestinationSelected,
                 labelType: NavigationRailLabelType.all,
                 groupAlignment: -1,
                 destinations: <NavigationRailDestination>[
-                  for (int i = 0; i < _destinations.length; i++)
+                  for (int i = 0; i < HomeShell._destinations.length; i++)
                     _railDestination(context, i, dragHovering: dragHovering),
                 ],
               );
@@ -144,8 +168,8 @@ class HomeShell extends StatelessWidget {
     int index, {
     required bool dragHovering,
   }) {
-    final NavigationDestination destination = _destinations[index];
-    final bool marked = dragHovering && index == playlistsBranchIndex;
+    final NavigationDestination destination = HomeShell._destinations[index];
+    final bool marked = dragHovering && index == HomeShell.playlistsBranchIndex;
     if (!marked) {
       return NavigationRailDestination(
         icon: destination.icon,
@@ -164,8 +188,9 @@ class HomeShell extends StatelessWidget {
 
   /// The bottom bar, wrapped in the same drag spring as the rail.
   ///
-  /// A Linux window narrower than [desktopNavigationBreakpoint] shows this
-  /// instead of the rail, and a mouse is still a mouse there: the drag starts
+  /// A Linux window narrower than [HomeShell.desktopNavigationBreakpoint]
+  /// shows this instead of the rail, and a mouse is still a mouse there: the
+  /// drag starts
   /// whatever the width, so without a spring here it would pick a row up and
   /// have nowhere in the app to put it. On a phone no drag ever reaches this,
   /// because the drag source is desktop-only.
@@ -174,10 +199,10 @@ class HomeShell extends StatelessWidget {
       onSpring: _springToPlaylists,
       builder: (BuildContext context, bool dragHovering) {
         return NavigationBar(
-          selectedIndex: navigationShell.currentIndex,
+          selectedIndex: widget.navigationShell.currentIndex,
           onDestinationSelected: _onDestinationSelected,
           destinations: <Widget>[
-            for (int i = 0; i < _destinations.length; i++)
+            for (int i = 0; i < HomeShell._destinations.length; i++)
               _barDestination(context, i, dragHovering: dragHovering),
           ],
         );
@@ -192,14 +217,31 @@ class HomeShell extends StatelessWidget {
     int index, {
     required bool dragHovering,
   }) {
-    final NavigationDestination destination = _destinations[index];
-    if (!(dragHovering && index == playlistsBranchIndex)) return destination;
+    final NavigationDestination destination = HomeShell._destinations[index];
+    final bool marked = dragHovering && index == HomeShell.playlistsBranchIndex;
+    if (!marked) return destination;
     final Color accent = Theme.of(context).colorScheme.primary;
     final Icon marker = Icon(Icons.playlist_add, color: accent);
     return NavigationDestination(
       icon: marker,
       selectedIcon: marker,
       label: destination.label,
+    );
+  }
+
+  /// The queue as a third column (#416), in its own traversal group so Tab
+  /// walks the panel whole (header actions, then rows) instead of weaving it
+  /// into the page beside it.
+  Widget _buildQueuePanel() {
+    return FocusTraversalOrder(
+      order: const NumericFocusOrder(2),
+      child: FocusTraversalGroup(
+        child: SafeArea(
+          left: false,
+          bottom: false,
+          child: QueueSidePanel(onClose: _toggleQueuePanel),
+        ),
+      ),
     );
   }
 
@@ -210,56 +252,78 @@ class HomeShell extends StatelessWidget {
       child: LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) {
           final bool desktop = _usesDesktopNavigation(context, constraints);
+          // The layout decides whether the panel exists at all; the queue it
+          // shows is the same one every other surface reads. Gated on the
+          // desktop frame as well as the width, so a wide Android tablet keeps
+          // the phone layout it has always had.
+          final bool queuePanelAvailable =
+              desktop && constraints.maxWidth >= queueSidePanelMinWindowWidth;
+          final bool queuePanelOpen = queuePanelAvailable && _queuePanelOpen;
 
           // Keep StatefulNavigationShell at the same element position across
           // the 900 px breakpoint. Only the two chrome slots before it change
           // between real desktop widgets and zero-sized placeholders, so an
           // inactive branch's Navigator stack and scroll state survive resize.
+          // The queue column is the same trick on the other side: it holds two
+          // slots after the shell whether or not it is drawn.
           //
           // The mini-player sits below the whole frame rather than inside the
           // content column, so on a desktop window the now-playing bar runs the
           // full width under the rail — the shape every desktop music player
           // has. On phones there is no rail, so nothing about it moves.
-          return Scaffold(
-            body: FocusTraversalGroup(
-              policy: OrderedTraversalPolicy(),
-              child: Column(
-                children: <Widget>[
-                  Expanded(
-                    child: Row(
-                      children: <Widget>[
-                        if (desktop)
-                          _buildNavigationRail()
-                        else
-                          const SizedBox.shrink(),
-                        if (desktop)
-                          const VerticalDivider(width: 1)
-                        else
-                          const SizedBox.shrink(),
-                        Expanded(
-                          child: FocusTraversalOrder(
-                            order: const NumericFocusOrder(1),
-                            child: FocusTraversalGroup(
-                              child: navigationShell,
+          return QueueSidePanelScope(
+            available: queuePanelAvailable,
+            visible: queuePanelOpen,
+            onToggle: _toggleQueuePanel,
+            child: Scaffold(
+              body: FocusTraversalGroup(
+                policy: OrderedTraversalPolicy(),
+                child: Column(
+                  children: <Widget>[
+                    Expanded(
+                      child: Row(
+                        children: <Widget>[
+                          if (desktop)
+                            _buildNavigationRail()
+                          else
+                            const SizedBox.shrink(),
+                          if (desktop)
+                            const VerticalDivider(width: 1)
+                          else
+                            const SizedBox.shrink(),
+                          Expanded(
+                            child: FocusTraversalOrder(
+                              order: const NumericFocusOrder(1),
+                              child: FocusTraversalGroup(
+                                child: widget.navigationShell,
+                              ),
                             ),
                           ),
-                        ),
-                      ],
+                          if (queuePanelOpen)
+                            const VerticalDivider(width: 1)
+                          else
+                            const SizedBox.shrink(),
+                          if (queuePanelOpen)
+                            _buildQueuePanel()
+                          else
+                            const SizedBox.shrink(),
+                        ],
+                      ),
                     ),
-                  ),
-                  // Last in the reading order: the bar spans everything above
-                  // it, so a keyboard user reaches it after both the page and
-                  // the destinations, not between them.
-                  FocusTraversalOrder(
-                    order: const NumericFocusOrder(3),
-                    child: FocusTraversalGroup(
-                      child: const MiniPlayer(),
+                    // Last in the reading order: the bar spans everything above
+                    // it, so a keyboard user reaches it after both the page and
+                    // the destinations, not between them.
+                    FocusTraversalOrder(
+                      order: const NumericFocusOrder(4),
+                      child: FocusTraversalGroup(
+                        child: const MiniPlayer(),
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
+              bottomNavigationBar: desktop ? null : _buildNavigationBar(),
             ),
-            bottomNavigationBar: desktop ? null : _buildNavigationBar(),
           );
         },
       ),

--- a/test/features/player/queue_side_panel_test.dart
+++ b/test/features/player/queue_side_panel_test.dart
@@ -1,0 +1,417 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/data/repositories/host_platform_provider.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/widgets/queue_sheet.dart';
+import 'package:linthra/features/player/widgets/queue_side_panel.dart';
+
+import 'fake_playback_controller.dart';
+
+/// The desktop queue column (#416), on its own.
+///
+/// The panel is a *host* for the queue, not a second copy of it: everything
+/// here is asserted against the controller the rest of the app reads, so a test
+/// that passes with a private list in the widget would fail on the state that
+/// actually plays. Where it is drawn at all is the shell's business and is
+/// pinned in `test/features/shell/queue_side_panel_shell_test.dart`.
+
+Track _track(String id) => Track(
+    id: id, title: 'Song $id', uri: 'jellyfin:$id', artistName: 'Artist $id');
+
+/// Pumps the panel at its real width beside a stand-in page, so the rows are
+/// laid out in the box the shell actually gives them.
+Future<void> _pumpPanel(
+  WidgetTester tester,
+  FakePlaybackController controller, {
+  VoidCallback? onClose,
+  Size size = const Size(1600, 900),
+  double textScale = 1.0,
+}) async {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = size;
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        playbackControllerProvider.overrideWithValue(controller),
+        hostPlatformProvider.overrideWithValue(HostPlatform.linux),
+      ],
+      child: MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.linux),
+        home: Builder(
+          builder: (BuildContext context) => MediaQuery(
+            data: MediaQuery.of(context)
+                .copyWith(textScaler: TextScaler.linear(textScale)),
+            child: Scaffold(
+              body: Row(
+                children: <Widget>[
+                  const Expanded(child: Center(child: Text('page'))),
+                  QueueSidePanel(onClose: onClose ?? () {}),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// Gives the up-next drag handle at [index] keyboard focus, the way Tab would.
+Future<void> _focusHandle(WidgetTester tester, int index) async {
+  final Finder handles = find.byIcon(Icons.drag_handle);
+  Focus.of(tester.element(handles.at(index))).requestFocus();
+  await tester.pumpAndSettle();
+}
+
+/// Presses Ctrl + Arrow Down, the chord that moves the focused row.
+Future<void> _pressMoveChordDown(WidgetTester tester) async {
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+  await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+  await tester.pumpAndSettle();
+}
+
+/// The titles the panel is listing under "Up next", top to bottom.
+List<String> _upNextTitles(WidgetTester tester) {
+  final Finder handles = find.byIcon(Icons.drag_handle);
+  return <String>[
+    for (int i = 0; i < handles.evaluate().length; i++)
+      tester
+          .widget<Text>(
+            find
+                .descendant(
+                  of: find.ancestor(
+                    of: handles.at(i),
+                    matching: find.byType(ListTile),
+                  ),
+                  matching: find.byType(Text),
+                )
+                .first,
+          )
+          .data!,
+  ];
+}
+
+void main() {
+  group('QueueSidePanel', () {
+    testWidgets('shows what is playing and what is next', (tester) async {
+      final FakePlaybackController controller = FakePlaybackController();
+      addTearDown(controller.dispose);
+      await controller
+          .playTracks(<Track>[_track('A'), _track('B'), _track('C')]);
+
+      await _pumpPanel(tester, controller);
+
+      expect(find.text('Queue'), findsOneWidget);
+      expect(find.text('Now playing'), findsOneWidget);
+      expect(find.text('Up next'), findsOneWidget);
+      expect(find.text('Song A'), findsOneWidget);
+      expect(find.text('Song B'), findsOneWidget);
+      expect(find.text('Song C'), findsOneWidget);
+      // The page beside it is still there: a column, not a cover.
+      expect(find.text('page'), findsOneWidget);
+    });
+
+    testWidgets('the playing row is the one marked as playing', (tester) async {
+      final SemanticsHandle semantics = tester.ensureSemantics();
+      final FakePlaybackController controller = FakePlaybackController();
+      addTearDown(controller.dispose);
+      await controller.playTracks(<Track>[_track('A'), _track('B')]);
+
+      await _pumpPanel(tester, controller);
+
+      expect(
+        tester.getSemantics(find.text('Song A')).label,
+        contains('Now playing'),
+      );
+      expect(
+        tester.getSemantics(find.text('Song B')).label,
+        isNot(contains('Now playing')),
+      );
+      semantics.dispose();
+    });
+
+    testWidgets('the highlight follows the track that is actually playing',
+        (tester) async {
+      final SemanticsHandle semantics = tester.ensureSemantics();
+      final FakePlaybackController controller = FakePlaybackController();
+      addTearDown(controller.dispose);
+      await controller.playTracks(<Track>[_track('A'), _track('B')]);
+
+      await _pumpPanel(tester, controller);
+      // Skipped from somewhere else entirely: a media key, the mini-player,
+      // the queue running on. The panel hears it through the same state stream.
+      await controller.skipToNext();
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.getSemantics(find.text('Song B')).label,
+        contains('Now playing'),
+      );
+      // B was the last one queued, so there is nothing after it now.
+      expect(find.textContaining('Nothing up next'), findsOneWidget);
+      semantics.dispose();
+    });
+
+    testWidgets('a source fallback leaves the queue exactly where it was',
+        (tester) async {
+      final SemanticsHandle semantics = tester.ensureSemantics();
+      final FakePlaybackController controller = FakePlaybackController();
+      addTearDown(controller.dispose);
+      await controller
+          .playTracks(<Track>[_track('A'), _track('B'), _track('C')]);
+
+      await _pumpPanel(tester, controller);
+
+      // The same logical track, now coming from a different copy: the server
+      // went away and the downloaded file took over. Nothing about the queue
+      // changed, so nothing about the panel may.
+      controller.emit(
+        controller.state.copyWith(source: PlaybackSource.offlineCache),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.getSemantics(find.text('Song A')).label,
+        contains('Now playing'),
+      );
+      expect(_upNextTitles(tester), <String>['Song B', 'Song C']);
+      // And nothing about where the audio comes from leaks into the rows.
+      expect(find.textContaining('OFFLINE CACHE'), findsNothing);
+      semantics.dispose();
+    });
+
+    testWidgets('nothing playing is said plainly', (tester) async {
+      final FakePlaybackController controller = FakePlaybackController();
+      addTearDown(controller.dispose);
+
+      await _pumpPanel(tester, controller);
+
+      expect(find.text('Nothing playing'), findsOneWidget);
+      expect(find.text('Up next'), findsNothing);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('a one-track queue says there is nothing after it',
+        (tester) async {
+      final FakePlaybackController controller = FakePlaybackController();
+      addTearDown(controller.dispose);
+      await controller.playTracks(<Track>[_track('A')]);
+
+      await _pumpPanel(tester, controller);
+
+      expect(find.text('Song A'), findsOneWidget);
+      expect(find.textContaining('Nothing up next'), findsOneWidget);
+      expect(find.byIcon(Icons.drag_handle), findsNothing);
+    });
+
+    testWidgets('a track added while the panel is open shows up at once',
+        (tester) async {
+      final FakePlaybackController controller = FakePlaybackController();
+      addTearDown(controller.dispose);
+      await controller.playTracks(<Track>[_track('A')]);
+
+      await _pumpPanel(tester, controller);
+      expect(find.text('Song Z'), findsNothing);
+
+      // Queued from the library, two panes away.
+      controller.addToQueue(_track('Z'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Song Z'), findsOneWidget);
+      expect(controller.state.upNext, <Track>[_track('Z')]);
+    });
+
+    testWidgets('removing a row removes it from the real queue',
+        (tester) async {
+      final FakePlaybackController controller = FakePlaybackController();
+      addTearDown(controller.dispose);
+      await controller
+          .playTracks(<Track>[_track('A'), _track('B'), _track('C')]);
+
+      await _pumpPanel(tester, controller);
+      await tester.tap(find.byTooltip('Remove from queue').first);
+      await tester.pumpAndSettle();
+
+      expect(controller.state.currentTrack, _track('A'));
+      expect(controller.state.upNext, <Track>[_track('C')]);
+      expect(find.text('Song B'), findsNothing);
+    });
+
+    testWidgets('tapping an upcoming row plays it now', (tester) async {
+      final FakePlaybackController controller = FakePlaybackController();
+      addTearDown(controller.dispose);
+      await controller
+          .playTracks(<Track>[_track('A'), _track('B'), _track('C')]);
+
+      await _pumpPanel(tester, controller);
+      await tester.tap(find.text('Song C'));
+      await tester.pumpAndSettle();
+
+      expect(controller.state.currentTrack, _track('C'));
+    });
+
+    testWidgets('the keyboard reorders the real queue, not a local copy',
+        (tester) async {
+      final FakePlaybackController controller = FakePlaybackController();
+      addTearDown(controller.dispose);
+      await controller
+          .playTracks(<Track>[_track('A'), _track('B'), _track('C')]);
+
+      await _pumpPanel(tester, controller);
+      await _focusHandle(tester, 0);
+      await _pressMoveChordDown(tester);
+
+      expect(controller.state.upNext, <Track>[_track('C'), _track('B')]);
+      expect(_upNextTitles(tester), <String>['Song C', 'Song B']);
+    });
+
+    testWidgets('shuffling reshuffles the list the panel is showing',
+        (tester) async {
+      final FakePlaybackController controller = FakePlaybackController();
+      addTearDown(controller.dispose);
+      await controller.playTracks(<Track>[
+        for (final String id in <String>['A', 'B', 'C', 'D', 'E']) _track(id),
+      ]);
+
+      await _pumpPanel(tester, controller);
+      controller.setShuffleEnabled(true);
+      await tester.pumpAndSettle();
+
+      // Whatever the shuffle produced, the panel is showing that order (the
+      // one that is going to play) rather than the order it was built with.
+      expect(
+        _upNextTitles(tester),
+        <String>[
+          for (final Track track in controller.state.upNext) track.title
+        ],
+      );
+    });
+
+    testWidgets('a very long title is trimmed, not overflowed', (tester) async {
+      final FakePlaybackController controller = FakePlaybackController();
+      addTearDown(controller.dispose);
+      final Track long = Track(
+        id: 'long',
+        title: 'A Title That Goes On ${'and on ' * 40}Forever',
+        uri: 'jellyfin:long',
+        artistName: 'Artist ${'Long ' * 40}',
+      );
+      await controller.playTracks(<Track>[_track('A'), long]);
+
+      await _pumpPanel(tester, controller);
+
+      expect(tester.takeException(), isNull);
+      final Text title = tester.widget<Text>(find.text(long.title));
+      expect(title.maxLines, 1);
+      expect(title.overflow, TextOverflow.ellipsis);
+    });
+
+    testWidgets('the header still fits at a large text scale', (tester) async {
+      final FakePlaybackController controller = FakePlaybackController();
+      addTearDown(controller.dispose);
+      await controller.playTracks(<Track>[_track('A'), _track('B')]);
+
+      await _pumpPanel(tester, controller, textScale: 1.6);
+
+      // A fixed-width column with four header controls is exactly where an
+      // overflow shows up first.
+      expect(tester.takeException(), isNull);
+      expect(find.byTooltip('Close queue'), findsOneWidget);
+      expect(find.text('Clear'), findsOneWidget);
+    });
+
+    testWidgets('a very long queue only builds the rows on screen',
+        (tester) async {
+      final FakePlaybackController controller = FakePlaybackController();
+      addTearDown(controller.dispose);
+      await controller.playTracks(<Track>[
+        for (int i = 0; i < 1000; i++) _track('$i'),
+      ]);
+
+      await _pumpPanel(tester, controller);
+
+      // A thousand queued songs must cost a screenful of rows, not a thousand:
+      // the up-next list is a sliver, and this is what keeps it one.
+      final int built = find.byIcon(Icons.drag_handle).evaluate().length;
+      expect(built, lessThan(60));
+      expect(built, greaterThan(0));
+      expect(controller.state.upNext, hasLength(999));
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('closing asks the host to collapse, and touches nothing else',
+        (tester) async {
+      final FakePlaybackController controller = FakePlaybackController();
+      addTearDown(controller.dispose);
+      await controller.playTracks(<Track>[_track('A'), _track('B')]);
+
+      int closes = 0;
+      await _pumpPanel(tester, controller, onClose: () => closes++);
+      await tester.tap(find.byTooltip('Close queue'));
+      await tester.pumpAndSettle();
+
+      expect(closes, 1);
+      // Collapsing a column is not a playback command.
+      expect(controller.state.currentTrack, _track('A'));
+      expect(controller.state.upNext, <Track>[_track('B')]);
+      expect(controller.pauseCount, 0);
+      expect(controller.stopCount, 0);
+    });
+
+    testWidgets('never renders a uri or an authenticated source string',
+        (tester) async {
+      final FakePlaybackController controller = FakePlaybackController();
+      addTearDown(controller.dispose);
+      await controller.playTracks(const <Track>[
+        Track(
+          id: 'r1',
+          title: 'Remote One',
+          uri: 'https://host/stream?api_key=SECRETTOKEN123',
+          artistName: 'Artist R',
+        ),
+        Track(id: 'r2', title: 'Remote Two', uri: 'jellyfin:r2'),
+      ]);
+
+      await _pumpPanel(tester, controller);
+
+      expect(find.text('Remote One'), findsOneWidget);
+      expect(find.text('Remote Two'), findsOneWidget);
+      expect(find.textContaining('SECRETTOKEN'), findsNothing);
+      expect(find.textContaining('api_key'), findsNothing);
+      expect(find.textContaining('https://'), findsNothing);
+      expect(find.textContaining('jellyfin:'), findsNothing);
+    });
+
+    testWidgets('the column is one named region for a screen reader',
+        (tester) async {
+      final SemanticsHandle semantics = tester.ensureSemantics();
+      final FakePlaybackController controller = FakePlaybackController();
+      addTearDown(controller.dispose);
+      await controller.playTracks(<Track>[_track('A'), _track('B')]);
+
+      await _pumpPanel(tester, controller);
+
+      // The nearest semantics node above the queue itself is the panel's own
+      // region node, rather than the page's.
+      expect(
+        tester.getSemantics(find.byType(QueueSheet)).label,
+        contains('Queue'),
+      );
+      // Named, but not merged: the rows keep their own labels and actions.
+      expect(
+        tester.getSemantics(find.text('Song B')).label,
+        contains('Song B'),
+      );
+      semantics.dispose();
+    });
+  });
+}

--- a/test/features/shell/queue_side_panel_shell_test.dart
+++ b/test/features/shell/queue_side_panel_shell_test.dart
@@ -1,0 +1,328 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/widgets/queue_side_panel.dart';
+import 'package:linthra/features/shell/home_shell.dart';
+import 'package:linthra/shared/layout/pane_layout.dart';
+
+import '../player/fake_playback_controller.dart';
+
+/// The desktop queue column, as the frame hosts it (#416).
+///
+/// The rule this file pins: the *layout* decides whether the column exists.
+/// Never the queue, never the platform channel, never the widget itself. A
+/// window wide enough can keep the queue beside the page; a narrower one hands
+/// the queue back to the sheet it has always had; Android keeps the phone
+/// layout at any width. The queue's own behaviour is pinned next door, in
+/// `test/features/player/queue_side_panel_test.dart`.
+
+/// Comfortably wider than [queueSidePanelMinWindowWidth].
+const Size _wideWindow = Size(1600, 900);
+
+/// A desktop window with the rail but no room for a third column.
+const Size _narrowDesktopWindow = Size(1280, 800);
+
+const Track _current = Track(
+  id: '1',
+  title: 'Song One',
+  uri: 'jellyfin:1',
+  artistName: 'Artist A',
+);
+
+const Track _next = Track(
+  id: '2',
+  title: 'Song Two',
+  uri: 'jellyfin:2',
+  artistName: 'Artist A',
+);
+
+const PlaybackState _playing = PlaybackState(
+  status: PlaybackStatus.playing,
+  currentTrack: _current,
+  upNext: <Track>[_next],
+);
+
+class _BranchScreen extends StatelessWidget {
+  const _BranchScreen(this.label, this.path);
+
+  final String label;
+  final String path;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text('$label screen'),
+            TextButton(
+              onPressed: () => context.push('$path/detail'),
+              child: Text('Open $label detail'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+GoRouter _router(
+  GlobalKey<NavigatorState> rootKey,
+  List<GlobalKey<NavigatorState>> branchKeys,
+) {
+  const List<String> paths = <String>[
+    '/library',
+    '/folders',
+    '/playlists',
+    '/downloads',
+    '/settings',
+  ];
+  final List<String> labels = HomeShell.destinationLabels;
+
+  return GoRouter(
+    navigatorKey: rootKey,
+    initialLocation: paths.first,
+    routes: <RouteBase>[
+      StatefulShellRoute.indexedStack(
+        builder: (_, __, StatefulNavigationShell shell) => HomeShell(
+          navigationShell: shell,
+          rootNavigatorKey: rootKey,
+          branchNavigatorKeys: branchKeys,
+        ),
+        branches: <StatefulShellBranch>[
+          for (int i = 0; i < paths.length; i++)
+            StatefulShellBranch(
+              navigatorKey: branchKeys[i],
+              routes: <RouteBase>[
+                GoRoute(
+                  path: paths[i],
+                  builder: (_, __) => _BranchScreen(labels[i], paths[i]),
+                  routes: <RouteBase>[
+                    GoRoute(
+                      path: 'detail',
+                      builder: (_, __) => Scaffold(
+                        body: Center(child: Text('${labels[i]} detail')),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+        ],
+      ),
+    ],
+  );
+}
+
+Future<FakePlaybackController> _pumpShell(
+  WidgetTester tester, {
+  required TargetPlatform platform,
+  required Size size,
+  PlaybackState playback = _playing,
+}) async {
+  tester.view.devicePixelRatio = 1;
+  tester.view.physicalSize = size;
+  addTearDown(tester.view.reset);
+
+  final GlobalKey<NavigatorState> rootKey = GlobalKey<NavigatorState>();
+  final List<GlobalKey<NavigatorState>> branchKeys =
+      <GlobalKey<NavigatorState>>[
+    for (int i = 0; i < 5; i++) GlobalKey<NavigatorState>(),
+  ];
+  final FakePlaybackController controller =
+      FakePlaybackController(initial: playback);
+  addTearDown(controller.dispose);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        playbackControllerProvider.overrideWithValue(controller),
+      ],
+      child: MaterialApp.router(
+        theme: ThemeData(platform: platform),
+        routerConfig: _router(rootKey, branchKeys),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return controller;
+}
+
+Future<void> _resize(WidgetTester tester, Size size) async {
+  tester.view.physicalSize = size;
+  await tester.pumpAndSettle();
+}
+
+/// Whether whatever holds focus sits inside a [T].
+bool _focusedInside<T extends Widget>() {
+  final BuildContext? context = FocusManager.instance.primaryFocus?.context;
+  return context != null && context.findAncestorWidgetOfExactType<T>() != null;
+}
+
+void main() {
+  testWidgets('a wide desktop window can keep the queue beside the page',
+      (WidgetTester tester) async {
+    await _pumpShell(
+      tester,
+      platform: TargetPlatform.linux,
+      size: _wideWindow,
+    );
+
+    // Closed until asked for: the column costs the page real width, and that
+    // is the listener's call.
+    expect(find.byType(QueueSidePanel), findsNothing);
+
+    await tester.tap(find.byTooltip('Show queue'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(QueueSidePanel), findsOneWidget);
+    expect(find.text('Song One'), findsWidgets);
+    expect(find.text('Song Two'), findsOneWidget);
+    // Beside the page, not over it: the library is still readable next to it.
+    expect(find.text('Library screen'), findsOneWidget);
+    expect(
+      tester.getRect(find.text('Library screen')).right,
+      lessThanOrEqualTo(tester.getRect(find.byType(QueueSidePanel)).left),
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('the page keeps room for its own detail pane beside the column',
+      (WidgetTester tester) async {
+    await _pumpShell(
+      tester,
+      platform: TargetPlatform.linux,
+      size: const Size(queueSidePanelMinWindowWidth, 900),
+    );
+
+    await tester.tap(find.byTooltip('Show queue'));
+    await tester.pumpAndSettle();
+
+    // At the narrowest window that hosts the column at all, what is left for
+    // the page is still a two-pane width. A queue that costs the library its
+    // detail pane has taken more than it gave.
+    final double railRight = tester.getRect(find.byType(NavigationRail)).right;
+    final double panelLeft = tester.getRect(find.byType(QueueSidePanel)).left;
+    // Minus the two hairline dividers the shell draws around the page.
+    expect(panelLeft - railRight - 2, greaterThanOrEqualTo(listDetailMinWidth));
+  });
+
+  testWidgets('either control collapses it again', (WidgetTester tester) async {
+    await _pumpShell(
+      tester,
+      platform: TargetPlatform.linux,
+      size: _wideWindow,
+    );
+
+    await tester.tap(find.byTooltip('Show queue'));
+    await tester.pumpAndSettle();
+    // The column's own close button.
+    await tester.tap(find.byTooltip('Close queue'));
+    await tester.pumpAndSettle();
+    expect(find.byType(QueueSidePanel), findsNothing);
+
+    await tester.tap(find.byTooltip('Show queue'));
+    await tester.pumpAndSettle();
+    // And the bar's toggle, which is lit while the column is open.
+    await tester.tap(find.byTooltip('Hide queue'));
+    await tester.pumpAndSettle();
+    expect(find.byType(QueueSidePanel), findsNothing);
+    expect(find.byTooltip('Show queue'), findsOneWidget);
+  });
+
+  testWidgets('narrowing takes the column away and widening brings it back',
+      (WidgetTester tester) async {
+    final FakePlaybackController controller = await _pumpShell(
+      tester,
+      platform: TargetPlatform.linux,
+      size: _wideWindow,
+    );
+
+    await tester.tap(find.byTooltip('Show queue'));
+    await tester.pumpAndSettle();
+    expect(find.byType(QueueSidePanel), findsOneWidget);
+
+    await _resize(tester, _narrowDesktopWindow);
+
+    expect(find.byType(QueueSidePanel), findsNothing);
+    // Playback is untouched by a resize, and the queue is still one click away
+    // as the sheet it has always been.
+    expect(controller.state.currentTrack, _current);
+    expect(controller.pauseCount, 0);
+    expect(find.byTooltip('Queue'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+
+    // Widening finds it open where it was left, rather than closed.
+    await _resize(tester, _wideWindow);
+    expect(find.byType(QueueSidePanel), findsOneWidget);
+  });
+
+  testWidgets('a narrow desktop window keeps the queue sheet',
+      (WidgetTester tester) async {
+    await _pumpShell(
+      tester,
+      platform: TargetPlatform.linux,
+      size: _narrowDesktopWindow,
+    );
+
+    expect(find.byTooltip('Show queue'), findsNothing);
+    await tester.tap(find.byTooltip('Queue'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(BottomSheet), findsOneWidget);
+    expect(find.byType(QueueSidePanel), findsNothing);
+  });
+
+  testWidgets('a wide Android window keeps the phone layout',
+      (WidgetTester tester) async {
+    await _pumpShell(
+      tester,
+      platform: TargetPlatform.android,
+      size: _wideWindow,
+    );
+
+    // No rail, no column, no toggle: a big tablet is still the phone layout.
+    expect(find.byType(NavigationRail), findsNothing);
+    expect(find.byType(NavigationBar), findsOneWidget);
+    expect(find.byType(QueueSidePanel), findsNothing);
+    expect(find.byTooltip('Show queue'), findsNothing);
+
+    await tester.tap(find.byTooltip('Queue'));
+    await tester.pumpAndSettle();
+    expect(find.byType(BottomSheet), findsOneWidget);
+  });
+
+  testWidgets('Tab reaches the column after the page and before the rail',
+      (WidgetTester tester) async {
+    await _pumpShell(
+      tester,
+      platform: TargetPlatform.linux,
+      size: _wideWindow,
+    );
+
+    await tester.tap(find.byTooltip('Show queue'));
+    await tester.pumpAndSettle();
+
+    Focus.of(tester.element(find.text('Open Library detail'))).requestFocus();
+    await tester.pump();
+
+    int panelStop = -1;
+    int railStop = -1;
+    for (int i = 0; i < 16; i++) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      if (panelStop < 0 && _focusedInside<QueueSidePanel>()) panelStop = i;
+      if (railStop < 0 && _focusedInside<NavigationRail>()) railStop = i;
+    }
+
+    expect(panelStop, isNonNegative, reason: 'the column is never reached');
+    expect(railStop, isNonNegative, reason: 'the rail is never reached');
+    expect(panelStop, lessThan(railStop));
+  });
+}


### PR DESCRIPTION
Closes #416

On a wide desktop window the shell can now hold the playback queue as a column between the page and the now-playing bar, so up next stays readable while you browse the library instead of only beside Now Playing.

## What it is

A host, not a new queue. The column renders the same `QueueSheet` the phone opens as a bottom sheet and Now Playing opens as a pane, so current track, up next, reorder, remove, play now, Save and Clear all go through the one `PlaybackController`. Nothing is duplicated locally, provider/logical track identity is untouched, and a change made anywhere (media keys, mini-player, "add to queue" from the library) shows up in the column immediately.

New files:

- `lib/features/player/widgets/queue_side_panel.dart`: the column (`QueueSidePanel`), its width and breakpoint, and `QueueSidePanelScope`, which is how the shell tells the frame whether a column can exist right now.

## Where it exists is the layout's call

- The window needs room for the column's 340 px, the navigation rail, and a page still wide enough to keep its own detail pane (`listDetailMinWidth`). Below that the column is simply not offered and the queue button opens the sheet, exactly as before.
- Gated on the desktop frame as well as the width, so a wide Android tablet keeps the phone layout at every width.
- Starts closed (it costs the page a whole column), toggled from the now-playing bar's queue button, which lights up while it is open, or closed from the column's own header button.
- Remembered across a resize that takes it away, so narrowing and widening a window finds it where you left it. Playback is never touched by any of this.

## Keyboard and semantics

The column is its own traversal group, walked after the page and before the rail. It is announced as one named region, and the rows keep their own labels and Move up / Move down actions, so Ctrl + arrow reordering works there like everywhere else.

## Performance

Up next stays a lazily built sliver: a thousand queued songs cost a screenful of rows, which is asserted in a test rather than assumed.

## Small fix carried along

The queue header's title now yields instead of overflowing. Four actions in a fixed-width column at a large text scale had nowhere to go, and the sheet was already close to the edge on a narrow phone.

## Tests

- `test/features/shell/queue_side_panel_shell_test.dart`: hosting. Wide desktop opens it beside the page, the page keeps its two-pane width at the narrowest hosting window, both close controls work, narrowing removes it and widening brings it back, a narrow desktop window and a wide Android window keep the sheet, and Tab reaches the column after the page and before the rail.
- `test/features/player/queue_side_panel_test.dart`: the column itself. Current track and highlight, the highlight following a skip, a source fallback leaving the queue alone, empty and one-track queues, a track queued while it is open, remove, play now, keyboard reorder, shuffle, long titles, a large text scale, a 1000-track queue, close, and no uri or token ever rendered.

Full suite is green (5330 tests), plus `dart format` and `flutter analyze`.

## Docs

`docs/queue.md` gains a section on the column and Linux checklist items; `docs/linux-desktop.md` picks it up in the layout table and the per-surface list.
