### PR TITLE
Add one local verify script for Rust, C++ and Python contributors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,16 @@ jobs:
       - name: Test what a Flatpak smoke may delete
         run: python3 test/tooling/flatpak_smoke_cleanup_test.py
 
+      # scripts/verify_native.sh is the local twin of the Rust, C++ and Python
+      # workflows (#354), and a twin is only worth having while it still says
+      # what its originals say. These tests read those workflows and run the
+      # script end to end against stub cargo/cmake/ctest/ruff binaries, so they
+      # need none of those toolchains and belong on every PR rather than behind
+      # the path filters of the three workflows they cover. Local twin:
+      # `python3 test/tooling/verify_native_test.py`.
+      - name: Test the local native verify script
+        run: python3 test/tooling/verify_native_test.py
+
   release-bump-guard:
     name: Release bump touches only version files
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,25 @@ For normal Dart/Flutter/Android work, start with:
 `verify_android.sh` runs the main Flutter checks and can build a debug APK when
 an Android SDK is available.
 
+If you came for the Rust core, the C++ DSP or the Python tooling instead, there
+is one command that covers all three:
+
+```bash
+./scripts/verify_native.sh
+```
+
+It runs what CI runs, in CI's order: `cargo fmt --check`, Clippy with warnings
+as errors, `cargo test` and the 200k-track benchmark for `native/linthra_core/`;
+a CMake configure, build and `ctest` in both Release and Debug for
+`native/linthra_audio/` and `native/linthra_desktop/`; then the Ruff checks and
+the Python tooling tests. The output is split into Rust, C++ and Python
+sections.
+
+A toolchain you don't have installed is skipped with a note about what it needs,
+so the script is still useful if you only have one of the three. Anything that
+actually fails makes it exit non-zero. `./scripts/doctor.sh` reports what it
+found without running any of it.
+
 More setup details are in [docs/development.md](./docs/development.md), and the
 [codebase tour](./docs/codebase-tour.md) is useful if you want to see where
 things live before touching the code.
@@ -52,7 +71,7 @@ things live before touching the code.
 For the other areas:
 
 - `native/linthra_core/` uses Cargo.
-- `native/linthra_audio/` uses CMake.
+- `native/linthra_audio/` and `native/linthra_desktop/` use CMake.
 - `linux/` is the native Linux desktop runner (C++/GTK/CMake). Its setup —
   required distribution packages, how to run Linthra on Linux from source, and
   what is still unsupported there — is in
@@ -65,7 +84,8 @@ For the other areas:
 - Python tooling (`scripts/`, `tool/`, `tools/`) is checked with
   [Ruff](https://docs.astral.sh/ruff/). Before pushing a Python change, run
   `ruff check scripts tool tools` and `ruff format --check scripts tool tools` —
-  the same two commands, with the same paths, that CI runs. Details are in
+  the same two commands, with the same paths, that CI runs.
+  `verify_native.sh` runs both of them for you. Details are in
   [docs/development.md](./docs/development.md#python-tooling-checks-ruff).
 
 ## Before you start

--- a/docs/development.md
+++ b/docs/development.md
@@ -82,6 +82,36 @@ If no Android SDK is found (`ANDROID_HOME`/`ANDROID_SDK_ROOT` unset and no
 verification does **not** fail just because the Android SDK is missing. The
 analyze/format/test steps still run and still fail the script if they fail.
 
+### What `verify_native.sh` does
+
+The same idea for the non-Flutter areas, so a Rust, C++ or Python contributor
+has one command instead of three workflows to read. It runs, in CI's order, and
+exits non-zero if any real check fails:
+
+1. **Rust** (`native/linthra_core`, mirroring `rust-core.yml`): `cargo fmt
+   --check`, `cargo clippy --all-targets` with `-D warnings`, `cargo test`, and
+   the `benchmark_200k` binary, which asserts the large-library search budget.
+2. **C++** (mirroring `cpp-audio-dsp.yml` and `cpp-desktop-window.yml`): a
+   CMake configure, build and `ctest` for `native/linthra_audio` and
+   `native/linthra_desktop`, in Release and Debug. Debug skips
+   `linthra_audio_realtime_budget` exactly as CI does: an unoptimized build says
+   nothing useful about the realtime budget of the build users actually get.
+3. **Python** (mirroring `python-lint.yml`): `ruff check scripts tool tools`,
+   `ruff format --check scripts tool tools`, and every `test/tooling/*_test.py`,
+   which CI runs a file at a time across five workflows.
+
+A toolchain that isn't installed **skips** that part with a message naming what
+to install, the same way the APK build is skipped above, and the summary lists
+everything skipped so a pass is never read as full coverage. If nothing at all
+could be checked, that is an error rather than a pass. `scripts/doctor.sh`
+reports the same toolchains without running anything.
+
+Nothing it runs writes to a tracked file: Cargo builds into
+`native/linthra_core/target/` and CMake into `build/`, both git-ignored, and
+Ruff runs with `--check`. `test/tooling/verify_native_test.py` holds it to all
+of that, using stub `cargo`/`cmake`/`ctest`/`ruff` binaries, so it needs none of
+those toolchains itself.
+
 ### How this helps
 
 Contributors and future Claude/agent sessions get a consistent toolchain in two

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 #
 # doctor.sh — quick read-only report of the dev toolchain state.
-# Tells you what's pinned, which Flutter would be used, and whether an
-# Android SDK is present. Makes no changes.
+# Tells you what's pinned, which Flutter would be used, whether an Android SDK
+# is present, and which of the Rust, C++ and Python toolchains
+# scripts/verify_native.sh needs are installed. Makes no changes.
 
 set -uo pipefail
 
@@ -53,4 +54,68 @@ elif command -v adb >/dev/null 2>&1 || command -v sdkmanager >/dev/null 2>&1; th
   line "Android SDK:" "tools on PATH (adb/sdkmanager)"
 else
   line "Android SDK:" "not detected (APK build will be skipped)"
+fi
+
+# The Rust, C++ and Python toolchains scripts/verify_native.sh runs on. That
+# script asks these same questions before it runs or skips a section, so this is
+# the quick way to find out what one of its skip messages wants installed.
+printf '\n'
+
+if command -v cargo >/dev/null 2>&1; then
+  line "Rust (cargo):" "$(cargo --version 2>/dev/null | head -1)"
+  # rustfmt and clippy are rustup components rather than part of cargo: cargo
+  # can be on PATH while `cargo fmt` and `cargo clippy` are unknown
+  # subcommands, and CI asks for both by name.
+  if cargo fmt --version >/dev/null 2>&1; then
+    line "  rustfmt:" "$(cargo fmt --version 2>/dev/null | head -1)"
+  else
+    line "  rustfmt:" "missing (rustup component add rustfmt)"
+  fi
+  if cargo clippy --version >/dev/null 2>&1; then
+    line "  clippy:" "$(cargo clippy --version 2>/dev/null | head -1)"
+  else
+    line "  clippy:" "missing (rustup component add clippy)"
+  fi
+else
+  line "Rust (cargo):" "none (see https://rustup.rs)"
+fi
+
+if command -v cmake >/dev/null 2>&1; then
+  line "CMake:" "$(cmake --version 2>/dev/null | head -1)"
+else
+  line "CMake:" "none (needed for the C++ in native/)"
+fi
+
+if command -v ctest >/dev/null 2>&1; then
+  line "  ctest:" "$(command -v ctest)"
+else
+  line "  ctest:" "none (it ships with CMake)"
+fi
+
+# Same order CMake itself resolves a compiler in: $CXX, then what is on PATH.
+CXX_FOUND="${CXX:-}"
+if [ -z "$CXX_FOUND" ]; then
+  for candidate in c++ g++ clang++; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      CXX_FOUND="$candidate"
+      break
+    fi
+  done
+fi
+if [ -n "$CXX_FOUND" ] && command -v "$CXX_FOUND" >/dev/null 2>&1; then
+  line "C++ compiler:" "$(command -v "$CXX_FOUND")"
+else
+  line "C++ compiler:" "none (install g++ or clang++)"
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+  line "Python 3:" "$(python3 --version 2>&1 | head -1)"
+else
+  line "Python 3:" "none (needed by the tooling checks and tests)"
+fi
+
+if command -v ruff >/dev/null 2>&1; then
+  line "  Ruff:" "$(ruff --version 2>/dev/null | head -1)"
+else
+  line "  Ruff:" "none (python3 -m pip install ruff)"
 fi

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -93,7 +93,12 @@ else
 fi
 
 # Same order CMake itself resolves a compiler in: $CXX, then what is on PATH.
+# CXX may carry required options as well as a program name (cmake-env-variables(7)
+# documents `CXX="custom-compiler --sysroot=/sdk"`), so only its first word is a
+# command to look for. Kept in step with cxx_compiler_available() in
+# scripts/verify_native.sh, which gates the C++ checks on the same question.
 CXX_FOUND="${CXX:-}"
+CXX_FOUND="${CXX_FOUND%% *}"
 if [ -z "$CXX_FOUND" ]; then
   for candidate in c++ g++ clang++; do
     if command -v "$candidate" >/dev/null 2>&1; then

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -100,7 +100,9 @@ fi
 CXX_FOUND="${CXX:-}"
 CXX_FOUND="${CXX_FOUND%% *}"
 if [ -z "$CXX_FOUND" ]; then
-  for candidate in c++ g++ clang++; do
+  # CMake's own candidate list, from CMakeDetermineCXXCompiler.cmake, so this
+  # report does not call a compiler missing that CMake would have found.
+  for candidate in c++ CC g++ aCC cl bcc xlC icpx icx clang++; do
     if command -v "$candidate" >/dev/null 2>&1; then
       CXX_FOUND="$candidate"
       break

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -92,16 +92,20 @@ else
   line "  ctest:" "none (it ships with CMake)"
 fi
 
-# Same order CMake itself resolves a compiler in: $CXX, then what is on PATH.
-# CXX may carry required options as well as a program name (cmake-env-variables(7)
-# documents `CXX="custom-compiler --sysroot=/sdk"`), so only its first word is a
-# command to look for. Kept in step with cxx_compiler_available() in
-# scripts/verify_native.sh, which gates the C++ checks on the same question.
+# A best-effort look, not a verdict. CMake resolves a compiler from CXX, a
+# toolchain file, an IDE generator's own environment and its own candidate list,
+# and scripts/verify_native.sh deliberately stopped trying to predict that: it
+# asks CMake and reads the answer. So this reports what is plainly visible and
+# says so when it finds nothing, rather than telling anyone their setup is
+# broken.
+#
+# CXX may carry required options as well as a program name
+# (cmake-env-variables(7) documents `CXX="custom-compiler --sysroot=/sdk"`), so
+# only its first word is a command to look for.
 CXX_FOUND="${CXX:-}"
 CXX_FOUND="${CXX_FOUND%% *}"
 if [ -z "$CXX_FOUND" ]; then
-  # CMake's own candidate list, from CMakeDetermineCXXCompiler.cmake, so this
-  # report does not call a compiler missing that CMake would have found.
+  # CMake's own candidate list, from CMakeDetermineCXXCompiler.cmake.
   for candidate in c++ CC g++ aCC cl bcc xlC icpx icx clang++; do
     if command -v "$candidate" >/dev/null 2>&1; then
       CXX_FOUND="$candidate"
@@ -111,8 +115,12 @@ if [ -z "$CXX_FOUND" ]; then
 fi
 if [ -n "$CXX_FOUND" ] && command -v "$CXX_FOUND" >/dev/null 2>&1; then
   line "C++ compiler:" "$(command -v "$CXX_FOUND")"
+elif [ -n "${CMAKE_TOOLCHAIN_FILE:-}" ]; then
+  line "C++ compiler:" "from CMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE"
+elif [ -n "${CMAKE_GENERATOR:-}" ]; then
+  line "C++ compiler:" "expected from generator $CMAKE_GENERATOR"
 else
-  line "C++ compiler:" "none (install g++ or clang++)"
+  line "C++ compiler:" "none on PATH (CMake may still find one)"
 fi
 
 if command -v python3 >/dev/null 2>&1; then

--- a/scripts/verify_native.sh
+++ b/scripts/verify_native.sh
@@ -141,12 +141,25 @@ rust_section() {
 # with. Only the first word names a program. A compiler path that itself
 # contains spaces is indistinguishable from a path plus options here, which is
 # a limitation CMake shares.
+#
+# The candidate list is CMake's own, from CMakeDetermineCXXCompiler.cmake. A
+# shorter list would be the wrong kind of wrong: this gate only decides whether
+# to run the C++ checks or skip them, so missing a compiler CMake would have
+# found drops real coverage silently, while guessing one that turns out not to
+# work costs nothing but a configure error, which is reported as a failure.
+CXX_CANDIDATES=(c++ CC g++ aCC cl bcc xlC icpx icx clang++)
+
 cxx_compiler_available() {
   if [ -n "${CXX:-}" ] && command -v "${CXX%% *}" >/dev/null 2>&1; then
     return 0
   fi
+  # An IDE generator brings its own toolchain instead of taking one from PATH,
+  # so nothing needs to be found here for the build to work.
+  case "${CMAKE_GENERATOR:-}" in
+    "Visual Studio"*|Xcode|"Green Hills MULTI") return 0 ;;
+  esac
   local candidate
-  for candidate in c++ g++ clang++; do
+  for candidate in "${CXX_CANDIDATES[@]}"; do
     command -v "$candidate" >/dev/null 2>&1 && return 0
   done
   return 1
@@ -266,11 +279,18 @@ run_python_test() {
 # sixth place, so this runs whatever the directory holds: a test added to it is
 # picked up without anyone remembering to touch this script.
 python_tooling_tests() {
-  local tests=()
+  # A glob rather than `find`: one fewer external tool in the way, and no way
+  # for a failure inside a process substitution to arrive here looking like an
+  # empty directory. That distinction matters, because "no tests found" is
+  # reported as a skip, so a silently broken listing would quietly drop the
+  # whole Python suite from the run.
+  local had_nullglob=0
+  shopt -q nullglob && had_nullglob=1
+  shopt -s nullglob
+  local tests=(test/tooling/*_test.py)
+  [ "$had_nullglob" -eq 1 ] || shopt -u nullglob
+
   local path
-  while IFS= read -r path; do
-    [ -n "$path" ] && tests+=("$path")
-  done < <(find test/tooling -maxdepth 1 -type f -name '*_test.py' | LC_ALL=C sort)
 
   if [ "${#tests[@]}" -eq 0 ]; then
     skip "Python tooling tests" "no test/tooling/*_test.py files found"

--- a/scripts/verify_native.sh
+++ b/scripts/verify_native.sh
@@ -134,8 +134,15 @@ rust_section() {
 # CMake finds the compiler on its own (CXX first, then c++/g++/clang++ on PATH).
 # This asks the same question up front so a machine without one reads as
 # "install a compiler" rather than as a CMake configure error.
+#
+# CXX may carry required options, not just a program name: cmake-env-variables(7)
+# documents `CXX="custom-compiler --sysroot=/sdk"`, and looking the whole string
+# up as one command would reject a cross toolchain CMake is perfectly happy
+# with. Only the first word names a program. A compiler path that itself
+# contains spaces is indistinguishable from a path plus options here, which is
+# a limitation CMake shares.
 cxx_compiler_available() {
-  if [ -n "${CXX:-}" ] && command -v "$CXX" >/dev/null 2>&1; then
+  if [ -n "${CXX:-}" ] && command -v "${CXX%% *}" >/dev/null 2>&1; then
     return 0
   fi
   local candidate
@@ -181,8 +188,14 @@ cpp_section() {
       run_step "$project $build_type: cmake configure" \
         cmake -S "native/$project" -B "$build_dir" \
         -DCMAKE_BUILD_TYPE="$build_type" || continue
+      # --config goes beyond the workflow's command line on purpose. CI's
+      # runner uses a single-config generator, where CMAKE_BUILD_TYPE above
+      # decides everything; a contributor with CMAKE_GENERATOR set to a
+      # multi-config generator (Ninja Multi-Config, Xcode, Visual Studio) has
+      # CMAKE_BUILD_TYPE ignored and would build the generator's default
+      # config in both legs. It is a no-op for single-config generators.
       run_step "$project $build_type: cmake build" \
-        cmake --build "$build_dir" --parallel || continue
+        cmake --build "$build_dir" --parallel --config "$build_type" || continue
 
       ctest_args=()
       if [ "$project" = "linthra_audio" ] && [ "$build_type" = "Debug" ]; then
@@ -191,8 +204,11 @@ cpp_section() {
         # the build users actually get.
         ctest_args=(--exclude-regex linthra_audio_realtime_budget)
       fi
+      # -C for the same reason, and it matters more here: under a
+      # multi-config generator ctest without it reports every test as "Not
+      # Run" and exits non-zero, which would read as a broken checkout.
       run_step "$project $build_type: ctest" \
-        ctest --test-dir "$build_dir" --output-on-failure \
+        ctest --test-dir "$build_dir" --output-on-failure -C "$build_type" \
         "${ctest_args[@]+"${ctest_args[@]}"}"
     done
   done
@@ -219,7 +235,14 @@ run_python_test() {
     return 0
   fi
 
-  if printf '%s\n' "$output" | grep -q 'ModuleNotFoundError'; then
+  # Only a module missing *before any test ran* is a skip. unittest prints a
+  # "Ran N tests" line as soon as it has run something, so the absence of that
+  # line is what separates "this machine cannot run the file at all" from "the
+  # file ran and something failed". Grepping the whole output for the error on
+  # its own would downgrade a genuine failure whose output merely quotes a
+  # ModuleNotFoundError, and the run would exit 0 with a regression inside it.
+  if ! printf '%s\n' "$output" | grep -q '^Ran [0-9]' &&
+    printf '%s\n' "$output" | grep -q 'ModuleNotFoundError'; then
     module="$(printf '%s\n' "$output" |
       sed -n "s/.*ModuleNotFoundError: No module named '\([^']*\)'.*/\1/p" |
       head -1)"

--- a/scripts/verify_native.sh
+++ b/scripts/verify_native.sh
@@ -158,6 +158,14 @@ cxx_compiler_available() {
   case "${CMAKE_GENERATOR:-}" in
     "Visual Studio"*|Xcode|"Green Hills MULTI") return 0 ;;
   esac
+  # The same applies when CMAKE_GENERATOR is unset on Windows, where CMake's
+  # default is a Visual Studio generator: cl is not on a Git Bash PATH, and
+  # cmake-generators(7) notes that "since the IDEs configure their own
+  # environment one may launch CMake from any environment". Nothing visible
+  # from here can confirm that toolchain, so do not skip the section over it.
+  case "${OSTYPE:-}" in
+    msys*|cygwin*|win32*) return 0 ;;
+  esac
   local candidate
   for candidate in "${CXX_CANDIDATES[@]}"; do
     command -v "$candidate" >/dev/null 2>&1 && return 0
@@ -227,6 +235,26 @@ cpp_section() {
   done
 }
 
+# The external Python packages CI installs before it runs these tests, and so
+# the only modules whose absence is this machine's problem rather than the
+# change's. ci.yml and pr-security-review-tests.yml both pip-install PyYAML;
+# everything else the tests import is either stdlib or owned by this
+# repository, and a repository module that has gone missing is a broken change,
+# not a missing tool. Kept honest by
+# test/tooling/verify_native_test.py, which reads the pip installs out of the
+# workflows and requires this list to match.
+PYTHON_EXTERNAL_MODULES=(yaml)
+
+# Whether a missing module names an external dependency rather than something
+# this repository is supposed to provide.
+is_external_python_module() {
+  local wanted="$1" known
+  for known in "${PYTHON_EXTERNAL_MODULES[@]}"; do
+    [ "$wanted" = "$known" ] && return 0
+  done
+  return 1
+}
+
 # One tooling test, run the way CI runs it. Output is captured and only printed
 # when the test fails, the same bargain `ctest --output-on-failure` makes: a
 # clean run stays readable, a broken one shows everything.
@@ -248,21 +276,31 @@ run_python_test() {
     return 0
   fi
 
-  # Only a module missing *before any test ran* is a skip. unittest prints a
+  # A skip has to clear two bars, because getting either wrong means a real
+  # regression leaves the run looking clean.
+  #
+  # First, the file must have failed *before any test ran*: unittest prints a
   # "Ran N tests" line as soon as it has run something, so the absence of that
   # line is what separates "this machine cannot run the file at all" from "the
-  # file ran and something failed". Grepping the whole output for the error on
-  # its own would downgrade a genuine failure whose output merely quotes a
-  # ModuleNotFoundError, and the run would exit 0 with a regression inside it.
-  if ! printf '%s\n' "$output" | grep -q '^Ran [0-9]' &&
-    printf '%s\n' "$output" | grep -q 'ModuleNotFoundError'; then
+  # file ran and something failed". Without it, a genuine failure whose output
+  # merely quotes a ModuleNotFoundError would be downgraded to a skip.
+  #
+  # Second, the missing module must be one CI installs rather than one this
+  # repository owns. Several of these tests import a repository module at the
+  # top of the file (test/tooling/large_library_memory_report_test.py takes
+  # memory_report from tools/large_library/, for instance). If a change removes
+  # or renames one, the import fails in exactly the shape a missing dependency
+  # does, and calling that a skip would pass the very change CI is about to
+  # reject.
+  if ! printf '%s\n' "$output" | grep -q '^Ran [0-9]'; then
     module="$(printf '%s\n' "$output" |
       sed -n "s/.*ModuleNotFoundError: No module named '\([^']*\)'.*/\1/p" |
       head -1)"
-    : "${module:=an unnamed module}"
-    printf '  skip  %s (needs the %s Python module)\n' "$path" "$module"
-    SKIPPED+=("python3 $path (needs the $module Python module)")
-    return 0
+    if [ -n "$module" ] && is_external_python_module "$module"; then
+      printf '  skip  %s (needs the %s Python module)\n' "$path" "$module"
+      SKIPPED+=("python3 $path (needs the $module Python module)")
+      return 0
+    fi
   fi
 
   RAN=$((RAN + 1))

--- a/scripts/verify_native.sh
+++ b/scripts/verify_native.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+#
+# verify_native.sh - run Linthra's Rust, C++ and Python checks locally, the way
+# CI runs them.
+#
+# The native/tooling twin of scripts/verify_android.sh (Flutter and Android) and
+# scripts/verify_linux.sh (the Linux desktop build). Someone who comes to
+# Linthra for the Rust core, the C++ DSP or the Python tooling gets one command
+# to run before pushing, instead of reassembling it from three workflows.
+#
+# What it runs, and where CI runs the same thing:
+#
+#   Rust    .github/workflows/rust-core.yml, over native/linthra_core:
+#           cargo fmt --check, clippy with -D warnings, cargo test, and the
+#           200k-track benchmark binary.
+#   C++     .github/workflows/cpp-audio-dsp.yml (native/linthra_audio) and
+#           .github/workflows/cpp-desktop-window.yml (native/linthra_desktop):
+#           cmake configure, cmake --build, ctest, in Release and Debug.
+#   Python  .github/workflows/python-lint.yml, plus the tooling unit tests that
+#           ci.yml and four other workflows run one file at a time:
+#           ruff check, ruff format --check, python3 test/tooling/*_test.py.
+#
+# A missing toolchain is not a failing check. A section whose tools are not
+# installed is skipped with a message saying what to install, the same shape as
+# verify_android.sh skipping the APK build when there is no Android SDK, and the
+# summary lists everything skipped so a pass is never read as full coverage. A
+# check that actually fails makes this script exit non-zero. If nothing could be
+# checked at all, that is an error rather than a pass: nothing was verified.
+#
+# Nothing here writes to tracked files. Cargo builds into
+# native/linthra_core/target/ and CMake into build/, both git-ignored, and Ruff
+# runs with --check so it reports formatting instead of rewriting it.
+#
+# scripts/doctor.sh reports the same toolchains without running anything, which
+# is the quicker way to find out what a skip message is asking you to install.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Paths stay relative to REPO_ROOT, which main() enters: that keeps every
+# command line identical to the workflow's, and keeps a checkout living under a
+# directory with spaces in its name out of the arguments entirely.
+RUST_MANIFEST="native/linthra_core/Cargo.toml"
+
+# The two CMake projects, in the order their workflows appear. They build
+# identically; only the Debug ctest exclusion below tells them apart.
+CPP_PROJECTS=(linthra_audio linthra_desktop)
+
+info()    { printf '\n==> %s\n' "$*"; }
+warn()    { printf 'WARNING: %s\n' "$*" >&2; }
+section() { printf '\n=== %s ===\n' "$*"; }
+
+FAILED=()
+SKIPPED=()
+RAN=0
+
+# Run a labelled check; record (but do not abort on) failure, so one pass shows
+# a contributor every problem rather than only the first. Returns the check's
+# own exit status, which the C++ section uses to stop building after a failed
+# configure.
+run_step() {
+  local label="$1"; shift
+  info "$label"
+  RAN=$((RAN + 1))
+  if "$@"; then
+    return 0
+  fi
+  warn "FAILED: $label"
+  FAILED+=("$label")
+  return 1
+}
+
+# Record something this machine cannot check. Never a failure: it only means the
+# tool is not installed here, and CI will still run it. Arguments after the
+# reason are printed as install hints.
+skip() {
+  local label="$1"
+  local reason="$2"
+  shift 2
+  SKIPPED+=("$label ($reason)")
+  warn "SKIPPED: $label, $reason"
+  local hint
+  for hint in "$@"; do
+    warn "  $hint"
+  done
+}
+
+rust_section() {
+  section "Rust: native/linthra_core"
+
+  if ! command -v cargo >/dev/null 2>&1; then
+    skip "Rust checks" "cargo not found" \
+      "Install a stable Rust toolchain from https://rustup.rs (CI uses stable)."
+    return
+  fi
+  cargo --version 2>/dev/null | head -1 || true
+
+  # rustfmt and clippy are rustup components rather than part of cargo itself: a
+  # toolchain installed without them has cargo on PATH and still cannot run
+  # either. CI asks for both by name (dtolnay/rust-toolchain with components),
+  # so ask here too, instead of letting cargo fail with "no such subcommand",
+  # which reads like a broken checkout.
+  if cargo fmt --version >/dev/null 2>&1; then
+    run_step "cargo fmt --check" \
+      cargo fmt --manifest-path "$RUST_MANIFEST" -- --check
+  else
+    skip "cargo fmt --check" "the rustfmt component is not installed" \
+      "rustup component add rustfmt"
+  fi
+
+  if cargo clippy --version >/dev/null 2>&1; then
+    run_step "cargo clippy (warnings are errors)" \
+      cargo clippy --locked --manifest-path "$RUST_MANIFEST" \
+      --all-targets -- -D warnings
+  else
+    skip "cargo clippy" "the clippy component is not installed" \
+      "rustup component add clippy"
+  fi
+
+  run_step "cargo test" cargo test --locked --manifest-path "$RUST_MANIFEST"
+
+  # CI's fourth Rust step, and a real check rather than a report: the binary
+  # asserts an average-search budget over a synthetic 200k-track library
+  # (native/linthra_core/src/bin/benchmark_200k.rs), so a search regression
+  # fails it. It is a release build, but a small and quick one, and leaving it
+  # out of the local twin would only move the surprise to CI.
+  run_step "cargo run --release --bin benchmark_200k" \
+    cargo run --locked --release --manifest-path "$RUST_MANIFEST" \
+    --bin benchmark_200k
+}
+
+# CMake finds the compiler on its own (CXX first, then c++/g++/clang++ on PATH).
+# This asks the same question up front so a machine without one reads as
+# "install a compiler" rather than as a CMake configure error.
+cxx_compiler_available() {
+  if [ -n "${CXX:-}" ] && command -v "$CXX" >/dev/null 2>&1; then
+    return 0
+  fi
+  local candidate
+  for candidate in c++ g++ clang++; do
+    command -v "$candidate" >/dev/null 2>&1 && return 0
+  done
+  return 1
+}
+
+cpp_section() {
+  section "C++: native/linthra_audio and native/linthra_desktop"
+
+  local missing=()
+  local tool
+  for tool in cmake ctest; do
+    command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
+  done
+  cxx_compiler_available || missing+=("a C++17 compiler (g++ or clang++)")
+
+  if [ "${#missing[@]}" -gt 0 ]; then
+    # Joined by hand rather than with printf: an entry can contain spaces, so the
+    # join has to go through IFS rather than through word splitting.
+    local list
+    list="$(IFS=','; printf '%s' "${missing[*]}")"
+    skip "C++ checks" "missing ${list//,/, }" \
+      "Both projects are plain CMake, with no other dependencies: install" \
+      "CMake (which provides ctest) and a C++17 compiler from your" \
+      "distribution's packages."
+    return
+  fi
+  cmake --version 2>/dev/null | head -1 || true
+
+  local project build_type build_dir
+  local ctest_args
+  for project in "${CPP_PROJECTS[@]}"; do
+    for build_type in Release Debug; do
+      # CI gets a fresh runner per matrix leg and can reuse one directory name.
+      # One local pass builds both, so each type gets its own directory under
+      # the same build/<project> path the workflows use, rather than
+      # reconfiguring in place and rebuilding everything on every switch.
+      build_dir="build/$project/$build_type"
+
+      run_step "$project $build_type: cmake configure" \
+        cmake -S "native/$project" -B "$build_dir" \
+        -DCMAKE_BUILD_TYPE="$build_type" || continue
+      run_step "$project $build_type: cmake build" \
+        cmake --build "$build_dir" --parallel || continue
+
+      ctest_args=()
+      if [ "$project" = "linthra_audio" ] && [ "$build_type" = "Debug" ]; then
+        # The same exclusion cpp-audio-dsp.yml applies to its Debug leg: an
+        # unoptimized build says nothing useful about the realtime budget of
+        # the build users actually get.
+        ctest_args=(--exclude-regex linthra_audio_realtime_budget)
+      fi
+      run_step "$project $build_type: ctest" \
+        ctest --test-dir "$build_dir" --output-on-failure \
+        "${ctest_args[@]+"${ctest_args[@]}"}"
+    done
+  done
+}
+
+# One tooling test, run the way CI runs it. Output is captured and only printed
+# when the test fails, the same bargain `ctest --output-on-failure` makes: a
+# clean run stays readable, a broken one shows everything.
+#
+# A test that cannot even import what it needs is reported as a skip rather than
+# a failure. PyYAML is the live example: ci.yml pip-installs it right before the
+# Flatpak smoke manifest tests, so on a machine without it that one file is a
+# missing tool, not a broken change, and failing the whole run for it would tell
+# a contributor nothing about what they are about to push.
+run_python_test() {
+  local path="$1"
+  local output status module
+  output="$(python3 "$path" 2>&1)"
+  status=$?
+
+  if [ "$status" -eq 0 ]; then
+    RAN=$((RAN + 1))
+    printf '  ok    %s\n' "$path"
+    return 0
+  fi
+
+  if printf '%s\n' "$output" | grep -q 'ModuleNotFoundError'; then
+    module="$(printf '%s\n' "$output" |
+      sed -n "s/.*ModuleNotFoundError: No module named '\([^']*\)'.*/\1/p" |
+      head -1)"
+    : "${module:=an unnamed module}"
+    printf '  skip  %s (needs the %s Python module)\n' "$path" "$module"
+    SKIPPED+=("python3 $path (needs the $module Python module)")
+    return 0
+  fi
+
+  RAN=$((RAN + 1))
+  printf '  FAIL  %s\n' "$path"
+  printf '%s\n' "$output"
+  FAILED+=("python3 $path")
+  return 1
+}
+
+# The Python unit tests under test/tooling/. CI runs them one `python3
+# test/tooling/<name>.py` step at a time, spread over ci.yml,
+# linux-desktop-build.yml, flatpak-build.yml, pr-security-review-tests.yml and
+# large-library-sql.yml. Repeating that list here would mean maintaining it in a
+# sixth place, so this runs whatever the directory holds: a test added to it is
+# picked up without anyone remembering to touch this script.
+python_tooling_tests() {
+  local tests=()
+  local path
+  while IFS= read -r path; do
+    [ -n "$path" ] && tests+=("$path")
+  done < <(find test/tooling -maxdepth 1 -type f -name '*_test.py' | LC_ALL=C sort)
+
+  if [ "${#tests[@]}" -eq 0 ]; then
+    skip "Python tooling tests" "no test/tooling/*_test.py files found"
+    return
+  fi
+
+  info "Python tooling tests (${#tests[@]} files under test/tooling/)"
+  for path in "${tests[@]}"; do
+    run_python_test "$path"
+  done
+}
+
+python_section() {
+  section "Python: scripts/, tool/, tools/ and test/tooling/"
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    skip "Python checks" "python3 not found" \
+      "Install Python 3 from your distribution's packages."
+    return
+  fi
+  python3 --version 2>/dev/null | head -1 || true
+
+  # The two commands python-lint.yml runs, with the three paths it passes.
+  # ruff.toml only adds excludes, it does not set the scope, so a bare
+  # `ruff check .` is a different check (ruff.toml explains this at length).
+  # --check on the formatter is the point rather than a detail: this script
+  # reports formatting, it never rewrites a file.
+  if command -v ruff >/dev/null 2>&1; then
+    ruff --version 2>/dev/null | head -1 || true
+    run_step "ruff check scripts tool tools" ruff check scripts tool tools
+    run_step "ruff format --check scripts tool tools" \
+      ruff format --check scripts tool tools
+  else
+    skip "ruff check and ruff format --check" "ruff not found" \
+      "python3 -m pip install ruff" \
+      "CI pins an exact version; .github/workflows/python-lint.yml has it," \
+      "and matching it locally avoids disagreeing about formatting."
+  fi
+
+  python_tooling_tests
+}
+
+main() {
+  cd "$REPO_ROOT" || {
+    printf 'ERROR: cannot enter %s\n' "$REPO_ROOT" >&2
+    exit 1
+  }
+
+  # A checkout is the only place these checks mean anything, and every command
+  # below is relative to it. If REPO_ROOT came out wrong, say so here rather
+  # than running cargo and cmake against whatever directory we landed in.
+  if [ ! -f "$RUST_MANIFEST" ] || [ ! -d "test/tooling" ]; then
+    printf 'ERROR: %s does not look like a Linthra checkout.\n' "$REPO_ROOT" >&2
+    exit 1
+  fi
+
+  rust_section
+  cpp_section
+  python_section
+
+  section "Summary"
+
+  if [ "${#SKIPPED[@]}" -gt 0 ]; then
+    printf '\nSkipped %d check(s) for want of the tools they need.\n' \
+      "${#SKIPPED[@]}"
+    printf 'CI still runs every one of them:\n'
+    printf '  - %s\n' "${SKIPPED[@]}"
+  fi
+
+  if [ "${#FAILED[@]}" -gt 0 ]; then
+    printf '\nFailed %d check(s):\n' "${#FAILED[@]}"
+    printf '  - %s\n' "${FAILED[@]}"
+    printf '\nVerification FAILED.\n'
+    exit 1
+  fi
+
+  # Everything skipped is not a pass. Same call verify_android.sh makes when
+  # there is no Flutter at all: the script could not answer the question it
+  # exists to answer, and saying "passed" would be worse than saying nothing.
+  if [ "$RAN" -eq 0 ]; then
+    printf '\nNothing could be checked: no Rust, C++ or Python toolchain was\n'
+    printf 'found. Run ./scripts/doctor.sh to see what is detected, and\n'
+    printf 'install at least one of them.\n'
+    exit 1
+  fi
+
+  printf '\nVerification passed (%d check(s) ran).\n' "$RAN"
+}
+
+main "$@"

--- a/scripts/verify_native.sh
+++ b/scripts/verify_native.sh
@@ -158,6 +158,12 @@ cxx_compiler_available() {
   case "${CMAKE_GENERATOR:-}" in
     "Visual Studio"*|Xcode|"Green Hills MULTI") return 0 ;;
   esac
+  # A toolchain file names its own compiler, typically an absolute path to a
+  # cross toolchain that is not on PATH at all. `cmake --help-variable
+  # CMAKE_TOOLCHAIN_FILE` describes it as specifying "locations for compilers
+  # and toolchain utilities", and the environment variable initialises it for a
+  # new build tree, so a contributor who set one has already answered this.
+  [ -n "${CMAKE_TOOLCHAIN_FILE:-}" ] && return 0
   # The same applies when CMAKE_GENERATOR is unset on Windows, where CMake's
   # default is a Visual Studio generator: cl is not on a Git Bash PATH, and
   # cmake-generators(7) notes that "since the IDEs configure their own
@@ -171,6 +177,21 @@ cxx_compiler_available() {
     command -v "$candidate" >/dev/null 2>&1 && return 0
   done
   return 1
+}
+
+# ctest over one build directory.
+#
+# The workflows say `ctest --test-dir <dir>`, which needs CMake 3.20 or newer.
+# Both projects declare cmake_minimum_required(VERSION 3.16) and Ubuntu 20.04
+# still ships 3.16.3, so a contributor who meets the projects' own stated
+# minimum would watch every test leg die on an unknown argument. Running from
+# inside the directory is the older spelling of the same thing and works on
+# both, in a subshell so the cd cannot leak into the rest of the run.
+run_ctest() {
+  local build_dir="$1"
+  local build_type="$2"
+  shift 2
+  (cd "$build_dir" && ctest --output-on-failure -C "$build_type" "$@")
 }
 
 cpp_section() {
@@ -229,7 +250,7 @@ cpp_section() {
       # multi-config generator ctest without it reports every test as "Not
       # Run" and exits non-zero, which would read as a broken checkout.
       run_step "$project $build_type: ctest" \
-        ctest --test-dir "$build_dir" --output-on-failure -C "$build_type" \
+        run_ctest "$build_dir" "$build_type" \
         "${ctest_args[@]+"${ctest_args[@]}"}"
     done
   done
@@ -266,12 +287,24 @@ is_external_python_module() {
 # a contributor nothing about what they are about to push.
 run_python_test() {
   local path="$1"
-  local output status module
+  local output status module skipped
   output="$(python3 "$path" 2>&1)"
   status=$?
 
   if [ "$status" -eq 0 ]; then
     RAN=$((RAN + 1))
+    # A file can pass while skipping tests inside it: several of these guard a
+    # class on a tool beyond Python (check_pr_security_surface_test.py needs jq
+    # for its review-decision tests). unittest reports that as "OK (skipped=N)".
+    # CI has those tools and runs what this machine did not, so calling the run
+    # a clean pass would overstate what was actually checked.
+    skipped="$(printf '%s\n' "$output" |
+      sed -n 's/^OK (.*skipped=\([0-9][0-9]*\).*/\1/p' | head -1)"
+    if [ -n "$skipped" ]; then
+      printf '  ok    %s (%s test(s) skipped inside it)\n' "$path" "$skipped"
+      SKIPPED+=("python3 $path ($skipped test(s) skipped inside it)")
+      return 0
+    fi
     printf '  ok    %s\n' "$path"
     return 0
   fi

--- a/scripts/verify_native.sh
+++ b/scripts/verify_native.sh
@@ -131,52 +131,34 @@ rust_section() {
     --bin benchmark_200k
 }
 
-# CMake finds the compiler on its own (CXX first, then c++/g++/clang++ on PATH).
-# This asks the same question up front so a machine without one reads as
-# "install a compiler" rather than as a CMake configure error.
+# Whether CMake found a C++ compiler, set by configure_cpp below.
 #
-# CXX may carry required options, not just a program name: cmake-env-variables(7)
-# documents `CXX="custom-compiler --sysroot=/sdk"`, and looking the whole string
-# up as one command would reject a cross toolchain CMake is perfectly happy
-# with. Only the first word names a program. A compiler path that itself
-# contains spaces is indistinguishable from a path plus options here, which is
-# a limitation CMake shares.
-#
-# The candidate list is CMake's own, from CMakeDetermineCXXCompiler.cmake. A
-# shorter list would be the wrong kind of wrong: this gate only decides whether
-# to run the C++ checks or skip them, so missing a compiler CMake would have
-# found drops real coverage silently, while guessing one that turns out not to
-# work costs nothing but a configure error, which is reported as a failure.
-CXX_CANDIDATES=(c++ CC g++ aCC cl bcc xlC icpx icx clang++)
+# There is deliberately no preflight for this any more. CMake resolves a
+# compiler from CXX (options and all), CMAKE_TOOLCHAIN_FILE, an IDE generator's
+# own environment, and its own candidate list, and four rounds of review found
+# four separate paths a shell-side guess did not cover. CMake is the authority,
+# so the section asks it and reads the answer: "no compiler here" is a skip with
+# something to install, anything else is a real failure.
+CPP_NO_COMPILER=0
 
-cxx_compiler_available() {
-  if [ -n "${CXX:-}" ] && command -v "${CXX%% *}" >/dev/null 2>&1; then
-    return 0
+# Configure one project, echoing CMake's output and remembering whether it
+# failed for want of a compiler. The two messages matched below are what CMake
+# prints when it cannot resolve one, whether that is an empty PATH or a CXX
+# pointing at nothing.
+configure_cpp() {
+  local build_dir="$1"
+  local source_dir="$2"
+  local build_type="$3"
+  local output status
+  output="$(cmake -S "$source_dir" -B "$build_dir" \
+    -DCMAKE_BUILD_TYPE="$build_type" 2>&1)"
+  status=$?
+  printf '%s\n' "$output"
+  if [ "$status" -ne 0 ] && printf '%s\n' "$output" | grep -qE \
+    'No CMAKE_CXX_COMPILER could be found|CMAKE_CXX_COMPILER not set, after EnableLanguage'; then
+    CPP_NO_COMPILER=1
   fi
-  # An IDE generator brings its own toolchain instead of taking one from PATH,
-  # so nothing needs to be found here for the build to work.
-  case "${CMAKE_GENERATOR:-}" in
-    "Visual Studio"*|Xcode|"Green Hills MULTI") return 0 ;;
-  esac
-  # A toolchain file names its own compiler, typically an absolute path to a
-  # cross toolchain that is not on PATH at all. `cmake --help-variable
-  # CMAKE_TOOLCHAIN_FILE` describes it as specifying "locations for compilers
-  # and toolchain utilities", and the environment variable initialises it for a
-  # new build tree, so a contributor who set one has already answered this.
-  [ -n "${CMAKE_TOOLCHAIN_FILE:-}" ] && return 0
-  # The same applies when CMAKE_GENERATOR is unset on Windows, where CMake's
-  # default is a Visual Studio generator: cl is not on a Git Bash PATH, and
-  # cmake-generators(7) notes that "since the IDEs configure their own
-  # environment one may launch CMake from any environment". Nothing visible
-  # from here can confirm that toolchain, so do not skip the section over it.
-  case "${OSTYPE:-}" in
-    msys*|cygwin*|win32*) return 0 ;;
-  esac
-  local candidate
-  for candidate in "${CXX_CANDIDATES[@]}"; do
-    command -v "$candidate" >/dev/null 2>&1 && return 0
-  done
-  return 1
+  return "$status"
 }
 
 # ctest over one build directory.
@@ -202,7 +184,6 @@ cpp_section() {
   for tool in cmake ctest; do
     command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
   done
-  cxx_compiler_available || missing+=("a C++17 compiler (g++ or clang++)")
 
   if [ "${#missing[@]}" -gt 0 ]; then
     # Joined by hand rather than with printf: an entry can contain spaces, so the
@@ -211,8 +192,7 @@ cpp_section() {
     list="$(IFS=','; printf '%s' "${missing[*]}")"
     skip "C++ checks" "missing ${list//,/, }" \
       "Both projects are plain CMake, with no other dependencies: install" \
-      "CMake (which provides ctest) and a C++17 compiler from your" \
-      "distribution's packages."
+      "CMake, which provides ctest, from your distribution's packages."
     return
   fi
   cmake --version 2>/dev/null | head -1 || true
@@ -227,9 +207,21 @@ cpp_section() {
       # reconfiguring in place and rebuilding everything on every switch.
       build_dir="build/$project/$build_type"
 
-      run_step "$project $build_type: cmake configure" \
-        cmake -S "native/$project" -B "$build_dir" \
-        -DCMAKE_BUILD_TYPE="$build_type" || continue
+      info "$project $build_type: cmake configure"
+      if ! configure_cpp "$build_dir" "native/$project" "$build_type"; then
+        if [ "$CPP_NO_COMPILER" -eq 1 ]; then
+          skip "C++ checks" "CMake found no C++ compiler" \
+            "Install a C++17 compiler (g++ or clang++) from your" \
+            "distribution's packages, or point CXX or CMAKE_TOOLCHAIN_FILE at" \
+            "one. CMake decides this, so whatever satisfies CMake works here."
+          return
+        fi
+        warn "FAILED: $project $build_type: cmake configure"
+        FAILED+=("$project $build_type: cmake configure")
+        RAN=$((RAN + 1))
+        continue
+      fi
+      RAN=$((RAN + 1))
       # --config goes beyond the workflow's command line on purpose. CI's
       # runner uses a single-config generator, where CMAKE_BUILD_TYPE above
       # decides everything; a contributor with CMAKE_GENERATOR set to a
@@ -374,17 +366,27 @@ python_tooling_tests() {
   done
 }
 
+# The Python version the tooling is written for, read from ruff.toml so there is
+# one source of truth rather than a number repeated here. "py311" means 3.11.
+required_python_version() {
+  sed -n 's/^target-version *= *"py\([0-9]\)\([0-9][0-9]*\)".*/\1.\2/p' \
+    ruff.toml 2>/dev/null | head -1
+}
+
+# True when $1 is an older version than $2.
+older_version() {
+  [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" = "$1" ] &&
+    [ "$1" != "$2" ]
+}
+
 python_section() {
   section "Python: scripts/, tool/, tools/ and test/tooling/"
 
-  if ! command -v python3 >/dev/null 2>&1; then
-    skip "Python checks" "python3 not found" \
-      "Install Python 3 from your distribution's packages."
-    return
-  fi
-  python3 --version 2>/dev/null | head -1 || true
-
-  # The two commands python-lint.yml runs, with the three paths it passes.
+  # Ruff first, and on its own: it is a standalone binary that never runs the
+  # interpreter, so a machine with Ruff but no python3 can still be told that
+  # its lint and formatting are wrong rather than hearing nothing at all.
+  #
+  # The two commands are python-lint.yml's, with the three paths it passes.
   # ruff.toml only adds excludes, it does not set the scope, so a bare
   # `ruff check .` is a different check (ruff.toml explains this at length).
   # --check on the formatter is the point rather than a detail: this script
@@ -400,6 +402,45 @@ python_section() {
       "CI pins an exact version; .github/workflows/python-lint.yml has it," \
       "and matching it locally avoids disagreeing about formatting."
   fi
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    skip "Python tooling tests" "python3 not found" \
+      "Install Python 3 from your distribution's packages."
+    return
+  fi
+  python3 --version 2>/dev/null | head -1 || true
+
+  # An interpreter older than the tooling targets fails these tests for reasons
+  # that have nothing to do with the change being checked:
+  # tools/large_library/memory_report.py uses zip(strict=...), which is 3.10 and
+  # later. Reporting that as a verdict on the change would be a lie.
+  local want have
+  want="$(required_python_version)"
+  have="$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2>/dev/null)"
+  if [ -n "$want" ] && [ -n "$have" ] && older_version "$have" "$want"; then
+    skip "Python tooling tests" "python3 is $have, the tooling targets $want" \
+      "ruff.toml sets that target and CI installs the same version." \
+      "An older interpreter fails these tests on syntax and library features," \
+      "which says nothing about your change."
+    return
+  fi
+
+  # Name a module CI installs that is missing here, before the tests run. Some
+  # of them shell out to scripts that import it, so its absence arrives as
+  # ordinary test failures rather than as an import error that can be
+  # classified. Saying so up front is the difference between a baffling red run
+  # and an obvious one command fix.
+  local module
+  for module in "${PYTHON_EXTERNAL_MODULES[@]}"; do
+    if ! python3 -c "import $module" >/dev/null 2>&1; then
+      warn "The $module Python module is not installed."
+      warn "CI installs it before running these tests (see the pip install"
+      warn "steps in .github/workflows/), and some of them shell out to"
+      warn "scripts that import it, so expect failures below that are about"
+      warn "the missing module rather than about your change."
+      SKIPPED+=("the $module Python module is missing (some tooling tests need it)")
+    fi
+  done
 
   python_tooling_tests
 }

--- a/test/tooling/verify_native_test.py
+++ b/test/tooling/verify_native_test.py
@@ -39,10 +39,11 @@ ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts" / "verify_native.sh"
 WORKFLOWS = ROOT / ".github" / "workflows"
 
-# Real tools the script itself needs. Everything else on PATH is deliberately
-# withheld, so "cargo is not installed" can be staged by simply not writing a
-# cargo stub.
+# Real tools the script itself needs, plus mkdir for the cmake stub's build
+# tree. Everything else on PATH is deliberately withheld, so "cargo is not
+# installed" can be staged by simply not writing a cargo stub.
 PASSTHROUGH_TOOLS = (
+    "mkdir",
     "bash",
     "sh",
     "env",
@@ -70,7 +71,7 @@ for arg in "$@"; do
   fi
 done
 
-printf '%s' "$name" >> "$LINTHRA_STUB_LOG"
+printf '%s\\t%s' "$name" "$PWD" >> "$LINTHRA_STUB_LOG"
 for arg in "$@"; do
   printf '\\t%s' "$arg" >> "$LINTHRA_STUB_LOG"
 done
@@ -82,6 +83,14 @@ case " ${LINTHRA_STUB_FAIL:-} " in
     exit 1
     ;;
 esac
+
+# Real cmake creates the build tree named by -B, and ctest is run from inside
+# it, so the stub has to do at least that much to be worth running against.
+previous=""
+for arg in "$@"; do
+  [ "$previous" = "-B" ] && mkdir -p -- "$arg"
+  previous="$arg"
+done
 exit 0
 """
 
@@ -98,6 +107,25 @@ FAILING_TEST = (
 MISSING_EXTERNAL_DEPENDENCY_TEST = (
     "raise ModuleNotFoundError(\"No module named 'yaml'\")\n"
 )
+# Passes, but skips a test inside itself, the way a suite that needs a tool
+# beyond Python does (check_pr_security_surface_test.py skips its
+# review-decision class when jq is absent). unittest reports "OK (skipped=1)".
+PASSING_TEST_WITH_AN_INTERNAL_SKIP = """import unittest
+
+
+class T(unittest.TestCase):
+    @unittest.skip("needs a tool this machine does not have")
+    def test_needs_a_tool(self):
+        pass
+
+    def test_runs(self):
+        pass
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+"""
+
 # The same shape, for a module this repository is supposed to provide.
 # test/tooling/large_library_memory_report_test.py really does import
 # memory_report from tools/large_library/ at the top of the file, so renaming
@@ -404,9 +432,23 @@ class StubHarness(unittest.TestCase):
     def _calls(run: "_Run", name: str, *, probes: bool = False) -> list[list[str]]:
         """The recorded argv for `name`, without the version probes."""
         return [
-            call
+            [call[0]] + call[2:]
             for call in run.calls
-            if call[0] == name and (probes or "--version" not in call)
+            if call[0] == name and (probes or "--version" not in call[2:])
+        ]
+
+    @staticmethod
+    def _cwds(run: "_Run", name: str) -> list[str]:
+        """The directory each `name` invocation ran in."""
+        return [inv[0] for inv in StubHarness._invocations(run, name)]
+
+    @staticmethod
+    def _invocations(run: "_Run", name: str) -> list[tuple[str, list[str]]]:
+        """(working directory, argv) for each non-probe call of `name`."""
+        return [
+            (call[1], [call[0]] + call[2:])
+            for call in run.calls
+            if call[0] == name and "--version" not in call[2:]
         ]
 
 
@@ -475,8 +517,12 @@ class RunAgainstStubs(StubHarness):
             msg=run.output,
         )
         built = [call[2] for call in self._calls(run, "cmake") if call[1] == "--build"]
-        tested = [call[2] for call in self._calls(run, "ctest")]
         self.assertEqual(built, [c[1] for c in configured])
+        # ctest is run from inside each build tree rather than pointed at it.
+        tested = [
+            cwd.split("/a checkout with spaces/")[-1]
+            for cwd in self._cwds(run, "ctest")
+        ]
         self.assertEqual(tested, [c[1] for c in configured])
 
     def test_the_build_and_the_tests_name_the_configuration(self) -> None:
@@ -498,18 +544,33 @@ class RunAgainstStubs(StubHarness):
                 call[2].split("/")[-1],
                 msg="built a different configuration than the directory is for",
             )
-        for call in self._calls(run, "ctest"):
+        for cwd, call in self._invocations(run, "ctest"):
             self.assertIn("-C", call, msg=" ".join(call))
             self.assertEqual(
                 call[call.index("-C") + 1],
-                call[2].split("/")[-1],
+                cwd.split("/")[-1],
                 msg="tested a different configuration than was built",
             )
+
+    def test_ctest_runs_from_inside_the_build_tree(self) -> None:
+        """`ctest --test-dir` is CMake 3.20; the projects declare 3.16.
+
+        Both native projects say cmake_minimum_required(VERSION 3.16), and
+        Ubuntu 20.04 still ships 3.16.3, so a contributor who meets the
+        projects' own stated minimum would watch every test leg die on an
+        unknown argument.
+        """
+        run = self._run()
+        for call in self._calls(run, "ctest"):
+            self.assertNotIn("--test-dir", call, msg=" ".join(call))
+        self.assertEqual(len(self._cwds(run, "ctest")), 4, msg=run.output)
 
     def test_only_the_audio_debug_leg_drops_the_realtime_budget(self) -> None:
         run = self._run()
         excluding = [
-            call[2] for call in self._calls(run, "ctest") if "--exclude-regex" in call
+            cwd.split("/a checkout with spaces/")[-1]
+            for cwd, call in self._invocations(run, "ctest")
+            if "--exclude-regex" in call
         ]
         self.assertEqual(excluding, ["build/linthra_audio/Debug"], msg=run.output)
 
@@ -694,12 +755,48 @@ class MissingToolsAreSkips(StubHarness):
         self.assertIn("SKIPPED: C++ checks", run.output)
         self.assertIn("C++17 compiler", run.output)
 
+    def test_a_cmake_toolchain_file_answers_the_compiler_question(self) -> None:
+        """A toolchain file names its own compiler, often off PATH entirely."""
+        run = self._run(
+            tools=("cargo", "cmake", "ctest", "ruff"),
+            env={"CMAKE_TOOLCHAIN_FILE": "/opt/sdk/arm-linux.cmake"},
+        )
+        self.assertEqual(run.process.returncode, 0, msg=run.output)
+        self.assertNotIn("SKIPPED: C++ checks", run.output)
+        self.assertTrue([c for c in run.calls if c[0] == "ctest"], msg=run.output)
+
     def test_no_ruff_still_runs_the_python_tooling_tests(self) -> None:
         run = self._run(tools=("cargo", "cmake", "ctest", "c++"))
         self.assertEqual(run.process.returncode, 0, msg=run.output)
         self.assertIn("ruff not found", run.output)
         self.assertIn("pip install ruff", run.output)
         self.assertIn("ok    test/tooling/example_test.py", run.output)
+
+    def test_a_suite_that_skipped_tests_inside_itself_says_so(self) -> None:
+        """A green summary must not hide coverage this machine did not run.
+
+        check_pr_security_surface_test.py skips its review-decision class when
+        jq is absent and still exits 0. CI has jq and runs those tests, so
+        reporting the file as a plain "ok" overstates what was checked.
+        """
+        run = self._run(
+            tooling_tests={
+                "ok_test.py": PASSING_TEST,
+                "partial_test.py": PASSING_TEST_WITH_AN_INTERNAL_SKIP,
+            }
+        )
+        self.assertEqual(run.process.returncode, 0, msg=run.output)
+        self.assertIn(
+            "ok    test/tooling/partial_test.py (1 test(s) skipped inside it)",
+            run.output,
+        )
+        # And it reaches the summary, which is what a contributor actually reads.
+        self.assertIn(
+            "python3 test/tooling/partial_test.py (1 test(s) skipped inside it)",
+            _summary_items(run.output, "Skipped"),
+        )
+        # A file with nothing skipped stays a plain ok.
+        self.assertIn("ok    test/tooling/ok_test.py\n", run.output)
 
     def test_a_missing_external_dependency_is_skipped_not_failed(self) -> None:
         """The PyYAML shape: ci.yml installs it, a contributor may not have it."""
@@ -781,11 +878,16 @@ class _Run:
 
 
 def _snapshot(repo: Path) -> dict[str, str]:
-    """Every file under `repo`, by relative path, with its contents."""
+    """Every file under `repo`, by relative path, with its contents.
+
+    build/ is left out: CMake writes its trees there, and .gitignore already
+    excludes it. The question this answers is whether the run rewrote anything
+    a contributor actually has checked out.
+    """
     return {
         str(path.relative_to(repo)): path.read_text(encoding="utf-8", errors="replace")
         for path in sorted(repo.rglob("*"))
-        if path.is_file()
+        if path.is_file() and not path.relative_to(repo).parts[:1] == ("build",)
     }
 
 

--- a/test/tooling/verify_native_test.py
+++ b/test/tooling/verify_native_test.py
@@ -94,6 +94,22 @@ FAILING_TEST = (
     "import sys\nsys.stderr.write('a real assertion failed\\n')\nsys.exit(1)\n"
 )
 UNIMPORTABLE_TEST = "import a_module_that_is_not_installed  # noqa: F401\n"
+# Runs, fails for real, and quotes a ModuleNotFoundError while doing it: a test
+# asserting on how some tool reports a missing dependency looks exactly like
+# this. The output must not be mistaken for the file failing to import.
+FAILING_TEST_QUOTING_AN_IMPORT_ERROR = """import sys
+import unittest
+
+
+class T(unittest.TestCase):
+    def test_a_genuine_regression(self):
+        self.assertEqual("ModuleNotFoundError: No module named 'x'", "clean")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2, exit=False)
+    sys.exit(1)
+"""
 
 
 def script_text() -> str:
@@ -220,6 +236,7 @@ class StubHarness(unittest.TestCase):
         tools: tuple[str, ...] = ("cargo", "cmake", "ctest", "c++", "ruff"),
         fail: tuple[str, ...] = (),
         tooling_tests: dict[str, str] | None = None,
+        env: dict[str, str] | None = None,
     ) -> "_Run":
         """Run verify_native.sh with exactly `tools` available on PATH.
 
@@ -277,6 +294,7 @@ class StubHarness(unittest.TestCase):
                 "HOME": str(tmp),
                 "LINTHRA_STUB_LOG": str(log),
                 "LINTHRA_STUB_FAIL": " ".join(fail),
+                **(env or {}),
             },
             capture_output=True,
             text=True,
@@ -375,6 +393,33 @@ class RunAgainstStubs(StubHarness):
         self.assertEqual(built, [c[1] for c in configured])
         self.assertEqual(tested, [c[1] for c in configured])
 
+    def test_the_build_and_the_tests_name_the_configuration(self) -> None:
+        """Under a multi-config generator, CMAKE_BUILD_TYPE alone is ignored.
+
+        CI's runner uses a single-config generator, so the workflows get away
+        with setting only CMAKE_BUILD_TYPE. A contributor with CMAKE_GENERATOR
+        set to Ninja Multi-Config, Xcode or Visual Studio would otherwise build
+        the generator's default config in both legs, and ctest without -C
+        reports every test as "Not Run" and exits non-zero.
+        """
+        run = self._run()
+        for call in self._calls(run, "cmake"):
+            if call[1] != "--build":
+                continue
+            self.assertIn("--config", call, msg=" ".join(call))
+            self.assertEqual(
+                call[call.index("--config") + 1],
+                call[2].split("/")[-1],
+                msg="built a different configuration than the directory is for",
+            )
+        for call in self._calls(run, "ctest"):
+            self.assertIn("-C", call, msg=" ".join(call))
+            self.assertEqual(
+                call[call.index("-C") + 1],
+                call[2].split("/")[-1],
+                msg="tested a different configuration than was built",
+            )
+
     def test_only_the_audio_debug_leg_drops_the_realtime_budget(self) -> None:
         run = self._run()
         excluding = [
@@ -436,6 +481,20 @@ class FailuresAreFailures(StubHarness):
             msg="ctest ran even though every build failed:\n" + run.output,
         )
 
+    def test_a_real_failure_quoting_an_import_error_is_still_a_failure(self) -> None:
+        """The skip is for a file that cannot start, not for any mention of it.
+
+        Classifying on the error string alone would downgrade a genuine
+        regression whose output happens to quote a ModuleNotFoundError, and the
+        whole run would exit 0 with that regression hidden inside it.
+        """
+        run = self._run(
+            tooling_tests={"quoting_test.py": FAILING_TEST_QUOTING_AN_IMPORT_ERROR}
+        )
+        self.assertEqual(run.process.returncode, 1, msg=run.output)
+        self.assertIn("FAIL  test/tooling/quoting_test.py", run.output)
+        self.assertNotIn("skip  test/tooling/quoting_test.py", run.output)
+
     def test_a_failing_tooling_test_fails_the_script_and_shows_its_output(self) -> None:
         run = self._run(
             tooling_tests={"ok_test.py": PASSING_TEST, "bad_test.py": FAILING_TEST}
@@ -472,6 +531,21 @@ class MissingToolsAreSkips(StubHarness):
         self.assertIn("SKIPPED: C++ checks", run.output)
         self.assertIn("cmake", run.output)
         self.assertIn("C++17 compiler", run.output)
+
+    def test_a_CXX_carrying_required_options_still_counts_as_a_compiler(self) -> None:
+        """cmake-env-variables(7) permits options in CXX, so the gate must too.
+
+        Looking the whole value up as one command name rejects a cross
+        toolchain CMake would configure happily, and on a machine without
+        c++/g++/clang++ that skipped every C++ check.
+        """
+        run = self._run(
+            tools=("cargo", "cmake", "ctest", "ruff", "custom-compiler"),
+            env={"CXX": "custom-compiler --sysroot=/sdk"},
+        )
+        self.assertEqual(run.process.returncode, 0, msg=run.output)
+        self.assertNotIn("SKIPPED: C++ checks", run.output)
+        self.assertTrue([c for c in run.calls if c[0] == "ctest"], msg=run.output)
 
     def test_no_ruff_still_runs_the_python_tooling_tests(self) -> None:
         run = self._run(tools=("cargo", "cmake", "ctest", "c++"))

--- a/test/tooling/verify_native_test.py
+++ b/test/tooling/verify_native_test.py
@@ -149,6 +149,18 @@ class TheScriptItself(unittest.TestCase):
                 msg="`cargo fmt` without `-- --check` rewrites the Rust sources",
             )
 
+    def test_the_tooling_tests_are_found_by_glob_not_by_find(self) -> None:
+        """ "No tests found" is a skip, so the listing must not be able to fail.
+
+        A `find` inside a process substitution hands the reading loop a
+        successful status whatever happened, so a listing that broke for any
+        reason would arrive looking like an empty directory and drop the whole
+        Python suite from the run without saying so.
+        """
+        text = script_text()
+        self.assertIn("local tests=(test/tooling/*_test.py)", text)
+        self.assertNotIn("find test/tooling", text)
+
     def test_every_section_names_the_workflow_it_stands_in_for(self) -> None:
         """A reader has to be able to get from the script back to CI."""
         for workflow in (
@@ -211,6 +223,35 @@ class AgreementWithCI(unittest.TestCase):
             "CPP_PROJECTS=({})".format(" ".join(sorted(sources))),
             script_text(),
         )
+
+    def test_the_compiler_gate_is_no_narrower_than_CMake_s_detection(self) -> None:
+        """Missing a compiler CMake would find drops coverage silently.
+
+        The gate only chooses between running the C++ checks and skipping
+        them, so it should err wide: a compiler that turns out not to work
+        costs a configure error, which is reported as a failure, while one the
+        gate fails to see costs the whole section with nothing said.
+        """
+        # CMakeDetermineCXXCompiler.cmake's candidates.
+        for candidate in (
+            "c++",
+            "CC",
+            "g++",
+            "aCC",
+            "cl",
+            "bcc",
+            "xlC",
+            "icpx",
+            "icx",
+            "clang++",
+        ):
+            self.assertIn(
+                candidate,
+                script_text().split("CXX_CANDIDATES=(")[1].split(")")[0].split(),
+            )
+        # An IDE generator supplies its own toolchain rather than taking one
+        # from PATH, so nothing has to be found for the build to work.
+        self.assertIn('"Visual Studio"*', script_text())
 
     def test_the_ruff_paths_are_the_ones_the_workflow_passes(self) -> None:
         """ruff.toml sets the rules, not the scope: the paths are the scope."""
@@ -546,6 +587,22 @@ class MissingToolsAreSkips(StubHarness):
         self.assertEqual(run.process.returncode, 0, msg=run.output)
         self.assertNotIn("SKIPPED: C++ checks", run.output)
         self.assertTrue([c for c in run.calls if c[0] == "ctest"], msg=run.output)
+
+    def test_a_compiler_only_CMake_would_have_named_still_counts(self) -> None:
+        """`cl`, `icpx` and friends are compilers too, not an absent toolchain."""
+        for compiler in ("cl", "icpx", "CC"):
+            with self.subTest(compiler=compiler):
+                run = self._run(tools=("cargo", "cmake", "ctest", "ruff", compiler))
+                self.assertEqual(run.process.returncode, 0, msg=run.output)
+                self.assertNotIn("SKIPPED: C++ checks", run.output)
+
+    def test_an_IDE_generator_supplies_its_own_toolchain(self) -> None:
+        run = self._run(
+            tools=("cargo", "cmake", "ctest", "ruff"),
+            env={"CMAKE_GENERATOR": "Visual Studio 17 2022"},
+        )
+        self.assertEqual(run.process.returncode, 0, msg=run.output)
+        self.assertNotIn("SKIPPED: C++ checks", run.output)
 
     def test_no_ruff_still_runs_the_python_tooling_tests(self) -> None:
         run = self._run(tools=("cargo", "cmake", "ctest", "c++"))

--- a/test/tooling/verify_native_test.py
+++ b/test/tooling/verify_native_test.py
@@ -93,7 +93,18 @@ PASSING_TEST = "import sys\nsys.exit(0)\n"
 FAILING_TEST = (
     "import sys\nsys.stderr.write('a real assertion failed\\n')\nsys.exit(1)\n"
 )
-UNIMPORTABLE_TEST = "import a_module_that_is_not_installed  # noqa: F401\n"
+# Fails to import an external dependency, in the shape a real one does, but
+# without depending on whether this machine happens to have PyYAML installed.
+MISSING_EXTERNAL_DEPENDENCY_TEST = (
+    "raise ModuleNotFoundError(\"No module named 'yaml'\")\n"
+)
+# The same shape, for a module this repository is supposed to provide.
+# test/tooling/large_library_memory_report_test.py really does import
+# memory_report from tools/large_library/ at the top of the file, so renaming
+# that module produces exactly this.
+MISSING_REPOSITORY_MODULE_TEST = (
+    "raise ModuleNotFoundError(\"No module named 'memory_report'\")\n"
+)
 # Runs, fails for real, and quotes a ModuleNotFoundError while doing it: a test
 # asserting on how some tool reports a missing dependency looks exactly like
 # this. The output must not be mistaken for the file failing to import.
@@ -260,6 +271,40 @@ class AgreementWithCI(unittest.TestCase):
         self.assertEqual(paths, {"scripts tool tools"})
         self.assertIn("ruff check scripts tool tools", script_text())
         self.assertIn("ruff format --check scripts tool tools", script_text())
+
+    def test_the_skippable_modules_are_the_ones_CI_installs(self) -> None:
+        """Only an external dependency may excuse a test from running.
+
+        CI pip-installs what the tooling tests need beyond stdlib, so that set
+        is the whole of what this machine can legitimately be missing.
+        Anything else is owned by this repository, and its absence is a broken
+        change rather than a missing tool.
+        """
+        installed: set[str] = set()
+        for path in sorted((WORKFLOWS).glob("*.yml")):
+            text = path.read_text(encoding="utf-8")
+            for match in re.finditer(r"pip install [^\n]*", text):
+                for package in re.findall(
+                    r"[\"']?([A-Za-z][\w.-]+)[\"']?", match.group(0)
+                ):
+                    if package in ("pip", "install", "python3", "m", "quiet"):
+                        continue
+                    installed.add(package.split("==")[0].lower())
+        self.assertIn("pyyaml", installed, msg="CI stopped installing PyYAML")
+
+        declared = set(
+            script_text().split("PYTHON_EXTERNAL_MODULES=(")[1].split(")")[0].split()
+        )
+        # PyYAML is the distribution; yaml is what a failed import names.
+        self.assertEqual(
+            declared,
+            {"yaml"},
+            msg=(
+                "the skippable set drifted from what CI installs "
+                "({}); widening it lets a broken repository module "
+                "pass as a missing tool".format(sorted(installed))
+            ),
+        )
 
     def test_no_ruff_version_is_pinned_in_two_places(self) -> None:
         """The pin lives in python-lint.yml. A copy here would rot."""
@@ -536,6 +581,24 @@ class FailuresAreFailures(StubHarness):
         self.assertIn("FAIL  test/tooling/quoting_test.py", run.output)
         self.assertNotIn("skip  test/tooling/quoting_test.py", run.output)
 
+    def test_a_missing_repository_module_is_a_failure_not_a_skip(self) -> None:
+        """A module this repo owns going missing is a broken change.
+
+        Several tooling tests import a repository module at the top of the
+        file, so removing or renaming one fails the import in exactly the shape
+        a missing dependency does. Calling that a skip would pass the very
+        change CI is about to reject.
+        """
+        run = self._run(
+            tooling_tests={
+                "ok_test.py": PASSING_TEST,
+                "repo_module_test.py": MISSING_REPOSITORY_MODULE_TEST,
+            }
+        )
+        self.assertEqual(run.process.returncode, 1, msg=run.output)
+        self.assertIn("FAIL  test/tooling/repo_module_test.py", run.output)
+        self.assertNotIn("skip  test/tooling/repo_module_test.py", run.output)
+
     def test_a_failing_tooling_test_fails_the_script_and_shows_its_output(self) -> None:
         run = self._run(
             tooling_tests={"ok_test.py": PASSING_TEST, "bad_test.py": FAILING_TEST}
@@ -604,6 +667,33 @@ class MissingToolsAreSkips(StubHarness):
         self.assertEqual(run.process.returncode, 0, msg=run.output)
         self.assertNotIn("SKIPPED: C++ checks", run.output)
 
+    def test_windows_defaults_to_an_IDE_generator_with_no_compiler_on_PATH(
+        self,
+    ) -> None:
+        """CMake's default generator on Windows supplies its own toolchain.
+
+        cl is not on a Git Bash PATH and CMAKE_GENERATOR need not be set for
+        CMake to find the Visual Studio toolchain, so nothing visible from the
+        script can confirm a compiler there. Skipping the section on that
+        basis would drop the C++ checks on a machine where they would run.
+        """
+        run = self._run(
+            tools=("cargo", "cmake", "ctest", "ruff"),
+            env={"OSTYPE": "msys"},
+        )
+        self.assertEqual(run.process.returncode, 0, msg=run.output)
+        self.assertNotIn("SKIPPED: C++ checks", run.output)
+        self.assertTrue([c for c in run.calls if c[0] == "ctest"], msg=run.output)
+
+    def test_a_unix_machine_with_no_compiler_still_skips(self) -> None:
+        """The exemption above must not become a blanket pass."""
+        run = self._run(
+            tools=("cargo", "cmake", "ctest", "ruff"),
+            env={"OSTYPE": "linux-gnu"},
+        )
+        self.assertIn("SKIPPED: C++ checks", run.output)
+        self.assertIn("C++17 compiler", run.output)
+
     def test_no_ruff_still_runs_the_python_tooling_tests(self) -> None:
         run = self._run(tools=("cargo", "cmake", "ctest", "c++"))
         self.assertEqual(run.process.returncode, 0, msg=run.output)
@@ -611,18 +701,17 @@ class MissingToolsAreSkips(StubHarness):
         self.assertIn("pip install ruff", run.output)
         self.assertIn("ok    test/tooling/example_test.py", run.output)
 
-    def test_a_test_that_cannot_import_its_module_is_skipped_not_failed(self) -> None:
+    def test_a_missing_external_dependency_is_skipped_not_failed(self) -> None:
         """The PyYAML shape: ci.yml installs it, a contributor may not have it."""
         run = self._run(
             tooling_tests={
                 "ok_test.py": PASSING_TEST,
-                "needs_module_test.py": UNIMPORTABLE_TEST,
+                "needs_module_test.py": MISSING_EXTERNAL_DEPENDENCY_TEST,
             }
         )
         self.assertEqual(run.process.returncode, 0, msg=run.output)
         self.assertIn(
-            "skip  test/tooling/needs_module_test.py "
-            "(needs the a_module_that_is_not_installed Python module)",
+            "skip  test/tooling/needs_module_test.py (needs the yaml Python module)",
             run.output,
         )
 

--- a/test/tooling/verify_native_test.py
+++ b/test/tooling/verify_native_test.py
@@ -77,6 +77,16 @@ for arg in "$@"; do
 done
 printf '\\n' >> "$LINTHRA_STUB_LOG"
 
+if [ "$name" = "cmake" ] && [ -n "${LINTHRA_STUB_NO_COMPILER:-}" ]; then
+  for arg in "$@"; do
+    if [ "$arg" = "-S" ]; then
+      echo "CMake Error at CMakeLists.txt:2 (project):" >&2
+      echo "  No CMAKE_CXX_COMPILER could be found." >&2
+      exit 1
+    fi
+  done
+fi
+
 case " ${LINTHRA_STUB_FAIL:-} " in
   *" $key "*)
     printf '%s: stubbed failure\\n' "$key" >&2
@@ -91,6 +101,30 @@ for arg in "$@"; do
   [ "$previous" = "-B" ] && mkdir -p -- "$arg"
   previous="$arg"
 done
+exit 0
+"""
+
+# Answers the two questions the Python section asks an interpreter before it
+# runs anything: which version are you, and can you import this module. Anything
+# else (running a test file) succeeds, since these scenarios stop before that.
+PYTHON_STUB = """#!/usr/bin/env bash
+version="${LINTHRA_STUB_PYTHON_VERSION:-3.11}"
+case "${1:-}" in
+  --version) printf 'Python %s.0\\n' "$version"; exit 0 ;;
+  -c)
+    case "$2" in
+      *version_info*) printf '%s\\n' "$version"; exit 0 ;;
+      "import "*)
+        module="${2#import }"
+        case " ${LINTHRA_STUB_MISSING_MODULES:-} " in
+          *" $module "*) printf 'ModuleNotFoundError\\n' >&2; exit 1 ;;
+        esac
+        exit 0
+        ;;
+    esac
+    exit 0
+    ;;
+esac
 exit 0
 """
 
@@ -263,34 +297,20 @@ class AgreementWithCI(unittest.TestCase):
             script_text(),
         )
 
-    def test_the_compiler_gate_is_no_narrower_than_CMake_s_detection(self) -> None:
-        """Missing a compiler CMake would find drops coverage silently.
+    def test_the_script_does_not_try_to_predict_CMake_s_compiler_choice(
+        self,
+    ) -> None:
+        """CMake is the authority on whether a compiler exists.
 
-        The gate only chooses between running the C++ checks and skipping
-        them, so it should err wide: a compiler that turns out not to work
-        costs a configure error, which is reported as a failure, while one the
-        gate fails to see costs the whole section with nothing said.
+        Four review rounds each found another discovery path a shell-side
+        guess did not cover (CXX with options, CMake's wider candidate list,
+        IDE generators, CMAKE_TOOLCHAIN_FILE). The section asks CMake instead,
+        so there is no list here to fall behind.
         """
-        # CMakeDetermineCXXCompiler.cmake's candidates.
-        for candidate in (
-            "c++",
-            "CC",
-            "g++",
-            "aCC",
-            "cl",
-            "bcc",
-            "xlC",
-            "icpx",
-            "icx",
-            "clang++",
-        ):
-            self.assertIn(
-                candidate,
-                script_text().split("CXX_CANDIDATES=(")[1].split(")")[0].split(),
-            )
-        # An IDE generator supplies its own toolchain rather than taking one
-        # from PATH, so nothing has to be found for the build to work.
-        self.assertIn('"Visual Studio"*', script_text())
+        text = script_text()
+        self.assertNotIn("CXX_CANDIDATES", text)
+        self.assertNotIn("cxx_compiler_available", text)
+        self.assertIn("No CMAKE_CXX_COMPILER could be found", text)
 
     def test_the_ruff_paths_are_the_ones_the_workflow_passes(self) -> None:
         """ruff.toml sets the rules, not the scope: the paths are the scope."""
@@ -351,6 +371,8 @@ class StubHarness(unittest.TestCase):
         fail: tuple[str, ...] = (),
         tooling_tests: dict[str, str] | None = None,
         env: dict[str, str] | None = None,
+        no_python: bool = False,
+        python_stub: bool = False,
     ) -> "_Run":
         """Run verify_native.sh with exactly `tools` available on PATH.
 
@@ -382,6 +404,7 @@ class StubHarness(unittest.TestCase):
             (repo / "native" / project / "CMakeLists.txt").write_text(
                 "project({})\n".format(project), encoding="utf-8"
             )
+        (repo / "ruff.toml").write_text('target-version = "py311"\n', encoding="utf-8")
         (repo / "test" / "tooling").mkdir(parents=True)
         if tooling_tests is None:
             tooling_tests = {"example_test.py": PASSING_TEST}
@@ -389,9 +412,15 @@ class StubHarness(unittest.TestCase):
             (repo / "test" / "tooling" / name).write_text(body, encoding="utf-8")
 
         for name in PASSTHROUGH_TOOLS:
+            if name == "python3" and (no_python or python_stub):
+                continue
             real = shutil.which(name)
             if real is not None:
                 (bin_dir / name).symlink_to(real)
+        if python_stub:
+            stub = bin_dir / "python3"
+            stub.write_text(PYTHON_STUB, encoding="utf-8")
+            stub.chmod(0o755)
         for name in tools:
             stub = bin_dir / name
             stub.write_text(STUB, encoding="utf-8")
@@ -694,76 +723,42 @@ class MissingToolsAreSkips(StubHarness):
         run = self._run(tools=("cargo", "ruff"))
         self.assertEqual(run.process.returncode, 0, msg=run.output)
         self.assertIn("SKIPPED: C++ checks", run.output)
-        self.assertIn("cmake", run.output)
-        self.assertIn("C++17 compiler", run.output)
+        self.assertIn("missing cmake, ctest", run.output)
+        # The compiler is CMake's business now, so a missing CMake says nothing
+        # about one.
+        self.assertNotIn("C++17 compiler", run.output)
 
-    def test_a_CXX_carrying_required_options_still_counts_as_a_compiler(self) -> None:
-        """cmake-env-variables(7) permits options in CXX, so the gate must too.
+    def test_CMake_finding_no_compiler_skips_the_section(self) -> None:
+        """Whatever satisfies CMake works, and nothing else has to be guessed."""
+        run = self._run(env={"LINTHRA_STUB_NO_COMPILER": "1"})
+        self.assertEqual(run.process.returncode, 0, msg=run.output)
+        self.assertIn("SKIPPED: C++ checks, CMake found no C++ compiler", run.output)
+        self.assertIn("CMAKE_TOOLCHAIN_FILE", run.output)
+        # It stops at the first project rather than repeating itself four times.
+        self.assertEqual(
+            run.output.count("CMake found no C++ compiler"), 2, msg=run.output
+        )
 
-        Looking the whole value up as one command name rejects a cross
-        toolchain CMake would configure happily, and on a machine without
-        c++/g++/clang++ that skipped every C++ check.
+    def test_ruff_runs_even_with_no_python3(self) -> None:
+        """Ruff is a standalone binary and never runs the interpreter.
+
+        Skipping it alongside the tooling tests meant a machine with Ruff but
+        no python3 heard nothing about lint or formatting errors Ruff would
+        have caught.
         """
         run = self._run(
-            tools=("cargo", "cmake", "ctest", "ruff", "custom-compiler"),
-            env={"CXX": "custom-compiler --sysroot=/sdk"},
+            tools=("cargo", "cmake", "ctest", "c++", "ruff"), no_python=True
         )
-        self.assertEqual(run.process.returncode, 0, msg=run.output)
-        self.assertNotIn("SKIPPED: C++ checks", run.output)
-        self.assertTrue([c for c in run.calls if c[0] == "ctest"], msg=run.output)
-
-    def test_a_compiler_only_CMake_would_have_named_still_counts(self) -> None:
-        """`cl`, `icpx` and friends are compilers too, not an absent toolchain."""
-        for compiler in ("cl", "icpx", "CC"):
-            with self.subTest(compiler=compiler):
-                run = self._run(tools=("cargo", "cmake", "ctest", "ruff", compiler))
-                self.assertEqual(run.process.returncode, 0, msg=run.output)
-                self.assertNotIn("SKIPPED: C++ checks", run.output)
-
-    def test_an_IDE_generator_supplies_its_own_toolchain(self) -> None:
-        run = self._run(
-            tools=("cargo", "cmake", "ctest", "ruff"),
-            env={"CMAKE_GENERATOR": "Visual Studio 17 2022"},
+        ruff = [" ".join(call) for call in self._calls(run, "ruff")]
+        self.assertEqual(
+            ruff,
+            [
+                "ruff check scripts tool tools",
+                "ruff format --check scripts tool tools",
+            ],
+            msg=run.output,
         )
-        self.assertEqual(run.process.returncode, 0, msg=run.output)
-        self.assertNotIn("SKIPPED: C++ checks", run.output)
-
-    def test_windows_defaults_to_an_IDE_generator_with_no_compiler_on_PATH(
-        self,
-    ) -> None:
-        """CMake's default generator on Windows supplies its own toolchain.
-
-        cl is not on a Git Bash PATH and CMAKE_GENERATOR need not be set for
-        CMake to find the Visual Studio toolchain, so nothing visible from the
-        script can confirm a compiler there. Skipping the section on that
-        basis would drop the C++ checks on a machine where they would run.
-        """
-        run = self._run(
-            tools=("cargo", "cmake", "ctest", "ruff"),
-            env={"OSTYPE": "msys"},
-        )
-        self.assertEqual(run.process.returncode, 0, msg=run.output)
-        self.assertNotIn("SKIPPED: C++ checks", run.output)
-        self.assertTrue([c for c in run.calls if c[0] == "ctest"], msg=run.output)
-
-    def test_a_unix_machine_with_no_compiler_still_skips(self) -> None:
-        """The exemption above must not become a blanket pass."""
-        run = self._run(
-            tools=("cargo", "cmake", "ctest", "ruff"),
-            env={"OSTYPE": "linux-gnu"},
-        )
-        self.assertIn("SKIPPED: C++ checks", run.output)
-        self.assertIn("C++17 compiler", run.output)
-
-    def test_a_cmake_toolchain_file_answers_the_compiler_question(self) -> None:
-        """A toolchain file names its own compiler, often off PATH entirely."""
-        run = self._run(
-            tools=("cargo", "cmake", "ctest", "ruff"),
-            env={"CMAKE_TOOLCHAIN_FILE": "/opt/sdk/arm-linux.cmake"},
-        )
-        self.assertEqual(run.process.returncode, 0, msg=run.output)
-        self.assertNotIn("SKIPPED: C++ checks", run.output)
-        self.assertTrue([c for c in run.calls if c[0] == "ctest"], msg=run.output)
+        self.assertIn("SKIPPED: Python tooling tests, python3 not found", run.output)
 
     def test_no_ruff_still_runs_the_python_tooling_tests(self) -> None:
         run = self._run(tools=("cargo", "cmake", "ctest", "c++"))
@@ -797,6 +792,40 @@ class MissingToolsAreSkips(StubHarness):
         )
         # A file with nothing skipped stays a plain ok.
         self.assertIn("ok    test/tooling/ok_test.py\n", run.output)
+
+    def test_an_interpreter_older_than_the_tooling_target_is_a_skip(self) -> None:
+        """3.9 fails these tests on language features, not on the change.
+
+        tools/large_library/memory_report.py uses zip(strict=...), which is
+        3.10 and later, and ruff.toml declares the target the tooling is
+        written for.
+        """
+        run = self._run(python_stub=True, env={"LINTHRA_STUB_PYTHON_VERSION": "3.9"})
+        self.assertEqual(run.process.returncode, 0, msg=run.output)
+        self.assertIn(
+            "SKIPPED: Python tooling tests, python3 is 3.9, the tooling targets 3.11",
+            run.output,
+        )
+
+    def test_an_interpreter_at_the_tooling_target_runs_the_tests(self) -> None:
+        """The version gate must not turn into a blanket skip."""
+        run = self._run(python_stub=True, env={"LINTHRA_STUB_PYTHON_VERSION": "3.12"})
+        self.assertEqual(run.process.returncode, 0, msg=run.output)
+        self.assertNotIn("SKIPPED: Python tooling tests", run.output)
+
+    def test_a_module_CI_installs_is_named_before_the_tests_run(self) -> None:
+        """Its absence arrives as ordinary failures, so say so in advance.
+
+        Some tooling tests shell out to scripts that import PyYAML, so without
+        it they fail inside the suite rather than failing to import, which is
+        not something the per-file classification can see.
+        """
+        run = self._run(python_stub=True, env={"LINTHRA_STUB_MISSING_MODULES": "yaml"})
+        self.assertIn("The yaml Python module is not installed.", run.output)
+        self.assertIn(
+            "the yaml Python module is missing (some tooling tests need it)",
+            _summary_items(run.output, "Skipped"),
+        )
 
     def test_a_missing_external_dependency_is_skipped_not_failed(self) -> None:
         """The PyYAML shape: ci.yml installs it, a contributor may not have it."""

--- a/test/tooling/verify_native_test.py
+++ b/test/tooling/verify_native_test.py
@@ -1,0 +1,592 @@
+#!/usr/bin/env python3
+"""`scripts/verify_native.sh` is a faithful, read-only local twin of CI (#354).
+
+    python3 test/tooling/verify_native_test.py
+
+The script exists so a Rust, C++ or Python contributor has one command to run
+before pushing. That is only worth anything if it runs what CI runs, so two
+kinds of test here:
+
+  * agreement rules, which read the workflows and the script and require them
+    to still say the same thing. The ctest exclusion and the three Ruff paths
+    are the ones most likely to drift, because they live in a workflow the
+    script never reads;
+  * the real script, run end to end against stub `cargo`, `cmake`, `ctest` and
+    `ruff` binaries in a throwaway checkout. The stubs record their argv, so
+    "it runs the same command CI runs" is checked rather than asserted, and
+    they can be told to fail, which is how the exit code, the keep-going
+    behaviour and the skip-vs-fail distinction get proven.
+
+The end-to-end checkout lives under a directory with a space in its name, so
+every run is also a test that the quoting holds.
+
+Nothing here needs Rust, CMake or Ruff installed: the point of the stubs is
+that this suite says the same thing on a machine that has none of them.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "verify_native.sh"
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+# Real tools the script itself needs. Everything else on PATH is deliberately
+# withheld, so "cargo is not installed" can be staged by simply not writing a
+# cargo stub.
+PASSTHROUGH_TOOLS = (
+    "bash",
+    "sh",
+    "env",
+    "dirname",
+    "find",
+    "sort",
+    "grep",
+    "sed",
+    "head",
+    "python3",
+)
+
+# A stub records `name<TAB>arg<TAB>arg...` and exits non-zero when the test
+# named it in LINTHRA_STUB_FAIL. The key is the command plus its first
+# argument, with `:--version` appended for a probe, so "clippy is not
+# installed" (`cargo:clippy:--version`) and "clippy found problems"
+# (`cargo:clippy`) are different things to ask for.
+STUB = """#!/usr/bin/env bash
+name="${0##*/}"
+key="$name:${1:-}"
+for arg in "$@"; do
+  if [ "$arg" = "--version" ]; then
+    key="$key:--version"
+    break
+  fi
+done
+
+printf '%s' "$name" >> "$LINTHRA_STUB_LOG"
+for arg in "$@"; do
+  printf '\\t%s' "$arg" >> "$LINTHRA_STUB_LOG"
+done
+printf '\\n' >> "$LINTHRA_STUB_LOG"
+
+case " ${LINTHRA_STUB_FAIL:-} " in
+  *" $key "*)
+    printf '%s: stubbed failure\\n' "$key" >&2
+    exit 1
+    ;;
+esac
+exit 0
+"""
+
+# A tooling test that passes, one that fails, and one that cannot import what
+# it needs. The third is the PyYAML shape: ci.yml pip-installs PyYAML right
+# before the Flatpak smoke manifest tests, so on a machine without it that file
+# is a missing tool rather than a broken change.
+PASSING_TEST = "import sys\nsys.exit(0)\n"
+FAILING_TEST = (
+    "import sys\nsys.stderr.write('a real assertion failed\\n')\nsys.exit(1)\n"
+)
+UNIMPORTABLE_TEST = "import a_module_that_is_not_installed  # noqa: F401\n"
+
+
+def script_text() -> str:
+    return SCRIPT.read_text(encoding="utf-8")
+
+
+def workflow_text(name: str) -> str:
+    return (WORKFLOWS / name).read_text(encoding="utf-8")
+
+
+class TheScriptItself(unittest.TestCase):
+    """Rules about the file, before anything is run."""
+
+    def test_it_is_executable_and_bash(self) -> None:
+        self.assertTrue(SCRIPT.exists(), msg="scripts/verify_native.sh is missing")
+        self.assertTrue(
+            os.access(SCRIPT, os.X_OK),
+            msg="CONTRIBUTING.md tells people to run ./scripts/verify_native.sh",
+        )
+        self.assertTrue(script_text().startswith("#!/usr/bin/env bash\n"))
+
+    def test_the_formatter_is_never_asked_to_rewrite_a_file(self) -> None:
+        """A verify script that reformats the tree is a trap, not a check."""
+        for match in re.finditer(r"^\s*(ruff format[^\n]*)$", script_text(), re.M):
+            self.assertIn(
+                "--check",
+                match.group(1),
+                msg="`ruff format` without --check edits the working tree",
+            )
+        for match in re.finditer(r"^\s*(cargo fmt[^\n]*)$", script_text(), re.M):
+            line = match.group(1)
+            if line.endswith("--version >/dev/null 2>&1; then"):
+                continue
+            self.assertIn(
+                "--",
+                line,
+                msg="`cargo fmt` without `-- --check` rewrites the Rust sources",
+            )
+
+    def test_every_section_names_the_workflow_it_stands_in_for(self) -> None:
+        """A reader has to be able to get from the script back to CI."""
+        for workflow in (
+            "rust-core.yml",
+            "cpp-audio-dsp.yml",
+            "cpp-desktop-window.yml",
+            "python-lint.yml",
+        ):
+            self.assertIn(workflow, script_text())
+
+
+class AgreementWithCI(unittest.TestCase):
+    """The parts most able to drift, because they live in two files."""
+
+    def test_the_rust_commands_carry_the_flags_the_workflow_uses(self) -> None:
+        rust = workflow_text("rust-core.yml")
+        text = script_text()
+        # --locked is the interesting one: without it a stale Cargo.lock is
+        # quietly resolved locally and only fails on the CI runner.
+        for flag in ("--locked", "--all-targets", "-D warnings", "benchmark_200k"):
+            self.assertIn(flag, rust, msg="rust-core.yml no longer uses " + flag)
+            self.assertIn(
+                flag,
+                text,
+                msg="rust-core.yml uses {} and verify_native.sh does not".format(flag),
+            )
+
+    def test_the_rust_manifest_is_the_one_the_workflow_builds(self) -> None:
+        manifests = set(
+            re.findall(r"--manifest-path (\S+)", workflow_text("rust-core.yml"))
+        )
+        self.assertEqual(manifests, {"native/linthra_core/Cargo.toml"})
+        self.assertIn('RUST_MANIFEST="native/linthra_core/Cargo.toml"', script_text())
+
+    def test_the_debug_ctest_exclusion_matches_the_workflow(self) -> None:
+        """CI skips the realtime budget in Debug; so must the local twin.
+
+        An unoptimized build says nothing useful about the performance of the
+        build users actually get, so a local run that kept the budget test in
+        Debug would fail for a reason CI never would.
+        """
+        excluded = [
+            name.strip("'\"")
+            for name in re.findall(
+                r"--exclude-regex (\S+)", workflow_text("cpp-audio-dsp.yml")
+            )
+        ]
+        self.assertEqual(len(excluded), 1, msg="the workflow's exclusion changed shape")
+        self.assertIn(
+            "ctest_args=(--exclude-regex {})".format(excluded[0]),
+            script_text(),
+        )
+
+    def test_both_cmake_projects_are_covered(self) -> None:
+        sources = set()
+        for name in ("cpp-audio-dsp.yml", "cpp-desktop-window.yml"):
+            sources.update(re.findall(r"cmake -S native/(\w+)", workflow_text(name)))
+        self.assertEqual(sources, {"linthra_audio", "linthra_desktop"})
+        self.assertIn(
+            "CPP_PROJECTS=({})".format(" ".join(sorted(sources))),
+            script_text(),
+        )
+
+    def test_the_ruff_paths_are_the_ones_the_workflow_passes(self) -> None:
+        """ruff.toml sets the rules, not the scope: the paths are the scope."""
+        lint = workflow_text("python-lint.yml")
+        paths = set(re.findall(r"ruff (?:check|format --check) ([\w /]+)", lint))
+        self.assertEqual(paths, {"scripts tool tools"})
+        self.assertIn("ruff check scripts tool tools", script_text())
+        self.assertIn("ruff format --check scripts tool tools", script_text())
+
+    def test_no_ruff_version_is_pinned_in_two_places(self) -> None:
+        """The pin lives in python-lint.yml. A copy here would rot."""
+        self.assertNotRegex(script_text(), r"ruff==\d")
+
+
+class StubHarness(unittest.TestCase):
+    """Runs the real script in a throwaway checkout, against stub binaries."""
+
+    maxDiff = None
+
+    def _run(
+        self,
+        *,
+        tools: tuple[str, ...] = ("cargo", "cmake", "ctest", "c++", "ruff"),
+        fail: tuple[str, ...] = (),
+        tooling_tests: dict[str, str] | None = None,
+    ) -> "_Run":
+        """Run verify_native.sh with exactly `tools` available on PATH.
+
+        `fail` names stub invocations that should exit non-zero, and
+        `tooling_tests` is the contents of test/tooling/, defaulting to a
+        single test that passes.
+        """
+        tmp = Path(tempfile.mkdtemp(prefix="linthra-verify-native-"))
+        self.addCleanup(shutil.rmtree, tmp, True)
+
+        # The space is deliberate and permanent: every run in this suite is
+        # also a test that the script's quoting survives a checkout under
+        # "~/My Projects/..." or an macOS-style path.
+        repo = tmp / "a checkout with spaces"
+        bin_dir = tmp / "stub bin"
+        for path in (repo, bin_dir):
+            path.mkdir(parents=True)
+
+        (repo / "scripts").mkdir()
+        shutil.copy2(SCRIPT, repo / "scripts" / "verify_native.sh")
+        # The two trees the script's own "is this a checkout" guard looks for,
+        # plus the CMake sources it points cmake at.
+        (repo / "native" / "linthra_core").mkdir(parents=True)
+        (repo / "native" / "linthra_core" / "Cargo.toml").write_text(
+            '[package]\nname = "linthra_core"\n', encoding="utf-8"
+        )
+        for project in ("linthra_audio", "linthra_desktop"):
+            (repo / "native" / project).mkdir(parents=True)
+            (repo / "native" / project / "CMakeLists.txt").write_text(
+                "project({})\n".format(project), encoding="utf-8"
+            )
+        (repo / "test" / "tooling").mkdir(parents=True)
+        if tooling_tests is None:
+            tooling_tests = {"example_test.py": PASSING_TEST}
+        for name, body in tooling_tests.items():
+            (repo / "test" / "tooling" / name).write_text(body, encoding="utf-8")
+
+        for name in PASSTHROUGH_TOOLS:
+            real = shutil.which(name)
+            if real is not None:
+                (bin_dir / name).symlink_to(real)
+        for name in tools:
+            stub = bin_dir / name
+            stub.write_text(STUB, encoding="utf-8")
+            stub.chmod(0o755)
+
+        log = tmp / "stub-calls.tsv"
+        log.touch()
+        before = _snapshot(repo)
+        process = subprocess.run(
+            ["bash", str(repo / "scripts" / "verify_native.sh")],
+            cwd=str(tmp),
+            env={
+                "PATH": str(bin_dir),
+                "HOME": str(tmp),
+                "LINTHRA_STUB_LOG": str(log),
+                "LINTHRA_STUB_FAIL": " ".join(fail),
+            },
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+        )
+        calls = [
+            line.split("\t")
+            for line in log.read_text(encoding="utf-8").splitlines()
+            if line
+        ]
+        return _Run(
+            process=process,
+            output=process.stdout + process.stderr,
+            calls=calls,
+            repo=repo,
+            before=before,
+        )
+
+    @staticmethod
+    def _calls(run: "_Run", name: str, *, probes: bool = False) -> list[list[str]]:
+        """The recorded argv for `name`, without the version probes."""
+        return [
+            call
+            for call in run.calls
+            if call[0] == name and (probes or "--version" not in call)
+        ]
+
+
+class RunAgainstStubs(StubHarness):
+    """What a clean run does."""
+
+    def test_a_clean_run_passes_and_says_what_it_ran(self) -> None:
+        run = self._run()
+        self.assertEqual(run.process.returncode, 0, msg=run.output)
+        self.assertIn("Verification passed", run.output)
+        self.assertNotIn("SKIPPED", run.output)
+
+    def test_the_three_sections_are_labelled_and_in_CI_order(self) -> None:
+        run = self._run()
+        headers = re.findall(r"^=== (.+?):", run.output, re.M)
+        self.assertEqual(headers, ["Rust", "C++", "Python"], msg=run.output)
+
+    def test_it_runs_the_rust_commands_the_workflow_runs(self) -> None:
+        run = self._run()
+        cargo = [" ".join(call) for call in self._calls(run, "cargo")]
+        manifest = "--manifest-path native/linthra_core/Cargo.toml"
+        self.assertEqual(
+            cargo,
+            [
+                "cargo fmt {} -- --check".format(manifest),
+                "cargo clippy --locked {} --all-targets -- -D warnings".format(
+                    manifest
+                ),
+                "cargo test --locked {}".format(manifest),
+                "cargo run --locked --release {} --bin benchmark_200k".format(manifest),
+            ],
+            msg=run.output,
+        )
+
+    def test_it_configures_builds_and_tests_both_projects_both_ways(self) -> None:
+        run = self._run()
+        configured = [
+            (call[2].split("/")[-1], call[4], call[5])
+            for call in self._calls(run, "cmake")
+            if call[1] == "-S"
+        ]
+        self.assertEqual(
+            configured,
+            [
+                (
+                    "linthra_audio",
+                    "build/linthra_audio/Release",
+                    "-DCMAKE_BUILD_TYPE=Release",
+                ),
+                (
+                    "linthra_audio",
+                    "build/linthra_audio/Debug",
+                    "-DCMAKE_BUILD_TYPE=Debug",
+                ),
+                (
+                    "linthra_desktop",
+                    "build/linthra_desktop/Release",
+                    "-DCMAKE_BUILD_TYPE=Release",
+                ),
+                (
+                    "linthra_desktop",
+                    "build/linthra_desktop/Debug",
+                    "-DCMAKE_BUILD_TYPE=Debug",
+                ),
+            ],
+            msg=run.output,
+        )
+        built = [call[2] for call in self._calls(run, "cmake") if call[1] == "--build"]
+        tested = [call[2] for call in self._calls(run, "ctest")]
+        self.assertEqual(built, [c[1] for c in configured])
+        self.assertEqual(tested, [c[1] for c in configured])
+
+    def test_only_the_audio_debug_leg_drops_the_realtime_budget(self) -> None:
+        run = self._run()
+        excluding = [
+            call[2] for call in self._calls(run, "ctest") if "--exclude-regex" in call
+        ]
+        self.assertEqual(excluding, ["build/linthra_audio/Debug"], msg=run.output)
+
+    def test_it_runs_the_two_ruff_commands_with_the_workflow_s_paths(self) -> None:
+        run = self._run()
+        ruff = [" ".join(call) for call in self._calls(run, "ruff")]
+        self.assertEqual(
+            ruff,
+            [
+                "ruff check scripts tool tools",
+                "ruff format --check scripts tool tools",
+            ],
+            msg=run.output,
+        )
+
+    def test_nothing_in_the_checkout_is_touched_by_a_passing_run(self) -> None:
+        """A verify script that edits the tree would be worse than none."""
+        run = self._run()
+        self.assertEqual(run.process.returncode, 0, msg=run.output)
+        self.assertEqual(
+            _snapshot(run.repo),
+            run.before,
+            msg="the run added, removed or rewrote something in the checkout",
+        )
+
+
+class FailuresAreFailures(StubHarness):
+    """An actual check failing has to reach the exit code."""
+
+    def test_a_failing_clippy_fails_the_script_and_is_named(self) -> None:
+        run = self._run(fail=("cargo:clippy",))
+        self.assertEqual(run.process.returncode, 1, msg=run.output)
+        self.assertIn("Verification FAILED", run.output)
+        self.assertIn("cargo clippy", run.output)
+
+    def test_one_failure_does_not_stop_the_other_sections(self) -> None:
+        """One pass should show a contributor every problem, not the first."""
+        run = self._run(fail=("cargo:clippy", "ruff:check"))
+        self.assertEqual(run.process.returncode, 1, msg=run.output)
+        # The C++ section sits between the two and has to have run anyway.
+        self.assertTrue(
+            [c for c in run.calls if c[0] == "ctest"],
+            msg="a failing Rust check stopped the C++ checks:\n" + run.output,
+        )
+        failed = _summary_items(run.output, "Failed")
+        self.assertEqual(len(failed), 2, msg=run.output)
+
+    def test_a_failing_build_does_not_pretend_to_test_it(self) -> None:
+        """ctest against a directory that never built is noise, not a result."""
+        run = self._run(fail=("cmake:--build",))
+        self.assertEqual(run.process.returncode, 1, msg=run.output)
+        self.assertEqual(
+            [c for c in run.calls if c[0] == "ctest"],
+            [],
+            msg="ctest ran even though every build failed:\n" + run.output,
+        )
+
+    def test_a_failing_tooling_test_fails_the_script_and_shows_its_output(self) -> None:
+        run = self._run(
+            tooling_tests={"ok_test.py": PASSING_TEST, "bad_test.py": FAILING_TEST}
+        )
+        self.assertEqual(run.process.returncode, 1, msg=run.output)
+        self.assertIn("a real assertion failed", run.output)
+        self.assertIn("python3 test/tooling/bad_test.py", run.output)
+        # The passing one is not drowned out by the failing one's output.
+        self.assertIn("ok    test/tooling/ok_test.py", run.output)
+
+
+class MissingToolsAreSkips(StubHarness):
+    """A tool this machine lacks is not a verdict on the change."""
+
+    def test_no_cargo_skips_rust_and_still_runs_the_rest(self) -> None:
+        run = self._run(tools=("cmake", "ctest", "c++", "ruff"))
+        self.assertEqual(run.process.returncode, 0, msg=run.output)
+        self.assertIn("SKIPPED: Rust checks, cargo not found", run.output)
+        self.assertIn("rustup.rs", run.output)
+        self.assertTrue([c for c in run.calls if c[0] == "ctest"], msg=run.output)
+        self.assertTrue([c for c in run.calls if c[0] == "ruff"], msg=run.output)
+
+    def test_a_missing_rustfmt_component_skips_only_that_check(self) -> None:
+        """cargo can be installed while `cargo fmt` is an unknown command."""
+        run = self._run(fail=("cargo:fmt:--version",))
+        self.assertEqual(run.process.returncode, 0, msg=run.output)
+        self.assertIn("rustup component add rustfmt", run.output)
+        ran = [call[1] for call in self._calls(run, "cargo")]
+        self.assertEqual(ran, ["clippy", "test", "run"], msg=run.output)
+
+    def test_no_cmake_skips_the_cpp_section_with_something_to_install(self) -> None:
+        run = self._run(tools=("cargo", "ruff"))
+        self.assertEqual(run.process.returncode, 0, msg=run.output)
+        self.assertIn("SKIPPED: C++ checks", run.output)
+        self.assertIn("cmake", run.output)
+        self.assertIn("C++17 compiler", run.output)
+
+    def test_no_ruff_still_runs_the_python_tooling_tests(self) -> None:
+        run = self._run(tools=("cargo", "cmake", "ctest", "c++"))
+        self.assertEqual(run.process.returncode, 0, msg=run.output)
+        self.assertIn("ruff not found", run.output)
+        self.assertIn("pip install ruff", run.output)
+        self.assertIn("ok    test/tooling/example_test.py", run.output)
+
+    def test_a_test_that_cannot_import_its_module_is_skipped_not_failed(self) -> None:
+        """The PyYAML shape: ci.yml installs it, a contributor may not have it."""
+        run = self._run(
+            tooling_tests={
+                "ok_test.py": PASSING_TEST,
+                "needs_module_test.py": UNIMPORTABLE_TEST,
+            }
+        )
+        self.assertEqual(run.process.returncode, 0, msg=run.output)
+        self.assertIn(
+            "skip  test/tooling/needs_module_test.py "
+            "(needs the a_module_that_is_not_installed Python module)",
+            run.output,
+        )
+
+    def test_a_skipped_run_never_reports_itself_as_a_full_pass(self) -> None:
+        run = self._run(tools=("cmake", "ctest", "c++", "ruff"))
+        self.assertIn("CI still runs every one of them", run.output)
+        self.assertTrue(_summary_items(run.output, "Skipped"), msg=run.output)
+
+    def test_no_toolchain_at_all_is_an_error_rather_than_a_pass(self) -> None:
+        """Nothing was verified, so "passed" would be the wrong word."""
+        run = self._run(tools=(), tooling_tests={})
+        self.assertEqual(run.process.returncode, 1, msg=run.output)
+        self.assertIn("Nothing could be checked", run.output)
+        self.assertIn("doctor.sh", run.output)
+        self.assertNotIn("Verification passed", run.output)
+
+
+class DoctorReportsTheSameToolchains(unittest.TestCase):
+    """scripts/doctor.sh is where a skip message sends you."""
+
+    def test_it_reports_every_toolchain_verify_native_can_skip_for(self) -> None:
+        doctor = (ROOT / "scripts" / "doctor.sh").read_text(encoding="utf-8")
+        for label in (
+            "Rust (cargo):",
+            "rustfmt:",
+            "clippy:",
+            "CMake:",
+            "ctest:",
+            "C++ compiler:",
+            "Python 3:",
+            "Ruff:",
+        ):
+            self.assertIn(label, doctor)
+
+    def test_it_still_changes_nothing(self) -> None:
+        doctor = (ROOT / "scripts" / "doctor.sh").read_text(encoding="utf-8")
+        self.assertIn("Makes no changes.", doctor)
+        commands = "\n".join(
+            line for line in doctor.splitlines() if not line.lstrip().startswith("#")
+        )
+        # Shapes that cannot appear in the strings it prints. A bare "install"
+        # can and does: the report already says "not installed".
+        for destructive in ("rm -", "mkdir", "cargo build", "cargo test", "--build"):
+            self.assertNotIn(destructive, commands, msg="doctor.sh is read-only")
+
+
+class ContributingDocumentsIt(unittest.TestCase):
+    """The issue asks for the command to be findable, not just present."""
+
+    def test_contributing_names_the_script(self) -> None:
+        text = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+        self.assertIn("./scripts/verify_native.sh", text)
+        # The three areas it is for, so the table above it stays honest.
+        for language in ("Rust", "C++", "Python"):
+            self.assertIn(language, text)
+
+
+@dataclass(frozen=True)
+class _Run:
+    process: subprocess.CompletedProcess[str]
+    output: str
+    # One recorded stub invocation per entry: [name, *argv].
+    calls: list[list[str]]
+    repo: Path
+    # The checkout's contents before the run, for the no-mutation check.
+    before: dict[str, str]
+
+
+def _snapshot(repo: Path) -> dict[str, str]:
+    """Every file under `repo`, by relative path, with its contents."""
+    return {
+        str(path.relative_to(repo)): path.read_text(encoding="utf-8", errors="replace")
+        for path in sorted(repo.rglob("*"))
+        if path.is_file()
+    }
+
+
+def _summary_items(output: str, heading: str) -> list[str]:
+    """The `  - ...` lines under one of the summary's headings."""
+    items: list[str] = []
+    collecting = False
+    for line in output.splitlines():
+        if line.startswith(heading):
+            collecting = True
+            continue
+        if not collecting:
+            continue
+        if line.startswith("  - "):
+            items.append(line[4:])
+        elif items:
+            # The heading wraps onto a second line, so only a non-item line
+            # after the list has started means the list is over.
+            break
+    return items
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #354

`verify_android.sh` and `verify_linux.sh` cover the Flutter side. Someone who comes to Linthra for the Rust core, the C++ DSP or the Python tooling had to reassemble the checks from three workflows first. `scripts/verify_native.sh` is the twin for those areas.

## What it runs

I audited the workflows first, so each section is the local twin of a real CI job rather than a guess:

| Section | CI it mirrors | Commands |
| --- | --- | --- |
| Rust | `rust-core.yml` | `cargo fmt --check`, `cargo clippy --locked --all-targets -- -D warnings`, `cargo test --locked`, `cargo run --release --bin benchmark_200k` |
| C++ | `cpp-audio-dsp.yml`, `cpp-desktop-window.yml` | cmake configure, `cmake --build`, `ctest`, in Release and Debug, for `native/linthra_audio` and `native/linthra_desktop` |
| Python | `python-lint.yml` | `ruff check scripts tool tools`, `ruff format --check scripts tool tools`, then every `test/tooling/*_test.py` |

A few details worth calling out:

- The audio Debug leg drops `linthra_audio_realtime_budget`, same as CI. An unoptimized build says nothing useful about the realtime budget of the build users actually get.
- `benchmark_200k` is in because it is a real check, not a report: it asserts the large-library search budget, and it takes about seven seconds.
- The Python tooling tests are discovered by glob rather than listed. CI runs them one file at a time across five workflows, and copying that list here would mean maintaining it in a sixth place.
- No second build system, and no `--locked`/`-D warnings` drift: the flags come straight from the workflows.

Two places where the script deliberately says something the workflows do not, both because CI's runner is one machine and contributors are not:

- `cmake --build` and `ctest` name the configuration (`--config`/`-C`). CI's runner uses a single-config generator where `CMAKE_BUILD_TYPE` decides everything; under a multi-config generator it is ignored, so both legs would build the same default and `ctest` would report every test as "Not Run".
- `ctest` runs from inside each build tree rather than via `--test-dir`, which is CMake 3.20+. Both projects declare `cmake_minimum_required(VERSION 3.16)` and Ubuntu 20.04 ships 3.16.3, so the workflow's spelling would fail for someone meeting the projects' own stated minimum.

I included `native/linthra_desktop` alongside `native/linthra_audio`. The issue says "the C++ DSP core", but it is the same four lines parameterised, and a C++ contributor who touches the desktop window state would otherwise push straight into red CI. Happy to drop it if you would rather keep the script strictly to the DSP.

## Skips, failures and the exit code

A toolchain that is not installed skips that part with a message naming what to install, the same shape as `verify_android.sh` skipping the APK build without an Android SDK. The summary lists the skips separately from the failures, so a pass is never read as full coverage. A check that actually fails exits non-zero.

The rule the script is most careful about is which way to be wrong. Reporting a failure that turns out to be an environment problem costs someone a minute; silently skipping work and calling the run a pass costs them the bug, and costs the script its entire reason to exist. So every judgement call leans toward reporting:

- rustfmt and clippy are rustup components, so cargo can be on `PATH` while `cargo fmt` is an unknown subcommand. Each is probed separately and skipped on its own, with the `rustup component add ...` line to fix it.
- A tooling test is skipped only if it cleared two bars: nothing ran at all (`unittest` never printed its `Ran N tests` line), **and** the module it could not import is one CI installs. That second bar matters because several of these tests import a repository module at the top of the file, so a renamed module fails in exactly the shape a missing dependency does. The skippable set is derived from the `pip install` steps in the workflows, and a test reads them back out so it cannot drift.
- A suite that passes while skipping tests *inside* itself says so, and the count reaches the summary. `check_pr_security_surface_test.py` skips its review-decision class without `jq` and still exits 0; CI has `jq` and runs them.
- Ruff runs whether or not `python3` exists, since it is a standalone binary. An interpreter older than the target in `ruff.toml` skips the tooling tests with an explanation rather than failing them on language features they were never written for.
- **There is no compiler preflight.** The C++ section runs CMake's configure and reads its answer: the two messages CMake prints when it cannot resolve a compiler mean "skip, here is what to install", and any other failure is a real failure. See the review-rounds note below for why.
- If nothing at all could be checked, that is an error rather than a pass. Nothing was verified, so "passed" would be the wrong word.

## Nothing is mutated

Cargo builds into `native/linthra_core/target/` and CMake into `build/`, both already git-ignored, and Ruff runs with `--check`. A test snapshots the whole checkout outside `build/` before and after a run and requires it to be byte-identical.

## doctor.sh

It already answered "what Flutter would be used", so it now answers the same question for cargo/rustfmt/clippy, CMake/ctest, the C++ compiler and python3/Ruff. That gives the skip messages somewhere to send you. It is still read-only, and it reports rather than judges: with no compiler on `PATH` it says `none on PATH (CMake may still find one)` rather than telling someone with a working cross toolchain to install g++.

```
Rust (cargo):          cargo 1.94.1 (29ea6fb6a 2026-03-24)
  rustfmt:             rustfmt 1.8.0-stable (e408947bfd 2026-03-25)
  clippy:              clippy 0.1.94 (e408947bfd 2026-03-25)
CMake:                 cmake version 3.28.3
  ctest:               /usr/bin/ctest
C++ compiler:          /usr/bin/c++
Python 3:              Python 3.11.15
  Ruff:                ruff 0.15.8
```

## Tests

`test/tooling/verify_native_test.py`, in the pattern the other tooling tests use (43 tests, about 4s):

- agreement rules that read `rust-core.yml`, `cpp-audio-dsp.yml`, `cpp-desktop-window.yml`, `python-lint.yml` and the `pip install` steps, and require the script to still say the same thing. The ctest exclusion, the three Ruff paths and the skippable-module set are the ones most likely to drift, since they live in workflows the script never reads;
- the real script run end to end against stub `cargo`/`cmake`/`ctest`/`ruff`/`python3` binaries that record their argv and working directory, so "it runs the command CI runs" is checked rather than asserted;
- the stubs can be told to fail, which is how the exit code, the keep-going behaviour, and the skip-vs-fail distinction get proven;
- every run happens in a checkout whose directory name contains a space, so the quoting is under test too.

It needs none of those toolchains itself, so it is wired into `ci.yml`'s toolchain-free job and runs on every PR rather than behind the path filters of the three workflows it covers.

## Review rounds

Five rounds of Codex findings, fifteen in total, addressed in 75b2fdb, 5191e1e, f6b2050, 672bf3a and 29547fc. Each fix has a regression test that was checked to fail against the code it covers.

Fourteen were real, and they cluster.

**A run looking cleaner than it was**, the failure mode that would make this script worse than useless:

- a genuine test failure was downgraded to a skip if its output merely quoted a `ModuleNotFoundError`;
- after that fix, a **repository** module going missing was still a skip. Moving `tools/large_library/memory_report.py` aside made the script pass while `large-library-sql.yml` would have failed, which is the script waving through the exact change CI was about to reject;
- a suite that passed while skipping tests inside itself was reported as a plain `ok`;
- `find` inside a process substitution could fail invisibly and read as an empty directory, dropping the whole Python suite;
- Ruff was hidden behind a `python3` probe it does not need, so a machine with Ruff and no python3 heard nothing about lint errors.

**A toolchain the script could not see**, each costing real coverage: multi-config generators, `ctest --test-dir` needing CMake 3.20 against the projects' declared 3.16, `CXX` carrying required options, a compiler allowlist narrower than CMake's own, `CMAKE_TOOLCHAIN_FILE` ignored, and then that same variable's environment form being 3.21+ and so meaningless on the 3.16 the projects support.

That last group is worth being blunt about: **four rounds in a row found another way for CMake to locate a compiler that my preflight did not know about.** The fifth round's fix was to delete the preflight. CMake consults `CXX` with its options, a toolchain file, an IDE generator's own environment and its own candidate list, and it is the thing that actually decides, so the section now asks it and reads the answer. That is shorter than the gate it replaces and correct for paths nobody has thought of yet. A text rule keeps a predictive list from coming back.

**One finding is addressed differently from how it was suggested**, and its thread is left open for that reason. Without PyYAML, `flatpak_smoke_cleanup_test.py` starts normally and four tests fail in subprocesses that import `yaml`, so the run goes red for the wrong reason. The suggestion was to classify those failures as a missing prerequisite. I warn loudly instead and leave the failures failing, because classifying failures by searching their output is precisely the mechanism that rounds two and three showed swallows genuine regressions. Over-reporting is survivable; under-reporting is what makes the script worthless. Happy to trade that off differently if you would rather.

One finding had a wrong premise and I said so on its thread rather than taking it: BSD and macOS `find` both support `-maxdepth`.

Every one of these was in a path CI cannot reach, which is the blind spot a local-twin script has by construction: CI's runner has a recent CMake, a single-config generator, an ordinary `CXX`, a current Python, `jq` and PyYAML installed, and every repository module present.

## Verified

Locally:

- `./scripts/verify_native.sh` on a full toolchain: 39 checks, green, about 53 seconds, and `git status` clean afterwards.
- The same under `CMAKE_GENERATOR='Ninja Multi-Config'`, and against a `ctest` that rejects `--test-dir` the way 3.16 does. Both green.
- With no compiler on `PATH`: CMake reports it, the C++ section skips with something to install, and the rest still runs.
- Both classification paths by hand: a missing PyYAML still skips the file that imports it directly; a moved-aside `memory_report.py` fails and exits 1.
- The skip paths with a trimmed `PATH` (no cargo, no cmake, no ruff) and the empty-toolchain path.
- `ruff check scripts tool tools` and `ruff format --check scripts tool tools`.
- All 21 `test/tooling/*_test.py`.
- `check_pr_security_surface.py` and `check_repository_integrity.py` against this diff.

On CI: green, including Flutter checks, which is what runs the Dart guardrail suites (`toolchain_pins_test.dart` and friends) that I had no SDK for locally.

The Rust, C++ and Python lint workflows do not trigger on this PR, since it touches neither `native/**` nor a linted `.py` path. That is also why the new test sits in `ci.yml`: a change to the verify script itself would otherwise go unchecked.
