### PR TITLE
feat(player): recover from a track that won't play (#423)

### DIFF
--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -206,6 +206,24 @@ The same resolved URI path handles regular filesystem files and direct or
 transcoded Jellyfin, Navidrome/Subsonic, and supported Plex HTTP(S) URLs. No
 source-specific player exists and credentials remain in the existing resolver.
 
+### When a track won't play
+
+Desktop listening runs into more of this than a phone does: a NAS that is
+asleep, an unmounted drive, a codec libmpv wasn't built with. So a track that
+gives up says what happened and offers what can still be done about it, in
+place. Now Playing shows the message where the source badge usually sits, with
+Retry, "Try another source" and Skip as they apply, and the mini-player's second
+line says the track is failing. Nothing is modal; the queue, the library and
+settings keep working.
+
+The model behind it (`PlaybackFailure`) and the controller actions
+(`retryCurrentTrack`, `tryAnotherSource`) live on the shared playback seam, so
+Android gets exactly the same behaviour from exactly the same code, and a source
+switch reuses the existing logical-track candidates rather than a second
+fallback path. The rules (which recoveries are valid for which failure, the
+bounded attempt budget, what happens to the queue) are in
+[streaming.md](streaming.md#when-a-track-cant-play-at-all).
+
 ### Volume
 
 Desktop needs its own volume control: there are no hardware volume keys bound to

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -99,6 +99,43 @@ The engine's raw error can carry the tokenized stream URL; it is **only
 classified, never echoed, logged, or surfaced** — the message shown is always a
 fixed, secret-free string.
 
+## When a track can't play at all
+
+When every automatic recovery is spent, the failure becomes something the
+listener can act on rather than a dead player. The controller publishes a
+`PlaybackFailure` on the playback state: a classified `kind`, a fixed
+secret-free message, and the recoveries that are valid *for this failure, right
+now*:
+
+| Kind | What it means | Recoveries |
+| --- | --- | --- |
+| `temporarySource` | server unreachable, connection dropped, a non-audio answer | Retry, another source, Skip |
+| `localFileUnavailable` | the file moved, was deleted, or its drive isn't mounted | Retry, another source, Skip |
+| `sourceSignInRequired` | no session, or one the server no longer accepts | another source, Skip |
+| `unplayableMedia` | unsupported container/codec, corrupt file, no decoder | another source, Skip |
+
+An action is only offered when it can do something: Retry is dropped where
+re-presenting the same session or re-reading the same bytes has a fixed answer,
+"try another source" appears only for a song that really does exist on another
+provider, and Skip only when the queue has a next track.
+
+**Bounded, so it can't become a loop.** Retry and "try another source" share a
+budget of three attempts per failing track. When it runs out those actions stop
+being offered (Skip remains), and the budget is returned in full the moment
+anything actually plays.
+
+**The queue stays put.** A retry re-plays the same queue entry. A source switch
+*replaces* that entry with the copy that works, using the same ordered
+candidates the automatic runtime fallback uses (see
+[playback-source-strategy.md](playback-source-strategy.md)), so the song keeps
+its one place in the queue instead of being added again. Skip advances exactly
+one track.
+
+The UI is the same on Android and Linux because both read the same model: the
+now-playing screen shows the message and the buttons in place of the source
+badge (no dialog, and nothing else in the app is blocked), and the
+mini-player's second line says, briefly, that the track is failing.
+
 ## Streaming over mobile data (LTE)
 
 - **Streaming works over LTE by default** when you've chosen to stream — normal
@@ -118,7 +155,7 @@ The player exposes distinct states so the UI is honest and never looks frozen:
 | `loading` | preparing (resolving + opening) | spinner |
 | `buffering` | mid-stream re-buffer (waiting on data) | calm "Buffering…" hint; mini-player spinner; transport stays usable |
 | `playing` / `paused` | steady playback | play/pause |
-| `error` | a specific, friendly failure | the friendly message |
+| `error` | a specific, friendly failure | the message plus the recoveries that apply (Retry / another source / Skip) |
 
 `loading` and `buffering` are deliberately separate: a fresh load shows a
 spinner, while a mid-stream stall shows a subtle "Buffering…" — so the

--- a/lib/core/models/playback_failure.dart
+++ b/lib/core/models/playback_failure.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/foundation.dart';
+
+/// What broadly stopped a track from playing, in the terms a listener can act
+/// on, not in the terms the backend failed in.
+///
+/// The four cases exist because each one has a *different* useful recovery:
+/// waiting/retrying, reconnecting a drive, signing in again, or moving on. A
+/// failure Linthra cannot place lands on [temporarySource], the kind whose
+/// recovery (try again) is the least likely to waste the listener's time.
+enum PlaybackFailureKind {
+  /// A network or provider problem that may well clear on its own: the server
+  /// is unreachable, the connection dropped, the stream came back as something
+  /// other than audio.
+  temporarySource,
+
+  /// An on-device file that isn't where the catalog has it: moved, deleted, or
+  /// on a drive that isn't mounted right now. Nothing here is a server.
+  localFileUnavailable,
+
+  /// The source rejected the session, or no account backs this track's source.
+  /// The fix is a sign-in, not another attempt with the same credentials.
+  sourceSignInRequired,
+
+  /// The audio backend cannot play these bytes: an unsupported container or
+  /// codec, a corrupt file, a decoder the platform doesn't have, or, on a host
+  /// with no audio engine at all, nothing to play them with.
+  unplayableMedia,
+}
+
+/// A recovery the listener can take from a failed track.
+///
+/// Deliberately small: everything else (open Settings, rescan, sign in) is a
+/// trip out of the player, and the player's job here is to get the music going
+/// again or get out of the way.
+enum PlaybackRecoveryAction {
+  /// Try the same copy of the same track again.
+  retry,
+
+  /// Play the same song from another provider that has it.
+  tryAnotherSource,
+
+  /// Give up on this track and advance to the next queued one.
+  skip,
+}
+
+extension PlaybackFailureKindRecovery on PlaybackFailureKind {
+  /// Whether trying the *same* copy again can plausibly work.
+  ///
+  /// A server that was unreachable a second ago may answer now, and a drive
+  /// that wasn't mounted may be mounted, so those two get a Retry. A rejected
+  /// session re-presented unchanged is rejected again, and bytes that would not
+  /// decode do not decode on the second read: offering Retry there would only
+  /// spend the listener's taps on a fixed answer.
+  bool get isWorthRetrying => switch (this) {
+        PlaybackFailureKind.temporarySource => true,
+        PlaybackFailureKind.localFileUnavailable => true,
+        PlaybackFailureKind.sourceSignInRequired => false,
+        PlaybackFailureKind.unplayableMedia => false,
+      };
+
+  /// A few words for a surface with one line to spare (the mini-player), where
+  /// the full [PlaybackFailure.message] would be cut off mid-sentence.
+  String get shortLabel => switch (this) {
+        PlaybackFailureKind.temporarySource => 'Playback problem',
+        PlaybackFailureKind.localFileUnavailable => 'File unavailable',
+        PlaybackFailureKind.sourceSignInRequired => 'Sign-in needed',
+        PlaybackFailureKind.unplayableMedia => "Can't play this track",
+      };
+}
+
+/// Why the current track isn't playing, and what the listener can do about it.
+///
+/// This is the single error model the player surfaces: the mini-player, the
+/// now-playing screen and (later) any other playback surface read this rather
+/// than each deciding for itself what a failure means. The controller builds it
+/// at the moment playback gives up, because that is the only place that knows
+/// all three inputs: what failed, whether another copy of the song exists, and
+/// whether the retry budget is spent.
+///
+/// Security invariant, inherited from every failure that feeds it: [message] is
+/// fixed, friendly text. It NEVER carries an access token, an authenticated
+/// stream URL, a server address, a local file path, or a raw backend exception.
+/// Constructing one from an engine or HTTP error means *classifying* that error
+/// and picking safe wording, never interpolating it.
+@immutable
+class PlaybackFailure {
+  const PlaybackFailure({
+    required this.kind,
+    required this.message,
+    this.canRetry = false,
+    this.canTryAnotherSource = false,
+    this.canSkip = false,
+  });
+
+  /// What broadly went wrong, for the UI to branch on instead of matching text.
+  final PlaybackFailureKind kind;
+
+  /// A friendly, secret-free explanation safe to show as-is.
+  final String message;
+
+  /// Whether trying this same copy again is worth offering: the kind can
+  /// plausibly recover ([PlaybackFailureKindRecovery.isWorthRetrying]) *and*
+  /// this track's bounded attempt budget still has room.
+  final bool canRetry;
+
+  /// Whether this song has another provider copy to try, and the attempt budget
+  /// still has room for it. False for a single-source track (the everyday
+  /// case), so the action never appears where it cannot do anything.
+  final bool canTryAnotherSource;
+
+  /// Whether there is a next track in the queue to move on to.
+  final bool canSkip;
+
+  /// The offered recoveries, in the order the UI should show them: the cheapest
+  /// and most likely to work first, giving up last. Empty when nothing can be
+  /// done here, which is an honest answer the UI renders as a plain message.
+  List<PlaybackRecoveryAction> get actions => <PlaybackRecoveryAction>[
+        if (canRetry) PlaybackRecoveryAction.retry,
+        if (canTryAnotherSource) PlaybackRecoveryAction.tryAnotherSource,
+        if (canSkip) PlaybackRecoveryAction.skip,
+      ];
+
+  /// Whether any recovery is on offer.
+  bool get hasActions => actions.isNotEmpty;
+
+  /// A few words for a one-line surface; the full [message] everywhere else.
+  String get shortLabel => kind.shortLabel;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PlaybackFailure &&
+          other.kind == kind &&
+          other.message == message &&
+          other.canRetry == canRetry &&
+          other.canTryAnotherSource == canTryAnotherSource &&
+          other.canSkip == canSkip);
+
+  @override
+  int get hashCode =>
+      Object.hash(kind, message, canRetry, canTryAnotherSource, canSkip);
+
+  /// Safe to log: the kind and the flags, never the message (which is fixed
+  /// text anyway) and never anything derived from the underlying error.
+  @override
+  String toString() => 'PlaybackFailure(${kind.name}, '
+      'retry: $canRetry, anotherSource: $canTryAnotherSource, skip: $canSkip)';
+}

--- a/lib/core/models/playback_state.dart
+++ b/lib/core/models/playback_state.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 
+import 'playback_failure.dart';
 import 'playback_source.dart';
 import 'repeat_mode.dart';
 import 'track.dart';
@@ -43,7 +44,7 @@ class PlaybackState {
     this.volume = 1.0,
     this.muted = false,
     this.interruptedByTransientFocus = false,
-    this.errorMessage,
+    this.failure,
   });
 
   static const PlaybackState idle = PlaybackState();
@@ -119,11 +120,21 @@ class PlaybackState {
   /// `LinthraAudioHandler._isSessionPlaying`.
   final bool interruptedByTransientFocus;
 
-  /// A friendly, secret-free explanation shown when [status] is
-  /// [PlaybackStatus.error]. Deliberately *not* carried by [copyWith]: it is set
-  /// only on a freshly built error state and clears on the next state change, so
-  /// a stale message can never ride along onto a later playing/paused state.
-  final String? errorMessage;
+  /// Why the current track isn't playing and what the listener can do about it,
+  /// set when [status] is [PlaybackStatus.error]. Deliberately *not* carried by
+  /// [copyWith]: it is set only on a freshly built error state and clears on the
+  /// next state change, so a stale failure can never ride along onto a later
+  /// playing/paused state.
+  ///
+  /// The controller decides the offered recoveries when it builds this, because
+  /// only it knows whether the song has another provider copy and whether the
+  /// bounded retry budget is spent, so the UI renders the actions rather than
+  /// deciding which ones are valid.
+  final PlaybackFailure? failure;
+
+  /// The failure's friendly, secret-free message, for the surfaces (and tests)
+  /// that only want the sentence. Null when nothing has failed.
+  String? get errorMessage => failure?.message;
 
   /// The level actually heard: zero while muted, [volume] otherwise. What a
   /// volume UI (and MPRIS' `Volume`) should show, so muted always reads as
@@ -186,10 +197,10 @@ class PlaybackState {
 
   /// Returns this state with [interruptedByTransientFocus] set to [value].
   ///
-  /// Unlike [copyWith] this preserves [errorMessage], because it re-stamps a
-  /// state the controller has *already* built rather than deriving a new one:
-  /// the focus hold is orthogonal to why playback stopped, so an error state
-  /// must keep its message when the flag is stamped onto it.
+  /// Unlike [copyWith] this preserves [failure], because it re-stamps a state
+  /// the controller has *already* built rather than deriving a new one: the
+  /// focus hold is orthogonal to why playback stopped, so an error state must
+  /// keep its failure when the flag is stamped onto it.
   PlaybackState withTransientFocusInterruption(bool value) {
     if (value == interruptedByTransientFocus) return this;
     return PlaybackState(
@@ -206,14 +217,14 @@ class PlaybackState {
       volume: volume,
       muted: muted,
       interruptedByTransientFocus: value,
-      errorMessage: errorMessage,
+      failure: failure,
     );
   }
 
   /// Returns this state carrying [volume] and [muted].
   ///
   /// Like [withTransientFocusInterruption] this re-stamps a state the
-  /// controller has already built, so [errorMessage] survives: the volume is
+  /// controller has already built, so [failure] survives: the volume is
   /// orthogonal to why playback stopped. Controllers stamp every emission
   /// through here, so no emit path can publish a stale level — including the
   /// paths that build a fresh state rather than copying the last one.
@@ -233,7 +244,7 @@ class PlaybackState {
       volume: volume,
       muted: muted,
       interruptedByTransientFocus: interruptedByTransientFocus,
-      errorMessage: errorMessage,
+      failure: failure,
     );
   }
 
@@ -265,7 +276,7 @@ class PlaybackState {
           other.volume == volume &&
           other.muted == muted &&
           other.interruptedByTransientFocus == interruptedByTransientFocus &&
-          other.errorMessage == errorMessage);
+          other.failure == failure);
 
   @override
   int get hashCode {
@@ -283,7 +294,7 @@ class PlaybackState {
       volume,
       muted,
       interruptedByTransientFocus,
-      errorMessage,
+      failure,
     );
   }
 }

--- a/lib/core/services/active_playback_controller.dart
+++ b/lib/core/services/active_playback_controller.dart
@@ -287,6 +287,17 @@ class ActivePlaybackController implements PlaybackController {
   @override
   Future<void> skipToPrevious() => _local.skipToPrevious();
 
+  // Recovery from a failed track is the local engine's business too: the queue
+  // and the source candidates live there, and a failure can only have come from
+  // it (while casting the receiver owns playback, and the merged state carries
+  // no local failure for the UI to offer a recovery for).
+
+  @override
+  Future<void> retryCurrentTrack() => _local.retryCurrentTrack();
+
+  @override
+  Future<void> tryAnotherSource() => _local.tryAnotherSource();
+
   @override
   void clearQueue() => _local.clearQueue();
 

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -6,6 +6,7 @@ import 'package:audio_session/audio_session.dart';
 import 'package:flutter/foundation.dart';
 import 'package:just_audio/just_audio.dart';
 
+import '../models/playback_failure.dart';
 import '../models/playback_queue.dart';
 import '../models/playback_source.dart';
 import '../models/playback_state.dart';
@@ -17,6 +18,7 @@ import 'local_playback_controller.dart';
 import 'playable_uri_resolver.dart';
 import 'playback_candidate_source.dart';
 import 'playback_controller.dart';
+import 'playback_failure_classifier.dart';
 import 'stability_diagnostics.dart';
 import 'stream_interruption.dart';
 
@@ -127,6 +129,17 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   /// One bounded retry per track for a mid-stream failure, so a transient drop
   /// recovers without ever looping forever on a real outage/expiry.
   static const int _maxStreamRetries = 1;
+
+  /// How many listener-driven recovery attempts (Retry, Try another source) one
+  /// failing track gets before the error state stops offering them.
+  ///
+  /// The automatic budget above bounds what Linthra does on its own; this bounds
+  /// what the error UI keeps offering, so a source that is simply down cannot be
+  /// tapped into an endless resolve/load cycle. Enough attempts to cover a
+  /// listener who reconnects a drive or waits out a blip, few enough that the
+  /// panel stops promising a recovery that clearly isn't coming. The budget is
+  /// per track and is returned in full the moment anything actually plays.
+  static const int maxRecoveryAttemptsPerTrack = 3;
 
   /// Pause before the bounded mid-stream retry so a brief glitch can clear and
   /// we never hammer the server on every drop. Zero in tests.
@@ -303,6 +316,14 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   // failure. Reset when a fresh track loads and when playback reaches `playing`,
   // so each track (and each successful stretch) gets its own one-retry budget.
   int _retriesForCurrent = 0;
+
+  /// The track uri [_recoveryAttempts] is counted for, so the budget follows the
+  /// failing track rather than the session. Null when no attempts are on record.
+  String? _recoveryTrackUri;
+
+  /// Listener-driven recovery attempts spent on [_recoveryTrackUri], bounded by
+  /// [maxRecoveryAttemptsPerTrack] and cleared whenever a track actually starts.
+  int _recoveryAttempts = 0;
 
   /// Whether a mid-stream recovery (bounded retry or sibling fallback) is
   /// already running. Set synchronously before the async work starts so a
@@ -912,7 +933,11 @@ class JustAudioPlaybackController implements LocalPlaybackController {
         await _playCurrent(startAt: _state.position, isRetry: true);
         return;
       }
-      await _tryRemainingCandidatesOrError(track, interruption.message);
+      await _tryRemainingCandidatesOrError(
+        track,
+        interruption.message,
+        playbackFailureKindForInterruption(interruption.kind),
+      );
     } finally {
       _streamRecoveryInFlight = false;
       // Recovery may finish while the UI is still on buffering/reconnecting
@@ -967,6 +992,7 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   Future<void> _tryRemainingCandidatesOrError(
     Track track,
     String message,
+    PlaybackFailureKind kind,
   ) async {
     final Track? current = _queue.current;
     final List<Track> candidates = _candidates.candidatesFor(track);
@@ -979,7 +1005,8 @@ class JustAudioPlaybackController implements LocalPlaybackController {
             : candidates.sublist(playedIndex + 1);
 
     if (remaining.isEmpty) {
-      _emitError(track, message);
+      _emitError(
+          track, _failureFor(track: track, message: message, kind: kind));
       return;
     }
 
@@ -995,12 +1022,13 @@ class JustAudioPlaybackController implements LocalPlaybackController {
       outcome = await _loadFirstWorkingCandidate(remaining, generation);
     } on PlaybackResolutionException catch (error) {
       if (generation != _playbackGeneration) return;
-      _emitError(track, error.message);
+      _emitError(track, _failureFrom(track, error));
       return;
     }
 
     if (outcome == null || generation != _playbackGeneration) return;
 
+    _resetRecoveryBudget();
     final Track played = outcome.track;
     final bool swappedProvider = played.uri != track.uri;
     if (swappedProvider) _queue = _queue.replaceCurrent(played);
@@ -1203,6 +1231,82 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     if (!_queue.hasPrevious) return;
     _queue = _queue.previous();
     await _playCurrent();
+  }
+
+  @override
+  Future<void> retryCurrentTrack() async {
+    // A cast receiver owns playback while suspended; never start local audio
+    // underneath it.
+    if (_suspended) return;
+    // Recovery belongs to a failure: without one there is nothing to retry, and
+    // taking a budget slot for a track that is playing fine would be wrong.
+    if (_state.status != PlaybackStatus.error) return;
+    final Track? track = _queue.current;
+    if (track == null) return;
+    if (!_claimRecoveryAttempt(track)) return;
+    // A deliberate retry is a fresh start for the automatic mid-stream budget
+    // too, exactly as pressing play on a failed track already is.
+    _retriesForCurrent = 0;
+    await _playCurrent(startAt: _state.position);
+  }
+
+  @override
+  Future<void> tryAnotherSource() async {
+    if (_suspended) return;
+    if (_state.status != PlaybackStatus.error) return;
+    final Track? track = _queue.current;
+    if (track == null) return;
+    // The same ordered candidates the automatic fallback uses, minus the copy
+    // that just failed. Empty for a single-source song: nothing to switch to.
+    final List<Track> alternates = _alternateSourcesFor(track);
+    if (alternates.isEmpty) return;
+    if (!_claimRecoveryAttempt(track)) return;
+
+    // This transition supersedes anything still resolving, and each alternate is
+    // tried at most once, so the pass always terminates.
+    final int generation = ++_playbackGeneration;
+    final Duration startAt = _state.position;
+    // Leave the error state while the attempt runs, so the panel doesn't sit
+    // there looking as though the tap did nothing.
+    _emit(_state.copyWith(status: PlaybackStatus.loading));
+
+    final ({Track track, ResolvedPlayable resolved})? outcome;
+    try {
+      outcome = await _loadFirstWorkingCandidate(alternates, generation);
+    } on PlaybackResolutionException catch (error) {
+      if (generation != _playbackGeneration) return;
+      // The other copies failed too: back to an error state, on the same queue
+      // entry, with whatever recoveries are still worth offering.
+      _emitError(track, _failureFrom(track, error));
+      return;
+    }
+
+    // Superseded by a newer skip/seek/play while the alternates resolved.
+    if (outcome == null || generation != _playbackGeneration) return;
+
+    _resetRecoveryBudget();
+    // Replace the queue's current entry rather than adding one: this is the same
+    // song, playing from somewhere else, and it keeps its place in the queue.
+    final Track played = outcome.track;
+    _queue = _queue.replaceCurrent(played);
+    _emit(
+      _state.copyWith(
+        currentTrack: played,
+        source: outcome.resolved.source,
+        upNext: _queue.upNext,
+        previous: _queue.history,
+        hasPrevious: _queue.hasPrevious,
+      ),
+      // A same-bare-id swap (jellyfin:101 -> subsonic:101) leaves every field
+      // equal under PlaybackState ==, so force the emission: otherwise the UI
+      // would keep naming the provider that failed.
+      force: true,
+    );
+
+    await _applyVolume();
+    if (startAt > Duration.zero) await _player.seek(startAt);
+    if (generation != _playbackGeneration) return;
+    unawaited(_player.play());
   }
 
   @override
@@ -1454,8 +1558,8 @@ class JustAudioPlaybackController implements LocalPlaybackController {
       // A failure from a transition the user has already skipped past must not
       // surface as an error on the track they actually landed on.
       if (generation != _playbackGeneration) return;
-      // Every candidate failed: surface one friendly, secret-free message.
-      _emitError(track, error.message);
+      // Every candidate failed: surface one friendly, secret-free failure.
+      _emitError(track, _failureFrom(track, error));
       return;
     }
 
@@ -1465,6 +1569,10 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     // touching the queue, the emitted state, or playback: the newer transition
     // now owns the engine and will load/play its own track.
     if (outcome == null || generation != _playbackGeneration) return;
+
+    // Something played: whatever the listener spent on recovering the previous
+    // attempt is theirs again if this track later fails.
+    _resetRecoveryBudget();
 
     // Make the copy that actually started the current one, so the queue, the
     // mini-player, and the "Playing from …" indicator all reflect the source
@@ -1556,7 +1664,7 @@ class JustAudioPlaybackController implements LocalPlaybackController {
         // — that is turned into an authenticated stream URL before it gets here.
         await _player.setUrl(resolved.uri.toString());
         return (track: candidate, resolved: resolved);
-      } catch (_) {
+      } catch (error) {
         // Resolved (and, for streams, probed) OK but the engine couldn't open
         // it: a start failure. Word it for the source.
         StabilityDiagnostics.playbackError('load');
@@ -1571,17 +1679,22 @@ class JustAudioPlaybackController implements LocalPlaybackController {
         // stale transition rather than recording a failure on a track the user
         // has already moved past.
         if (generation != _playbackGeneration) return null;
-        failures.add(PlaybackResolutionException(
-          _loadErrorFor(resolved.source),
-          kind: PlaybackResolutionErrorKind.streamUnavailable,
-        ));
+        failures.add(_loadFailureFor(error, resolved.source));
         continue;
       }
     }
     if (failures.length == 1) throw failures.first;
-    throw const PlaybackResolutionException(
+    // Every copy failed the same way (all unreachable, none decodable): keep
+    // that kind so the error offers the recovery that fits, with wording that
+    // doesn't pin it on one provider. Mixed causes stay generic.
+    final bool sameKind = failures.isNotEmpty &&
+        failures.every((PlaybackResolutionException failure) =>
+            failure.kind == failures.first.kind);
+    throw PlaybackResolutionException(
       "Couldn't play this track from any available source.",
-      kind: PlaybackResolutionErrorKind.streamUnavailable,
+      kind: sameKind
+          ? failures.first.kind
+          : PlaybackResolutionErrorKind.streamUnavailable,
     );
   }
 
@@ -1627,6 +1740,32 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     }
   }
 
+  /// The failure to record when the engine cannot open an already-resolved
+  /// source.
+  ///
+  /// The engine's raw [error] is *classified*, never echoed (it can carry the
+  /// tokenized stream URL), and only to answer one question: were these bytes
+  /// undecodable, or did the source stop answering? They take different
+  /// recoveries (another copy of the song vs. trying again), so the error UI
+  /// needs them apart. Anything the classifier can't place keeps the previous
+  /// wording and kind, so only a recognised decode failure changes behaviour.
+  static PlaybackResolutionException _loadFailureFor(
+    Object error,
+    PlaybackSource source,
+  ) {
+    if (classifyEngineError(error).kind ==
+        StreamInterruptionKind.formatUnsupported) {
+      return const PlaybackResolutionException(
+        "This track's format isn't supported on this device.",
+        kind: PlaybackResolutionErrorKind.mediaUnsupported,
+      );
+    }
+    return PlaybackResolutionException(
+      _loadErrorFor(source),
+      kind: PlaybackResolutionErrorKind.streamUnavailable,
+    );
+  }
+
   /// The generic message for an engine load failure *after* a successful
   /// resolve, worded for the resolved [source] (a direct stream "couldn't
   /// stream", an on-device/cached file "couldn't play").
@@ -1635,9 +1774,9 @@ class JustAudioPlaybackController implements LocalPlaybackController {
           ? "Couldn't stream this track."
           : "Couldn't play this track.";
 
-  /// Emits an error state for [track] carrying a friendly [message], preserving
-  /// the queue context so the UI keeps showing the right track and up-next.
-  void _emitError(Track track, String message) {
+  /// Emits an error state for [track] carrying [failure], preserving the queue
+  /// context so the UI keeps showing the right track and up-next.
+  void _emitError(Track track, PlaybackFailure failure) {
     _cancelBufferingWatchdog();
     _emit(PlaybackState(
       status: PlaybackStatus.error,
@@ -1647,8 +1786,76 @@ class JustAudioPlaybackController implements LocalPlaybackController {
       hasPrevious: _queue.hasPrevious,
       shuffleEnabled: _shuffleEnabled,
       repeatMode: _repeatMode,
-      errorMessage: message,
+      failure: failure,
     ));
+  }
+
+  /// The user-facing failure for a resolution/load [error] on [track].
+  PlaybackFailure _failureFrom(
+          Track track, PlaybackResolutionException error) =>
+      _failureFor(
+        track: track,
+        message: error.message,
+        kind: playbackFailureKindForResolution(error.kind),
+      );
+
+  /// Builds the failure the error UI renders: the classified [kind], its
+  /// friendly [message], and the recoveries that are actually valid *now*.
+  ///
+  /// Validity is decided here rather than in the UI because only the controller
+  /// knows all three inputs: what failed, whether this song has another provider
+  /// copy, and whether the bounded attempt budget still has room. A track with no
+  /// sibling copy never offers "another source"; a last-in-queue track never
+  /// offers Skip; a spent budget offers neither Retry nor another source, which
+  /// is what keeps the panel from becoming a loop.
+  PlaybackFailure _failureFor({
+    required Track track,
+    required String message,
+    required PlaybackFailureKind kind,
+  }) {
+    final bool hasAttemptsLeft = _recoveryAttemptsLeftFor(track) > 0;
+    return PlaybackFailure(
+      kind: kind,
+      message: message,
+      canRetry: hasAttemptsLeft && kind.isWorthRetrying,
+      canTryAnotherSource:
+          hasAttemptsLeft && _alternateSourcesFor(track).isNotEmpty,
+      canSkip: _queue.hasNext,
+    );
+  }
+
+  /// The other provider copies of [track]'s song, most-preferred first and
+  /// without the copy that is loaded (and failing) right now. Empty for the
+  /// everyday single-source track.
+  List<Track> _alternateSourcesFor(Track track) => <Track>[
+        for (final Track candidate in _candidates.candidatesFor(track))
+          if (candidate.uri != track.uri) candidate,
+      ];
+
+  /// How many listener-driven recovery attempts [track] has left. A track the
+  /// budget isn't counting yet has the full allowance.
+  int _recoveryAttemptsLeftFor(Track track) => _recoveryTrackUri == track.uri
+      ? maxRecoveryAttemptsPerTrack - _recoveryAttempts
+      : maxRecoveryAttemptsPerTrack;
+
+  /// Takes one attempt from [track]'s budget, returning false when it is spent.
+  /// Moving to a different track starts a fresh budget.
+  bool _claimRecoveryAttempt(Track track) {
+    if (_recoveryTrackUri != track.uri) {
+      _recoveryTrackUri = track.uri;
+      _recoveryAttempts = 0;
+    }
+    if (_recoveryAttempts >= maxRecoveryAttemptsPerTrack) return false;
+    _recoveryAttempts++;
+    return true;
+  }
+
+  /// Returns the budget in full. Called the moment a track actually starts, so
+  /// the allowance is spent on a track that is failing *now*, never carried over
+  /// from a stretch of playback that worked.
+  void _resetRecoveryBudget() {
+    _recoveryTrackUri = null;
+    _recoveryAttempts = 0;
   }
 
   @override

--- a/lib/core/services/playable_uri_resolver.dart
+++ b/lib/core/services/playable_uri_resolver.dart
@@ -51,6 +51,16 @@ enum PlaybackResolutionErrorKind {
   /// at its new path), or plugging the drive back in. Nothing on disk is
   /// touched either way, because Linthra never deletes or moves the user's audio.
   localFileMissing,
+
+  /// The URI resolved and the bytes were reachable, but the audio backend could
+  /// not play them: an unsupported container or codec, a corrupt file, or a
+  /// decoder this platform doesn't have.
+  ///
+  /// Raised where a *load* fails rather than a resolve: the engine's own error
+  /// is classified (never echoed) to tell this apart from a source that simply
+  /// stopped answering, because the two have different recoveries. Retrying the
+  /// same bytes cannot fix a decode, but another copy of the song might play.
+  mediaUnsupported,
 }
 
 /// A typed, user-facing failure raised while resolving a [Track] to a URI the

--- a/lib/core/services/playback_controller.dart
+++ b/lib/core/services/playback_controller.dart
@@ -57,6 +57,27 @@ abstract interface class PlaybackController {
   /// has no upcoming tracks.
   Future<void> skipToNext();
 
+  /// Tries the *same* copy of the failed track again, from the position it
+  /// stopped at.
+  ///
+  /// The listener's half of playback recovery: called when the error UI's Retry
+  /// is tapped, never automatically. Attempts are bounded per track, so a source
+  /// that keeps failing stops offering Retry
+  /// ([PlaybackState.failure]'s `canRetry`) instead of looping; once the budget
+  /// is spent this is a no-op. A no-op too when nothing is loaded.
+  Future<void> retryCurrentTrack();
+
+  /// Plays the same song from another provider that has it, keeping its place in
+  /// the queue.
+  ///
+  /// Uses the same ordered logical-track candidates the automatic runtime
+  /// fallback uses, most-preferred first, skipping the copy that just failed;
+  /// the queue entry is *replaced* by the copy that works rather than a second
+  /// entry being added. Shares the bounded per-track attempt budget with
+  /// [retryCurrentTrack]. A no-op when the song has no other copy, when the
+  /// budget is spent, or when nothing is loaded.
+  Future<void> tryAnotherSource();
+
   /// Steps back to the previous track in the queue, if any. A no-op when the
   /// current track is the first one.
   Future<void> skipToPrevious();

--- a/lib/core/services/playback_failure_classifier.dart
+++ b/lib/core/services/playback_failure_classifier.dart
@@ -1,0 +1,60 @@
+import '../models/playback_failure.dart';
+import 'playable_uri_resolver.dart';
+import 'stream_interruption.dart';
+
+/// Bridges the two typed failure vocabularies playback already has,
+/// [PlaybackResolutionErrorKind] (couldn't produce a playable URI) and
+/// [StreamInterruptionKind] (the engine stopped mid-stream), onto the single
+/// [PlaybackFailureKind] the UI reasons about.
+///
+/// Both switches are exhaustive on purpose: adding a resolution or interruption
+/// kind is a compile error here rather than a failure that silently lands on
+/// the wrong recovery. Nothing in this file touches an error's *text*, so no
+/// message, URL, or token can leak through the mapping.
+PlaybackFailureKind playbackFailureKindForResolution(
+  PlaybackResolutionErrorKind kind,
+) {
+  switch (kind) {
+    // No session, or one the server no longer accepts: another attempt with the
+    // same credentials gets the same answer.
+    case PlaybackResolutionErrorKind.notSignedIn:
+    case PlaybackResolutionErrorKind.sessionExpired:
+      return PlaybackFailureKind.sourceSignInRequired;
+
+    // The file is the thing that isn't there; no server was involved.
+    case PlaybackResolutionErrorKind.localFileMissing:
+      return PlaybackFailureKind.localFileUnavailable;
+
+    // The backend could not open or decode what it was handed.
+    case PlaybackResolutionErrorKind.mediaUnsupported:
+      return PlaybackFailureKind.unplayableMedia;
+
+    // Everything else is the source misbehaving rather than the music being
+    // unplayable: unreachable, a challenge/login page, a non-audio answer, or
+    // no stream right now. All of them can be fine on the next attempt.
+    case PlaybackResolutionErrorKind.serverUnreachable:
+    case PlaybackResolutionErrorKind.invalidStream:
+    case PlaybackResolutionErrorKind.serverReturnedWebPage:
+    case PlaybackResolutionErrorKind.streamUnavailable:
+      return PlaybackFailureKind.temporarySource;
+  }
+}
+
+/// The [PlaybackFailureKind] a classified mid-stream interruption implies.
+PlaybackFailureKind playbackFailureKindForInterruption(
+  StreamInterruptionKind kind,
+) {
+  switch (kind) {
+    case StreamInterruptionKind.sessionExpired:
+      return PlaybackFailureKind.sourceSignInRequired;
+    case StreamInterruptionKind.formatUnsupported:
+      return PlaybackFailureKind.unplayableMedia;
+    case StreamInterruptionKind.networkDropped:
+    case StreamInterruptionKind.serverUnreachable:
+    // An interruption Linthra can't place is treated as a glitch, here as in
+    // [classifyEngineError]: the recovery it offers (try again) is the one most
+    // likely to help and the cheapest to be wrong about.
+    case StreamInterruptionKind.unknown:
+      return PlaybackFailureKind.temporarySource;
+  }
+}

--- a/lib/core/services/reachability.dart
+++ b/lib/core/services/reachability.dart
@@ -72,7 +72,8 @@ enum ReachabilityStatus {
 /// Returns `null` for track-specific or content failures
 /// ([PlaybackResolutionErrorKind.streamUnavailable],
 /// [PlaybackResolutionErrorKind.invalidStream],
-/// [PlaybackResolutionErrorKind.serverReturnedWebPage]) and for
+/// [PlaybackResolutionErrorKind.serverReturnedWebPage],
+/// [PlaybackResolutionErrorKind.mediaUnsupported]) and for
 /// [PlaybackResolutionErrorKind.notSignedIn]: the server may well be fine for
 /// the *next* track, so caching "unreachable" off one of these would wrongly
 /// suppress good copies.
@@ -92,6 +93,9 @@ ReachabilityStatus? reachabilityFromPlaybackError(
     // server: no provider was contacted, and caching an outage off it would
     // suppress perfectly good remote copies of the same song.
     case PlaybackResolutionErrorKind.localFileMissing:
+    // Nor does one track the backend couldn't decode: the server delivered the
+    // bytes it was asked for, so the next track may well play fine.
+    case PlaybackResolutionErrorKind.mediaUnsupported:
       return null;
   }
 }

--- a/lib/core/services/unsupported_playback_controller.dart
+++ b/lib/core/services/unsupported_playback_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import '../models/playback_failure.dart';
 import '../models/playback_state.dart';
 import '../models/repeat_mode.dart';
 import '../models/track.dart';
@@ -35,6 +36,14 @@ class UnsupportedPlaybackController implements LocalPlaybackController {
       'Audio playback is not available on this platform yet.';
 
   final String _reason;
+
+  /// The failure every refusal publishes: this host has no audio backend, so
+  /// nothing here is retryable and no other provider copy would fare better.
+  /// Skipping is left to the queue, which [_refuse] fills in.
+  late final PlaybackFailure _failure = PlaybackFailure(
+    kind: PlaybackFailureKind.unplayableMedia,
+    message: _reason,
+  );
   final StreamController<PlaybackState> _states =
       StreamController<PlaybackState>.broadcast();
 
@@ -58,7 +67,7 @@ class UnsupportedPlaybackController implements LocalPlaybackController {
     _emit(PlaybackState(
       status: PlaybackStatus.error,
       currentTrack: track ?? _state.currentTrack,
-      errorMessage: _reason,
+      failure: _failure,
       shuffleEnabled: _state.shuffleEnabled,
       repeatMode: _state.repeatMode,
     ));
@@ -106,6 +115,15 @@ class UnsupportedPlaybackController implements LocalPlaybackController {
   @override
   Future<void> skipToPrevious() async => _refuse(null);
 
+  // There is nothing to recover *to* on a host with no audio engine, so the
+  // recovery actions refuse exactly like play does rather than pretending to
+  // try. The published failure offers neither, so the error UI shows neither.
+  @override
+  Future<void> retryCurrentTrack() async => _refuse(null);
+
+  @override
+  Future<void> tryAnotherSource() async => _refuse(null);
+
   // Everything below either has no audio to act on or is a mode the UI may set
   // before anything plays. These stay quiet no-ops so the settings and queue
   // screens behave normally instead of erroring at rest.
@@ -124,7 +142,7 @@ class UnsupportedPlaybackController implements LocalPlaybackController {
     _emit(PlaybackState(
       status: _state.status,
       currentTrack: _state.currentTrack,
-      errorMessage: _state.errorMessage,
+      failure: _state.failure,
       shuffleEnabled: enabled,
       repeatMode: _state.repeatMode,
     ));
@@ -135,7 +153,7 @@ class UnsupportedPlaybackController implements LocalPlaybackController {
     _emit(PlaybackState(
       status: _state.status,
       currentTrack: _state.currentTrack,
-      errorMessage: _state.errorMessage,
+      failure: _state.failure,
       shuffleEnabled: _state.shuffleEnabled,
       repeatMode: mode,
     ));

--- a/lib/features/player/mini_player.dart
+++ b/lib/features/player/mini_player.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../app/dimens.dart';
 import '../../app/routes.dart';
+import '../../core/models/playback_failure.dart';
 import '../../core/models/playback_source.dart';
 import '../../core/models/playback_state.dart';
 import '../../core/models/track.dart';
@@ -66,20 +67,28 @@ class MiniPlayer extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // Watch only the current track (id-distinct) and its resolved source, so the
-    // ~5 Hz position ticks rebuild just the thin progress line and the transport
-    // buttons below — not the whole bar (artwork, text) on every screen, every
-    // tick. The source changes only when the track does, so including it adds no
-    // tick rebuilds. Falls back to the controller's latest state until the first
-    // stream event arrives.
-    final (Track?, PlaybackSource?) streamed = ref.watch(
+    // Watch only the current track (id-distinct), its resolved source and
+    // whether it is failing, so the ~5 Hz position ticks rebuild just the thin
+    // progress line and the transport buttons below, not the whole bar
+    // (artwork, text) on every screen, every tick. All three change only when
+    // the track or its outcome does, so they add no tick rebuilds. Falls back to
+    // the controller's latest state until the first stream event arrives.
+    final (Track?, PlaybackSource?, PlaybackFailure?) streamed = ref.watch(
       playbackStateProvider.select(
-        (s) => (s.valueOrNull?.currentTrack, s.valueOrNull?.source),
+        (s) => (
+          s.valueOrNull?.currentTrack,
+          s.valueOrNull?.source,
+          s.valueOrNull?.failure,
+        ),
       ),
     );
     final PlaybackState fallback = ref.read(playbackControllerProvider).state;
     final Track? track = streamed.$1 ?? fallback.currentTrack;
     final PlaybackSource? source = streamed.$2 ?? fallback.source;
+    // Why the bar is quiet, when it is. The bar has one line for it, so it shows
+    // the short form and the full message plus its recoveries live on the
+    // now-playing screen a tap away.
+    final PlaybackFailure? failure = streamed.$3 ?? fallback.failure;
 
     // Collapse entirely when there is nothing to show, so screens without a
     // loaded track look exactly as they did before.
@@ -127,6 +136,7 @@ class MiniPlayer extends ConsumerWidget {
                         subtitle: subtitle,
                         sourceName: sourceName,
                         isCasting: isCasting,
+                        failure: failure,
                       );
 
                       // Desktop bars wide enough for the full transport also
@@ -204,12 +214,17 @@ class _NowPlayingMetadata extends StatelessWidget {
     required this.subtitle,
     required this.sourceName,
     required this.isCasting,
+    required this.failure,
   });
 
   final Track track;
   final String? subtitle;
   final String? sourceName;
   final bool isCasting;
+
+  /// Set when the current track failed to play; the second line then says so
+  /// instead of naming an artist and a source that isn't playing anything.
+  final PlaybackFailure? failure;
 
   @override
   Widget build(BuildContext context) {
@@ -246,7 +261,9 @@ class _NowPlayingMetadata extends StatelessWidget {
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                 ),
-                if (subtitle != null || sourceName != null)
+                if (failure != null)
+                  _MiniFailureLine(failure: failure!)
+                else if (subtitle != null || sourceName != null)
                   _MiniSubtitle(subtitle: subtitle, sourceName: sourceName),
               ],
             ),
@@ -263,6 +280,46 @@ class _NowPlayingMetadata extends StatelessWidget {
             semanticLabel: 'Casting',
           ),
         ],
+      ],
+    );
+  }
+}
+
+/// The mini-player's second line when the current track failed: a short reason,
+/// in the error colour, in place of the artist • source line.
+///
+/// One line is all the bar has, so it carries the short form of the failure and
+/// nothing else. The full message and the Retry / another source / Skip actions
+/// are on the now-playing screen, which tapping the bar opens. It reads from the
+/// same [PlaybackFailure] that screen does, so the two can never disagree about
+/// what went wrong.
+class _MiniFailureLine extends StatelessWidget {
+  const _MiniFailureLine({required this.failure});
+
+  final PlaybackFailure failure;
+
+  /// Finds the line in tests.
+  static const ValueKey<String> lineKey =
+      ValueKey<String>('mini-player-failure');
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color color = theme.colorScheme.error;
+    return Row(
+      key: lineKey,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        Icon(Icons.error_outline, size: 14, color: color),
+        const SizedBox(width: AppSpacing.xs),
+        Flexible(
+          child: Text(
+            failure.shortLabel,
+            style: theme.textTheme.bodySmall?.copyWith(color: color),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
       ],
     );
   }

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -1,9 +1,8 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../app/dimens.dart';
+import '../../core/models/playback_failure.dart';
 import '../../core/models/playback_state.dart';
 import '../../core/models/track.dart';
 import '../../data/repositories/host_platform_provider.dart';
@@ -18,6 +17,7 @@ import 'widgets/lyrics_view.dart';
 import 'widgets/now_playing_actions.dart';
 import 'widgets/now_playing_background.dart';
 import 'widgets/playback_controls.dart';
+import 'widgets/playback_error_notice.dart';
 import 'widgets/playback_progress_bar.dart';
 import 'widgets/queue_sheet.dart';
 import 'widgets/track_metadata.dart';
@@ -512,10 +512,18 @@ class _LiveControls extends ConsumerWidget {
     final controller = ref.watch(playbackControllerProvider);
     final PlaybackState state =
         ref.watch(playbackStateProvider).valueOrNull ?? controller.state;
+    // A failed track takes the status strip rather than a dialog: the transport,
+    // the queue and the rest of the app stay usable underneath it. It needs more
+    // than the one line the strip reserves (a readable sentence plus its
+    // actions), so it replaces the slot instead of squeezing into it.
+    final PlaybackFailure? failure = state.failure;
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        _StatusSlot(child: _SourceOrError(state: state)),
+        if (failure != null)
+          PlaybackErrorNotice(failure: failure)
+        else
+          _StatusSlot(child: _SourceIndicator(state: state)),
         const SizedBox(height: AppSpacing.md),
         PlaybackProgressBar(
           // Identity is the track, so a track change disposes the bar's state
@@ -573,19 +581,21 @@ class _StatusSlot extends StatelessWidget {
 }
 
 /// Under the metadata: while casting, a clear `Casting to …` indicator;
-/// otherwise a friendly error message when playback failed, or the
-/// playback-source badge ("Playing from Navidrome / Jellyfin / Local music /
-/// Cache") once a track has resolved — naming the copy actually playing, not the
-/// active/default provider. Shows nothing while a track is still loading locally.
-class _SourceOrError extends ConsumerWidget {
-  const _SourceOrError({required this.state});
+/// otherwise a buffering/reconnecting hint, or the playback-source badge
+/// ("Playing from Navidrome / Jellyfin / Local music / Cache") once a track has
+/// resolved, naming the copy actually playing, not the active/default provider.
+/// Shows nothing while a track is still loading locally.
+///
+/// A *failed* track is not shown here: [PlaybackErrorNotice] takes this whole
+/// band, because an error has a message and recoveries rather than a one-line
+/// badge.
+class _SourceIndicator extends ConsumerWidget {
+  const _SourceIndicator({required this.state});
 
   final PlaybackState state;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final theme = Theme.of(context);
-
     // While casting, the source badge would be misleading (the receiver, not
     // this device, is playing); show where the audio is going instead.
     final castState = ref.watch(
@@ -597,45 +607,8 @@ class _SourceOrError extends ConsumerWidget {
       return _CastingIndicator(deviceName: cast.connectedDevice!.name);
     }
 
-    if (state.status == PlaybackStatus.error) {
-      return Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Flexible(
-            child: Text(
-              state.errorMessage ?? "Couldn't play this track",
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: theme.colorScheme.error,
-              ),
-              textAlign: TextAlign.center,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-            ),
-          ),
-          if (state.currentTrack != null) ...[
-            const SizedBox(width: AppSpacing.xs),
-            TextButton(
-              onPressed: () =>
-                  unawaited(ref.read(playbackControllerProvider).play()),
-              style: TextButton.styleFrom(
-                padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
-                minimumSize: Size.zero,
-                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              ),
-              child: Text(
-                'Retry',
-                style: theme.textTheme.labelLarge?.copyWith(
-                  color: theme.colorScheme.primary,
-                ),
-              ),
-            ),
-          ],
-        ],
-      );
-    }
     // A mid-stream network reconnect: distinct from plain "Buffering…" and from
-    // a permanent error + Retry, so the listener knows recovery is in flight.
+    // the permanent-failure panel, so the listener knows recovery is in flight.
     if (state.status == PlaybackStatus.reconnecting) {
       return const _ReconnectingIndicator();
     }

--- a/lib/features/player/widgets/playback_error_notice.dart
+++ b/lib/features/player/widgets/playback_error_notice.dart
@@ -1,0 +1,222 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/models/playback_failure.dart';
+import '../../../core/models/playback_state.dart';
+import '../../../core/services/playback_controller.dart';
+import '../../../core/services/playback_source_label.dart';
+import '../player_providers.dart';
+
+/// The in-place panel shown when the current track can't play: what went wrong,
+/// in plain words, and the recoveries that are actually available for it.
+///
+/// Deliberately *not* a dialog. A failed track is a small problem (the queue,
+/// the library, search and settings all still work), so it takes the strip the
+/// source badge normally occupies rather than taking over the screen. Nothing
+/// here decides what is recoverable: the actions come from
+/// [PlaybackFailure] as the controller built it, which is why a single-source
+/// song never offers "another source" and the last track in a queue never offers
+/// Skip.
+///
+/// Every action runs through the shared [PlaybackController] (the same one
+/// transport buttons use), so recovery behaves identically on Android and Linux
+/// and cannot drift into a second, parallel playback path.
+class PlaybackErrorNotice extends ConsumerStatefulWidget {
+  const PlaybackErrorNotice({required this.failure, super.key});
+
+  /// Why playback stopped, and which recoveries are valid.
+  final PlaybackFailure failure;
+
+  /// Finds the panel in tests.
+  static const ValueKey<String> noticeKey =
+      ValueKey<String>('playback-error-notice');
+
+  /// Finds one action button in tests.
+  static ValueKey<String> keyForAction(PlaybackRecoveryAction action) =>
+      ValueKey<String>('playback-error-action-${action.name}');
+
+  @override
+  ConsumerState<PlaybackErrorNotice> createState() =>
+      _PlaybackErrorNoticeState();
+}
+
+class _PlaybackErrorNoticeState extends ConsumerState<PlaybackErrorNotice> {
+  /// The action currently running, or null when the panel is idle.
+  ///
+  /// It is what keeps a recovery to exactly one attempt per tap: while it is
+  /// set the buttons are gone, so an impatient second tap on Skip cannot advance
+  /// the queue twice, and two recoveries can never race each other.
+  PlaybackRecoveryAction? _running;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color onError = theme.colorScheme.onErrorContainer;
+    final PlaybackRecoveryAction? running = _running;
+
+    return Semantics(
+      container: true,
+      // Playback fails without the listener touching anything, so a screen
+      // reader should hear about it when it happens rather than on the next
+      // focus change.
+      liveRegion: true,
+      child: Container(
+        key: PlaybackErrorNotice.noticeKey,
+        width: double.infinity,
+        padding: const EdgeInsets.all(AppSpacing.md),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.errorContainer,
+          borderRadius: BorderRadius.circular(AppRadii.md),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Icon(_iconFor(widget.failure.kind), size: 20, color: onError),
+                const SizedBox(width: AppSpacing.sm),
+                Expanded(
+                  child: Text(
+                    widget.failure.message,
+                    style: theme.textTheme.bodyMedium?.copyWith(color: onError),
+                  ),
+                ),
+              ],
+            ),
+            if (running != null) ...<Widget>[
+              const SizedBox(height: AppSpacing.sm),
+              _BusyRow(label: _busyLabelFor(running), color: onError),
+            ] else if (widget.failure.hasActions) ...<Widget>[
+              const SizedBox(height: AppSpacing.xs),
+              // Wraps rather than scrolls: at a large text scale three buttons
+              // do not fit one line on a phone, and a recovery the listener
+              // cannot see is no recovery at all.
+              Wrap(
+                spacing: AppSpacing.xs,
+                runSpacing: AppSpacing.xs,
+                children: <Widget>[
+                  for (final PlaybackRecoveryAction action
+                      in widget.failure.actions)
+                    TextButton.icon(
+                      key: PlaybackErrorNotice.keyForAction(action),
+                      onPressed: () => _run(action),
+                      icon: Icon(_actionIconFor(action), size: 18),
+                      label: Text(_actionLabelFor(action)),
+                      style: TextButton.styleFrom(foregroundColor: onError),
+                    ),
+                ],
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Runs one recovery through the shared controller and reports what came of
+  /// it.
+  Future<void> _run(PlaybackRecoveryAction action) async {
+    if (_running != null) return;
+    setState(() => _running = action);
+
+    final PlaybackController controller = ref.read(playbackControllerProvider);
+    final String? failedUri = controller.state.currentTrack?.uri;
+    final ScaffoldMessengerState? messenger =
+        ScaffoldMessenger.maybeOf(context);
+
+    switch (action) {
+      case PlaybackRecoveryAction.retry:
+        await controller.retryCurrentTrack();
+      case PlaybackRecoveryAction.tryAnotherSource:
+        await controller.tryAnotherSource();
+      case PlaybackRecoveryAction.skip:
+        await controller.skipToNext();
+    }
+
+    // This panel is usually gone by now: playback leaves the error state the
+    // moment an attempt starts, which takes the panel with it. So the outcome is
+    // reported through the messenger captured above rather than through this
+    // widget, and the reset below only matters when the panel is still up (a
+    // recovery that changed nothing).
+    if (mounted) setState(() => _running = null);
+
+    // A retry that worked, or a skip, is obvious: the music plays and the panel
+    // is gone. A source switch is the quiet one: same song, same place in the
+    // queue, only a different provider behind it. So say so.
+    if (action != PlaybackRecoveryAction.tryAnotherSource) return;
+    final PlaybackState after = controller.state;
+    final bool switched = after.status != PlaybackStatus.error &&
+        after.currentTrack?.uri != failedUri;
+    if (!switched) return;
+    if (messenger == null || !messenger.mounted) return;
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(
+          'Playing from ${PlaybackSourceLabel.of(
+            trackUri: after.currentTrack?.uri,
+            source: after.source,
+          )}.',
+        ),
+      ),
+    );
+  }
+
+  static IconData _iconFor(PlaybackFailureKind kind) => switch (kind) {
+        PlaybackFailureKind.temporarySource => Icons.cloud_off,
+        PlaybackFailureKind.localFileUnavailable => Icons.folder_off,
+        PlaybackFailureKind.sourceSignInRequired => Icons.lock_outline,
+        PlaybackFailureKind.unplayableMedia => Icons.music_off,
+      };
+
+  static IconData _actionIconFor(PlaybackRecoveryAction action) =>
+      switch (action) {
+        PlaybackRecoveryAction.retry => Icons.refresh,
+        PlaybackRecoveryAction.tryAnotherSource => Icons.swap_horiz,
+        PlaybackRecoveryAction.skip => Icons.skip_next,
+      };
+
+  static String _actionLabelFor(PlaybackRecoveryAction action) =>
+      switch (action) {
+        PlaybackRecoveryAction.retry => 'Retry',
+        PlaybackRecoveryAction.tryAnotherSource => 'Try another source',
+        PlaybackRecoveryAction.skip => 'Skip',
+      };
+
+  static String _busyLabelFor(PlaybackRecoveryAction action) =>
+      switch (action) {
+        PlaybackRecoveryAction.retry => 'Trying again…',
+        PlaybackRecoveryAction.tryAnotherSource => 'Trying another source…',
+        PlaybackRecoveryAction.skip => 'Skipping…',
+      };
+}
+
+/// What the panel shows while a recovery is in flight, so a tap is visibly
+/// doing something even when resolving a fresh stream takes a moment.
+class _BusyRow extends StatelessWidget {
+  const _BusyRow({required this.label, required this.color});
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        SizedBox.square(
+          dimension: 14,
+          child: CircularProgressIndicator(strokeWidth: 2, color: color),
+        ),
+        const SizedBox(width: AppSpacing.sm),
+        Text(
+          label,
+          style: theme.textTheme.labelLarge?.copyWith(color: color),
+        ),
+      ],
+    );
+  }
+}

--- a/test/core/models/playback_failure_test.dart
+++ b/test/core/models/playback_failure_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_failure.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/services/playable_uri_resolver.dart';
+import 'package:linthra/core/services/playback_failure_classifier.dart';
+import 'package:linthra/core/services/stream_interruption.dart';
+
+void main() {
+  group('offered actions', () {
+    test('are listed cheapest-first and only when valid', () {
+      const PlaybackFailure failure = PlaybackFailure(
+        kind: PlaybackFailureKind.temporarySource,
+        message: "Couldn't reach your music server.",
+        canRetry: true,
+        canTryAnotherSource: true,
+        canSkip: true,
+      );
+
+      expect(failure.actions, <PlaybackRecoveryAction>[
+        PlaybackRecoveryAction.retry,
+        PlaybackRecoveryAction.tryAnotherSource,
+        PlaybackRecoveryAction.skip,
+      ]);
+      expect(failure.hasActions, isTrue);
+    });
+
+    test('a failure with nothing to offer says so rather than pretending', () {
+      const PlaybackFailure failure = PlaybackFailure(
+        kind: PlaybackFailureKind.unplayableMedia,
+        message: "This track's format isn't supported on this device.",
+      );
+
+      expect(failure.actions, isEmpty);
+      expect(failure.hasActions, isFalse);
+    });
+  });
+
+  group('what is worth retrying', () {
+    test('a source or a drive can come back; a session and a codec cannot', () {
+      expect(PlaybackFailureKind.temporarySource.isWorthRetrying, isTrue);
+      expect(PlaybackFailureKind.localFileUnavailable.isWorthRetrying, isTrue);
+      expect(PlaybackFailureKind.sourceSignInRequired.isWorthRetrying, isFalse);
+      expect(PlaybackFailureKind.unplayableMedia.isWorthRetrying, isFalse);
+    });
+  });
+
+  group('classifying the failures playback already has', () {
+    test('every resolution kind maps to the recovery that fits it', () {
+      const Map<PlaybackResolutionErrorKind, PlaybackFailureKind> expected =
+          <PlaybackResolutionErrorKind, PlaybackFailureKind>{
+        PlaybackResolutionErrorKind.notSignedIn:
+            PlaybackFailureKind.sourceSignInRequired,
+        PlaybackResolutionErrorKind.sessionExpired:
+            PlaybackFailureKind.sourceSignInRequired,
+        PlaybackResolutionErrorKind.serverUnreachable:
+            PlaybackFailureKind.temporarySource,
+        PlaybackResolutionErrorKind.invalidStream:
+            PlaybackFailureKind.temporarySource,
+        PlaybackResolutionErrorKind.serverReturnedWebPage:
+            PlaybackFailureKind.temporarySource,
+        PlaybackResolutionErrorKind.streamUnavailable:
+            PlaybackFailureKind.temporarySource,
+        PlaybackResolutionErrorKind.localFileMissing:
+            PlaybackFailureKind.localFileUnavailable,
+        PlaybackResolutionErrorKind.mediaUnsupported:
+            PlaybackFailureKind.unplayableMedia,
+      };
+
+      // Every kind is covered, so a new one cannot slip through untested.
+      expect(expected.keys, containsAll(PlaybackResolutionErrorKind.values));
+      expected.forEach((
+        PlaybackResolutionErrorKind kind,
+        PlaybackFailureKind failure,
+      ) {
+        expect(playbackFailureKindForResolution(kind), failure,
+            reason: '$kind');
+      });
+    });
+
+    test('every mid-stream interruption maps too', () {
+      const Map<StreamInterruptionKind, PlaybackFailureKind> expected =
+          <StreamInterruptionKind, PlaybackFailureKind>{
+        StreamInterruptionKind.networkDropped:
+            PlaybackFailureKind.temporarySource,
+        StreamInterruptionKind.serverUnreachable:
+            PlaybackFailureKind.temporarySource,
+        StreamInterruptionKind.unknown: PlaybackFailureKind.temporarySource,
+        StreamInterruptionKind.sessionExpired:
+            PlaybackFailureKind.sourceSignInRequired,
+        StreamInterruptionKind.formatUnsupported:
+            PlaybackFailureKind.unplayableMedia,
+      };
+
+      expect(expected.keys, containsAll(StreamInterruptionKind.values));
+      expected.forEach((
+        StreamInterruptionKind kind,
+        PlaybackFailureKind failure,
+      ) {
+        expect(
+          playbackFailureKindForInterruption(kind),
+          failure,
+          reason: '$kind',
+        );
+      });
+    });
+  });
+
+  group('on the playback state', () {
+    const PlaybackFailure failure = PlaybackFailure(
+      kind: PlaybackFailureKind.temporarySource,
+      message: "Couldn't reach your music server.",
+      canRetry: true,
+    );
+
+    test('the message reads through for the surfaces that only want it', () {
+      const PlaybackState state = PlaybackState(
+        status: PlaybackStatus.error,
+        failure: failure,
+      );
+
+      expect(state.errorMessage, "Couldn't reach your music server.");
+      expect(const PlaybackState().errorMessage, isNull);
+    });
+
+    test('it clears on the next state change but survives a volume stamp', () {
+      const PlaybackState errored = PlaybackState(
+        status: PlaybackStatus.error,
+        failure: failure,
+      );
+
+      // A derived state is a *new* situation: the failure does not ride along.
+      expect(errored.copyWith(status: PlaybackStatus.loading).failure, isNull);
+      // A re-stamp of the same situation keeps it.
+      expect(
+        errored.withVolume(volume: 0.4, muted: false).failure,
+        failure,
+      );
+      expect(errored.withTransientFocusInterruption(true).failure, failure);
+    });
+
+    test('two states differing only in their failure are not equal', () {
+      const PlaybackState a = PlaybackState(
+        status: PlaybackStatus.error,
+        failure: failure,
+      );
+      const PlaybackState b = PlaybackState(
+        status: PlaybackStatus.error,
+        failure: PlaybackFailure(
+          kind: PlaybackFailureKind.unplayableMedia,
+          message: "Couldn't reach your music server.",
+          canRetry: true,
+        ),
+      );
+
+      expect(a, isNot(b));
+      expect(
+          a,
+          const PlaybackState(
+            status: PlaybackStatus.error,
+            failure: failure,
+          ));
+    });
+  });
+}

--- a/test/core/services/active_playback_controller_test.dart
+++ b/test/core/services/active_playback_controller_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/active_playback_output.dart';
 import 'package:linthra/core/models/cast_playback_status.dart';
 import 'package:linthra/core/models/cast_state.dart';
+import 'package:linthra/core/models/playback_failure.dart';
 import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/models/repeat_mode.dart';
 import 'package:linthra/core/models/track.dart';
@@ -233,12 +234,16 @@ void main() {
       local.emit(const PlaybackState(
         status: PlaybackStatus.error,
         currentTrack: _trackA,
-        errorMessage: "Couldn't stream this track.",
+        failure: PlaybackFailure(
+          kind: PlaybackFailureKind.temporarySource,
+          message: "Couldn't stream this track.",
+        ),
       ));
       await Future<void>.delayed(const Duration(milliseconds: 10));
 
       expect(controller.activeOutput, ActivePlaybackOutput.cast);
       expect(controller.state.status, PlaybackStatus.playing);
+      expect(controller.state.failure, isNull);
       expect(controller.state.errorMessage, isNull);
       expect(local.playCount, 0);
     });

--- a/test/core/services/playback_error_recovery_test.dart
+++ b/test/core/services/playback_error_recovery_test.dart
@@ -1,0 +1,631 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:linthra/core/models/playback_failure.dart';
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/just_audio_playback_controller.dart';
+import 'package:linthra/core/services/playable_uri_resolver.dart';
+import 'package:linthra/core/services/playback_candidate_source.dart';
+import 'package:linthra/core/services/stream_interruption.dart';
+
+/// A secret the fakes weave into every URL and raw error they produce, so a test
+/// can assert that nothing the listener is shown was built from one.
+const String _secret = 'token=SUPERSECRET';
+
+/// A fake engine that records what it opened and can be told to fail opening
+/// specific URLs, either as a generic start failure or as a decode failure,
+/// whose raw error deliberately carries the tokenized URL a real engine echoes.
+class _FakePlayer extends Fake implements AudioPlayer {
+  _FakePlayer({
+    Set<String> failUrls = const <String>{},
+    Set<String> undecodableUrls = const <String>{},
+  })  : failUrls = <String>{...failUrls},
+        undecodableUrls = <String>{...undecodableUrls};
+
+  final Set<String> failUrls;
+  final Set<String> undecodableUrls;
+  final List<String> setUrlCalls = <String>[];
+
+  @override
+  Stream<PlayerState> get playerStateStream =>
+      const Stream<PlayerState>.empty();
+  @override
+  Stream<Duration> get positionStream => const Stream<Duration>.empty();
+  @override
+  Stream<Duration?> get durationStream => const Stream<Duration?>.empty();
+  @override
+  Stream<PlaybackEvent> get playbackEventStream =>
+      const Stream<PlaybackEvent>.empty();
+
+  @override
+  Future<Duration?> setUrl(
+    String url, {
+    Map<String, String>? headers,
+    Duration? initialPosition,
+    bool preload = true,
+    dynamic tag,
+  }) async {
+    setUrlCalls.add(url);
+    if (undecodableUrls.contains(url)) {
+      // What a real backend says when it cannot decode a container/codec,
+      // including the request URL, secret and all.
+      throw Exception('Unable to instantiate decoder for $url');
+    }
+    if (failUrls.contains(url)) {
+      throw Exception('source error opening $url');
+    }
+    return const Duration(minutes: 3);
+  }
+
+  @override
+  Future<void> setVolume(double volume) async {}
+  @override
+  Future<void> play() async {}
+  @override
+  Future<void> pause() async {}
+  @override
+  Future<void> stop() async {}
+  @override
+  Future<void> seek(Duration? position, {int? index}) async {}
+  @override
+  Future<void> dispose() async {}
+}
+
+/// A resolver driven by the track's opaque uri, whose behaviour a test can
+/// change between attempts, which is how a retry that *works* is staged.
+class _FakeResolver implements PlayableUriResolver {
+  _FakeResolver({
+    Map<String, ResolvedPlayable> resolved = const <String, ResolvedPlayable>{},
+    Map<String, PlaybackResolutionException> failures =
+        const <String, PlaybackResolutionException>{},
+  })  : resolved = <String, ResolvedPlayable>{...resolved},
+        failures = <String, PlaybackResolutionException>{...failures};
+
+  final Map<String, ResolvedPlayable> resolved;
+  final Map<String, PlaybackResolutionException> failures;
+  final List<String> calls = <String>[];
+
+  @override
+  bool handles(Track track) => true;
+
+  @override
+  Future<ResolvedPlayable> resolve(Track track) async {
+    calls.add(track.uri);
+    final PlaybackResolutionException? failure = failures[track.uri];
+    if (failure != null) throw failure;
+    final ResolvedPlayable? playable = resolved[track.uri];
+    if (playable == null) {
+      throw const PlaybackResolutionException(
+        "Couldn't reach this source.",
+        kind: PlaybackResolutionErrorKind.serverUnreachable,
+      );
+    }
+    return playable;
+  }
+}
+
+Track _track(String id, String uri) => Track(
+      id: id,
+      title: 'Hello',
+      uri: uri,
+      artistName: 'Adele',
+      albumName: '25',
+      duration: const Duration(minutes: 3),
+    );
+
+ResolvedPlayable _stream(String url) => ResolvedPlayable(
+    Uri.parse('$url?$_secret'), PlaybackSource.streamingDirect);
+
+ResolvedPlayable _localFile(String path) =>
+    ResolvedPlayable(Uri.file(path), PlaybackSource.localFile);
+
+const PlaybackResolutionException _serverDown = PlaybackResolutionException(
+  "Couldn't reach your music server. Check your connection and try again.",
+  kind: PlaybackResolutionErrorKind.serverUnreachable,
+);
+
+const PlaybackResolutionException _fileMissing = PlaybackResolutionException(
+  "This track's file isn't there anymore. It may have been moved or deleted.",
+  kind: PlaybackResolutionErrorKind.localFileMissing,
+);
+
+const PlaybackResolutionException _sessionExpired = PlaybackResolutionException(
+  'Your session expired. Sign in again to keep streaming.',
+  kind: PlaybackResolutionErrorKind.sessionExpired,
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // The same song on two providers, plus an unrelated third track to queue
+  // behind it so Skip has somewhere to go.
+  final Track jelly = _track('j', 'jellyfin:j');
+  final Track sub = _track('s', 'subsonic:s');
+  final Track next = _track('n', 'jellyfin:n');
+  final Track localOnly = _track('l', '/music/one.mp3');
+
+  JustAudioPlaybackController build({
+    required _FakePlayer player,
+    required _FakeResolver resolver,
+    Map<String, List<Track>> candidates = const <String, List<Track>>{},
+  }) {
+    final JustAudioPlaybackController controller = JustAudioPlaybackController(
+      player: player,
+      resolver: resolver,
+      candidates: MapPlaybackCandidateSource(() => candidates),
+    );
+    addTearDown(controller.dispose);
+    return controller;
+  }
+
+  group('the failure a listener is shown', () {
+    test('a provider that is down is temporary, retryable and skippable',
+        () async {
+      final _FakeResolver resolver = _FakeResolver(
+        failures: <String, PlaybackResolutionException>{
+          'jellyfin:j': _serverDown,
+        },
+        resolved: <String, ResolvedPlayable>{
+          'jellyfin:n': _stream('https://jelly/stream/n'),
+        },
+      );
+      final JustAudioPlaybackController controller = build(
+        player: _FakePlayer(),
+        resolver: resolver,
+      );
+
+      await controller.playTracks(<Track>[jelly, next]);
+
+      final PlaybackFailure? failure = controller.state.failure;
+      expect(controller.state.status, PlaybackStatus.error);
+      expect(failure?.kind, PlaybackFailureKind.temporarySource);
+      expect(failure?.message, _serverDown.message);
+      expect(failure?.canRetry, isTrue);
+      // A single-source song has nowhere else to play from.
+      expect(failure?.canTryAnotherSource, isFalse);
+      expect(failure?.canSkip, isTrue);
+      expect(
+        failure?.actions,
+        <PlaybackRecoveryAction>[
+          PlaybackRecoveryAction.retry,
+          PlaybackRecoveryAction.skip,
+        ],
+      );
+    });
+
+    test('a local file that is gone reads as a file problem, not a server one',
+        () async {
+      final _FakeResolver resolver = _FakeResolver(
+        failures: <String, PlaybackResolutionException>{
+          '/music/one.mp3': _fileMissing,
+        },
+      );
+      final JustAudioPlaybackController controller = build(
+        player: _FakePlayer(),
+        resolver: resolver,
+      );
+
+      await controller.playTracks(<Track>[localOnly]);
+
+      final PlaybackFailure? failure = controller.state.failure;
+      expect(failure?.kind, PlaybackFailureKind.localFileUnavailable);
+      // A reconnected drive (or a rescan) makes the same copy playable again,
+      // so Retry stays on offer; there is no next track, so Skip does not.
+      expect(failure?.canRetry, isTrue);
+      expect(failure?.canSkip, isFalse);
+      expect(failure?.canTryAnotherSource, isFalse);
+    });
+
+    test('a backend that cannot decode the media offers no retry', () async {
+      final _FakePlayer player = _FakePlayer(
+        undecodableUrls: <String>{'https://jelly/stream/j?$_secret'},
+      );
+      final _FakeResolver resolver = _FakeResolver(
+        resolved: <String, ResolvedPlayable>{
+          'jellyfin:j': _stream('https://jelly/stream/j'),
+        },
+      );
+      final JustAudioPlaybackController controller = build(
+        player: player,
+        resolver: resolver,
+      );
+
+      await controller.playTracks(<Track>[jelly]);
+
+      final PlaybackFailure? failure = controller.state.failure;
+      expect(controller.state.status, PlaybackStatus.error);
+      expect(failure?.kind, PlaybackFailureKind.unplayableMedia);
+      // The same bytes decode the same way next time, so Retry is not offered.
+      expect(failure?.canRetry, isFalse);
+      expect(failure?.actions, isEmpty);
+    });
+
+    test('an expired session asks for a sign-in rather than another attempt',
+        () async {
+      final _FakeResolver resolver = _FakeResolver(
+        failures: <String, PlaybackResolutionException>{
+          'jellyfin:j': _sessionExpired,
+        },
+      );
+      final JustAudioPlaybackController controller = build(
+        player: _FakePlayer(),
+        resolver: resolver,
+      );
+
+      await controller.playTracks(<Track>[jelly]);
+
+      expect(
+        controller.state.failure?.kind,
+        PlaybackFailureKind.sourceSignInRequired,
+      );
+      expect(controller.state.failure?.canRetry, isFalse);
+    });
+
+    test('a mid-stream rejection asks for a sign-in, not another attempt',
+        () async {
+      final _FakeResolver resolver = _FakeResolver(
+        resolved: <String, ResolvedPlayable>{
+          'jellyfin:j': _stream('https://jelly/stream/j'),
+          'jellyfin:n': _stream('https://jelly/stream/n'),
+        },
+      );
+      final JustAudioPlaybackController controller = build(
+        player: _FakePlayer(),
+        resolver: resolver,
+      );
+
+      await controller.playTracks(<Track>[jelly, next]);
+      expect(controller.state.failure, isNull);
+
+      // The server rejects the session part-way through the stream.
+      await controller.handleStreamFailureForTestingAsync(
+        const StreamInterruption(
+          StreamInterruptionKind.sessionExpired,
+          'Your session expired. Sign in again to keep streaming.',
+          retryable: false,
+        ),
+      );
+
+      final PlaybackFailure? failure = controller.state.failure;
+      expect(failure?.kind, PlaybackFailureKind.sourceSignInRequired);
+      expect(failure?.canRetry, isFalse);
+      expect(failure?.canSkip, isTrue);
+      // The classification is what reaches the listener, not the engine's text.
+      expect(failure?.message,
+          'Your session expired. Sign in again to keep streaming.');
+    });
+
+    test('no message carries a URL, a token or a file path', () async {
+      final _FakePlayer player = _FakePlayer(
+        undecodableUrls: <String>{'https://jelly/stream/j?$_secret'},
+      );
+      final _FakeResolver resolver = _FakeResolver(
+        resolved: <String, ResolvedPlayable>{
+          'jellyfin:j': _stream('https://jelly/stream/j'),
+        },
+      );
+      final JustAudioPlaybackController controller = build(
+        player: player,
+        resolver: resolver,
+      );
+
+      await controller.playTracks(<Track>[jelly]);
+
+      final String message = controller.state.failure!.message;
+      expect(message, isNot(contains('SUPERSECRET')));
+      expect(message, isNot(contains('token')));
+      expect(message, isNot(contains('http')));
+      expect(message, isNot(contains('jelly')));
+      expect(message, isNot(contains('/')));
+      expect(message, isNot(contains('Exception')));
+      // The classification is logged/diagnosed, never the engine's own text.
+      expect(controller.state.failure.toString(), isNot(contains('http')));
+    });
+  });
+
+  group('retry', () {
+    test('retries the same logical track and plays it when the source is back',
+        () async {
+      final _FakeResolver resolver = _FakeResolver(
+        failures: <String, PlaybackResolutionException>{
+          'jellyfin:j': _serverDown,
+        },
+      );
+      final JustAudioPlaybackController controller = build(
+        player: _FakePlayer(),
+        resolver: resolver,
+      );
+
+      await controller.playTracks(<Track>[jelly, next]);
+      expect(controller.state.status, PlaybackStatus.error);
+
+      // The server comes back.
+      resolver.failures.remove('jellyfin:j');
+      resolver.resolved['jellyfin:j'] = _stream('https://jelly/stream/j');
+      await controller.retryCurrentTrack();
+
+      expect(controller.state.failure, isNull);
+      expect(controller.state.currentTrack?.uri, 'jellyfin:j');
+      expect(controller.state.source, PlaybackSource.streamingDirect);
+      // Same queue entry, same up-next: a retry is not a re-queue.
+      expect(
+        controller.state.upNext.map((Track t) => t.uri),
+        <String>['jellyfin:n'],
+      );
+    });
+
+    test('is bounded: repeated failures stop offering it instead of looping',
+        () async {
+      final _FakeResolver resolver = _FakeResolver(
+        failures: <String, PlaybackResolutionException>{
+          'jellyfin:j': _serverDown,
+        },
+      );
+      final JustAudioPlaybackController controller = build(
+        player: _FakePlayer(),
+        resolver: resolver,
+      );
+
+      await controller.playTracks(<Track>[jelly, next]);
+      final int callsAfterFirstPlay = resolver.calls.length;
+
+      // Spend the whole budget, then keep asking.
+      for (int i = 0;
+          i < JustAudioPlaybackController.maxRecoveryAttemptsPerTrack;
+          i++) {
+        expect(controller.state.failure?.canRetry, isTrue,
+            reason: 'attempt ${i + 1} should still be offered');
+        await controller.retryCurrentTrack();
+      }
+
+      expect(controller.state.status, PlaybackStatus.error);
+      expect(controller.state.failure?.canRetry, isFalse);
+
+      final int callsAfterBudget = resolver.calls.length;
+      await controller.retryCurrentTrack();
+      await controller.retryCurrentTrack();
+
+      // A spent budget is a no-op, so the source is not hit again: the failure
+      // cannot become a retry loop, however many times the button is tapped.
+      expect(resolver.calls.length, callsAfterBudget);
+      expect(
+        callsAfterBudget - callsAfterFirstPlay,
+        JustAudioPlaybackController.maxRecoveryAttemptsPerTrack,
+      );
+      // Moving on is still offered, so the listener is never stuck.
+      expect(controller.state.failure?.canSkip, isTrue);
+    });
+
+    test('a track that plays again gets its full budget back', () async {
+      final _FakeResolver resolver = _FakeResolver(
+        failures: <String, PlaybackResolutionException>{
+          'jellyfin:j': _serverDown,
+        },
+      );
+      final JustAudioPlaybackController controller = build(
+        player: _FakePlayer(),
+        resolver: resolver,
+      );
+
+      await controller.playTracks(<Track>[jelly, next]);
+      await controller.retryCurrentTrack();
+      await controller.retryCurrentTrack();
+
+      // It finally works, and then fails again later.
+      resolver.failures.remove('jellyfin:j');
+      resolver.resolved['jellyfin:j'] = _stream('https://jelly/stream/j');
+      await controller.retryCurrentTrack();
+      expect(controller.state.failure, isNull);
+
+      resolver.failures['jellyfin:j'] = _serverDown;
+      resolver.resolved.remove('jellyfin:j');
+      await controller.playTracks(<Track>[jelly, next]);
+
+      expect(controller.state.failure?.canRetry, isTrue);
+    });
+
+    test('does nothing when playback is healthy', () async {
+      final _FakeResolver resolver = _FakeResolver(
+        resolved: <String, ResolvedPlayable>{
+          'jellyfin:j': _stream('https://jelly/stream/j'),
+        },
+      );
+      final JustAudioPlaybackController controller = build(
+        player: _FakePlayer(),
+        resolver: resolver,
+      );
+
+      await controller.playTracks(<Track>[jelly]);
+      final int calls = resolver.calls.length;
+      await controller.retryCurrentTrack();
+
+      expect(resolver.calls.length, calls);
+    });
+  });
+
+  group('another source', () {
+    test('plays the sibling copy and keeps the same place in the queue',
+        () async {
+      final _FakeResolver resolver = _FakeResolver(
+        failures: <String, PlaybackResolutionException>{
+          'jellyfin:j': _serverDown,
+          'subsonic:s': _serverDown,
+        },
+        resolved: <String, ResolvedPlayable>{
+          'jellyfin:n': _stream('https://jelly/stream/n'),
+        },
+      );
+      final JustAudioPlaybackController controller = build(
+        player: _FakePlayer(),
+        resolver: resolver,
+        candidates: <String, List<Track>>{
+          'jellyfin:j': <Track>[jelly, sub],
+        },
+      );
+
+      await controller.playTracks(<Track>[jelly, next]);
+      expect(controller.state.failure?.canTryAnotherSource, isTrue);
+
+      // Navidrome answers now.
+      resolver.failures.remove('subsonic:s');
+      resolver.resolved['subsonic:s'] = _stream('https://sub/stream/s');
+      await controller.tryAnotherSource();
+
+      expect(controller.state.failure, isNull);
+      // The queue entry became the copy that works: it was replaced, not
+      // duplicated, so the song keeps its one place in the queue.
+      expect(controller.state.currentTrack?.uri, 'subsonic:s');
+      expect(
+        controller.state.upNext.map((Track t) => t.uri),
+        <String>['jellyfin:n'],
+      );
+      expect(controller.state.previous, isEmpty);
+      expect(controller.state.source, PlaybackSource.streamingDirect);
+    });
+
+    test('is not offered, and does nothing, for a single-source song',
+        () async {
+      final _FakeResolver resolver = _FakeResolver(
+        failures: <String, PlaybackResolutionException>{
+          'jellyfin:j': _serverDown,
+        },
+      );
+      final JustAudioPlaybackController controller = build(
+        player: _FakePlayer(),
+        resolver: resolver,
+        candidates: <String, List<Track>>{
+          'jellyfin:j': <Track>[jelly],
+        },
+      );
+
+      await controller.playTracks(<Track>[jelly]);
+      final int calls = resolver.calls.length;
+
+      expect(controller.state.failure?.canTryAnotherSource, isFalse);
+      await controller.tryAnotherSource();
+
+      // No candidate to try means no work and no state churn, not a silent
+      // re-run of the copy that just failed.
+      expect(resolver.calls.length, calls);
+      expect(controller.state.status, PlaybackStatus.error);
+      expect(controller.state.currentTrack?.uri, 'jellyfin:j');
+    });
+
+    test('every copy failing leaves one clear error on the same queue entry',
+        () async {
+      final _FakeResolver resolver = _FakeResolver(
+        failures: <String, PlaybackResolutionException>{
+          'jellyfin:j': _serverDown,
+          'subsonic:s': _serverDown,
+        },
+        resolved: <String, ResolvedPlayable>{
+          'jellyfin:n': _stream('https://jelly/stream/n'),
+        },
+      );
+      final JustAudioPlaybackController controller = build(
+        player: _FakePlayer(),
+        resolver: resolver,
+        candidates: <String, List<Track>>{
+          'jellyfin:j': <Track>[jelly, sub],
+        },
+      );
+
+      await controller.playTracks(<Track>[jelly, next]);
+      await controller.tryAnotherSource();
+
+      expect(controller.state.status, PlaybackStatus.error);
+      expect(controller.state.currentTrack?.uri, 'jellyfin:j');
+      expect(controller.state.failure?.message, isNot(contains('http')));
+      expect(
+        controller.state.upNext.map((Track t) => t.uri),
+        <String>['jellyfin:n'],
+      );
+    });
+  });
+
+  group('skip', () {
+    test('advances exactly one track and leaves the rest of the queue alone',
+        () async {
+      final Track third = _track('t', 'jellyfin:t');
+      final _FakeResolver resolver = _FakeResolver(
+        failures: <String, PlaybackResolutionException>{
+          'jellyfin:j': _serverDown,
+        },
+        resolved: <String, ResolvedPlayable>{
+          'jellyfin:n': _stream('https://jelly/stream/n'),
+          'jellyfin:t': _stream('https://jelly/stream/t'),
+        },
+      );
+      final JustAudioPlaybackController controller = build(
+        player: _FakePlayer(),
+        resolver: resolver,
+      );
+
+      await controller.playTracks(<Track>[jelly, next, third]);
+      expect(controller.state.failure?.canSkip, isTrue);
+
+      await controller.skipToNext();
+
+      expect(controller.state.failure, isNull);
+      expect(controller.state.currentTrack?.uri, 'jellyfin:n');
+      expect(
+        controller.state.upNext.map((Track t) => t.uri),
+        <String>['jellyfin:t'],
+      );
+      // The failed track is history, exactly once.
+      expect(
+        controller.state.previous.map((Track t) => t.uri),
+        <String>['jellyfin:j'],
+      );
+    });
+
+    test('is not offered for the last track in the queue', () async {
+      final _FakeResolver resolver = _FakeResolver(
+        failures: <String, PlaybackResolutionException>{
+          'jellyfin:j': _serverDown,
+        },
+      );
+      final JustAudioPlaybackController controller = build(
+        player: _FakePlayer(),
+        resolver: resolver,
+      );
+
+      await controller.playTracks(<Track>[jelly]);
+
+      expect(controller.state.failure?.canSkip, isFalse);
+    });
+  });
+
+  test('a failed track leaves the queue exactly as it was', () async {
+    final _FakeResolver resolver = _FakeResolver(
+      failures: <String, PlaybackResolutionException>{
+        'jellyfin:n': _serverDown,
+      },
+      resolved: <String, ResolvedPlayable>{
+        'jellyfin:j': _stream('https://jelly/stream/j'),
+        '/music/one.mp3': _localFile('/music/one.mp3'),
+      },
+    );
+    final JustAudioPlaybackController controller = build(
+      player: _FakePlayer(),
+      resolver: resolver,
+    );
+
+    await controller.playTracks(<Track>[jelly, next, localOnly]);
+    // Move onto the track that cannot play.
+    await controller.skipToNext();
+
+    expect(controller.state.status, PlaybackStatus.error);
+    expect(controller.state.currentTrack?.uri, 'jellyfin:n');
+    expect(
+      controller.state.previous.map((Track t) => t.uri),
+      <String>['jellyfin:j'],
+    );
+    expect(
+      controller.state.upNext.map((Track t) => t.uri),
+      <String>['/music/one.mp3'],
+    );
+    expect(controller.state.hasPrevious, isTrue);
+  });
+}

--- a/test/features/player/fake_playback_controller.dart
+++ b/test/features/player/fake_playback_controller.dart
@@ -146,6 +146,30 @@ class FakePlaybackController implements LocalPlaybackController {
     _playCurrent();
   }
 
+  /// How many times each listener-driven recovery was asked for, so widget
+  /// tests can assert that a button reached the shared controller, and reached
+  /// it exactly once.
+  int retryCount = 0;
+  int anotherSourceCount = 0;
+
+  /// What [tryAnotherSource] should publish when it runs. Null (the default)
+  /// records the call and changes nothing, which is what a test asserting "the
+  /// button reached the controller" wants; a state here plays out a switch that
+  /// worked, or one that failed again.
+  PlaybackState? anotherSourceResult;
+
+  @override
+  Future<void> retryCurrentTrack() async {
+    retryCount++;
+  }
+
+  @override
+  Future<void> tryAnotherSource() async {
+    anotherSourceCount++;
+    final PlaybackState? result = anotherSourceResult;
+    if (result != null) emit(result);
+  }
+
   @override
   void clearQueue() {
     clearCount++;

--- a/test/features/player/playback_error_ui_test.dart
+++ b/test/features/player/playback_error_ui_test.dart
@@ -1,0 +1,375 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_failure.dart';
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/features/player/mini_player.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/player_screen.dart';
+import 'package:linthra/features/player/widgets/playback_error_notice.dart';
+
+import 'fake_playback_controller.dart';
+
+const Track _track = Track(
+  id: 't1',
+  title: 'Remote Song',
+  uri: 'jellyfin:t1',
+  artistName: 'Artist',
+  albumName: 'Album',
+);
+
+const Track _sibling = Track(
+  id: 't1',
+  title: 'Remote Song',
+  uri: 'subsonic:t1',
+  artistName: 'Artist',
+  albumName: 'Album',
+);
+
+PlaybackState _errorState(
+  PlaybackFailure failure, {
+  List<Track> upNext = const <Track>[],
+}) =>
+    PlaybackState(
+      status: PlaybackStatus.error,
+      currentTrack: _track,
+      upNext: upNext,
+      failure: failure,
+    );
+
+/// A controller whose Skip does not finish until the test lets it, so the panel
+/// can be observed mid-recovery, which is when an impatient second tap would
+/// land.
+class _SlowSkipController extends FakePlaybackController {
+  _SlowSkipController({required super.initial});
+
+  final Completer<void> skipGate = Completer<void>();
+
+  @override
+  Future<void> skipToNext() async {
+    await skipGate.future;
+    return super.skipToNext();
+  }
+}
+
+/// A controller that behaves like the real one during a source switch: it leaves
+/// the error state as soon as the attempt starts (which takes the panel off
+/// screen), and only finishes once the test lets it.
+class _SourceSwitchController extends FakePlaybackController {
+  _SourceSwitchController({required super.initial, required this.switched});
+
+  /// What plays once the switch lands.
+  final PlaybackState switched;
+
+  final Completer<void> gate = Completer<void>();
+
+  @override
+  Future<void> tryAnotherSource() async {
+    anotherSourceCount++;
+    // Leaving `error` is what removes the panel mid-attempt.
+    emit(const PlaybackState(
+        status: PlaybackStatus.loading, currentTrack: _track));
+    await gate.future;
+    emit(switched);
+  }
+}
+
+Future<void> _pumpPlayer(
+  WidgetTester tester,
+  FakePlaybackController controller,
+) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        playbackControllerProvider.overrideWithValue(controller),
+      ],
+      child: const MaterialApp(home: PlayerScreen()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> _pumpMiniPlayer(
+  WidgetTester tester,
+  FakePlaybackController controller,
+) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        playbackControllerProvider.overrideWithValue(controller),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(
+            body:
+                Align(alignment: Alignment.bottomCenter, child: MiniPlayer())),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('the now-playing error panel', () {
+    testWidgets('explains the failure and offers only the valid recoveries',
+        (WidgetTester tester) async {
+      final FakePlaybackController controller = FakePlaybackController(
+        initial: _errorState(const PlaybackFailure(
+          kind: PlaybackFailureKind.localFileUnavailable,
+          message: "This track's file isn't there anymore.",
+          canRetry: true,
+        )),
+      );
+      await _pumpPlayer(tester, controller);
+
+      expect(find.byKey(PlaybackErrorNotice.noticeKey), findsOneWidget);
+      expect(
+          find.text("This track's file isn't there anymore."), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+      // The failure says these are not available here, so they are not drawn.
+      expect(find.text('Try another source'), findsNothing);
+      expect(find.text('Skip'), findsNothing);
+    });
+
+    testWidgets('shows no buttons at all when nothing can be done',
+        (WidgetTester tester) async {
+      final FakePlaybackController controller = FakePlaybackController(
+        initial: _errorState(const PlaybackFailure(
+          kind: PlaybackFailureKind.unplayableMedia,
+          message: "This track's format isn't supported on this device.",
+        )),
+      );
+      await _pumpPlayer(tester, controller);
+
+      expect(
+        find.text("This track's format isn't supported on this device."),
+        findsOneWidget,
+      );
+      expect(find.byType(TextButton), findsNothing);
+    });
+
+    testWidgets('leaves the rest of the player usable: it is not a dialog',
+        (WidgetTester tester) async {
+      final FakePlaybackController controller = FakePlaybackController(
+        initial: _errorState(
+          const PlaybackFailure(
+            kind: PlaybackFailureKind.temporarySource,
+            message: "Couldn't reach your music server.",
+            canRetry: true,
+            canSkip: true,
+          ),
+          upNext: <Track>[_sibling],
+        ),
+      );
+      await _pumpPlayer(tester, controller);
+
+      // Nothing modal is pushed over the screen…
+      expect(find.byType(Dialog), findsNothing);
+      expect(find.text('Remote Song'), findsOneWidget);
+      // …and the transport underneath it still answers.
+      await tester.tap(find.byTooltip('Next'));
+      await tester.pumpAndSettle();
+
+      expect(controller.skipCount, 1);
+    });
+
+    testWidgets('Retry runs the bounded controller retry, once per tap',
+        (WidgetTester tester) async {
+      final FakePlaybackController controller = FakePlaybackController(
+        initial: _errorState(const PlaybackFailure(
+          kind: PlaybackFailureKind.temporarySource,
+          message: "Couldn't reach your music server.",
+          canRetry: true,
+          canSkip: true,
+        )),
+      );
+      await _pumpPlayer(tester, controller);
+
+      await tester.tap(find.byKey(
+        PlaybackErrorNotice.keyForAction(PlaybackRecoveryAction.retry),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(controller.retryCount, 1);
+      expect(controller.skipCount, 0);
+      expect(controller.anotherSourceCount, 0);
+    });
+
+    testWidgets('Skip advances the queue exactly once',
+        (WidgetTester tester) async {
+      final FakePlaybackController controller = FakePlaybackController(
+        initial: _errorState(const PlaybackFailure(
+          kind: PlaybackFailureKind.sourceSignInRequired,
+          message: 'Your session expired. Sign in again to keep streaming.',
+          canSkip: true,
+        )),
+      );
+      await _pumpPlayer(tester, controller);
+
+      // No Retry for an expired session, and skipping is a single advance.
+      expect(find.text('Retry'), findsNothing);
+      await tester.tap(find.byKey(
+        PlaybackErrorNotice.keyForAction(PlaybackRecoveryAction.skip),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(controller.skipCount, 1);
+    });
+
+    testWidgets('a recovery in flight is visible, and cannot be tapped twice',
+        (WidgetTester tester) async {
+      final _SlowSkipController controller = _SlowSkipController(
+        initial: _errorState(const PlaybackFailure(
+          kind: PlaybackFailureKind.temporarySource,
+          message: "Couldn't reach your music server.",
+          canRetry: true,
+          canSkip: true,
+        )),
+      );
+      await _pumpPlayer(tester, controller);
+
+      final Finder skip = find.byKey(
+        PlaybackErrorNotice.keyForAction(PlaybackRecoveryAction.skip),
+      );
+      await tester.tap(skip);
+      await tester.pump();
+
+      // While it runs the panel says so and the buttons are gone, so a second
+      // tap has nothing to hit and the queue cannot advance twice.
+      expect(find.text('Skipping…'), findsOneWidget);
+      expect(skip, findsNothing);
+      expect(
+        find.byKey(
+          PlaybackErrorNotice.keyForAction(PlaybackRecoveryAction.retry),
+        ),
+        findsNothing,
+      );
+
+      controller.skipGate.complete();
+      await tester.pumpAndSettle();
+
+      expect(controller.skipCount, 1);
+    });
+
+    testWidgets('a successful source switch says where the music came from',
+        (WidgetTester tester) async {
+      final _SourceSwitchController controller = _SourceSwitchController(
+        initial: _errorState(const PlaybackFailure(
+          kind: PlaybackFailureKind.temporarySource,
+          message: "Couldn't reach your music server.",
+          canRetry: true,
+          canTryAnotherSource: true,
+        )),
+        // What plays when the sibling copy works: same song, same queue entry,
+        // a different provider behind it.
+        switched: const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: _sibling,
+          source: PlaybackSource.streamingDirect,
+        ),
+      );
+      await _pumpPlayer(tester, controller);
+
+      await tester.tap(find.byKey(
+        PlaybackErrorNotice.keyForAction(
+          PlaybackRecoveryAction.tryAnotherSource,
+        ),
+      ));
+      // The attempt takes the panel off screen before it lands, exactly as the
+      // real controller does, and the confirmation must survive that.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 16));
+      expect(find.byKey(PlaybackErrorNotice.noticeKey), findsNothing);
+
+      controller.gate.complete();
+      await tester.pumpAndSettle();
+
+      expect(controller.anotherSourceCount, 1);
+      // The one recovery whose result is otherwise invisible is confirmed by
+      // name.
+      expect(find.byKey(PlaybackErrorNotice.noticeKey), findsNothing);
+      expect(find.text('Playing from Navidrome.'), findsOneWidget);
+    });
+
+    testWidgets('a recovery that fails again leaves the panel up, not a toast',
+        (WidgetTester tester) async {
+      final FakePlaybackController controller = FakePlaybackController(
+        initial: _errorState(const PlaybackFailure(
+          kind: PlaybackFailureKind.temporarySource,
+          message: "Couldn't reach your music server.",
+          canTryAnotherSource: true,
+        )),
+      );
+      controller.anotherSourceResult = _errorState(const PlaybackFailure(
+        kind: PlaybackFailureKind.temporarySource,
+        message: "Couldn't play this track from any available source.",
+        canSkip: true,
+      ));
+      await _pumpPlayer(tester, controller);
+
+      await tester.tap(find.byKey(
+        PlaybackErrorNotice.keyForAction(
+          PlaybackRecoveryAction.tryAnotherSource,
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SnackBar), findsNothing);
+      expect(
+        find.text("Couldn't play this track from any available source."),
+        findsOneWidget,
+      );
+      // The recoveries follow the new failure: nowhere else to try, but the
+      // listener can still move on.
+      expect(find.text('Try another source'), findsNothing);
+      expect(find.text('Skip'), findsOneWidget);
+    });
+  });
+
+  group('the mini-player', () {
+    testWidgets('says the track is failing instead of naming a source',
+        (WidgetTester tester) async {
+      final FakePlaybackController controller = FakePlaybackController(
+        initial: _errorState(const PlaybackFailure(
+          kind: PlaybackFailureKind.sourceSignInRequired,
+          message: 'Your session expired. Sign in again to keep streaming.',
+          canSkip: true,
+        )),
+      );
+      await _pumpMiniPlayer(tester, controller);
+
+      expect(find.text('Remote Song'), findsOneWidget);
+      expect(find.text('Sign-in needed'), findsOneWidget);
+      // The bar has one line: the artist/source line steps aside for it, and
+      // the full message stays on the now-playing screen a tap away.
+      expect(find.text('Artist • Album'), findsNothing);
+    });
+
+    testWidgets('goes back to the normal line once something plays',
+        (WidgetTester tester) async {
+      final FakePlaybackController controller = FakePlaybackController(
+        initial: _errorState(const PlaybackFailure(
+          kind: PlaybackFailureKind.temporarySource,
+          message: "Couldn't reach your music server.",
+          canRetry: true,
+        )),
+      );
+      await _pumpMiniPlayer(tester, controller);
+      expect(find.text('Playback problem'), findsOneWidget);
+
+      controller.emit(const PlaybackState(
+        status: PlaybackStatus.playing,
+        currentTrack: _sibling,
+        source: PlaybackSource.streamingDirect,
+      ));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 16));
+
+      expect(find.text('Playback problem'), findsNothing);
+      expect(find.textContaining('Navidrome'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/player/player_screen_test.dart
+++ b/test/features/player/player_screen_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart' hide RepeatMode;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_failure.dart';
 import 'package:linthra/core/models/playback_source.dart';
 import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/models/repeat_mode.dart';
@@ -261,15 +262,21 @@ void main() {
             title: 'Remote Song',
             uri: 'jellyfin:t1',
           ),
-          errorMessage: 'Your Jellyfin session has expired.',
+          failure: PlaybackFailure(
+            kind: PlaybackFailureKind.sourceSignInRequired,
+            message: 'Your Jellyfin session has expired.',
+            canSkip: true,
+          ),
         ),
       );
       await _pumpScreen(tester, controller);
 
       expect(find.text('Remote Song'), findsOneWidget);
       expect(find.text('Your Jellyfin session has expired.'), findsOneWidget);
-      // The generic fallback is not shown when a specific message exists.
-      expect(find.text("Couldn't play this track"), findsNothing);
+      // An expired session is not fixed by asking the same server again, so no
+      // Retry is offered; moving on is still valid and is.
+      expect(find.text('Retry'), findsNothing);
+      expect(find.text('Skip'), findsOneWidget);
     });
 
     testWidgets('shows the Lyrics empty state with no source', (tester) async {

--- a/test/features/player/player_status_layout_test.dart
+++ b/test/features/player/player_status_layout_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_failure.dart';
 import 'package:linthra/core/models/playback_source.dart';
 import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/models/track.dart';
@@ -120,23 +121,31 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('an error shows a Retry control that re-triggers play', (
+  testWidgets('an error shows a Retry control that retries the same track', (
     tester,
   ) async {
     final controller = FakePlaybackController(
       initial: const PlaybackState(
         status: PlaybackStatus.error,
         currentTrack: _track,
-        errorMessage: "Couldn't reach your music server.",
+        failure: PlaybackFailure(
+          kind: PlaybackFailureKind.temporarySource,
+          message: "Couldn't reach your music server.",
+          canRetry: true,
+        ),
       ),
     );
     await _pumpPlayer(tester, controller);
 
+    expect(find.text("Couldn't reach your music server."), findsOneWidget);
     expect(find.text('Retry'), findsOneWidget);
     await tester.tap(find.text('Retry'));
     await tester.pump();
 
-    expect(controller.playCount, 1);
+    // The bounded recovery action, not a bare play(): the controller owns the
+    // retry budget.
+    expect(controller.retryCount, 1);
+    expect(controller.playCount, 0);
   });
 
   testWidgets('reconnecting is distinct from buffering and from error', (


### PR DESCRIPTION
Closes #423

## What this fixes

A failed track ended in one ellipsized line and a Retry button that called
`play()` again, unbounded. Nothing told a server that was down apart from a
file that had moved or a codec the backend doesn't have, and on desktop that
is most of what goes wrong.

## The model

Playback now publishes a classified, secret-free `PlaybackFailure` on its
state, and the UI renders it instead of deciding for itself.

| Kind | Meaning | Offered |
| --- | --- | --- |
| `temporarySource` | server unreachable, connection dropped, non-audio answer | Retry, another source, Skip |
| `localFileUnavailable` | moved, deleted, or an unmounted drive | Retry, another source, Skip |
| `sourceSignInRequired` | no session, or one the server rejects | another source, Skip |
| `unplayableMedia` | unsupported container/codec, corrupt file, no decoder | another source, Skip |

The kinds come from the typed errors playback already had
(`PlaybackResolutionErrorKind`, `StreamInterruptionKind`) through exhaustive
switches, so adding a kind is a compile error rather than a silently wrong
recovery. Engine load failures are classified too, which is what tells a file
that won't decode apart from a source that stopped answering;
`mediaUnsupported` is the new resolution kind carrying that.

The controller decides which actions are valid, because only it knows what
failed, whether the song has another provider copy, and whether the attempt
budget is spent. Retry is dropped where re-presenting the same session or
re-reading the same bytes has a fixed answer, "try another source" appears
only for a song that really is on another provider, Skip only when there is a
next track.

## Recovery

Both new actions go through the shared `PlaybackController`:

- `retryCurrentTrack()` replays the same queue entry.
- `tryAnotherSource()` reuses the existing logical-track candidates (the same
  ones runtime fallback uses), skips the copy that failed, and **replaces**
  the queue entry with the copy that works, so the song keeps its one place in
  the queue rather than being added twice.

They share a budget of three attempts per failing track, returned in full the
moment anything plays, so the panel cannot be tapped into a loop. Skip
advances exactly one track. No provider URL is constructed anywhere in this
path.

## UI

Shared, so Android gets the same behaviour from the same code:

- Now Playing shows the message and the valid buttons where the source badge
  normally sits. Not a dialog, and nothing else in the app is blocked (there
  is a test that taps the transport while the panel is up).
- The mini-player's second line says, briefly, that the track is failing.
- A successful source switch is confirmed by name, since it is the one
  recovery whose result is otherwise invisible.

## Security

Messages stay fixed strings. The engine's raw error can carry the tokenized
stream URL, so it is classified and never echoed, and tests assert that no
surfaced message contains a URL, token, path or exception text.

## Tests

New: each failure kind (including a mid-stream session rejection), retry
succeeding, retry bounded without looping, the budget returning after
playback, skip advancing exactly once, a provider fallback that works, no
candidate to fall back to, the queue surviving all of it, and the UI showing
only valid actions and running each exactly once.

`dart format`, `flutter analyze` and the full `flutter test` suite (5340
tests) pass locally, as does `scripts/check_secrets.sh`.

## Notes for review

- `PlaybackState.errorMessage` is now a getter over `failure`, so existing
  read sites are unchanged and there is one source of truth.
- Android's playback path is otherwise untouched: same engine, same automatic
  fallback, same queue behaviour. The only behaviour change it sees is a
  decode failure now being worded as such.
