### PR TITLE
feat(local): read disc numbers from local audio metadata (#335)

### DIFF
--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
@@ -295,6 +295,7 @@ class SafDocumentScanner(
                                         "albumArtist" to metadata["albumArtist"],
                                         "album" to metadata["album"],
                                         "track" to metadata["track"],
+                                        "disc" to metadata["disc"],
                                         "durationMs" to metadata["durationMs"],
                                         "artworkUri" to metadata["artworkUri"],
                                     ),
@@ -347,8 +348,8 @@ class SafDocumentScanner(
      * Reads the audio tags for one document through [MediaMetadataRetriever],
      * which works on a content:// URI under the existing tree grant — no extra
      * permission, no broad storage access. Returns the raw tag strings (title,
-     * artist, album artist, album, track, duration in ms); the Dart side parses
-     * the track ("3/12") and duration values.
+     * artist, album artist, album, track, disc, duration in ms); the Dart side
+     * parses the track ("3/12"), disc ("1/2") and duration values.
      *
      * Deliberately total: any failure (a malformed file, an unreadable entry, a
      * codec the device can't open) returns an empty map so the walk keeps going
@@ -374,6 +375,14 @@ class SafDocumentScanner(
                 ),
                 "track" to retriever.extractMetadata(
                     MediaMetadataRetriever.METADATA_KEY_CD_TRACK_NUMBER,
+                ),
+                // The disc number of a multi-disc album. One key covers the
+                // common tag forms, because the platform extractors map their
+                // own spelling onto it: ID3v2 TPOS, Vorbis/FLAC DISCNUMBER and
+                // MP4 "disk". The value keeps whatever the tagger wrote ("1",
+                // "1/2", "02"), and the Dart side parses it like "track".
+                "disc" to retriever.extractMetadata(
+                    MediaMetadataRetriever.METADATA_KEY_DISC_NUMBER,
                 ),
                 "durationMs" to retriever.extractMetadata(
                     MediaMetadataRetriever.METADATA_KEY_DURATION,

--- a/lib/core/sources/local/local_audio_metadata.dart
+++ b/lib/core/sources/local/local_audio_metadata.dart
@@ -16,6 +16,7 @@ class LocalAudioMetadata {
     this.album,
     this.albumId,
     this.trackNumber,
+    this.discNumber,
     this.duration,
     this.artworkUri,
   });
@@ -43,6 +44,19 @@ class LocalAudioMetadata {
   /// The 1-based track number within its album, when known.
   final int? trackNumber;
 
+  /// The 1-based disc number within a multi-disc album (e.g. ID3 `TPOS`,
+  /// Vorbis `DISCNUMBER`), when the file carries a usable one.
+  ///
+  /// Null for a single-disc release, a file with no disc tag, and a tag that
+  /// can't be trusted (blank, non-numeric, zero or negative) — the same "no
+  /// trustworthy value" meaning every other field here has. There is no
+  /// filename fallback: a disc number is never guessed from a name or folder,
+  /// only read from real tags.
+  ///
+  /// Reported by the Android SAF walk today; the desktop reader leaves it null
+  /// until it reads the tag too, and nothing groups albums by it yet (#85).
+  final int? discNumber;
+
   /// The track's real duration, when the source reported one. Distinct from the
   /// filename — a filename can never reveal a duration, so this only comes from
   /// actual tag/stream metadata.
@@ -66,6 +80,7 @@ class LocalAudioMetadata {
       album == null &&
       albumId == null &&
       trackNumber == null &&
+      discNumber == null &&
       duration == null &&
       artworkUri == null;
 

--- a/lib/core/sources/local/method_channel_saf_document_lister.dart
+++ b/lib/core/sources/local/method_channel_saf_document_lister.dart
@@ -111,16 +111,16 @@ class MethodChannelSafDocumentLister implements SafDocumentLister {
 
   /// Builds the [LocalAudioMetadata] for one document [entry] from the optional
   /// tag fields the native walk attached (`title`, `artist`, `albumArtist`,
-  /// `album`, `albumId`, `track`, `durationMs`, `artworkUri`), or null when none
-  /// are present — an older native build, or a file the platform could not read
-  /// tags from.
+  /// `album`, `albumId`, `track`, `disc`, `durationMs`, `artworkUri`), or null
+  /// when none are present — an older native build, or a file the platform could
+  /// not read tags from.
   ///
   /// Pure and tolerant so it is unit-testable and never throws on a malformed or
-  /// partial reply: a non-string text field, a `track` like `"3/12"`, a
-  /// `durationMs` sent as either an int or a numeric string, and a malformed
-  /// `artworkUri` are all handled, and a blank or unparseable value simply drops
-  /// to null (the mapper then falls back to the file name, and the row keeps the
-  /// artwork placeholder).
+  /// partial reply: a non-string text field, a `track` like `"3/12"`, a `disc`
+  /// like `"1/2"` or `"02"`, a `durationMs` sent as either an int or a numeric
+  /// string, and a malformed `artworkUri` are all handled, and a blank or
+  /// unparseable value simply drops to null (the mapper then falls back to the
+  /// file name, and the row keeps the artwork placeholder).
   static LocalAudioMetadata? parseMetadata(Map<Object?, Object?> entry) {
     final String? title = _string(entry['title']);
     final String? artist = _string(entry['artist']);
@@ -128,6 +128,7 @@ class MethodChannelSafDocumentLister implements SafDocumentLister {
     final String? album = _string(entry['album']);
     final String? albumId = _string(entry['albumId']);
     final int? trackNumber = _trackNumber(entry['track']);
+    final int? discNumber = _discNumber(entry['disc']);
     final Duration? duration = _durationMs(entry['durationMs']);
     final Uri? artworkUri = _artworkUri(entry['artworkUri']);
     if (title == null &&
@@ -136,6 +137,7 @@ class MethodChannelSafDocumentLister implements SafDocumentLister {
         album == null &&
         albumId == null &&
         trackNumber == null &&
+        discNumber == null &&
         duration == null &&
         artworkUri == null) {
       return null;
@@ -147,6 +149,7 @@ class MethodChannelSafDocumentLister implements SafDocumentLister {
       album: album,
       albumId: albumId,
       trackNumber: trackNumber,
+      discNumber: discNumber,
       duration: duration,
       artworkUri: artworkUri,
     );
@@ -170,6 +173,31 @@ class MethodChannelSafDocumentLister implements SafDocumentLister {
     final int? parsed = int.tryParse(match.group(0)!);
     return (parsed != null && parsed > 0) ? parsed : null;
   }
+
+  /// The disc number of a multi-disc album, from the leading integer of the
+  /// native `disc` field. Taggers write it as `"1"`, `"1/2"` (disc/total) or a
+  /// zero-padded `"02"`, and the platform reports whichever form the file has,
+  /// so all three parse to the same number.
+  ///
+  /// Anchored at the start deliberately, unlike [_trackNumber]: a disc tag that
+  /// doesn't *begin* with a number (`"-1"`, `"/2"`, `"Disc"`) is malformed, and
+  /// taking some digit from the middle of it would invent an ordering the file
+  /// never claimed. Zero, negative and unparseable values are null — a disc
+  /// number is 1-based, and null simply means "no disc info", which is also what
+  /// a single-disc album reports.
+  static int? _discNumber(Object? value) {
+    if (value is int) return value > 0 ? value : null;
+    if (value is! String) return null;
+    final RegExpMatch? match = _leadingInteger.firstMatch(value.trim());
+    if (match == null) return null;
+    final int? parsed = int.tryParse(match.group(1)!);
+    return (parsed != null && parsed > 0) ? parsed : null;
+  }
+
+  /// The run of digits a string starts with, if it starts with one. Matches a
+  /// zero-padded value too (`"02"`), and an absurdly long run simply fails
+  /// [int.tryParse] and drops to null rather than throwing.
+  static final RegExp _leadingInteger = RegExp(r'^(\d+)');
 
   /// A duration from a milliseconds value sent as an int or a numeric string.
   /// Zero/negative/unparseable maps to null (unknown), so the mapper leaves the

--- a/lib/core/sources/local/saf_document_lister.dart
+++ b/lib/core/sources/local/saf_document_lister.dart
@@ -10,12 +10,12 @@ import 'local_audio_metadata.dart';
 /// lacks a known extension — the catalog needs both signals to recognise audio.
 ///
 /// [metadata] carries the audio tags the native walk extracted for this document
-/// (title/artist/album/duration/track number) and a `file://` URI to its cached
-/// embedded cover art, or null when none were available — an older native build,
-/// an unreadable file, or a format with no tags. It is only a *hint*:
-/// [LocalTrackMapper] still falls back to the name when a field is missing, so a
-/// document without metadata indexes exactly as before (and shows the artwork
-/// placeholder).
+/// (title/artist/album/duration/track number/disc number) and a `file://` URI to
+/// its cached embedded cover art, or null when none were available — an older
+/// native build, an unreadable file, or a format with no tags. It is only a
+/// *hint*: [LocalTrackMapper] still falls back to the name when a field is
+/// missing, so a document without metadata indexes exactly as before (and shows
+/// the artwork placeholder).
 class SafAudioDocument {
   const SafAudioDocument({
     required this.uri,

--- a/test/core/sources/local/method_channel_saf_document_lister_test.dart
+++ b/test/core/sources/local/method_channel_saf_document_lister_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/sources/local/method_channel_saf_document_lister.dart';
 import 'package:linthra/core/sources/local/saf_document_lister.dart';
@@ -146,6 +148,71 @@ void main() {
       expect(metadata.duration, const Duration(milliseconds: 337000));
     });
 
+    test('attaches the disc number to the parsed document', () {
+      final result = MethodChannelSafDocumentLister.parseScanResult(
+        <Object?, Object?>{
+          'documents': <Object?>[
+            <Object?, Object?>{
+              'uri': 'content://doc/1',
+              'name': 'One.mp3',
+              'album': 'Sign O\' the Times',
+              'track': '1/8',
+              'disc': '2/2',
+            },
+          ],
+        },
+      );
+
+      expect(result.documents.single.metadata!.discNumber, 2);
+    });
+
+    test('a multi-disc album\'s documents carry enough to order by disc', () {
+      // The disc number only has to survive the native reply for a multi-disc
+      // album to be orderable; grouping itself is not this layer's job (#85).
+      final result = MethodChannelSafDocumentLister.parseScanResult(
+        <Object?, Object?>{
+          'documents': <Object?>[
+            <Object?, Object?>{
+              'uri': 'content://doc/d2t1',
+              'name': 'Disc2-01.mp3',
+              'title': 'Disc two, first',
+              'disc': '2/2',
+              'track': '1/2',
+            },
+            <Object?, Object?>{
+              'uri': 'content://doc/d1t2',
+              'name': 'Disc1-02.mp3',
+              'title': 'Disc one, second',
+              'disc': '1/2',
+              'track': '2/2',
+            },
+            <Object?, Object?>{
+              'uri': 'content://doc/d1t1',
+              'name': 'Disc1-01.mp3',
+              'title': 'Disc one, first',
+              'disc': '01/02',
+              'track': '1/2',
+            },
+          ],
+        },
+      );
+
+      final ordered = result.documents.toList()
+        ..sort((a, b) {
+          final int disc = a.metadata!.discNumber!.compareTo(
+            b.metadata!.discNumber!,
+          );
+          return disc != 0
+              ? disc
+              : a.metadata!.trackNumber!.compareTo(b.metadata!.trackNumber!);
+        });
+
+      expect(
+        ordered.map((d) => d.metadata!.title).toList(),
+        <String>['Disc one, first', 'Disc one, second', 'Disc two, first'],
+      );
+    });
+
     test('a document with no tag fields has null metadata', () {
       final result = MethodChannelSafDocumentLister.parseScanResult(
         <Object?, Object?>{
@@ -221,6 +288,103 @@ void main() {
       );
     });
 
+    test('parses a plain, "disc/total" or zero-padded disc number', () {
+      expect(
+        MethodChannelSafDocumentLister.parseMetadata(
+          <Object?, Object?>{'disc': '1'},
+        )!
+            .discNumber,
+        1,
+      );
+      expect(
+        MethodChannelSafDocumentLister.parseMetadata(
+          <Object?, Object?>{'disc': '1/2'},
+        )!
+            .discNumber,
+        1,
+      );
+      expect(
+        MethodChannelSafDocumentLister.parseMetadata(
+          <Object?, Object?>{'disc': '02'},
+        )!
+            .discNumber,
+        2,
+      );
+      // Surrounding whitespace from a sloppy tagger is still a real value.
+      expect(
+        MethodChannelSafDocumentLister.parseMetadata(
+          <Object?, Object?>{'disc': ' 3/4 '},
+        )!
+            .discNumber,
+        3,
+      );
+      // Tolerated even though the native side sends strings, like `track`.
+      expect(
+        MethodChannelSafDocumentLister.parseMetadata(
+          <Object?, Object?>{'disc': 2},
+        )!
+            .discNumber,
+        2,
+      );
+    });
+
+    test('a file with no disc tag has no disc number', () {
+      // The common case: a single-disc album, which tags usually leave out.
+      final metadata = MethodChannelSafDocumentLister.parseMetadata(
+        <Object?, Object?>{'title': 'Only a title', 'track': '4'},
+      );
+
+      expect(metadata!.title, 'Only a title');
+      expect(metadata.trackNumber, 4);
+      expect(metadata.discNumber, isNull);
+    });
+
+    test('drops a malformed disc number to null without throwing', () {
+      for (final Object? value in <Object?>[
+        '', // present but blank
+        '   ',
+        'Disc', // no number at all
+        'Disc 2', // a number, but not where a disc tag puts it
+        '/2', // only the total survived
+        '-1', // a leading sign is not a disc number
+        'one',
+        '99999999999999999999999999', // wider than an int
+        42.5, // not a string or an int
+        <String>['1'],
+      ]) {
+        final metadata = MethodChannelSafDocumentLister.parseMetadata(
+          <Object?, Object?>{'album': 'Real', 'disc': value},
+        );
+
+        expect(metadata!.album, 'Real', reason: 'disc: $value');
+        expect(metadata.discNumber, isNull, reason: 'disc: $value');
+      }
+    });
+
+    test('drops a zero or negative disc number to null', () {
+      // A disc number is 1-based, so "0" is no more usable than a missing tag.
+      for (final Object? value in <Object?>['0', '0/2', '00', 0, -1]) {
+        expect(
+          MethodChannelSafDocumentLister.parseMetadata(
+            <Object?, Object?>{'disc': value},
+          ),
+          isNull,
+          reason: 'disc: $value',
+        );
+      }
+    });
+
+    test('a disc tag alone still yields metadata', () {
+      // Same reason art-only files do: dropping to null would lose the value.
+      final metadata = MethodChannelSafDocumentLister.parseMetadata(
+        <Object?, Object?>{'disc': '2/2'},
+      );
+
+      expect(metadata, isNotNull);
+      expect(metadata!.discNumber, 2);
+      expect(metadata.title, isNull);
+    });
+
     test('parses durationMs sent as an int or a numeric string', () {
       expect(
         MethodChannelSafDocumentLister.parseMetadata(
@@ -284,6 +448,50 @@ void main() {
       );
       expect(metadata!.album, 'Real');
       expect(metadata.artworkUri, isNull);
+    });
+  });
+
+  group('SAF disc tag wiring', () {
+    test('the native walk sends the disc tag under the key this parser reads',
+        () {
+      // The one seam the pure parsing tests above cannot see: the Kotlin walk
+      // puts the disc tag in its reply under a string key, and parseMetadata
+      // reads it back by that same string. A typo on either side would drop
+      // every disc number with all the other tests still green.
+      final File scanner = File(
+        'android/app/src/main/kotlin/io/github/thezupzup/linthra/'
+        'SafDocumentScanner.kt',
+      );
+      expect(
+        scanner.existsSync(),
+        isTrue,
+        reason: 'SafDocumentScanner.kt must remain available for this guard',
+      );
+      final String source = scanner.readAsStringSync();
+
+      final RegExpMatch? read = RegExp(
+        r'"(\w+)" to retriever\.extractMetadata\(\s*'
+        r'MediaMetadataRetriever\.METADATA_KEY_DISC_NUMBER',
+      ).firstMatch(source);
+      expect(
+        read,
+        isNotNull,
+        reason: 'the SAF walk must read the disc tag from the retriever',
+      );
+
+      final String key = read!.group(1)!;
+      expect(
+        source,
+        contains('"$key" to metadata["$key"]'),
+        reason: "the disc tag must be forwarded in the walk's reply",
+      );
+      expect(
+        MethodChannelSafDocumentLister.parseMetadata(
+          <Object?, Object?>{key: '2/2'},
+        )!
+            .discNumber,
+        2,
+      );
     });
   });
 


### PR DESCRIPTION
Closes #335

Local audio already reads title, artist, album artist, album, track number, duration and embedded art, but never the disc number, so a multi-disc album had nothing to order by. This adds the tag on the Android SAF path and carries it as far as the current model goes.

## What changed

**`SafDocumentScanner.kt`** asks `MediaMetadataRetriever` for `METADATA_KEY_DISC_NUMBER` alongside the tags it already extracts, and sends the raw string in its reply next to `"track"`. One key covers the common tag spellings, because the platform extractors map their own onto it: ID3v2 `TPOS`, Vorbis/FLAC `DISCNUMBER`, MP4 `disk`.

**`MethodChannelSafDocumentLister`** parses it, like the other numeric tags:

- `1`, `1/2` (disc/total) and `02` all parse to the same number
- blank, non-numeric, zero, negative, non-string, or absurdly long values drop to null

The parse is anchored at the start of the value, unlike `_trackNumber`: a disc tag that does not *begin* with a number (`-1`, `/2`, `Disc`) is malformed, and grabbing a digit from the middle of it would invent an ordering the file never claimed. I left `_trackNumber` alone so track parsing behaves exactly as before.

**`LocalAudioMetadata`** gains an optional `discNumber`, with the same "null means no trustworthy value" meaning as every other field. No filename fallback: a disc number is only ever read from real tags, never guessed from a name or folder.

## What deliberately did not change

- Access stays inside the folder grant the user already picked. No new permission, no MediaStore, no raw paths.
- Filename and folder fallbacks are untouched, and a file whose tags cannot be read still indexes from its display name (the tag read is still best-effort and total).
- The value stops at `LocalAudioMetadata`. `Track` has no disc field yet, so nothing regroups or reorders albums. That part stays in #85, along with the desktop reader and the MediaStore path.
- No user-facing docs change, since nothing is visible in the app yet.

## Tests

All in `method_channel_saf_document_lister_test.dart`:

- a plain number, `disc/total`, zero-padded `02`, surrounding whitespace, and a value sent as an int
- a missing disc tag (the common single-disc case)
- malformed values: blank, `Disc`, `Disc 2`, `/2`, `-1`, `one`, wider than an int, a double, a list
- zero and negative values
- a disc-only file, which must still yield metadata rather than dropping to null
- a multi-disc set, shuffled, ordering by disc then track
- a small wiring guard: the disc key the Kotlin walk sends is the key this parser reads. A typo on either side would silently drop every disc number with all the other tests green, so this reads the key out of `SafDocumentScanner.kt` and feeds it through `parseMetadata`. I checked it fails when the Kotlin key is renamed.

`./scripts/verify_android.sh` passes: format, analyze, 5439 tests, privacy scan. APK build skipped, no Android SDK here. Not tested on a device yet, so real multi-disc files are still worth a look.
