### PR TITLE
feat(linux): add optional desktop notifications for track changes (#400)

### DIFF
--- a/docs/flatpak-permissions.md
+++ b/docs/flatpak-permissions.md
@@ -65,7 +65,7 @@ was avoided.
 | --- | --- | --- |
 | Local music libraries | `--filesystem=home`, `--filesystem=xdg-music`, `--filesystem=host` | `GtkFileChooserNative` (`linux/runner/folder_picker_channel.cc`), which GTK redirects to the xdg-desktop-portal FileChooser inside a sandbox. The user's choice becomes a document-portal grant for that folder alone. See [flatpak-filesystem-audit.md](./flatpak-filesystem-audit.md). |
 | Server credentials | `--talk-name=org.freedesktop.secrets` | `flutter_secure_storage_linux` → libsecret. Inside a Flatpak with the Secret portal available, libsecret keeps its own encrypted file under the app's data directory, with the master secret handed over by the portal from the host keyring. Documented at `lib/data/repositories/secure_session_storage.dart`. |
-| Desktop notifications | `--talk-name=org.freedesktop.Notifications` | The Notification portal, which every Flatpak may use without a finish-arg. |
+| Desktop notifications | `--talk-name=org.freedesktop.Notifications` | The Notification portal, which every Flatpak may use without a finish-arg. `lib/core/services/notifications/dbus_desktop_notifier.dart` calls it first and only falls back to the spec interface outside the sandbox, where the session bus is directly reachable. |
 | The app's own database, caches and downloads | `--persist=`, `--filesystem=~/.local/share/linthra` | The private XDG tree Flatpak gives every app under `~/.var/app/<app-id>/`, reached through `path_provider`. |
 | Opening a link (bug report, docs) | `--talk-name=org.freedesktop.portal.OpenURI` | The OpenURI portal, again available without a grant. |
 

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -562,7 +562,8 @@ loaded:
 | Media session / MPRIS | Supported | `PlatformMediaSessionBinding` routes Linux to `MprisMediaSessionBinding`, which exports `/org/mpris/MediaPlayer2` and owns `org.mpris.MediaPlayer2.linthra` ([issue #397](https://github.com/TheZupZup/Linthra/issues/397)). Shells get PlaybackStatus, Metadata, Position and the transport methods; media keys work through the same interface. `Volume` is read/write, so a shell's own volume slider drives Linthra's level (and reads zero while muted); `Rate` stays honestly read-only. `Raise` and `Quit` are answered too, so a listener whose window is hidden by background mode can bring Linthra back or shut it down from the shell's media widget (#401). `audio_service` is still never initialised on Linux — it stays the Android delegate. A machine with no session bus simply gets no desktop controls. |
 | Close-window behaviour | Supported | Settings → Music & playback → Desktop window chooses between quitting and keeping playback running ([issue #401](https://github.com/TheZupZup/Linthra/issues/401)). The runner answers the close, Dart decides what the answer should be, and background mode only ever starts while audio is actually playing. See [Closing the window](#closing-the-window). |
 | Android Auto | Android-only, by design | It is an Android platform integration, not a Linthra feature. |
-| Media notification + `POST_NOTIFICATIONS` | Android-only, by design | There is no equivalent gate on Linux; desktop controls come from MPRIS instead. Standalone track-change notifications are [issue #400](https://github.com/TheZupZup/Linthra/issues/400). |
+| Media notification + `POST_NOTIFICATIONS` | Android-only, by design | There is no equivalent gate on Linux; desktop controls come from MPRIS instead, and a Linux notification needs no runtime permission. |
+| Track change notifications | Supported, off by default | Settings → Music & playback → Desktop notifications shows a short notification when the song changes ([issue #400](https://github.com/TheZupZup/Linthra/issues/400)). D-Bus, through the Notification portal where there is one and `org.freedesktop.Notifications` otherwise, so it works in the Flatpak without widening the sandbox. Android is untouched: its per-track notification is the media session's. See [Track change notifications](#track-change-notifications). |
 | Android audio focus | Android-only, by design | `JustAudioPlaybackController` already scopes its focus handling to Android/iOS. |
 | SAF (`content://` folders) | Android-only, by design | Linux picks a real filesystem path. The scanner's desktop path is the one that runs. |
 | Folder chooser | Supported | Linthra's own runner channel (`linux/runner/folder_picker_channel.cc`) opens `GtkFileChooserNative`: the ordinary GTK dialog natively, and the xdg-desktop-portal chooser inside the Flatpak, where `file_picker`'s `zenity`/`kdialog` do not exist ([issue #438](https://github.com/TheZupZup/Linthra/issues/438)). `scripts/check_linux_runner.py` holds the runner's channel name to the Dart side's. |
@@ -997,6 +998,132 @@ desktop can answer, to re-check before a Linux milestone release:
 | Close the window while a track plays | Quit | Linthra quits, audio stops |
 | Quit from the media widget, or "Quit Linthra now" | Either | Playback stops, the window goes, the MPRIS name is released |
 | Reopen after any quit | Either | Normal cold start; the crash-safe session restores paused, as it always did |
+
+## Track change notifications
+
+Off by default. Settings → Music & playback → **Desktop notifications** turns
+on a short notification when the song changes: the title, the catalog's
+"Artist • Album" subtitle, and the cover when there is a safe one to hand over.
+
+It is off by default because a desktop shell already draws a now-playing card
+from Linthra's MPRIS session. A toast per track is a useful addition for
+someone who wants it and an unasked-for interruption otherwise, so it is the
+listener's choice, and the switch turns it off completely rather than making it
+quieter.
+
+### What counts as a track change
+
+`TrackChangeNotifier` watches the same `PlaybackState` stream MPRIS and the
+recent-played recorder read, and is a pure observer of it: it never touches the
+queue, the controller or the audio engine. The stream carries a state several
+times a second, and almost none of them are news, so three rules reduce it to
+real transitions:
+
+* **Identity.** The track's logical identity has to differ from the last one
+  announced. Position ticks, a pause, a resume, a seek, a volume change, a
+  mid-stream reconnect and a queue rebuild that re-creates the same song all
+  say nothing, and neither does repeat-one starting the same song again,
+  because that is not a new song.
+* **Something is actually playing.** A queue restored paused at launch, a track
+  loaded but not started, and a load that errored are all "nothing is playing".
+  Announcing one would be a claim Linthra cannot back.
+* **At most one per five seconds.** Holding *next* down through an album must
+  not put a notification per track on the bus. A burst is coalesced rather than
+  dropped: the newest track replaces whatever was waiting, one timer covers the
+  whole burst, and the track the listener actually landed on is the one
+  announced. Ordinary listening never meets this limit at all.
+
+Turning the preference off is read live, so it silences the next track change
+immediately, including one already waiting out that window.
+
+### What it says, and what it never says
+
+`nowPlayingNotification` is the whole of what Linthra is willing to tell a
+notification daemon, and it is a pure function so that the rule is in one
+readable place rather than inside a D-Bus call. It sends the title and the
+artist/album subtitle. It never sends:
+
+* the track's URI: for a remote track that is an authenticated stream URL, for
+  a local one the listener's own file path;
+* the track or album id, or anything naming the server it came from;
+* a cover *reference*, or any URL at all.
+
+Artwork follows the same rule MPRIS publishes `mpris:artUrl` under, narrowed
+for a consumer that opens files rather than fetching URLs:
+
+* a `file:` cover passes through. Every `file:` cover in the catalog is a copy
+  Linthra wrote into its own artwork cache, under the application cache
+  directory, which is the same path inside the Flatpak and outside it, so the
+  daemon can actually open it;
+* an app-internal reference (`subsonic-cover:<id>`, `plex-thumb:<path>`) is
+  published only as the local copy the media-artwork cache has *already*
+  fetched. Nothing is fetched on the track change itself;
+* an `http(s)` cover is dropped: a daemon does not fetch a URL for an image,
+  and a cover URL is the shape a credentialed one would arrive in;
+* a `content:` cover is dropped: that is Android's FileProvider form, and
+  nothing on a Linux desktop can open it.
+
+A track with no title at all reads as "Unknown track", never as its path.
+
+### How it reaches the desktop
+
+A desktop notification is a D-Bus method call, and that is what Linthra makes,
+through the same `dbus` package MPRIS already uses, so there is no new
+dependency, no native code, and **no subprocess**. Shelling out to
+`notify-send` would mean a music player spawning a binary off `PATH` with
+strings built from track metadata, and it does not exist inside the Flatpak
+anyway.
+
+`DBusDesktopNotifier` tries two routes and remembers which one answered:
+
+1. **`org.freedesktop.portal.Notification`** on the desktop portal. First,
+   because it is the only route a sandboxed Linthra has: the Flatpak asks for
+   no `--talk-name` at all (`scripts/check_flatpak_permissions.py` refuses
+   every spelling of one), and the portal is available to every Flatpak with no
+   finish-arg. See [docs/flatpak-permissions.md](./flatpak-permissions.md).
+2. **`org.freedesktop.Notifications`**, the spec interface every notification
+   daemon implements, for a host that has no portal running: a bare window
+   manager with `dunst`, say.
+
+Both keep one notification rather than a pile: the portal route reuses a fixed
+id, which is how the portal replaces a notification, and the spec route passes
+the previous notification's id as `replaces_id`. The spec route also asks for
+low urgency and marks the notification transient, so a track change belongs on
+screen for a moment rather than in the shell's history for the evening.
+
+Artwork goes out in whichever form the route can take safely: an `image-path`
+hint on the spec route, and on the portal route a serialized `bytes` icon,
+only when the running portal reports interface version 2 or newer, which is
+where that icon form was added, and bounded to 512 KiB so a cover cannot
+become a large transfer on every track change.
+
+Failure is silent and total: a missing daemon, a refused call, a bus that went
+away, a cover evicted between being cached and being sent. Every delivery is
+guarded and never awaited by playback, so the worst case is a notification that
+did not appear. Each call is also given a five-second deadline, because nothing
+awaits it: a wedged notification service must not leave a pending call behind
+for every track change of the session.
+
+Automated coverage:
+`test/core/services/notifications/track_change_notifier_test.dart`,
+`test/core/services/notifications/now_playing_notification_test.dart`,
+`test/core/services/notifications/dbus_desktop_notifier_test.dart`,
+`test/core/services/notifications/platform_desktop_notifier_test.dart`,
+`test/features/settings/desktop/desktop_notifications_section_test.dart`, and
+`test/data/repositories/shared_preferences_desktop_notification_preferences_test.dart`.
+What only a real desktop can answer, to re-check before a Linux milestone
+release:
+
+| Scenario | Expect |
+| --- | --- |
+| Turn the switch on, then let a track end into the next one | One notification, with title, artist and cover |
+| Pause, resume, seek, change the volume | No notification |
+| Hold *next* through several tracks | One notification, for the track you land on |
+| Turn the switch off, then change track | Nothing at all |
+| Play a local file with embedded art, and a server track whose cover is cached | Cover shown in both |
+| Play a server track whose cover has not been fetched yet | Notification without a cover, never a placeholder or a URL |
+| Same, in the Flatpak | Identical behaviour; `flatpak info --show-permissions` unchanged |
+| Kill the notification daemon, then change track | Playback unaffected, no error anywhere in the app |
 
 ## Crash-safe playback restore
 

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -1033,6 +1033,13 @@ real transitions:
   whole burst, and the track the listener actually landed on is the one
   announced. Ordinary listening never meets this limit at all.
 
+  A waiting announcement is only made if it is still true when the window
+  closes. Skip to a track and back inside those five seconds, or pause inside
+  them, and it is dropped rather than naming a track the listener has left.
+  The window is measured on a monotonic clock, so a time correction (NTP, a
+  manual change) cannot make the gap since the last notification negative and
+  silence the next one for the length of the correction.
+
 Turning the preference off is read live, so it silences the next track change
 immediately, including one already waiting out that window.
 
@@ -1064,6 +1071,14 @@ for a consumer that opens files rather than fetching URLs:
   nothing on a Linux desktop can open it.
 
 A track with no title at all reads as "Unknown track", never as its path.
+
+One escaping detail, because the metadata comes from a server the listener
+configured rather than from Linthra: the freedesktop spec's `body` is
+markup-capable, so the subtitle is escaped for that route. Without it an
+ordinary `&` in a name is invalid markup a daemon may drop, and a server could
+put formatting or a link in an artist name and have the desktop render it. The
+portal's `body` is literal text by contract (markup lives behind a separate
+key it is never sent), so it takes the text as it is.
 
 ### How it reaches the desktop
 
@@ -1101,8 +1116,10 @@ Failure is silent and total: a missing daemon, a refused call, a bus that went
 away, a cover evicted between being cached and being sent. Every delivery is
 guarded and never awaited by playback, so the worst case is a notification that
 did not appear. Each call is also given a five-second deadline, because nothing
-awaits it: a wedged notification service must not leave a pending call behind
-for every track change of the session.
+awaits it. A deadline alone is not enough there: Dart's `Future.timeout` ends
+the wait, not the D-Bus call underneath it, so a timeout also drops the
+connection, which is what abandons the outstanding call and stops it landing a
+stale notification later. The next track change opens a fresh one.
 
 Automated coverage:
 `test/core/services/notifications/track_change_notifier_test.dart`,

--- a/lib/app/application_container.dart
+++ b/lib/app/application_container.dart
@@ -9,6 +9,8 @@ import '../data/repositories/audiobookshelf_session_store_provider.dart';
 import '../data/repositories/cast_receiver_pin_store_provider.dart';
 import '../data/repositories/default_provider_store_provider.dart';
 import '../data/repositories/desktop_density_store_provider.dart';
+import '../data/repositories/desktop_notification_preferences_provider.dart';
+import '../data/repositories/desktop_notifier_provider.dart';
 import '../data/repositories/desktop_window_controller_provider.dart';
 import '../data/repositories/desktop_window_preferences_provider.dart';
 import '../data/repositories/download_repository_provider.dart';
@@ -66,6 +68,7 @@ List<Override> productionApplicationOverrides({
     sharedPreferencesDownloadPreferencesOverride,
     sharedPreferencesPlaybackPreferencesOverride,
     sharedPreferencesDesktopWindowPreferencesOverride,
+    sharedPreferencesDesktopNotificationPreferencesOverride,
     if (resolvedHost == HostPlatform.linux) ...<Override>[
       sharedPreferencesPlaybackSessionStoreOverride,
       // The window-lifecycle channel is Linthra's own GTK runner (#401), so
@@ -106,6 +109,7 @@ List<Override> productionApplicationOverrides({
     platformLauncherIconServiceOverride,
     platformShareServiceOverride,
     platformAudioOutputDeviceServiceOverride,
+    platformDesktopNotifierOverride,
     lyricsServiceOverride,
     // Casting is withheld from production builds by the security
     // containment; see [CastContainment].

--- a/lib/app/application_lifecycle.dart
+++ b/lib/app/application_lifecycle.dart
@@ -26,6 +26,7 @@ import '../features/library/local_root_availability_controller.dart';
 import '../features/player/media_artwork_providers.dart';
 import '../features/player/playback_history_providers.dart';
 import '../features/player/player_providers.dart';
+import '../features/player/track_notification_providers.dart';
 import '../features/settings/audiobookshelf/audiobookshelf_settings_controller.dart';
 import '../features/settings/desktop/close_behavior_controller.dart';
 import '../features/settings/desktop/desktop_window_providers.dart';
@@ -278,6 +279,13 @@ Future<ApplicationHandle> bootstrapApplication(
     // played before the listener first opened it. Off desktop this creates no
     // recorder at all.
     container.read(playbackHistoryProvider);
+    // Desktop track-change notifications (#400). Read here for the same reason
+    // as the history recorder: the state stream does not replay, so an observer
+    // created later would miss every track played before it. Null off the
+    // desktop and wherever there is no notification seam, and silent until the
+    // listener turns the preference on, so this read costs one null or one
+    // subscription that announces nothing.
+    container.read(trackChangeNotifierProvider);
     // Loads and prunes the credential-free remote-cache manifest off the
     // first-frame path. Owned rather than merely unawaited: it writes to the
     // app-support directory, so a restart must not race a prune still in

--- a/lib/core/repositories/desktop_notification_preferences.dart
+++ b/lib/core/repositories/desktop_notification_preferences.dart
@@ -1,0 +1,17 @@
+/// The user's desktop-notification preferences (issue #400).
+///
+/// One choice today: whether a track change shows a notification. Kept behind
+/// an interface like [DesktopWindowPreferences] so the notification path can
+/// read it without binding to a storage plugin, and so tests can hand it a
+/// value with no plugin registered at all.
+abstract interface class DesktopNotificationPreferences {
+  /// Whether a track change shows a desktop notification.
+  ///
+  /// Defaults to **false**. A desktop shell already draws a now-playing card
+  /// from Linthra's MPRIS session, so a toast per track is an addition the
+  /// listener asks for rather than something a music player should start
+  /// doing to their screen on its own.
+  Future<bool> trackChangeNotifications();
+
+  Future<void> setTrackChangeNotifications(bool enabled);
+}

--- a/lib/core/services/notifications/dbus_desktop_notifier.dart
+++ b/lib/core/services/notifications/dbus_desktop_notifier.dart
@@ -1,0 +1,338 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dbus/dbus.dart';
+
+import '../../app_info.dart';
+import 'desktop_notifier.dart';
+
+/// Which of the two D-Bus ways to show a notification is being used.
+enum NotificationTransport {
+  /// `org.freedesktop.portal.Notification` on the desktop portal. Tried first
+  /// because it is the only route a Flatpak has: the sandbox may not talk to
+  /// an arbitrary bus name, and Linthra deliberately asks for no
+  /// `--talk-name` (see docs/flatpak-permissions.md).
+  portal,
+
+  /// `org.freedesktop.Notifications`, the freedesktop spec interface every
+  /// notification daemon implements. The route on a host with no portal (a
+  /// bare window manager with `dunst`, say), where the session bus is
+  /// directly reachable.
+  freedesktop,
+}
+
+/// Shows Linux desktop notifications over D-Bus (issue #400).
+///
+/// D-Bus is what a desktop notification *is*: a method call to the session's
+/// notification service. Linthra already speaks it for MPRIS through the same
+/// package, so this needs no new dependency, no native code, and, the part
+/// that matters, no subprocess. Shelling out to `notify-send` would mean
+/// spawning a binary found on `PATH` with strings built from track metadata,
+/// from a music player, which is a worse idea than it first looks and is not
+/// available inside the Flatpak anyway.
+///
+/// **Two routes, portal first.** The portal is what the sandbox can reach, and
+/// asking for it costs no permission at all; the spec interface is the
+/// fallback for a host that has no portal running. Whichever answers is
+/// remembered, so the common case is one call per notification. Both are
+/// best-effort: a refusal, a missing service or a bus that went away is
+/// swallowed and the notifier simply re-probes next time.
+///
+/// **One notification, replaced.** The portal route reuses a fixed id and the
+/// spec route passes the previous notification's id as `replaces_id`, so a
+/// listener moving through an album ends up with one "now playing" entry that
+/// updates, not a stack of them in the shell's tray.
+///
+/// **Artwork, when the route supports it safely.** The spec interface takes an
+/// `image-path` hint, which is a local file the daemon opens itself. The
+/// portal takes a serialized icon, and only accepted the `bytes` form from
+/// version 2 of its interface, so the cover is attached there only when the
+/// running portal says it is that new, and then as bytes read from Linthra's
+/// own cache, bounded by [maxImageBytes], rather than as a path the sandbox
+/// and the host would disagree about.
+class DBusDesktopNotifier implements DesktopNotifier {
+  DBusDesktopNotifier({
+    DBusClient Function() clientFactory = DBusClient.session,
+    Future<Uint8List?> Function(Uri image)? readImage,
+    this.callDeadline = defaultCallDeadline,
+  })  : _clientFactory = clientFactory,
+        _readImage = readImage ?? _readImageFile;
+
+  /// The installed desktop entry, minus its `.desktop` suffix. Also the name
+  /// of the installed hicolor icon, which is what makes a daemon draw
+  /// Linthra's icon beside the notification. Must stay the app id
+  /// `linux/packaging/<app id>.desktop` is installed under, like
+  /// `MprisPlayerObject.desktopEntry`.
+  static const String desktopEntry = 'io.github.thezupzup.linthra';
+
+  /// The id every "now playing" notification is filed under on the portal
+  /// route. Fixed on purpose: the portal replaces a notification that reuses
+  /// an id, which is exactly the behaviour wanted here.
+  static const String notificationId = 'now-playing';
+
+  /// The largest cover worth sending as bytes, in bytes.
+  ///
+  /// Covers in Linthra's caches are bounded already (the media-session copy is
+  /// requested small, and embedded local art is capped at 1024 px), so this is
+  /// the backstop for an unexpectedly large one rather than the normal case: a
+  /// megabyte of image per track change does not belong on the session bus,
+  /// and a notification without a cover is a much smaller loss than a stalled
+  /// call.
+  static const int maxImageBytes = 512 * 1024;
+
+  /// How long the spec route asks the daemon to keep the notification up.
+  ///
+  /// Only a request: every daemon is free to ignore it, and several do. Long
+  /// enough to read a title and an artist, short enough that it is gone before
+  /// the next track.
+  static const Duration expireAfter = Duration(seconds: 5);
+
+  /// How long one notification may take before it is given up on.
+  ///
+  /// A notification service is local and answers in milliseconds, so a call
+  /// still outstanding after this was never coming back. It is bounded because
+  /// nothing awaits these: without a deadline a wedged daemon would leave a
+  /// pending call behind for every track change of the session.
+  static const Duration defaultCallDeadline = Duration(seconds: 5);
+
+  static const String _portalDestination = 'org.freedesktop.portal.Desktop';
+  static const String _portalInterface = 'org.freedesktop.portal.Notification';
+  static const String _propertiesInterface = 'org.freedesktop.DBus.Properties';
+  static const String _freedesktopName = 'org.freedesktop.Notifications';
+
+  /// The deadline for one notification. Injectable so a test can assert the
+  /// bound without waiting for it.
+  final Duration callDeadline;
+
+  final DBusClient Function() _clientFactory;
+  final Future<Uint8List?> Function(Uri image) _readImage;
+
+  DBusClient? _client;
+  bool _disposed = false;
+
+  /// The route that last worked, or null while it is still unknown (or has
+  /// just stopped working).
+  NotificationTransport? _transport;
+
+  /// The portal's interface version, once read successfully. Cached only on
+  /// success: a failed read must not pin the portal as unusable for the rest
+  /// of the session.
+  int? _portalVersion;
+
+  /// The id the daemon gave the last notification, passed back as
+  /// `replaces_id` so the next one takes its place instead of stacking.
+  int _replacesId = 0;
+
+  /// Which route was last used, for diagnostics and tests. Null until a
+  /// notification has actually been delivered.
+  NotificationTransport? get transport => _transport;
+
+  @override
+  bool get isSupported => true;
+
+  @override
+  Future<void> show(DesktopNotification notification) async {
+    if (_disposed) return;
+    final DBusClient? client = _connect();
+    if (client == null) return;
+
+    for (final NotificationTransport route in _routes) {
+      if (await _send(client, route, notification)) {
+        _transport = route;
+        return;
+      }
+    }
+    // Nothing answered. Forget the route rather than pinning one that is not
+    // there, so a daemon that shows up later is found on the next track.
+    _transport = null;
+  }
+
+  /// The routes to try, in order: whichever worked last, then the rest.
+  Iterable<NotificationTransport> get _routes {
+    final NotificationTransport? known = _transport;
+    if (known == null) return NotificationTransport.values;
+    return <NotificationTransport>[
+      known,
+      for (final NotificationTransport route in NotificationTransport.values)
+        if (route != known) route,
+    ];
+  }
+
+  /// The bus connection, opened on first use.
+  ///
+  /// Lazy so a listener who never turns notifications on never opens one, and
+  /// guarded so a host with no session bus is "no notifications" rather than a
+  /// thrown error. `DBusClient` connects on its first call, not here.
+  DBusClient? _connect() {
+    if (_client != null) return _client;
+    try {
+      return _client = _clientFactory();
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<bool> _send(
+    DBusClient client,
+    NotificationTransport route,
+    DesktopNotification notification,
+  ) async {
+    try {
+      switch (route) {
+        case NotificationTransport.portal:
+          return await _sendPortal(client, notification).timeout(callDeadline);
+        case NotificationTransport.freedesktop:
+          return await _sendFreedesktop(client, notification)
+              .timeout(callDeadline);
+      }
+    } catch (_) {
+      // A service that is not on the bus, a refused call, a reply that never
+      // came: all of them mean "try the other route", never an error the
+      // caller has to handle.
+      return false;
+    }
+  }
+
+  Future<bool> _sendPortal(
+    DBusClient client,
+    DesktopNotification notification,
+  ) async {
+    final int version = await _readPortalVersion(client);
+    // No readable version means no portal to talk to.
+    if (version < 1) return false;
+
+    final Map<String, DBusValue> body = <String, DBusValue>{
+      'title': DBusString(notification.title),
+      if (notification.body.isNotEmpty) 'body': DBusString(notification.body),
+      // A now-playing toast is never urgent; "low" is what keeps it out of a
+      // do-not-disturb break-through on the desktops that honour priorities.
+      'priority': const DBusString('low'),
+    };
+    if (version >= 2) {
+      final Uint8List? bytes = await _imageBytes(notification.image);
+      if (bytes != null) {
+        // The `g_icon_serialize` form for a GBytesIcon: ('bytes', <ay>).
+        body['icon'] = DBusStruct(<DBusValue>[
+          const DBusString('bytes'),
+          DBusVariant(DBusArray.byte(bytes)),
+        ]);
+      }
+    }
+
+    await client.callMethod(
+      destination: _portalDestination,
+      path: DBusObjectPath('/org/freedesktop/portal/desktop'),
+      interface: _portalInterface,
+      name: 'AddNotification',
+      values: <DBusValue>[
+        const DBusString(notificationId),
+        DBusDict.stringVariant(body),
+      ],
+    );
+    return true;
+  }
+
+  /// The portal's `version` property, or 0 when there is no portal to ask.
+  Future<int> _readPortalVersion(DBusClient client) async {
+    final int? known = _portalVersion;
+    if (known != null) return known;
+    try {
+      final DBusMethodSuccessResponse reply = await client.callMethod(
+        destination: _portalDestination,
+        path: DBusObjectPath('/org/freedesktop/portal/desktop'),
+        interface: _propertiesInterface,
+        name: 'Get',
+        values: <DBusValue>[
+          const DBusString(_portalInterface),
+          const DBusString('version'),
+        ],
+      );
+      final DBusValue? returned =
+          reply.returnValues.isEmpty ? null : reply.returnValues.first;
+      final DBusValue? value =
+          returned is DBusVariant ? returned.value : returned;
+      if (value is! DBusUint32) return 0;
+      return _portalVersion = value.value;
+    } catch (_) {
+      // Not cached: a portal that is merely slow or restarting must still get
+      // another chance on the next track.
+      return 0;
+    }
+  }
+
+  Future<bool> _sendFreedesktop(
+    DBusClient client,
+    DesktopNotification notification,
+  ) async {
+    final Map<String, DBusValue> hints = <String, DBusValue>{
+      // Low urgency, and transient: a track change belongs on screen for a
+      // moment, not in the shell's notification history for the evening.
+      'urgency': const DBusByte(0),
+      'transient': const DBusBoolean(true),
+      'desktop-entry': const DBusString(desktopEntry),
+    };
+    final Uri? image = notification.image;
+    if (image != null) hints['image-path'] = DBusString(image.toString());
+
+    final DBusMethodSuccessResponse reply = await client.callMethod(
+      destination: _freedesktopName,
+      path: DBusObjectPath('/org/freedesktop/Notifications'),
+      interface: _freedesktopName,
+      name: 'Notify',
+      values: <DBusValue>[
+        const DBusString(AppInfo.name),
+        DBusUint32(_replacesId),
+        // An icon-theme name, not a path: the same one the installed desktop
+        // entry's `Icon=` resolves through.
+        const DBusString(desktopEntry),
+        DBusString(notification.title),
+        DBusString(notification.body),
+        // No actions. A notification with buttons would be a second transport
+        // control, and the shell already has the MPRIS one.
+        DBusArray.string(const <String>[]),
+        DBusDict.stringVariant(hints),
+        DBusInt32(expireAfter.inMilliseconds),
+      ],
+    );
+    final DBusValue? id =
+        reply.returnValues.isEmpty ? null : reply.returnValues.first;
+    if (id is DBusUint32) _replacesId = id.value;
+    return true;
+  }
+
+  /// The cover's bytes, or null when there is no cover, it cannot be read, or
+  /// it is larger than [maxImageBytes].
+  Future<Uint8List?> _imageBytes(Uri? image) async {
+    if (image == null || !image.isScheme('file')) return null;
+    try {
+      return await _readImage(image);
+    } catch (_) {
+      // A cover that has been evicted between being cached and being sent is
+      // "no cover", not a failed notification.
+      return null;
+    }
+  }
+
+  static Future<Uint8List?> _readImageFile(Uri image) async {
+    final File file = File(image.toFilePath());
+    if (!await file.exists()) return null;
+    if (await file.length() > maxImageBytes) return null;
+    return file.readAsBytes();
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    final DBusClient? client = _client;
+    _client = null;
+    if (client == null) return;
+    try {
+      await client.close();
+    } catch (_) {
+      // Closing a client that never connected can throw; teardown is
+      // best-effort like every other step at shutdown.
+    }
+  }
+}

--- a/lib/core/services/notifications/dbus_desktop_notifier.dart
+++ b/lib/core/services/notifications/dbus_desktop_notifier.dart
@@ -22,6 +22,13 @@ enum NotificationTransport {
   freedesktop,
 }
 
+/// What one attempt at one route came to.
+///
+/// A refusal and a silence are handled differently: a refusal means "ask the
+/// other route", a silence means the connection is carrying a call that will
+/// never come back and has to be given up.
+enum _SendOutcome { delivered, refused, timedOut }
+
 /// Shows Linux desktop notifications over D-Bus (issue #400).
 ///
 /// D-Bus is what a desktop notification *is*: a method call to the session's
@@ -91,9 +98,12 @@ class DBusDesktopNotifier implements DesktopNotifier {
   /// How long one notification may take before it is given up on.
   ///
   /// A notification service is local and answers in milliseconds, so a call
-  /// still outstanding after this was never coming back. It is bounded because
-  /// nothing awaits these: without a deadline a wedged daemon would leave a
-  /// pending call behind for every track change of the session.
+  /// still outstanding after this was never coming back. `Future.timeout`
+  /// only ends the *wait*, though, not the D-Bus call underneath it: that call
+  /// stays outstanding, and could still land a stale notification later. So a
+  /// timeout also drops the connection (see [_discardClient]), which is what
+  /// actually abandons the call, and leaves the rest to the next track change
+  /// rather than piling a second call onto a service that is not answering.
   static const Duration defaultCallDeadline = Duration(seconds: 5);
 
   static const String _portalDestination = 'org.freedesktop.portal.Desktop';
@@ -138,9 +148,22 @@ class DBusDesktopNotifier implements DesktopNotifier {
     if (client == null) return;
 
     for (final NotificationTransport route in _routes) {
-      if (await _send(client, route, notification)) {
-        _transport = route;
-        return;
+      switch (await _send(client, route, notification)) {
+        case _SendOutcome.delivered:
+          _transport = route;
+          return;
+        case _SendOutcome.refused:
+          // Not on the bus, or it said no. Try the other route on the same
+          // connection.
+          continue;
+        case _SendOutcome.timedOut:
+          // A service that took the call and went quiet. The call is still
+          // outstanding, so give up the connection it is on rather than
+          // leaving it to land a stale notification later, and stop here: a
+          // second call to something that is not answering buys nothing.
+          await _discardClient();
+          _transport = null;
+          return;
       }
     }
     // Nothing answered. Forget the route rather than pinning one that is not
@@ -173,24 +196,46 @@ class DBusDesktopNotifier implements DesktopNotifier {
     }
   }
 
-  Future<bool> _send(
+  Future<_SendOutcome> _send(
     DBusClient client,
     NotificationTransport route,
     DesktopNotification notification,
   ) async {
     try {
+      final bool delivered;
       switch (route) {
         case NotificationTransport.portal:
-          return await _sendPortal(client, notification).timeout(callDeadline);
+          delivered =
+              await _sendPortal(client, notification).timeout(callDeadline);
         case NotificationTransport.freedesktop:
-          return await _sendFreedesktop(client, notification)
+          delivered = await _sendFreedesktop(client, notification)
               .timeout(callDeadline);
       }
+      return delivered ? _SendOutcome.delivered : _SendOutcome.refused;
+    } on TimeoutException {
+      return _SendOutcome.timedOut;
     } catch (_) {
-      // A service that is not on the bus, a refused call, a reply that never
-      // came: all of them mean "try the other route", never an error the
-      // caller has to handle.
-      return false;
+      // A service that is not on the bus, or one that refused the call: try
+      // the other route, never an error the caller has to handle.
+      return _SendOutcome.refused;
+    }
+  }
+
+  /// Closes and forgets the bus connection, so the next notification opens a
+  /// fresh one.
+  ///
+  /// What abandons a call that timed out: closing the connection takes the
+  /// outstanding call with it. The notification id is kept on purpose, since
+  /// it belongs to the daemon's id space rather than to this connection, so a
+  /// reconnect still replaces the notification already on screen.
+  Future<void> _discardClient() async {
+    final DBusClient? client = _client;
+    _client = null;
+    if (client == null) return;
+    try {
+      await client.close();
+    } catch (_) {
+      // Best-effort: a connection being thrown away cannot fail usefully.
     }
   }
 
@@ -287,7 +332,7 @@ class DBusDesktopNotifier implements DesktopNotifier {
         // entry's `Icon=` resolves through.
         const DBusString(desktopEntry),
         DBusString(notification.title),
-        DBusString(notification.body),
+        DBusString(_escapeBodyMarkup(notification.body)),
         // No actions. A notification with buttons would be a second transport
         // control, and the shell already has the MPRIS one.
         DBusArray.string(const <String>[]),
@@ -300,6 +345,27 @@ class DBusDesktopNotifier implements DesktopNotifier {
     if (id is DBusUint32) _replacesId = id.value;
     return true;
   }
+
+  /// The body with the spec's markup characters made literal.
+  ///
+  /// The freedesktop spec's `body` is markup-capable: a daemon advertising
+  /// `body-markup` parses a small HTML-like subset of it, links and formatting
+  /// included. A track's artist and album are whatever a tagger or a server
+  /// put there, so unescaped an ordinary `&` or `<` in a name makes invalid
+  /// markup, which is a subtitle a daemon is free to mangle or drop, and a
+  /// server could put formatting or a link in a name and have a desktop
+  /// render it. Escaping here keeps the subtitle exactly the text the app
+  /// shows.
+  ///
+  /// Only this route needs it. The portal's `body` is literal text by
+  /// contract (markup is a separate `markup-body` key, which Linthra does not
+  /// send), so escaping there would put a visible `&amp;` in a song's title.
+  /// The spec's `summary` is not markup either and is left alone for the same
+  /// reason.
+  static String _escapeBodyMarkup(String body) => body
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;');
 
   /// The cover's bytes, or null when there is no cover, it cannot be read, or
   /// it is larger than [maxImageBytes].

--- a/lib/core/services/notifications/desktop_notifier.dart
+++ b/lib/core/services/notifications/desktop_notifier.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/foundation.dart';
+
+/// One notification Linthra is asking the desktop to show, reduced to the
+/// three things a shell actually draws.
+///
+/// Deliberately a plain value with no provider, session or playback types in
+/// it. Everything that decides *what may be said* happens before a
+/// [DesktopNotification] exists (see `nowPlayingNotification`), so the
+/// transport underneath can be read as "put these fields on the bus" rather
+/// than audited for what it might reach into.
+@immutable
+class DesktopNotification {
+  const DesktopNotification({
+    required this.title,
+    this.body = '',
+    this.image,
+  });
+
+  /// The heading: a track title, never a path, id or URL.
+  final String title;
+
+  /// The second line, empty when the catalog knows nothing to put there.
+  final String body;
+
+  /// A cover the notification daemon can open by itself, or null.
+  ///
+  /// Only ever a `file:` URI into one of Linthra's own artwork caches. Those
+  /// live under the application cache directory, which is a real host path
+  /// inside a Flatpak as much as outside it, so the daemon can read it, and
+  /// the file is a credential-free copy Linthra wrote, not a file from the
+  /// user's library. Nothing else gets this far: see
+  /// `nowPlayingNotification`.
+  final Uri? image;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is DesktopNotification &&
+          other.title == title &&
+          other.body == body &&
+          other.image == image);
+
+  @override
+  int get hashCode => Object.hash(title, body, image);
+
+  @override
+  String toString() =>
+      'DesktopNotification(title: $title, body: $body, image: $image)';
+}
+
+/// The one seam Linthra shows a desktop notification through.
+///
+/// It exists so the *decision* to notify (see `TrackChangeNotifier`) is
+/// testable without a session bus, and so the platform-specific transport is
+/// reached through one narrow interface rather than from wherever a widget
+/// happens to want a toast. In particular there is no "run notify-send"
+/// anywhere in the app: on Linux this is a D-Bus call
+/// (`DBusDesktopNotifier`), which is what a desktop notification actually is.
+abstract interface class DesktopNotifier {
+  /// Whether this host has a notification seam at all. False for the no-op,
+  /// which is what every non-Linux platform gets.
+  bool get isSupported;
+
+  /// Shows [notification], replacing whichever one this notifier showed last.
+  ///
+  /// Best-effort: an implementation swallows a missing daemon, a refused call
+  /// and a bus that went away, because a notification that did not appear is
+  /// never worth failing anything else over. Callers guard anyway (see
+  /// `TrackChangeNotifier`), so a future or test implementation that does
+  /// throw still cannot reach playback.
+  Future<void> show(DesktopNotification notification);
+
+  /// Releases whatever the notifier holds (on Linux, a bus connection).
+  /// Idempotent and never throws.
+  Future<void> dispose();
+}
+
+/// A [DesktopNotifier] that shows nothing.
+///
+/// What Android and every non-Linux platform get, and what tests get unless
+/// they ask for something else. A real, named class rather than a nullable
+/// notifier: "this platform has no desktop notifications" is a fact the
+/// settings card and diagnostics can read, and one the notification path can
+/// short-circuit on without a platform check of its own.
+class NoopDesktopNotifier implements DesktopNotifier {
+  const NoopDesktopNotifier();
+
+  @override
+  bool get isSupported => false;
+
+  @override
+  Future<void> show(DesktopNotification notification) async {}
+
+  @override
+  Future<void> dispose() async {}
+}

--- a/lib/core/services/notifications/now_playing_notification.dart
+++ b/lib/core/services/notifications/now_playing_notification.dart
@@ -1,0 +1,81 @@
+import '../../models/track.dart';
+import '../media_artwork_source.dart';
+import 'desktop_notifier.dart';
+
+/// The heading used when a track carries no title at all.
+///
+/// A file with no tags still has a path, and the path is exactly what must
+/// never be shown: a notification is drawn by another process and, on most
+/// desktops, kept in a tray the whole session. "Unknown track" says as much as
+/// can be said safely.
+const String kUnknownTrackNotificationTitle = 'Unknown track';
+
+/// Builds the "now playing" notification for [track].
+///
+/// This is the whole of what Linthra is willing to tell a notification daemon,
+/// and it is deliberately a pure function: everything that decides what may
+/// leave the app happens here, in one place a reviewer can read, rather than
+/// inside the D-Bus call.
+///
+/// **What goes out.** The title and the catalog's own "Artist • Album"
+/// subtitle: the same two lines the in-app mini player draws.
+///
+/// **What never does.** No [Track.uri] (a remote track's is a stream URL that
+/// can carry a provider credential; a local one's is the listener's own file
+/// path), no [Track.id], no album id, no server address, and no cover
+/// reference. None of them would help a shell draw a card, and a notification
+/// leaves the sandbox and usually outlives the track.
+///
+/// **Artwork, when it is safely supported.** The same rule the MPRIS session
+/// publishes `mpris:artUrl` under, narrowed for a consumer that loads files
+/// rather than URLs:
+///
+///  * a `file:` cover passes through. Every `file:` cover in the catalog is a
+///    copy Linthra itself wrote into its own artwork cache (embedded local art
+///    via `LocalArtworkCache`, or Android's SAF walk): a credential-free file
+///    under the application cache directory, which resolves to the same path
+///    inside a Flatpak and outside it, so the daemon can actually open it;
+///  * an app-internal reference (`subsonic-cover:<id>`, `plex-thumb:<path>`)
+///    is only ever published as the local copy the media-artwork cache has
+///    *already* fetched. Nothing is fetched here: this runs on a track change
+///    and must not wait on a server;
+///  * an `http(s)` cover is dropped. A notification daemon does not fetch
+///    URLs for an image, so it would buy nothing, and "a cover URL" is the
+///    shape a credentialed one would arrive in;
+///  * a `content:` cover is dropped. That is Android's FileProvider form, and
+///    nothing on a Linux desktop can open it.
+DesktopNotification nowPlayingNotification(
+  Track track, {
+  MediaArtworkSource? artwork,
+}) {
+  final String title = track.title.trim();
+  return DesktopNotification(
+    title: title.isEmpty ? kUnknownTrackNotificationTitle : title,
+    body: track.artistAlbumLabel,
+    image: safeNotificationImage(track.artworkUri, artwork: artwork),
+  );
+}
+
+/// The cover a notification daemon may be handed for [artworkUri], or null.
+///
+/// Exposed separately from [nowPlayingNotification] because it is the part
+/// worth testing on its own: it is the filter that decides whether a reference
+/// leaves the app, and every scheme it lets through has to be a local file
+/// Linthra wrote. See [nowPlayingNotification] for why each answer is what it
+/// is.
+Uri? safeNotificationImage(
+  Uri? artworkUri, {
+  MediaArtworkSource? artwork,
+}) {
+  if (artworkUri == null) return null;
+  if (artworkUri.isScheme('file')) return artworkUri;
+  if (artworkUri.isScheme('content') ||
+      artworkUri.isScheme('http') ||
+      artworkUri.isScheme('https')) {
+    return null;
+  }
+  // An app-internal reference: publish it only once its credential-free copy
+  // is on disk. `cachedFileUri` is synchronous and starts no fetch, so a cover
+  // that has not been warmed yet simply means a notification without one.
+  return artwork?.cachedFileUri(artworkUri);
+}

--- a/lib/core/services/notifications/platform_desktop_notifier.dart
+++ b/lib/core/services/notifications/platform_desktop_notifier.dart
@@ -1,0 +1,55 @@
+import '../../platform/host_platform.dart';
+import 'dbus_desktop_notifier.dart';
+import 'desktop_notifier.dart';
+
+/// The default [DesktopNotifier]: real D-Bus notifications on Linux, a no-op
+/// everywhere else.
+///
+/// This is the one place that knows about the platform split, mirroring
+/// [PlatformAudioOutputDeviceService] and [PlatformMediaSessionBinding]. Linux
+/// gets [DBusDesktopNotifier]; every other platform, Android included, gets
+/// [NoopDesktopNotifier], so nothing here can change what Android does. The
+/// media notification there belongs to `audio_service` and the media session,
+/// and a second per-track notification on top of it would be both duplicated
+/// and wrong.
+class PlatformDesktopNotifier implements DesktopNotifier {
+  PlatformDesktopNotifier({
+    HostPlatform? host,
+    DesktopNotifier? linuxNotifier,
+    DesktopNotifier fallbackNotifier = const NoopDesktopNotifier(),
+  })  : _host = host,
+        _linuxNotifier = linuxNotifier,
+        _fallbackNotifier = fallbackNotifier;
+
+  /// The platform to route for; null reads the real host. Injectable so the
+  /// split can be exercised for both platforms on one machine.
+  final HostPlatform? _host;
+
+  /// Built lazily: constructing it is cheap and opens nothing (the D-Bus
+  /// client connects on its first call), but a platform that has no
+  /// notification bus should never own one at all.
+  DesktopNotifier? _linuxNotifier;
+  final DesktopNotifier _fallbackNotifier;
+
+  bool get _isLinux => (_host ?? HostPlatform.current) == HostPlatform.linux;
+
+  DesktopNotifier get _delegate {
+    if (!_isLinux) return _fallbackNotifier;
+    return _linuxNotifier ??= DBusDesktopNotifier();
+  }
+
+  @override
+  bool get isSupported => _delegate.isSupported;
+
+  @override
+  Future<void> show(DesktopNotification notification) =>
+      _delegate.show(notification);
+
+  @override
+  Future<void> dispose() async {
+    // Deliberately not through [_delegate]: disposing must never be the thing
+    // that first creates a bus client.
+    await _linuxNotifier?.dispose();
+    await _fallbackNotifier.dispose();
+  }
+}

--- a/lib/core/services/notifications/track_change_notifier.dart
+++ b/lib/core/services/notifications/track_change_notifier.dart
@@ -218,8 +218,17 @@ class TrackChangeNotifier {
     final Track? track = _pending;
     _pending = null;
     if (track == null) return;
-    // Turned off, or already announced by something else, while the window ran.
-    if (!_enabled() || track.uri == _announced) return;
+    // Already announced by something else while the window ran.
+    if (track.uri == _announced) return;
+    if (!_enabled()) {
+      // Turned off while the window ran. Recorded as observed anyway, exactly
+      // as the disabled path in [onState] does: the track was playing while
+      // the preference was off, so switching it back on has to stay quiet
+      // until the next real change rather than announce a song that has been
+      // playing for two minutes.
+      _announced = track.uri;
+      return;
+    }
     _announce(track, _elapsed());
   }
 

--- a/lib/core/services/notifications/track_change_notifier.dart
+++ b/lib/core/services/notifications/track_change_notifier.dart
@@ -42,7 +42,14 @@ typedef DesktopNotificationBuilder = DesktopNotification Function(Track track);
 /// eligible track replaces whatever was waiting, one timer covers the whole
 /// burst, and when it fires the track the listener actually landed on is the
 /// one announced. Dropping instead would either announce the first track of a
-/// burst (the one they skipped away from) or nothing at all.
+/// burst (the one they skipped away from) or nothing at all. A waiting
+/// announcement is only ever made if it is still true when the window closes:
+/// skipping to a track and back inside it, or pausing inside it, drops the
+/// announcement rather than naming a track the listener has left.
+///
+/// The window is measured on a monotonic clock, not a wall clock, so a time
+/// correction cannot turn the gap since the last notification negative and
+/// silence the next one for the length of the correction.
 ///
 /// **Failure.** Every delivery is guarded and unawaited. A missing daemon, a
 /// refused call or a bus that went away costs one absent toast and nothing
@@ -54,14 +61,14 @@ class TrackChangeNotifier {
     required bool Function() enabled,
     required DesktopNotificationBuilder build,
     Duration minInterval = defaultMinInterval,
-    DateTime Function()? now,
+    Duration Function()? elapsed,
     Timer Function(Duration, void Function())? createTimer,
   })  : _states = states,
         _notifier = notifier,
         _enabled = enabled,
         _build = build,
         _minInterval = minInterval,
-        _now = now ?? DateTime.now,
+        _elapsed = elapsed ?? _monotonicElapsed(),
         _createTimer = createTimer ?? _scheduleTimer;
 
   /// The shortest gap between two notifications.
@@ -81,7 +88,17 @@ class TrackChangeNotifier {
 
   final DesktopNotificationBuilder _build;
   final Duration _minInterval;
-  final DateTime Function() _now;
+
+  /// How long this notifier has been running, from a *monotonic* source.
+  ///
+  /// The rate limit measures an interval, and a wall clock is the wrong
+  /// instrument for that: it can move backwards (an NTP correction, a manual
+  /// change, a resume from suspend). Measured with `DateTime.now`, one
+  /// backwards jump makes the gap since the last notification negative and
+  /// pushes the next one out by the whole adjustment, so an hour's correction
+  /// would buy an hour of silence while tracks kept changing.
+  final Duration Function() _elapsed;
+
   final Timer Function(Duration, void Function()) _createTimer;
 
   StreamSubscription<PlaybackState>? _subscription;
@@ -93,8 +110,9 @@ class TrackChangeNotifier {
   /// a song that has been playing for two minutes.
   String? _announced;
 
-  /// When the last notification was handed to the notifier.
-  DateTime? _lastAt;
+  /// The reading of [_elapsed] when the last notification was handed to the
+  /// notifier.
+  Duration? _lastAt;
 
   /// The newest eligible track seen inside the rate-limit window.
   Track? _pending;
@@ -102,6 +120,12 @@ class TrackChangeNotifier {
 
   static Timer _scheduleTimer(Duration delay, void Function() callback) =>
       Timer(delay, callback);
+
+  /// A monotonic elapsed-time source for one notifier. See [_elapsed].
+  static Duration Function() _monotonicElapsed() {
+    final Stopwatch stopwatch = Stopwatch()..start();
+    return () => stopwatch.elapsed;
+  }
 
   /// Begins observing. Idempotent: calling it twice never adds a second
   /// listener, which is what keeps one track change from notifying twice.
@@ -115,6 +139,11 @@ class TrackChangeNotifier {
     // Nothing to talk to (every platform but Linux): no state to keep either.
     if (!_notifier.isSupported) return;
 
+    // Before any of the rules below can return early, this state is the newest
+    // truth about what is playing, and a waiting announcement it contradicts
+    // has to go.
+    _dropStalePending(state);
+
     final Track? track = state.currentTrack;
     if (track == null) return;
     if (!_isPlayingSomething(state)) return;
@@ -125,9 +154,14 @@ class TrackChangeNotifier {
       return;
     }
 
-    final DateTime at = _now();
-    final DateTime? last = _lastAt;
-    final Duration since = last == null ? _minInterval : at.difference(last);
+    final Duration at = _elapsed();
+    final Duration? last = _lastAt;
+    // A reading behind the last one is treated as a window that has passed,
+    // not as a negative gap. [_elapsed] is monotonic, so this cannot happen
+    // from the default source; the guard is here so that a source which does
+    // go backwards costs an early notification rather than a silent one
+    // delayed by the whole jump.
+    final Duration since = last == null || at < last ? _minInterval : at - last;
     if (since >= _minInterval) {
       _announce(track, at);
       return;
@@ -148,7 +182,28 @@ class TrackChangeNotifier {
   static bool _isPlayingSomething(PlaybackState state) =>
       state.isPlaying || state.isBuffering;
 
-  void _announce(Track track, DateTime at) {
+  /// Forgets a pending announcement that [state] has made untrue.
+  ///
+  /// A track waiting out the rate limit is only worth announcing while it is
+  /// still the one playing. Skip to it and straight back, or pause inside that
+  /// window, and the waiting announcement now describes a track the listener
+  /// has left: announcing it would name the song they skipped away from, or
+  /// claim something is playing when nothing is.
+  ///
+  /// The timer is deliberately left armed. It is what closes the window for
+  /// whatever the burst lands on next, and firing with nothing pending does
+  /// nothing, so one timer still covers a whole burst instead of being
+  /// cancelled and re-armed per skip.
+  void _dropStalePending(PlaybackState state) {
+    final Track? pending = _pending;
+    if (pending == null) return;
+    if (state.currentTrack?.uri == pending.uri && _isPlayingSomething(state)) {
+      return;
+    }
+    _pending = null;
+  }
+
+  void _announce(Track track, Duration at) {
     _announced = track.uri;
     _lastAt = at;
     _pending = null;
@@ -165,7 +220,7 @@ class TrackChangeNotifier {
     if (track == null) return;
     // Turned off, or already announced by something else, while the window ran.
     if (!_enabled() || track.uri == _announced) return;
-    _announce(track, _now());
+    _announce(track, _elapsed());
   }
 
   Future<void> _deliver(Track track) async {

--- a/lib/core/services/notifications/track_change_notifier.dart
+++ b/lib/core/services/notifications/track_change_notifier.dart
@@ -1,0 +1,190 @@
+import 'dart:async';
+
+import '../../models/playback_state.dart';
+import '../../models/track.dart';
+import 'desktop_notifier.dart';
+
+/// Turns a track into the notification that announces it. Injected so the
+/// content rules (and the artwork filter behind them) stay in
+/// `now_playing_notification.dart` and this class stays about *when* to notify.
+typedef DesktopNotificationBuilder = DesktopNotification Function(Track track);
+
+/// Watches the playback state stream and announces the track that is actually
+/// playing now (issue #400).
+///
+/// A pure observer, the same shape as `PlaybackHistoryRecorder`: it never
+/// touches the queue, the controller or the audio engine, and it emits nothing
+/// back into playback. Switching it off (which is what the preference does)
+/// changes nothing except whether a toast appears.
+///
+/// **Why the state stream.** A track change is not an event the controller
+/// raises; it is a state. Reading the stream sees a skip, a natural advance and
+/// a queue jump identically, for every controller implementation, without the
+/// playback seam growing a callback for the benefit of a desktop toast.
+///
+/// **What counts as a track change.** The stream carries a state several times
+/// a second while playing, and almost none of those are news. Three rules
+/// between them reduce it to real transitions:
+///
+///  * the track's logical identity ([Track.uri]) has to differ from the last
+///    one announced, so position ticks, a pause, a resume, a volume change, a
+///    seek, a reconnect and a queue rebuild all say nothing. Repeat-one, which
+///    starts the *same* song again, is deliberately included in that: it is
+///    not a new song;
+///  * something has to actually be playing. A queue restored paused at launch,
+///    a track loaded but not started, and a load that errored are all "nothing
+///    is playing", and announcing one would be a claim Linthra cannot back;
+///  * at most one notification per [minInterval]. Holding the button down
+///    through twenty tracks must not put twenty notifications on the bus. See
+///    below for why the last one still wins.
+///
+/// **Rapid skipping.** A burst is coalesced rather than dropped: the newest
+/// eligible track replaces whatever was waiting, one timer covers the whole
+/// burst, and when it fires the track the listener actually landed on is the
+/// one announced. Dropping instead would either announce the first track of a
+/// burst (the one they skipped away from) or nothing at all.
+///
+/// **Failure.** Every delivery is guarded and unawaited. A missing daemon, a
+/// refused call or a bus that went away costs one absent toast and nothing
+/// else; playback never waits for a notification and never sees it fail.
+class TrackChangeNotifier {
+  TrackChangeNotifier({
+    required Stream<PlaybackState> states,
+    required DesktopNotifier notifier,
+    required bool Function() enabled,
+    required DesktopNotificationBuilder build,
+    Duration minInterval = defaultMinInterval,
+    DateTime Function()? now,
+    Timer Function(Duration, void Function())? createTimer,
+  })  : _states = states,
+        _notifier = notifier,
+        _enabled = enabled,
+        _build = build,
+        _minInterval = minInterval,
+        _now = now ?? DateTime.now,
+        _createTimer = createTimer ?? _scheduleTimer;
+
+  /// The shortest gap between two notifications.
+  ///
+  /// Long enough that a listener stepping through a few tracks produces one
+  /// notification rather than one per track; short enough that ordinary
+  /// listening, where a track change is minutes apart, is never delayed by
+  /// it at all.
+  static const Duration defaultMinInterval = Duration(seconds: 5);
+
+  final Stream<PlaybackState> _states;
+  final DesktopNotifier _notifier;
+
+  /// Read live, on every candidate, so turning the preference off silences the
+  /// next track change (and a burst still waiting on its timer) at once.
+  final bool Function() _enabled;
+
+  final DesktopNotificationBuilder _build;
+  final Duration _minInterval;
+  final DateTime Function() _now;
+  final Timer Function(Duration, void Function()) _createTimer;
+
+  StreamSubscription<PlaybackState>? _subscription;
+
+  /// The identity of the track the listener has already been told about.
+  ///
+  /// Updated even while the preference is off, so switching notifications on
+  /// mid-track stays quiet until the *next* real change instead of announcing
+  /// a song that has been playing for two minutes.
+  String? _announced;
+
+  /// When the last notification was handed to the notifier.
+  DateTime? _lastAt;
+
+  /// The newest eligible track seen inside the rate-limit window.
+  Track? _pending;
+  Timer? _timer;
+
+  static Timer _scheduleTimer(Duration delay, void Function() callback) =>
+      Timer(delay, callback);
+
+  /// Begins observing. Idempotent: calling it twice never adds a second
+  /// listener, which is what keeps one track change from notifying twice.
+  void start() {
+    _subscription ??= _states.listen(onState);
+  }
+
+  /// Feeds one state in. Public so the transition and rate-limit rules can be
+  /// exercised without a stream, and used by [start] as the listener.
+  void onState(PlaybackState state) {
+    // Nothing to talk to (every platform but Linux): no state to keep either.
+    if (!_notifier.isSupported) return;
+
+    final Track? track = state.currentTrack;
+    if (track == null) return;
+    if (!_isPlayingSomething(state)) return;
+    if (track.uri == _announced) return;
+
+    if (!_enabled()) {
+      _announced = track.uri;
+      return;
+    }
+
+    final DateTime at = _now();
+    final DateTime? last = _lastAt;
+    final Duration since = last == null ? _minInterval : at.difference(last);
+    if (since >= _minInterval) {
+      _announce(track, at);
+      return;
+    }
+
+    // Inside the window. Remember the newest track and let the one armed timer
+    // announce whatever is newest when the window closes.
+    _pending = track;
+    _timer ??= _createTimer(_minInterval - since, _announcePending);
+  }
+
+  /// Whether [state] is a claim that audio is on this track.
+  ///
+  /// Buffering and reconnecting count: both mean the engine is working toward
+  /// sound on the current track, and both are what `PlaybackStatus` reports
+  /// mid-stream rather than a reason to stay silent. Loading, paused, idle,
+  /// completed and error do not.
+  static bool _isPlayingSomething(PlaybackState state) =>
+      state.isPlaying || state.isBuffering;
+
+  void _announce(Track track, DateTime at) {
+    _announced = track.uri;
+    _lastAt = at;
+    _pending = null;
+    _timer?.cancel();
+    _timer = null;
+    unawaited(_deliver(track));
+  }
+
+  /// Announces whatever the burst landed on, if it is still worth announcing.
+  void _announcePending() {
+    _timer = null;
+    final Track? track = _pending;
+    _pending = null;
+    if (track == null) return;
+    // Turned off, or already announced by something else, while the window ran.
+    if (!_enabled() || track.uri == _announced) return;
+    _announce(track, _now());
+  }
+
+  Future<void> _deliver(Track track) async {
+    try {
+      await _notifier.show(_build(track));
+    } catch (_) {
+      // Best-effort by contract. A notification backend that throws (a daemon
+      // that vanished, a bus that refused the call) must never surface as an
+      // unhandled error on the playback stream's listener.
+    }
+  }
+
+  /// Stops observing and drops a pending announcement. Idempotent.
+  Future<void> dispose() async {
+    _timer?.cancel();
+    _timer = null;
+    _pending = null;
+    final StreamSubscription<PlaybackState>? subscription = _subscription;
+    _subscription = null;
+    await subscription?.cancel();
+  }
+}

--- a/lib/data/repositories/desktop_notification_preferences_provider.dart
+++ b/lib/data/repositories/desktop_notification_preferences_provider.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/repositories/desktop_notification_preferences.dart';
+import 'in_memory_desktop_notification_preferences.dart';
+import 'shared_preferences_desktop_notification_preferences.dart';
+
+/// The user's desktop-notification preferences (currently "notify me when the
+/// track changes"). In-memory by default so tests and dev runs need no
+/// plugins; the app persists them via `shared_preferences` through
+/// [sharedPreferencesDesktopNotificationPreferencesOverride].
+final desktopNotificationPreferencesProvider =
+    Provider<DesktopNotificationPreferences>((ref) {
+  return InMemoryDesktopNotificationPreferences();
+});
+
+final sharedPreferencesDesktopNotificationPreferencesOverride =
+    desktopNotificationPreferencesProvider.overrideWithValue(
+  const SharedPreferencesDesktopNotificationPreferences(),
+);

--- a/lib/data/repositories/desktop_notifier_provider.dart
+++ b/lib/data/repositories/desktop_notifier_provider.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/lifecycle/async_disposal_registry.dart';
+import '../../core/services/notifications/desktop_notifier.dart';
+import '../../core/services/notifications/platform_desktop_notifier.dart';
+
+/// The single seam the app shows a desktop notification through.
+///
+/// Defaults to the no-op implementation so unit and widget tests never open a
+/// session bus. The running app overrides this with
+/// [platformDesktopNotifierOverride], which gives Linux the real D-Bus
+/// notifier and leaves every other platform, Android included, on the no-op.
+/// Mirrors the [audioOutputDeviceServiceProvider] seam.
+final desktopNotifierProvider = Provider<DesktopNotifier>(
+  (ref) => const NoopDesktopNotifier(),
+);
+
+/// Production binding: real D-Bus notifications on Linux, a safe no-op
+/// elsewhere. Applied in `main`.
+///
+/// Overridden with a builder rather than a value because this seam owns a
+/// resource: the bus connection it opens on first use is released with the
+/// container, and awaited by the shutdown lifecycle.
+final platformDesktopNotifierOverride =
+    desktopNotifierProvider.overrideWith((ref) {
+  final PlatformDesktopNotifier notifier = PlatformDesktopNotifier();
+  ref.onDisposeAsync(notifier.dispose);
+  return notifier;
+});

--- a/lib/data/repositories/in_memory_desktop_notification_preferences.dart
+++ b/lib/data/repositories/in_memory_desktop_notification_preferences.dart
@@ -1,0 +1,19 @@
+import '../../core/repositories/desktop_notification_preferences.dart';
+
+/// A non-persistent [DesktopNotificationPreferences] for development and
+/// tests.
+class InMemoryDesktopNotificationPreferences
+    implements DesktopNotificationPreferences {
+  InMemoryDesktopNotificationPreferences({bool trackChanges = false})
+      : _trackChanges = trackChanges;
+
+  bool _trackChanges;
+
+  @override
+  Future<bool> trackChangeNotifications() async => _trackChanges;
+
+  @override
+  Future<void> setTrackChangeNotifications(bool enabled) async {
+    _trackChanges = enabled;
+  }
+}

--- a/lib/data/repositories/shared_preferences_desktop_notification_preferences.dart
+++ b/lib/data/repositories/shared_preferences_desktop_notification_preferences.dart
@@ -1,0 +1,26 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/repositories/desktop_notification_preferences.dart';
+
+/// A [DesktopNotificationPreferences] backed by `shared_preferences`. One
+/// boolean, so it lives next to the other small user choices in the key/value
+/// store rather than in the SQLite catalog.
+class SharedPreferencesDesktopNotificationPreferences
+    implements DesktopNotificationPreferences {
+  const SharedPreferencesDesktopNotificationPreferences();
+
+  static const String _trackChangesKey = 'desktop_track_change_notifications';
+
+  @override
+  Future<bool> trackChangeNotifications() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    // Unset reads as off, which is what a build without this feature did.
+    return prefs.getBool(_trackChangesKey) ?? false;
+  }
+
+  @override
+  Future<void> setTrackChangeNotifications(bool enabled) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_trackChangesKey, enabled);
+  }
+}

--- a/lib/features/player/track_notification_providers.dart
+++ b/lib/features/player/track_notification_providers.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/lifecycle/async_disposal_registry.dart';
+import '../../core/models/track.dart';
+import '../../core/services/media_artwork_source.dart';
+import '../../core/services/notifications/desktop_notifier.dart';
+import '../../core/services/notifications/now_playing_notification.dart';
+import '../../core/services/notifications/track_change_notifier.dart';
+import '../../data/repositories/desktop_notifier_provider.dart';
+import '../../data/repositories/host_platform_provider.dart';
+import '../settings/desktop/track_change_notifications_controller.dart';
+import 'media_artwork_providers.dart';
+import 'player_providers.dart';
+
+/// Announces track changes on the desktop (issue #400), or null where there is
+/// nothing to announce them through.
+///
+/// **Instantiated at bootstrap, not by the UI.** The controller's state stream
+/// is a plain broadcast stream with no replay, so an observer only sees what
+/// happens after it subscribes; created lazily by a settings page nobody
+/// opened, it would notify nothing. `bootstrapApplication` reads this
+/// alongside the other side-effect-only services, the same way it reads the
+/// recent-playback recorder.
+///
+/// Null (no observer, no subscription, nothing) off the desktop and wherever
+/// the notification seam reports itself unsupported, which is every platform
+/// but Linux. Android's per-track notification is the media session's, drawn
+/// by the system, and nothing here changes it.
+///
+/// The preference is read *live* on each candidate rather than captured, so
+/// switching notifications off in Settings silences the next track change at
+/// once. Creating the controller here is deliberate too: it starts the stored
+/// value loading at bootstrap, so the first song of the session is already
+/// answerable instead of arriving before the answer does.
+final trackChangeNotifierProvider = Provider<TrackChangeNotifier?>((ref) {
+  if (!ref.watch(hostPlatformProvider).isDesktop) return null;
+
+  final DesktopNotifier notifier = ref.read(desktopNotifierProvider);
+  if (!notifier.isSupported) return null;
+
+  final MediaArtworkSource artwork = ref.read(mediaArtworkCacheProvider);
+  ref.read(trackChangeNotificationsControllerProvider);
+
+  final TrackChangeNotifier service = TrackChangeNotifier(
+    states: ref.read(playbackControllerProvider).stateStream,
+    notifier: notifier,
+    enabled: () =>
+        ref.read(trackChangeNotificationsControllerProvider).valueOrNull ??
+        false,
+    build: (Track track) => nowPlayingNotification(track, artwork: artwork),
+  );
+  service.start();
+  ref.onDisposeAsync(service.dispose);
+  return service;
+});

--- a/lib/features/settings/desktop/desktop_notifications_section.dart
+++ b/lib/features/settings/desktop/desktop_notifications_section.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/dimens.dart';
+import '../../../data/repositories/desktop_notifier_provider.dart';
+import 'track_change_notifications_controller.dart';
+
+/// The "Desktop notifications" card on the Music & playback settings page.
+///
+/// Only shown where Linthra can actually show one: Linux, over D-Bus. On
+/// Android the media notification belongs to the media session and the system
+/// draws it, so the seam reports itself unsupported and this widget renders
+/// nothing rather than offering a switch that would do nothing.
+///
+/// Off by default, and the card says what turning it on does and what it will
+/// never do: a desktop shell already shows a now-playing card from Linthra's
+/// media session, so this is an addition rather than the only way to see what
+/// is playing.
+class DesktopNotificationsSettingsSection extends ConsumerWidget {
+  const DesktopNotificationsSettingsSection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!ref.watch(desktopNotifierProvider).isSupported) {
+      return const SizedBox.shrink();
+    }
+
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    final AsyncValue<bool> enabled =
+        ref.watch(trackChangeNotificationsControllerProvider);
+    final bool selected = enabled.valueOrNull ?? false;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.md,
+          AppSpacing.md,
+          AppSpacing.md,
+          AppSpacing.sm,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Icon(
+                  Icons.notifications_none_outlined,
+                  color: theme.colorScheme.primary,
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                Text(
+                  'Desktop notifications',
+                  style: theme.textTheme.titleMedium,
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              'Show a short notification when the song changes, with its '
+              'title, artist and cover. Nothing is shown for pausing, '
+              'resuming or moving through a track, and skipping quickly only '
+              'announces the song you land on.',
+              style: theme.textTheme.bodySmall?.copyWith(color: muted),
+            ),
+            SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              value: selected,
+              // Ignore taps until the stored choice has loaded, so a fast tap
+              // cannot be overwritten by the value still on its way in from
+              // storage.
+              onChanged: enabled.isLoading
+                  ? null
+                  : (bool value) => ref
+                      .read(trackChangeNotificationsControllerProvider.notifier)
+                      .setEnabled(value),
+              title: const Text('Notify me when the track changes'),
+              subtitle: const Text(
+                'Off by default. Your desktop already shows what is playing '
+                'through Linthra’s media controls.',
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/settings/desktop/track_change_notifications_controller.dart
+++ b/lib/features/settings/desktop/track_change_notifications_controller.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../data/repositories/desktop_notification_preferences_provider.dart';
+
+/// Owns the "Notify me when the track changes" choice: loads the persisted
+/// value and writes changes back through [DesktopNotificationPreferences].
+///
+/// Only the *stored choice* lives here. What it means (which transitions
+/// count, what may be said, and how often) is `TrackChangeNotifier`'s and
+/// `nowPlayingNotification`'s decision.
+///
+/// Read live by the notification path on every candidate track change, so
+/// turning this off silences the very next one, including one already waiting
+/// out the rate limit.
+class TrackChangeNotificationsController extends AsyncNotifier<bool> {
+  @override
+  Future<bool> build() {
+    return ref
+        .read(desktopNotificationPreferencesProvider)
+        .trackChangeNotifications();
+  }
+
+  Future<void> setEnabled(bool enabled) async {
+    await ref
+        .read(desktopNotificationPreferencesProvider)
+        .setTrackChangeNotifications(enabled);
+    state = AsyncData<bool>(enabled);
+  }
+}
+
+final trackChangeNotificationsControllerProvider =
+    AsyncNotifierProvider<TrackChangeNotificationsController, bool>(
+  TrackChangeNotificationsController.new,
+);

--- a/lib/features/settings/desktop/track_change_notifications_controller.dart
+++ b/lib/features/settings/desktop/track_change_notifications_controller.dart
@@ -21,10 +21,24 @@ class TrackChangeNotificationsController extends AsyncNotifier<bool> {
   }
 
   Future<void> setEnabled(bool enabled) async {
-    await ref
-        .read(desktopNotificationPreferencesProvider)
-        .setTrackChangeNotifications(enabled);
+    final AsyncValue<bool> previous = state;
+    // Applied before the write, not after it. The notification path reads this
+    // live on every track change, and persisting is a platform round-trip: in
+    // between, a track change would still see the old answer, so turning
+    // notifications off could let one more notification through and turning
+    // them on could mark the next track as already seen.
     state = AsyncData<bool>(enabled);
+    try {
+      await ref
+          .read(desktopNotificationPreferencesProvider)
+          .setTrackChangeNotifications(enabled);
+    } catch (_) {
+      // The choice did not reach storage, so stop claiming it: a switch left
+      // on would disagree with the next launch. Restored only if nothing has
+      // since been chosen on top of it, so a second tap is never undone by the
+      // first tap's failure.
+      if (state.valueOrNull == enabled) state = previous;
+    }
   }
 }
 

--- a/lib/features/settings/hub/music_and_playback_screen.dart
+++ b/lib/features/settings/hub/music_and_playback_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../app/dimens.dart';
 import '../../../core/platform/host_platform.dart';
 import '../../../data/repositories/host_platform_provider.dart';
+import '../desktop/desktop_notifications_section.dart';
 import '../desktop/desktop_window_section.dart';
 import '../playback/audio_output_settings_section.dart';
 import '../playback/playback_settings_section.dart';
@@ -23,6 +24,10 @@ import 'settings_detail_scaffold.dart';
 /// closing the window does is a playback choice there, since the answer is
 /// whether the music keeps going. Android never shows it, because closing a
 /// window is not something Android does.
+///
+/// The same goes for desktop notifications (#400), the opt-in toast when the
+/// track changes: on Android that notification is the media session's, drawn
+/// by the system, so there is nothing there to offer a switch for.
 class MusicAndPlaybackScreen extends ConsumerWidget {
   const MusicAndPlaybackScreen({super.key});
 
@@ -43,6 +48,10 @@ class MusicAndPlaybackScreen extends ConsumerWidget {
         if (host.isDesktop) ...<Widget>[
           const SizedBox(height: AppSpacing.md),
           const DesktopWindowSettingsSection(),
+          // Renders nothing where notifications belong to the system, so a
+          // desktop platform without a notification seam shows no card.
+          const SizedBox(height: AppSpacing.md),
+          const DesktopNotificationsSettingsSection(),
         ],
       ],
     );

--- a/test/core/services/notifications/dbus_desktop_notifier_test.dart
+++ b/test/core/services/notifications/dbus_desktop_notifier_test.dart
@@ -159,6 +159,23 @@ void main() {
       expect(body['priority'], const DBusString('low'));
     });
 
+    test('takes the body literally, since the portal is not markup', () async {
+      final _FakeBus bus = _FakeBus(portalVersion: 1);
+      final DBusDesktopNotifier notifier = notifierFor(bus);
+      addTearDown(notifier.dispose);
+
+      await notifier.show(
+        const DesktopNotification(title: 'Trouble', body: 'Sparks & friends'),
+      );
+
+      // Escaping here would put a visible "&amp;" in the notification: the
+      // portal's `body` is literal text, with markup behind its own key.
+      expect(
+        _portalBody(bus.callsTo('AddNotification').single)['body'],
+        const DBusString('Sparks & friends'),
+      );
+    });
+
     test('reuses one id, so the shell keeps one entry', () async {
       final _FakeBus bus = _FakeBus(portalVersion: 1);
       final DBusDesktopNotifier notifier = notifierFor(bus);
@@ -277,6 +294,31 @@ void main() {
       expect(_hints(bus.callsTo('Notify').single)['image-path'], isNull);
     });
 
+    test('makes the markup characters in a name literal', () async {
+      final _FakeBus bus = _FakeBus();
+      final DBusDesktopNotifier notifier = notifierFor(bus);
+      addTearDown(notifier.dispose);
+
+      await notifier.show(
+        const DesktopNotification(
+          title: 'Fish & Chips',
+          body: 'Sparks & <unknown> • 4 > 3',
+        ),
+      );
+
+      final _Call call = bus.callsTo('Notify').single;
+      // The spec's body is markup-capable, so an ordinary ampersand in a name
+      // would otherwise be invalid markup, and a server could put a link in
+      // one.
+      expect(
+        (call.values[4] as DBusString).value,
+        'Sparks &amp; &lt;unknown&gt; • 4 &gt; 3',
+      );
+      // The summary is not markup in the spec, so it is left as the app shows
+      // it.
+      expect((call.values[3] as DBusString).value, 'Fish & Chips');
+    });
+
     test('replaces the previous notification instead of stacking', () async {
       final _FakeBus bus = _FakeBus();
       final DBusDesktopNotifier notifier = notifierFor(bus);
@@ -352,6 +394,32 @@ void main() {
       // outstanding per track change for the rest of the session.
       await expectLater(notifier.show(plain), completes);
       expect(notifier.transport, isNull);
+    });
+
+    test('a timed-out call is abandoned with its connection', () async {
+      // Dart's `Future.timeout` ends the wait, not the D-Bus call: the call
+      // stays outstanding and could still land a stale notification. Closing
+      // the connection is what actually abandons it.
+      final _FakeBus wedged = _FakeBus(hangs: true);
+      final _FakeBus fresh = _FakeBus(portalVersion: 1);
+      final List<_FakeBus> buses = <_FakeBus>[wedged, fresh];
+      final DBusDesktopNotifier notifier = DBusDesktopNotifier(
+        clientFactory: () => buses.removeAt(0),
+        readImage: (Uri _) async => null,
+        callDeadline: const Duration(milliseconds: 20),
+      );
+      addTearDown(notifier.dispose);
+
+      await notifier.show(plain);
+      expect(wedged.closeCalls, 1);
+      // Only one call went out: a second route on a connection that is being
+      // thrown away would buy nothing.
+      expect(wedged.callsTo('Notify'), isEmpty);
+
+      // The next track change opens a fresh connection and works.
+      await notifier.show(plain);
+      expect(notifier.transport, NotificationTransport.portal);
+      expect(fresh.callsTo('AddNotification'), hasLength(1));
     });
 
     test('a bus that cannot even be opened is not an error', () async {

--- a/test/core/services/notifications/dbus_desktop_notifier_test.dart
+++ b/test/core/services/notifications/dbus_desktop_notifier_test.dart
@@ -1,0 +1,402 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dbus/dbus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/services/notifications/dbus_desktop_notifier.dart';
+import 'package:linthra/core/services/notifications/desktop_notifier.dart';
+
+/// One call the notifier asked the bus to make.
+class _Call {
+  _Call(this.destination, this.interface, this.name, this.values);
+
+  final String? destination;
+  final String? interface;
+  final String name;
+  final List<DBusValue> values;
+}
+
+/// A [DBusClient] that answers like a bus without being one.
+///
+/// Subclassed rather than mocked because `DBusClient` is a concrete class and
+/// its constructor is lazy: nothing connects until a method is called, and
+/// the only method this notifier uses is overridden here. So these tests
+/// exercise the real call-building code with no session bus, no portal and no
+/// notification daemon anywhere in sight. Mirrors the MPRIS session's
+/// `_FakeBus`.
+class _FakeBus extends DBusClient {
+  _FakeBus({this.portalVersion, this.daemon = true, this.hangs = false})
+      : super(DBusAddress('unix:path=/nonexistent/linthra-test-bus'));
+
+  /// The version the Notification portal reports, or null when there is no
+  /// portal on this bus at all.
+  final int? portalVersion;
+
+  /// Whether `org.freedesktop.Notifications` answers.
+  final bool daemon;
+
+  /// A service that takes the call and never replies, the way a wedged daemon
+  /// does.
+  final bool hangs;
+
+  final List<_Call> calls = <_Call>[];
+  int closeCalls = 0;
+  int nextNotificationId = 11;
+
+  List<_Call> callsTo(String name) =>
+      calls.where((_Call call) => call.name == name).toList();
+
+  @override
+  Future<DBusMethodSuccessResponse> callMethod({
+    String? destination,
+    required DBusObjectPath path,
+    String? interface,
+    required String name,
+    Iterable<DBusValue> values = const <DBusValue>[],
+    DBusSignature? replySignature,
+    bool noReplyExpected = false,
+    bool noAutoStart = false,
+    bool allowInteractiveAuthorization = false,
+  }) async {
+    calls.add(
+      _Call(destination, interface, name, values.toList()),
+    );
+    if (hangs) return Completer<DBusMethodSuccessResponse>().future;
+    if (destination == 'org.freedesktop.portal.Desktop') {
+      final int? version = portalVersion;
+      if (version == null) {
+        throw DBusServiceUnknownException(
+          DBusMethodErrorResponse.unknownMethod(),
+        );
+      }
+      if (name == 'Get') {
+        return DBusMethodSuccessResponse(
+          <DBusValue>[DBusVariant(DBusUint32(version))],
+        );
+      }
+      return DBusMethodSuccessResponse();
+    }
+    if (!daemon) {
+      throw DBusServiceUnknownException(
+        DBusMethodErrorResponse.unknownMethod(),
+      );
+    }
+    return DBusMethodSuccessResponse(
+      <DBusValue>[DBusUint32(nextNotificationId++)],
+    );
+  }
+
+  @override
+  Future<void> close() async => closeCalls++;
+}
+
+/// The `a{sv}` body of an `AddNotification` call, as a plain map.
+Map<String, DBusValue> _portalBody(_Call call) {
+  final DBusDict dict = call.values[1] as DBusDict;
+  return dict.children.map(
+    (DBusValue key, DBusValue value) => MapEntry<String, DBusValue>(
+      (key as DBusString).value,
+      (value as DBusVariant).value,
+    ),
+  );
+}
+
+/// The `hints` argument of a `Notify` call, as a plain map.
+Map<String, DBusValue> _hints(_Call call) {
+  final DBusDict dict = call.values[6] as DBusDict;
+  return dict.children.map(
+    (DBusValue key, DBusValue value) => MapEntry<String, DBusValue>(
+      (key as DBusString).value,
+      (value as DBusVariant).value,
+    ),
+  );
+}
+
+void main() {
+  const DesktopNotification plain = DesktopNotification(
+    title: 'Trouble',
+    body: 'Cat Power • Moon Pix',
+  );
+  final DesktopNotification withCover = DesktopNotification(
+    title: 'Trouble',
+    body: 'Cat Power • Moon Pix',
+    image: Uri.file('/home/dana/.cache/linthra/media/9f.img'),
+  );
+
+  DBusDesktopNotifier notifierFor(
+    _FakeBus bus, {
+    Uint8List? cover,
+  }) {
+    return DBusDesktopNotifier(
+      clientFactory: () => bus,
+      readImage: (Uri _) async => cover,
+    );
+  }
+
+  group('the portal route', () {
+    test('is the one tried first, and carries title and body', () async {
+      final _FakeBus bus = _FakeBus(portalVersion: 1);
+      final DBusDesktopNotifier notifier = notifierFor(bus);
+      addTearDown(notifier.dispose);
+
+      await notifier.show(plain);
+
+      expect(notifier.transport, NotificationTransport.portal);
+      // Nothing was said to the spec interface at all.
+      expect(bus.callsTo('Notify'), isEmpty);
+
+      final _Call call = bus.callsTo('AddNotification').single;
+      expect(call.destination, 'org.freedesktop.portal.Desktop');
+      expect(call.interface, 'org.freedesktop.portal.Notification');
+      expect(
+        (call.values.first as DBusString).value,
+        DBusDesktopNotifier.notificationId,
+      );
+
+      final Map<String, DBusValue> body = _portalBody(call);
+      expect(body['title'], const DBusString('Trouble'));
+      expect(body['body'], const DBusString('Cat Power • Moon Pix'));
+      expect(body['priority'], const DBusString('low'));
+    });
+
+    test('reuses one id, so the shell keeps one entry', () async {
+      final _FakeBus bus = _FakeBus(portalVersion: 1);
+      final DBusDesktopNotifier notifier = notifierFor(bus);
+      addTearDown(notifier.dispose);
+
+      await notifier.show(plain);
+      await notifier.show(withCover);
+
+      final List<_Call> added = bus.callsTo('AddNotification');
+      expect(added, hasLength(2));
+      expect(
+        added.map((_Call call) => (call.values.first as DBusString).value),
+        everyElement(DBusDesktopNotifier.notificationId),
+      );
+    });
+
+    test('reads the interface version once', () async {
+      final _FakeBus bus = _FakeBus(portalVersion: 2);
+      final DBusDesktopNotifier notifier = notifierFor(bus);
+      addTearDown(notifier.dispose);
+
+      await notifier.show(plain);
+      await notifier.show(plain);
+
+      expect(bus.callsTo('Get'), hasLength(1));
+    });
+
+    test('version 1 gets no cover: that icon form did not exist yet', () async {
+      final _FakeBus bus = _FakeBus(portalVersion: 1);
+      final DBusDesktopNotifier notifier = notifierFor(
+        bus,
+        cover: Uint8List.fromList(<int>[1, 2, 3]),
+      );
+      addTearDown(notifier.dispose);
+
+      await notifier.show(withCover);
+
+      expect(
+          _portalBody(bus.callsTo('AddNotification').single)['icon'], isNull);
+    });
+
+    test('version 2 carries the cover as bytes', () async {
+      final _FakeBus bus = _FakeBus(portalVersion: 2);
+      final DBusDesktopNotifier notifier = notifierFor(
+        bus,
+        cover: Uint8List.fromList(<int>[1, 2, 3]),
+      );
+      addTearDown(notifier.dispose);
+
+      await notifier.show(withCover);
+
+      final DBusValue? icon =
+          _portalBody(bus.callsTo('AddNotification').single)['icon'];
+      expect(icon, isA<DBusStruct>());
+      final DBusStruct serialized = icon! as DBusStruct;
+      // g_icon_serialize's GBytesIcon form.
+      expect(serialized.children.first, const DBusString('bytes'));
+      expect(
+        ((serialized.children.last as DBusVariant).value as DBusArray)
+            .children
+            .map((DBusValue byte) => (byte as DBusByte).value),
+        <int>[1, 2, 3],
+      );
+    });
+
+    test('a cover that cannot be read is simply no cover', () async {
+      final _FakeBus bus = _FakeBus(portalVersion: 2);
+      final DBusDesktopNotifier notifier = notifierFor(bus);
+      addTearDown(notifier.dispose);
+
+      await notifier.show(withCover);
+
+      expect(notifier.transport, NotificationTransport.portal);
+      expect(
+          _portalBody(bus.callsTo('AddNotification').single)['icon'], isNull);
+    });
+  });
+
+  group('the freedesktop route', () {
+    test('takes over on a host with no portal', () async {
+      final _FakeBus bus = _FakeBus();
+      final DBusDesktopNotifier notifier = notifierFor(bus);
+      addTearDown(notifier.dispose);
+
+      await notifier.show(withCover);
+
+      expect(notifier.transport, NotificationTransport.freedesktop);
+      final _Call call = bus.callsTo('Notify').single;
+      expect(call.destination, 'org.freedesktop.Notifications');
+      expect((call.values[3] as DBusString).value, 'Trouble');
+      expect((call.values[4] as DBusString).value, 'Cat Power • Moon Pix');
+      // No actions: the shell's transport controls are MPRIS's job.
+      expect((call.values[5] as DBusArray).children, isEmpty);
+
+      final Map<String, DBusValue> hints = _hints(call);
+      expect(hints['urgency'], const DBusByte(0));
+      expect(hints['transient'], const DBusBoolean(true));
+      expect(
+        hints['desktop-entry'],
+        const DBusString(DBusDesktopNotifier.desktopEntry),
+      );
+      expect(
+        hints['image-path'],
+        DBusString(
+            Uri.file('/home/dana/.cache/linthra/media/9f.img').toString()),
+      );
+    });
+
+    test('a notification with no cover sends no image hint', () async {
+      final _FakeBus bus = _FakeBus();
+      final DBusDesktopNotifier notifier = notifierFor(bus);
+      addTearDown(notifier.dispose);
+
+      await notifier.show(plain);
+
+      expect(_hints(bus.callsTo('Notify').single)['image-path'], isNull);
+    });
+
+    test('replaces the previous notification instead of stacking', () async {
+      final _FakeBus bus = _FakeBus();
+      final DBusDesktopNotifier notifier = notifierFor(bus);
+      addTearDown(notifier.dispose);
+
+      await notifier.show(plain);
+      await notifier.show(plain);
+      await notifier.show(plain);
+
+      expect(
+        bus
+            .callsTo('Notify')
+            .map((_Call call) => (call.values[1] as DBusUint32).value),
+        // The first has nothing to replace; each one after replaces the id the
+        // daemon just handed back.
+        <int>[0, 11, 12],
+      );
+    });
+
+    test('the route it found is remembered, so the portal is not re-probed',
+        () async {
+      final _FakeBus bus = _FakeBus();
+      final DBusDesktopNotifier notifier = notifierFor(bus);
+      addTearDown(notifier.dispose);
+
+      await notifier.show(plain);
+      await notifier.show(plain);
+
+      expect(bus.callsTo('AddNotification'), isEmpty);
+      // One failed probe in total, on the first notification only.
+      expect(bus.callsTo('Get'), hasLength(1));
+      expect(bus.callsTo('Notify'), hasLength(2));
+    });
+  });
+
+  group('when nothing answers', () {
+    test('show completes quietly and keeps no route', () async {
+      final _FakeBus bus = _FakeBus(daemon: false);
+      final DBusDesktopNotifier notifier = notifierFor(bus);
+      addTearDown(notifier.dispose);
+
+      await expectLater(notifier.show(plain), completes);
+
+      expect(notifier.transport, isNull);
+      // Both routes were tried, and both failures were swallowed.
+      expect(bus.callsTo('Get'), hasLength(1));
+      expect(bus.callsTo('Notify'), hasLength(1));
+    });
+
+    test('a daemon that shows up later is found on the next notification',
+        () async {
+      final _FakeBus bus = _FakeBus(daemon: false);
+      final DBusDesktopNotifier notifier = notifierFor(bus);
+      addTearDown(notifier.dispose);
+
+      await notifier.show(plain);
+      // Nothing is pinned, so the next attempt probes again rather than
+      // assuming the desktop is still empty.
+      expect(notifier.transport, isNull);
+      expect(bus.callsTo('Notify'), hasLength(1));
+    });
+
+    test('a service that never replies is given up on', () async {
+      final _FakeBus bus = _FakeBus(hangs: true);
+      final DBusDesktopNotifier notifier = DBusDesktopNotifier(
+        clientFactory: () => bus,
+        readImage: (Uri _) async => null,
+        callDeadline: const Duration(milliseconds: 20),
+      );
+      addTearDown(notifier.dispose);
+
+      // Nothing awaits a notification, so a wedged daemon must not leave one
+      // outstanding per track change for the rest of the session.
+      await expectLater(notifier.show(plain), completes);
+      expect(notifier.transport, isNull);
+    });
+
+    test('a bus that cannot even be opened is not an error', () async {
+      final DBusDesktopNotifier notifier = DBusDesktopNotifier(
+        clientFactory: () => throw StateError('no session bus'),
+      );
+      addTearDown(notifier.dispose);
+
+      await expectLater(notifier.show(plain), completes);
+      expect(notifier.transport, isNull);
+    });
+  });
+
+  group('dispose', () {
+    test('closes the connection it opened', () async {
+      final _FakeBus bus = _FakeBus(portalVersion: 1);
+      final DBusDesktopNotifier notifier = notifierFor(bus);
+
+      await notifier.show(plain);
+      await notifier.dispose();
+
+      expect(bus.closeCalls, 1);
+    });
+
+    test('is idempotent, and shows nothing afterwards', () async {
+      final _FakeBus bus = _FakeBus(portalVersion: 1);
+      final DBusDesktopNotifier notifier = notifierFor(bus);
+
+      await notifier.show(plain);
+      await notifier.dispose();
+      await notifier.dispose();
+      await notifier.show(plain);
+
+      expect(bus.closeCalls, 1);
+      expect(bus.callsTo('AddNotification'), hasLength(1));
+    });
+
+    test('opens nothing when there was nothing to close', () async {
+      final _FakeBus bus = _FakeBus(portalVersion: 1);
+      final DBusDesktopNotifier notifier = notifierFor(bus);
+
+      await notifier.dispose();
+
+      expect(bus.closeCalls, 0);
+      expect(bus.calls, isEmpty);
+    });
+  });
+}

--- a/test/core/services/notifications/now_playing_notification_test.dart
+++ b/test/core/services/notifications/now_playing_notification_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/media_artwork_source.dart';
+import 'package:linthra/core/services/notifications/desktop_notifier.dart';
+import 'package:linthra/core/services/notifications/now_playing_notification.dart';
+
+/// A [MediaArtworkSource] holding exactly the covers a test says are cached.
+class _FakeArtwork implements MediaArtworkSource {
+  _FakeArtwork({this.files = const <String, String>{}});
+
+  /// Reference string -> cached file path.
+  final Map<String, String> files;
+
+  final List<Uri> asked = <Uri>[];
+
+  @override
+  Uri? cached(Uri reference) => throw UnimplementedError(
+        'the notification path must ask for the file form, not the '
+        'Android content:// form',
+      );
+
+  @override
+  Uri? cachedFileUri(Uri reference) {
+    asked.add(reference);
+    final String? path = files[reference.toString()];
+    return path == null ? null : Uri.file(path);
+  }
+
+  @override
+  Stream<Uri> get coverReady => const Stream<Uri>.empty();
+}
+
+Track _track({
+  String title = 'Trouble',
+  String? artist = 'Cat Power',
+  String? album = 'Moon Pix',
+  String uri = 'jellyfin:track-7',
+  Uri? artworkUri,
+}) =>
+    Track(
+      id: 'track-7',
+      title: title,
+      uri: uri,
+      artistName: artist,
+      albumName: album,
+      albumId: 'jellyfin:al-3',
+      artworkUri: artworkUri,
+    );
+
+void main() {
+  group('what is said', () {
+    test('the title and the catalog subtitle, and nothing else', () {
+      final DesktopNotification notification = nowPlayingNotification(_track());
+
+      expect(notification.title, 'Trouble');
+      expect(notification.body, 'Cat Power • Moon Pix');
+      expect(notification.image, isNull);
+    });
+
+    test('an unknown artist and album leave the body empty', () {
+      final DesktopNotification notification = nowPlayingNotification(
+        _track(artist: null, album: null),
+      );
+
+      expect(notification.title, 'Trouble');
+      expect(notification.body, isEmpty);
+    });
+
+    test('a track with no title reads as unknown, never as its path', () {
+      final DesktopNotification notification = nowPlayingNotification(
+        _track(title: '   ', uri: '/home/dana/Music/Secret Project/01.flac'),
+      );
+
+      expect(notification.title, kUnknownTrackNotificationTitle);
+      expect(notification.body, 'Cat Power • Moon Pix');
+    });
+
+    test('nothing a server or a filesystem knows leaks into it', () {
+      final DesktopNotification notification = nowPlayingNotification(
+        _track(
+          uri: 'https://music.example.com/stream?id=7&api_key=SECRET-TOKEN',
+          artworkUri: Uri.parse(
+            'https://music.example.com/art/7?api_key=SECRET-TOKEN',
+          ),
+        ),
+      );
+
+      final String everything =
+          '${notification.title}|${notification.body}|${notification.image}';
+      for (final String forbidden in <String>[
+        'SECRET-TOKEN',
+        'api_key',
+        'music.example.com',
+        'jellyfin:al-3',
+        'track-7',
+      ]) {
+        expect(everything, isNot(contains(forbidden)));
+      }
+    });
+  });
+
+  group('artwork', () {
+    test('a cover Linthra cached as a file passes through', () {
+      final Uri cover = Uri.file('/home/dana/.cache/linthra/local/abc.img');
+
+      expect(safeNotificationImage(cover), cover);
+    });
+
+    test('a credentialed or remote cover URL never goes out', () {
+      expect(
+        safeNotificationImage(
+          Uri.parse('https://music.example.com/art/7?api_key=SECRET-TOKEN'),
+        ),
+        isNull,
+      );
+      expect(
+        safeNotificationImage(Uri.parse('http://192.168.1.9/art/7')),
+        isNull,
+      );
+    });
+
+    test('an Android content:// cover never goes out', () {
+      // Nothing on a Linux desktop can open one, and it is the platform's
+      // FileProvider form rather than a file.
+      expect(
+        safeNotificationImage(
+          Uri.parse('content://io.github.thezupzup.linthra.mediaartwork/a.img'),
+        ),
+        isNull,
+      );
+    });
+
+    test('an app-internal reference goes out only once it is cached', () {
+      final Uri reference = Uri.parse('subsonic-cover:al-27');
+      final _FakeArtwork empty = _FakeArtwork();
+
+      expect(safeNotificationImage(reference, artwork: empty), isNull);
+      expect(empty.asked, <Uri>[reference]);
+
+      final _FakeArtwork warmed = _FakeArtwork(
+        files: <String, String>{
+          'subsonic-cover:al-27': '/home/dana/.cache/linthra/media/9f.img',
+        },
+      );
+      expect(
+        safeNotificationImage(reference, artwork: warmed),
+        Uri.file('/home/dana/.cache/linthra/media/9f.img'),
+      );
+    });
+
+    test('a reference with no artwork cache at all is simply no cover', () {
+      expect(safeNotificationImage(Uri.parse('plex-thumb:/library/1')), isNull);
+      expect(safeNotificationImage(null), isNull);
+    });
+
+    test('the built notification carries the cached cover', () {
+      final DesktopNotification notification = nowPlayingNotification(
+        _track(artworkUri: Uri.parse('subsonic-cover:al-27')),
+        artwork: _FakeArtwork(
+          files: <String, String>{
+            'subsonic-cover:al-27': '/home/dana/.cache/linthra/media/9f.img',
+          },
+        ),
+      );
+
+      expect(
+        notification.image,
+        Uri.file('/home/dana/.cache/linthra/media/9f.img'),
+      );
+    });
+  });
+}

--- a/test/core/services/notifications/platform_desktop_notifier_test.dart
+++ b/test/core/services/notifications/platform_desktop_notifier_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/core/services/notifications/desktop_notifier.dart';
+import 'package:linthra/core/services/notifications/platform_desktop_notifier.dart';
+
+/// Records what it was asked to do, so the platform split can be asserted
+/// without a session bus.
+class _RecordingNotifier implements DesktopNotifier {
+  _RecordingNotifier({required this.isSupported});
+
+  @override
+  final bool isSupported;
+
+  final List<DesktopNotification> shown = <DesktopNotification>[];
+  int disposeCount = 0;
+
+  @override
+  Future<void> show(DesktopNotification notification) async =>
+      shown.add(notification);
+
+  @override
+  Future<void> dispose() async => disposeCount++;
+}
+
+void main() {
+  const DesktopNotification notification = DesktopNotification(
+    title: 'Trouble',
+    body: 'Cat Power',
+  );
+
+  group('PlatformDesktopNotifier', () {
+    test('on Linux, routes to the D-Bus notifier', () async {
+      final _RecordingNotifier linux = _RecordingNotifier(isSupported: true);
+      final _RecordingNotifier fallback =
+          _RecordingNotifier(isSupported: false);
+      final PlatformDesktopNotifier notifier = PlatformDesktopNotifier(
+        host: HostPlatform.linux,
+        linuxNotifier: linux,
+        fallbackNotifier: fallback,
+      );
+
+      expect(notifier.isSupported, isTrue);
+      await notifier.show(notification);
+
+      expect(linux.shown, <DesktopNotification>[notification]);
+      expect(fallback.shown, isEmpty);
+    });
+
+    test('on Android, shows nothing and reports itself unsupported', () async {
+      final _RecordingNotifier linux = _RecordingNotifier(isSupported: true);
+      final _RecordingNotifier fallback =
+          _RecordingNotifier(isSupported: false);
+      final PlatformDesktopNotifier notifier = PlatformDesktopNotifier(
+        host: HostPlatform.android,
+        linuxNotifier: linux,
+        fallbackNotifier: fallback,
+      );
+
+      expect(notifier.isSupported, isFalse);
+      await notifier.show(notification);
+
+      // The Android per-track notification is the media session's, drawn by
+      // the system. Nothing here may add a second one.
+      expect(linux.shown, isEmpty);
+      expect(fallback.shown, <DesktopNotification>[notification]);
+    });
+
+    test('macOS and Windows get the no-op too', () {
+      for (final HostPlatform host in <HostPlatform>[
+        HostPlatform.macOS,
+        HostPlatform.windows,
+        HostPlatform.ios,
+        HostPlatform.other,
+      ]) {
+        expect(
+          PlatformDesktopNotifier(host: host).isSupported,
+          isFalse,
+          reason: 'D-Bus notifications are Linux’s alone',
+        );
+      }
+    });
+
+    test('disposing never creates the Linux notifier it did not need',
+        () async {
+      final _RecordingNotifier fallback =
+          _RecordingNotifier(isSupported: false);
+      final PlatformDesktopNotifier notifier = PlatformDesktopNotifier(
+        host: HostPlatform.android,
+        fallbackNotifier: fallback,
+      );
+
+      await notifier.dispose();
+
+      expect(fallback.disposeCount, 1);
+    });
+
+    test('disposing releases the Linux notifier it did create', () async {
+      final _RecordingNotifier linux = _RecordingNotifier(isSupported: true);
+      final PlatformDesktopNotifier notifier = PlatformDesktopNotifier(
+        host: HostPlatform.linux,
+        linuxNotifier: linux,
+      );
+
+      await notifier.show(notification);
+      await notifier.dispose();
+
+      expect(linux.disposeCount, 1);
+    });
+  });
+}

--- a/test/core/services/notifications/track_change_notifier_test.dart
+++ b/test/core/services/notifications/track_change_notifier_test.dart
@@ -269,6 +269,29 @@ void main() {
 
       expect(announced(), <String>['Song 1']);
     });
+
+    test('a track dropped by turning it off counts as already observed', () {
+      observer.onState(_state(_track('1')));
+      clock += const Duration(seconds: 1);
+      observer.onState(_state(_track('2')));
+      enabled = false;
+      timers.single.fire();
+      expect(announced(), <String>['Song 1']);
+
+      // Back on, with the same song still playing. Same rule as turning it on
+      // mid-track: quiet until the next real change, not a toast for a song
+      // that has been playing for minutes.
+      enabled = true;
+      clock += const Duration(seconds: 30);
+      observer.onState(
+        _state(_track('2'), position: const Duration(seconds: 30)),
+      );
+      expect(announced(), <String>['Song 1']);
+
+      clock += const Duration(minutes: 3);
+      observer.onState(_state(_track('3')));
+      expect(announced(), <String>['Song 1', 'Song 3']);
+    });
   });
 
   group('rapid skipping', () {

--- a/test/core/services/notifications/track_change_notifier_test.dart
+++ b/test/core/services/notifications/track_change_notifier_test.dart
@@ -1,0 +1,413 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/notifications/desktop_notifier.dart';
+import 'package:linthra/core/services/notifications/track_change_notifier.dart';
+
+Track _track(String id) => Track(
+      id: id,
+      title: 'Song $id',
+      uri: 'jellyfin:$id',
+      artistName: 'Artist $id',
+      duration: const Duration(minutes: 3),
+    );
+
+PlaybackState _state(
+  Track? track, {
+  PlaybackStatus status = PlaybackStatus.playing,
+  Duration position = Duration.zero,
+}) =>
+    PlaybackState(
+      status: status,
+      currentTrack: track,
+      position: position,
+      duration: const Duration(minutes: 3),
+    );
+
+/// A notifier that records what it was asked to show, and can refuse.
+class _RecordingNotifier implements DesktopNotifier {
+  _RecordingNotifier({this.isSupported = true, this.failWith});
+
+  @override
+  final bool isSupported;
+
+  /// Thrown by every [show] when set: a daemon that is not there.
+  final Object? failWith;
+
+  final List<DesktopNotification> shown = <DesktopNotification>[];
+  int disposeCount = 0;
+
+  @override
+  Future<void> show(DesktopNotification notification) async {
+    shown.add(notification);
+    final Object? failure = failWith;
+    if (failure != null) throw failure;
+  }
+
+  @override
+  Future<void> dispose() async => disposeCount++;
+}
+
+class _FakeTimer implements Timer {
+  _FakeTimer(this.delay, this._callback);
+
+  final Duration delay;
+  final void Function() _callback;
+  bool cancelled = false;
+
+  @override
+  void cancel() => cancelled = true;
+
+  @override
+  bool get isActive => !cancelled;
+
+  @override
+  int get tick => 0;
+
+  /// Runs the scheduled callback, the way real time would.
+  void fire() {
+    if (cancelled) return;
+    _callback();
+  }
+}
+
+void main() {
+  late _RecordingNotifier notifier;
+  late List<_FakeTimer> timers;
+  late DateTime clock;
+  late bool enabled;
+  late TrackChangeNotifier observer;
+
+  /// The titles announced, in order: enough to say *which* track each
+  /// notification was for.
+  List<String> announced() =>
+      notifier.shown.map((DesktopNotification n) => n.title).toList();
+
+  TrackChangeNotifier build({
+    _RecordingNotifier? recording,
+    Duration minInterval = const Duration(seconds: 5),
+  }) {
+    notifier = recording ?? _RecordingNotifier();
+    return observer = TrackChangeNotifier(
+      states: const Stream<PlaybackState>.empty(),
+      notifier: notifier,
+      enabled: () => enabled,
+      build: (Track track) => DesktopNotification(
+        title: track.title,
+        body: track.artistName ?? '',
+      ),
+      minInterval: minInterval,
+      now: () => clock,
+      createTimer: (Duration delay, void Function() callback) {
+        final _FakeTimer timer = _FakeTimer(delay, callback);
+        timers.add(timer);
+        return timer;
+      },
+    );
+  }
+
+  setUp(() {
+    timers = <_FakeTimer>[];
+    clock = DateTime.utc(2026, 1, 1);
+    enabled = true;
+    build();
+  });
+
+  tearDown(() => observer.dispose());
+
+  group('a real track change', () {
+    test('announces the track that starts playing', () {
+      observer.onState(_state(_track('1')));
+
+      expect(announced(), <String>['Song 1']);
+      expect(notifier.shown.single.body, 'Artist 1');
+    });
+
+    test('announces the next track when it starts playing', () {
+      observer.onState(_state(_track('1')));
+      clock = clock.add(const Duration(minutes: 3));
+      observer.onState(_state(_track('2')));
+
+      expect(announced(), <String>['Song 1', 'Song 2']);
+    });
+
+    test('position updates on the same track say nothing', () {
+      observer.onState(_state(_track('1')));
+      for (int second = 1; second <= 30; second++) {
+        clock = clock.add(const Duration(seconds: 1));
+        observer.onState(
+          _state(_track('1'), position: Duration(seconds: second)),
+        );
+      }
+
+      expect(announced(), <String>['Song 1']);
+    });
+
+    test('a pause and a resume say nothing', () {
+      final Track track = _track('1');
+      observer.onState(_state(track));
+      clock = clock.add(const Duration(minutes: 1));
+      observer.onState(_state(track, status: PlaybackStatus.paused));
+      clock = clock.add(const Duration(minutes: 1));
+      observer.onState(_state(track));
+
+      expect(announced(), <String>['Song 1']);
+    });
+
+    test('the same track state pushed twice does not announce twice', () {
+      final PlaybackState state = _state(_track('1'));
+      observer.onState(state);
+      observer.onState(state);
+      clock = clock.add(const Duration(minutes: 3));
+      observer.onState(state);
+
+      expect(announced(), <String>['Song 1']);
+    });
+
+    test('a queue rebuild carrying the same song says nothing', () {
+      // A fresh Track object for the same song: what a re-queue, a favourite
+      // toggle or a catalog refresh produces.
+      observer.onState(_state(_track('1')));
+      clock = clock.add(const Duration(minutes: 1));
+      observer.onState(_state(_track('1')));
+
+      expect(announced(), <String>['Song 1']);
+    });
+
+    test('repeat-one starting the same song again says nothing', () {
+      final Track track = _track('1');
+      observer.onState(_state(track, position: const Duration(minutes: 2)));
+      clock = clock.add(const Duration(minutes: 1));
+      // The replay: same track, back at the beginning.
+      observer.onState(_state(track));
+
+      expect(announced(), <String>['Song 1']);
+    });
+
+    test('a track that starts while buffering is announced', () {
+      // Buffering means the engine is working toward sound on this track,
+      // which is as much a track change as reaching playing.
+      observer.onState(_state(_track('1'), status: PlaybackStatus.buffering));
+
+      expect(announced(), <String>['Song 1']);
+    });
+
+    test('a reconnect mid-stream says nothing', () {
+      final Track track = _track('1');
+      observer.onState(_state(track));
+      clock = clock.add(const Duration(minutes: 1));
+      observer.onState(
+        _state(track, status: PlaybackStatus.reconnecting),
+      );
+
+      expect(announced(), <String>['Song 1']);
+    });
+  });
+
+  group('nothing is playing', () {
+    test('a track that is only loading is not announced', () {
+      observer.onState(_state(_track('1'), status: PlaybackStatus.loading));
+
+      expect(announced(), isEmpty);
+    });
+
+    test('a queue restored paused is not announced', () {
+      observer.onState(_state(_track('1'), status: PlaybackStatus.paused));
+
+      expect(announced(), isEmpty);
+    });
+
+    test('a load that errored is not announced', () {
+      observer.onState(_state(_track('1'), status: PlaybackStatus.error));
+
+      expect(announced(), isEmpty);
+    });
+
+    test('an empty player is not announced', () {
+      observer.onState(_state(null, status: PlaybackStatus.idle));
+
+      expect(announced(), isEmpty);
+    });
+  });
+
+  group('the preference', () {
+    test('off announces nothing at all', () {
+      enabled = false;
+      observer.onState(_state(_track('1')));
+      clock = clock.add(const Duration(minutes: 3));
+      observer.onState(_state(_track('2')));
+
+      expect(announced(), isEmpty);
+      expect(timers, isEmpty);
+    });
+
+    test('turning it on mid-track stays quiet until the next change', () {
+      enabled = false;
+      observer.onState(_state(_track('1')));
+      enabled = true;
+      clock = clock.add(const Duration(seconds: 30));
+      // Still the same song, just a later position.
+      observer.onState(
+        _state(_track('1'), position: const Duration(seconds: 30)),
+      );
+
+      expect(announced(), isEmpty);
+
+      clock = clock.add(const Duration(minutes: 3));
+      observer.onState(_state(_track('2')));
+      expect(announced(), <String>['Song 2']);
+    });
+
+    test('turning it off while a burst waits cancels the pending one', () {
+      observer.onState(_state(_track('1')));
+      clock = clock.add(const Duration(seconds: 1));
+      observer.onState(_state(_track('2')));
+      enabled = false;
+      timers.single.fire();
+
+      expect(announced(), <String>['Song 1']);
+    });
+  });
+
+  group('rapid skipping', () {
+    test('a burst produces one notification, for the track landed on', () {
+      observer.onState(_state(_track('1')));
+      for (final String id in <String>['2', '3', '4', '5']) {
+        clock = clock.add(const Duration(milliseconds: 400));
+        observer.onState(_state(_track(id)));
+      }
+
+      // Nothing beyond the first has reached the daemon yet, and the whole
+      // burst shares one timer.
+      expect(announced(), <String>['Song 1']);
+      expect(timers, hasLength(1));
+
+      timers.single.fire();
+      expect(announced(), <String>['Song 1', 'Song 5']);
+    });
+
+    test('the wait is only the rest of the window', () {
+      observer.onState(_state(_track('1')));
+      clock = clock.add(const Duration(seconds: 4));
+      observer.onState(_state(_track('2')));
+
+      expect(timers.single.delay, const Duration(seconds: 1));
+    });
+
+    test('a change past the window announces immediately', () {
+      observer.onState(_state(_track('1')));
+      clock = clock.add(const Duration(seconds: 5));
+      observer.onState(_state(_track('2')));
+
+      expect(announced(), <String>['Song 1', 'Song 2']);
+      expect(timers, isEmpty);
+    });
+
+    test('the window restarts from the coalesced notification', () {
+      observer.onState(_state(_track('1')));
+      clock = clock.add(const Duration(seconds: 1));
+      observer.onState(_state(_track('2')));
+      timers.single.fire();
+      expect(announced(), <String>['Song 1', 'Song 2']);
+
+      // One second after the coalesced one: still inside the window.
+      clock = clock.add(const Duration(seconds: 1));
+      observer.onState(_state(_track('3')));
+      expect(announced(), <String>['Song 1', 'Song 2']);
+      expect(timers, hasLength(2));
+    });
+
+    test('dispose drops a pending announcement', () async {
+      observer.onState(_state(_track('1')));
+      clock = clock.add(const Duration(seconds: 1));
+      observer.onState(_state(_track('2')));
+
+      await observer.dispose();
+      expect(timers.single.cancelled, isTrue);
+      timers.single.fire();
+
+      expect(announced(), <String>['Song 1']);
+    });
+  });
+
+  group('a notification backend that fails', () {
+    test('never reaches the caller, and the next track is still tried',
+        () async {
+      build(recording: _RecordingNotifier(failWith: StateError('no daemon')));
+
+      expect(() => observer.onState(_state(_track('1'))), returnsNormally);
+      clock = clock.add(const Duration(minutes: 3));
+      expect(() => observer.onState(_state(_track('2'))), returnsNormally);
+
+      // Both were attempted; both failures were swallowed.
+      await Future<void>.delayed(Duration.zero);
+      expect(announced(), <String>['Song 1', 'Song 2']);
+    });
+
+    test('a failing notifier does not stop the state stream', () async {
+      final StreamController<PlaybackState> states =
+          StreamController<PlaybackState>();
+      addTearDown(states.close);
+      final _RecordingNotifier failing =
+          _RecordingNotifier(failWith: StateError('no daemon'));
+      final TrackChangeNotifier live = TrackChangeNotifier(
+        states: states.stream,
+        notifier: failing,
+        enabled: () => true,
+        build: (Track track) => DesktopNotification(title: track.title),
+        now: () => clock,
+      );
+      addTearDown(live.dispose);
+      live.start();
+
+      states.add(_state(_track('1')));
+      await Future<void>.delayed(Duration.zero);
+      clock = clock.add(const Duration(minutes: 3));
+      states.add(_state(_track('2')));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        failing.shown.map((DesktopNotification n) => n.title),
+        <String>['Song 1', 'Song 2'],
+      );
+    });
+  });
+
+  group('a platform with no notifications', () {
+    test('an unsupported notifier is never asked to show anything', () {
+      build(recording: _RecordingNotifier(isSupported: false));
+
+      observer.onState(_state(_track('1')));
+      clock = clock.add(const Duration(minutes: 3));
+      observer.onState(_state(_track('2')));
+
+      expect(announced(), isEmpty);
+    });
+  });
+
+  group('start', () {
+    test('is idempotent, so one track change announces once', () async {
+      final StreamController<PlaybackState> states =
+          StreamController<PlaybackState>.broadcast();
+      addTearDown(states.close);
+      final _RecordingNotifier recording = _RecordingNotifier();
+      final TrackChangeNotifier live = TrackChangeNotifier(
+        states: states.stream,
+        notifier: recording,
+        enabled: () => true,
+        build: (Track track) => DesktopNotification(title: track.title),
+        now: () => clock,
+      );
+      addTearDown(live.dispose);
+      live.start();
+      live.start();
+
+      states.add(_state(_track('1')));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(recording.shown, hasLength(1));
+    });
+  });
+}

--- a/test/core/services/notifications/track_change_notifier_test.dart
+++ b/test/core/services/notifications/track_change_notifier_test.dart
@@ -76,7 +76,7 @@ class _FakeTimer implements Timer {
 void main() {
   late _RecordingNotifier notifier;
   late List<_FakeTimer> timers;
-  late DateTime clock;
+  late Duration clock;
   late bool enabled;
   late TrackChangeNotifier observer;
 
@@ -99,7 +99,7 @@ void main() {
         body: track.artistName ?? '',
       ),
       minInterval: minInterval,
-      now: () => clock,
+      elapsed: () => clock,
       createTimer: (Duration delay, void Function() callback) {
         final _FakeTimer timer = _FakeTimer(delay, callback);
         timers.add(timer);
@@ -110,7 +110,7 @@ void main() {
 
   setUp(() {
     timers = <_FakeTimer>[];
-    clock = DateTime.utc(2026, 1, 1);
+    clock = Duration.zero;
     enabled = true;
     build();
   });
@@ -127,7 +127,7 @@ void main() {
 
     test('announces the next track when it starts playing', () {
       observer.onState(_state(_track('1')));
-      clock = clock.add(const Duration(minutes: 3));
+      clock += const Duration(minutes: 3);
       observer.onState(_state(_track('2')));
 
       expect(announced(), <String>['Song 1', 'Song 2']);
@@ -136,7 +136,7 @@ void main() {
     test('position updates on the same track say nothing', () {
       observer.onState(_state(_track('1')));
       for (int second = 1; second <= 30; second++) {
-        clock = clock.add(const Duration(seconds: 1));
+        clock += const Duration(seconds: 1);
         observer.onState(
           _state(_track('1'), position: Duration(seconds: second)),
         );
@@ -148,9 +148,9 @@ void main() {
     test('a pause and a resume say nothing', () {
       final Track track = _track('1');
       observer.onState(_state(track));
-      clock = clock.add(const Duration(minutes: 1));
+      clock += const Duration(minutes: 1);
       observer.onState(_state(track, status: PlaybackStatus.paused));
-      clock = clock.add(const Duration(minutes: 1));
+      clock += const Duration(minutes: 1);
       observer.onState(_state(track));
 
       expect(announced(), <String>['Song 1']);
@@ -160,7 +160,7 @@ void main() {
       final PlaybackState state = _state(_track('1'));
       observer.onState(state);
       observer.onState(state);
-      clock = clock.add(const Duration(minutes: 3));
+      clock += const Duration(minutes: 3);
       observer.onState(state);
 
       expect(announced(), <String>['Song 1']);
@@ -170,7 +170,7 @@ void main() {
       // A fresh Track object for the same song: what a re-queue, a favourite
       // toggle or a catalog refresh produces.
       observer.onState(_state(_track('1')));
-      clock = clock.add(const Duration(minutes: 1));
+      clock += const Duration(minutes: 1);
       observer.onState(_state(_track('1')));
 
       expect(announced(), <String>['Song 1']);
@@ -179,7 +179,7 @@ void main() {
     test('repeat-one starting the same song again says nothing', () {
       final Track track = _track('1');
       observer.onState(_state(track, position: const Duration(minutes: 2)));
-      clock = clock.add(const Duration(minutes: 1));
+      clock += const Duration(minutes: 1);
       // The replay: same track, back at the beginning.
       observer.onState(_state(track));
 
@@ -197,7 +197,7 @@ void main() {
     test('a reconnect mid-stream says nothing', () {
       final Track track = _track('1');
       observer.onState(_state(track));
-      clock = clock.add(const Duration(minutes: 1));
+      clock += const Duration(minutes: 1);
       observer.onState(
         _state(track, status: PlaybackStatus.reconnecting),
       );
@@ -236,7 +236,7 @@ void main() {
     test('off announces nothing at all', () {
       enabled = false;
       observer.onState(_state(_track('1')));
-      clock = clock.add(const Duration(minutes: 3));
+      clock += const Duration(minutes: 3);
       observer.onState(_state(_track('2')));
 
       expect(announced(), isEmpty);
@@ -247,7 +247,7 @@ void main() {
       enabled = false;
       observer.onState(_state(_track('1')));
       enabled = true;
-      clock = clock.add(const Duration(seconds: 30));
+      clock += const Duration(seconds: 30);
       // Still the same song, just a later position.
       observer.onState(
         _state(_track('1'), position: const Duration(seconds: 30)),
@@ -255,14 +255,14 @@ void main() {
 
       expect(announced(), isEmpty);
 
-      clock = clock.add(const Duration(minutes: 3));
+      clock += const Duration(minutes: 3);
       observer.onState(_state(_track('2')));
       expect(announced(), <String>['Song 2']);
     });
 
     test('turning it off while a burst waits cancels the pending one', () {
       observer.onState(_state(_track('1')));
-      clock = clock.add(const Duration(seconds: 1));
+      clock += const Duration(seconds: 1);
       observer.onState(_state(_track('2')));
       enabled = false;
       timers.single.fire();
@@ -275,7 +275,7 @@ void main() {
     test('a burst produces one notification, for the track landed on', () {
       observer.onState(_state(_track('1')));
       for (final String id in <String>['2', '3', '4', '5']) {
-        clock = clock.add(const Duration(milliseconds: 400));
+        clock += const Duration(milliseconds: 400);
         observer.onState(_state(_track(id)));
       }
 
@@ -290,7 +290,7 @@ void main() {
 
     test('the wait is only the rest of the window', () {
       observer.onState(_state(_track('1')));
-      clock = clock.add(const Duration(seconds: 4));
+      clock += const Duration(seconds: 4);
       observer.onState(_state(_track('2')));
 
       expect(timers.single.delay, const Duration(seconds: 1));
@@ -298,7 +298,7 @@ void main() {
 
     test('a change past the window announces immediately', () {
       observer.onState(_state(_track('1')));
-      clock = clock.add(const Duration(seconds: 5));
+      clock += const Duration(seconds: 5);
       observer.onState(_state(_track('2')));
 
       expect(announced(), <String>['Song 1', 'Song 2']);
@@ -307,21 +307,89 @@ void main() {
 
     test('the window restarts from the coalesced notification', () {
       observer.onState(_state(_track('1')));
-      clock = clock.add(const Duration(seconds: 1));
+      clock += const Duration(seconds: 1);
       observer.onState(_state(_track('2')));
       timers.single.fire();
       expect(announced(), <String>['Song 1', 'Song 2']);
 
       // One second after the coalesced one: still inside the window.
-      clock = clock.add(const Duration(seconds: 1));
+      clock += const Duration(seconds: 1);
       observer.onState(_state(_track('3')));
       expect(announced(), <String>['Song 1', 'Song 2']);
       expect(timers, hasLength(2));
     });
 
+    test('skipping back to the announced track drops the waiting one', () {
+      observer.onState(_state(_track('1')));
+      clock += const Duration(seconds: 1);
+      observer.onState(_state(_track('2')));
+      // Straight back to the song they were already told about.
+      clock += const Duration(seconds: 1);
+      observer.onState(_state(_track('1')));
+      timers.single.fire();
+
+      // Announcing "Song 2" here would name the track they skipped away from.
+      expect(announced(), <String>['Song 1']);
+    });
+
+    test('pausing inside the window drops the waiting announcement', () {
+      observer.onState(_state(_track('1')));
+      clock += const Duration(seconds: 1);
+      observer.onState(_state(_track('2')));
+      clock += const Duration(seconds: 1);
+      observer.onState(_state(_track('2'), status: PlaybackStatus.paused));
+      timers.single.fire();
+
+      expect(announced(), <String>['Song 1']);
+
+      // Still announced properly once it really is playing again.
+      clock += const Duration(seconds: 10);
+      observer.onState(_state(_track('2')));
+      expect(announced(), <String>['Song 1', 'Song 2']);
+    });
+
+    test('the queue emptying inside the window drops it too', () {
+      observer.onState(_state(_track('1')));
+      clock += const Duration(seconds: 1);
+      observer.onState(_state(_track('2')));
+      clock += const Duration(seconds: 1);
+      observer.onState(_state(null, status: PlaybackStatus.idle));
+      timers.single.fire();
+
+      expect(announced(), <String>['Song 1']);
+    });
+
+    test('a track still playing when the window closes is announced', () {
+      observer.onState(_state(_track('1')));
+      clock += const Duration(seconds: 1);
+      observer.onState(_state(_track('2')));
+      // Ordinary position ticks on the pending track keep it valid.
+      for (int second = 2; second <= 4; second++) {
+        clock += const Duration(seconds: 1);
+        observer.onState(
+          _state(_track('2'), position: Duration(seconds: second)),
+        );
+      }
+      timers.single.fire();
+
+      expect(announced(), <String>['Song 1', 'Song 2']);
+    });
+
+    test('a clock that jumps backwards never buys silence', () {
+      observer.onState(_state(_track('1')));
+      // What a wall clock does on an NTP correction. The real source is
+      // monotonic, so this is the guard rather than the normal path: the
+      // window must read as passed, not as an hour of negative gap.
+      clock -= const Duration(hours: 1);
+      observer.onState(_state(_track('2')));
+
+      expect(announced(), <String>['Song 1', 'Song 2']);
+      expect(timers, isEmpty);
+    });
+
     test('dispose drops a pending announcement', () async {
       observer.onState(_state(_track('1')));
-      clock = clock.add(const Duration(seconds: 1));
+      clock += const Duration(seconds: 1);
       observer.onState(_state(_track('2')));
 
       await observer.dispose();
@@ -338,7 +406,7 @@ void main() {
       build(recording: _RecordingNotifier(failWith: StateError('no daemon')));
 
       expect(() => observer.onState(_state(_track('1'))), returnsNormally);
-      clock = clock.add(const Duration(minutes: 3));
+      clock += const Duration(minutes: 3);
       expect(() => observer.onState(_state(_track('2'))), returnsNormally);
 
       // Both were attempted; both failures were swallowed.
@@ -357,14 +425,14 @@ void main() {
         notifier: failing,
         enabled: () => true,
         build: (Track track) => DesktopNotification(title: track.title),
-        now: () => clock,
+        elapsed: () => clock,
       );
       addTearDown(live.dispose);
       live.start();
 
       states.add(_state(_track('1')));
       await Future<void>.delayed(Duration.zero);
-      clock = clock.add(const Duration(minutes: 3));
+      clock += const Duration(minutes: 3);
       states.add(_state(_track('2')));
       await Future<void>.delayed(Duration.zero);
 
@@ -380,7 +448,7 @@ void main() {
       build(recording: _RecordingNotifier(isSupported: false));
 
       observer.onState(_state(_track('1')));
-      clock = clock.add(const Duration(minutes: 3));
+      clock += const Duration(minutes: 3);
       observer.onState(_state(_track('2')));
 
       expect(announced(), isEmpty);
@@ -398,7 +466,7 @@ void main() {
         notifier: recording,
         enabled: () => true,
         build: (Track track) => DesktopNotification(title: track.title),
-        now: () => clock,
+        elapsed: () => clock,
       );
       addTearDown(live.dispose);
       live.start();

--- a/test/data/repositories/shared_preferences_desktop_notification_preferences_test.dart
+++ b/test/data/repositories/shared_preferences_desktop_notification_preferences_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/data/repositories/shared_preferences_desktop_notification_preferences.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  group('SharedPreferencesDesktopNotificationPreferences', () {
+    const SharedPreferencesDesktopNotificationPreferences preferences =
+        SharedPreferencesDesktopNotificationPreferences();
+
+    test('nothing stored reads as off', () async {
+      // The conservative default, and what a build without this feature did.
+      expect(await preferences.trackChangeNotifications(), isFalse);
+    });
+
+    test('round-trips the choice', () async {
+      await preferences.setTrackChangeNotifications(true);
+      expect(await preferences.trackChangeNotifications(), isTrue);
+
+      await preferences.setTrackChangeNotifications(false);
+      expect(await preferences.trackChangeNotifications(), isFalse);
+    });
+
+    test('reads a value an earlier run stored', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'desktop_track_change_notifications': true,
+      });
+
+      expect(await preferences.trackChangeNotifications(), isTrue);
+    });
+  });
+}

--- a/test/features/settings/desktop/desktop_notifications_section_test.dart
+++ b/test/features/settings/desktop/desktop_notifications_section_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/core/services/notifications/desktop_notifier.dart';
+import 'package:linthra/data/repositories/desktop_notification_preferences_provider.dart';
+import 'package:linthra/data/repositories/desktop_notifier_provider.dart';
+import 'package:linthra/data/repositories/host_platform_provider.dart';
+import 'package:linthra/data/repositories/in_memory_desktop_notification_preferences.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/settings/desktop/desktop_notifications_section.dart';
+import 'package:linthra/features/settings/hub/music_and_playback_screen.dart';
+
+import '../../player/fake_playback_controller.dart';
+
+/// A notifier that only answers whether it exists: enough for a card that
+/// decides whether to render.
+class _StubNotifier implements DesktopNotifier {
+  const _StubNotifier({required this.isSupported});
+
+  @override
+  final bool isSupported;
+
+  @override
+  Future<void> show(DesktopNotification notification) async {}
+
+  @override
+  Future<void> dispose() async {}
+}
+
+void main() {
+  group('DesktopNotificationsSettingsSection', () {
+    late InMemoryDesktopNotificationPreferences preferences;
+
+    Future<void> pump(
+      WidgetTester tester, {
+      bool stored = false,
+      bool supported = true,
+      Widget child = const DesktopNotificationsSettingsSection(),
+      HostPlatform host = HostPlatform.linux,
+    }) async {
+      preferences =
+          InMemoryDesktopNotificationPreferences(trackChanges: stored);
+      final FakePlaybackController playback = FakePlaybackController();
+      addTearDown(playback.dispose);
+      final container = ProviderContainer(
+        overrides: <Override>[
+          desktopNotificationPreferencesProvider.overrideWithValue(preferences),
+          desktopNotifierProvider
+              .overrideWithValue(_StubNotifier(isSupported: supported)),
+          hostPlatformProvider.overrideWithValue(host),
+          // The Music & playback page reaches the playback controller; the
+          // real one on Linux opens libmpv.
+          playbackControllerProvider.overrideWithValue(playback),
+        ],
+      );
+      addTearDown(container.dispose);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(home: Scaffold(body: child)),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('says what it does, and starts off', (tester) async {
+      await pump(tester);
+
+      expect(find.text('Desktop notifications'), findsOneWidget);
+      expect(find.text('Notify me when the track changes'), findsOneWidget);
+      expect(tester.widget<SwitchListTile>(find.byType(SwitchListTile)).value,
+          isFalse);
+    });
+
+    testWidgets('reflects a stored choice', (tester) async {
+      await pump(tester, stored: true);
+
+      expect(tester.widget<SwitchListTile>(find.byType(SwitchListTile)).value,
+          isTrue);
+    });
+
+    testWidgets('turning it on persists the choice', (tester) async {
+      await pump(tester);
+
+      await tester.tap(find.byType(SwitchListTile));
+      await tester.pumpAndSettle();
+
+      expect(await preferences.trackChangeNotifications(), isTrue);
+      expect(tester.widget<SwitchListTile>(find.byType(SwitchListTile)).value,
+          isTrue);
+    });
+
+    testWidgets('turning it off again persists that too', (tester) async {
+      await pump(tester, stored: true);
+
+      await tester.tap(find.byType(SwitchListTile));
+      await tester.pumpAndSettle();
+
+      expect(await preferences.trackChangeNotifications(), isFalse);
+    });
+
+    testWidgets('renders nothing where notifications are unsupported',
+        (tester) async {
+      await pump(tester, supported: false);
+
+      expect(find.byType(SwitchListTile), findsNothing);
+      expect(find.text('Desktop notifications'), findsNothing);
+    });
+
+    testWidgets('the Music & playback page shows the card on a desktop',
+        (tester) async {
+      // Tall enough for the whole page: the card is the last one on it, and a
+      // ListView does not build what it cannot show.
+      tester.view.physicalSize = const Size(1200, 3600);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      await pump(tester, child: const MusicAndPlaybackScreen());
+
+      expect(
+        find.byType(DesktopNotificationsSettingsSection),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('Android never sees it: its notification is the session’s',
+        (tester) async {
+      tester.view.physicalSize = const Size(1200, 3600);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      await pump(
+        tester,
+        child: const MusicAndPlaybackScreen(),
+        host: HostPlatform.android,
+        supported: false,
+      );
+
+      expect(find.byType(DesktopNotificationsSettingsSection), findsNothing);
+    });
+  });
+}

--- a/test/features/settings/desktop/track_change_notifications_controller_test.dart
+++ b/test/features/settings/desktop/track_change_notifications_controller_test.dart
@@ -1,0 +1,141 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/repositories/desktop_notification_preferences.dart';
+import 'package:linthra/data/repositories/desktop_notification_preferences_provider.dart';
+import 'package:linthra/features/settings/desktop/track_change_notifications_controller.dart';
+
+/// Preferences whose writes the test decides when, and whether, to finish,
+/// standing in for the platform round-trip `shared_preferences` makes. One
+/// gate per call, so two overlapping writes can settle in either order.
+class _GatedPreferences implements DesktopNotificationPreferences {
+  _GatedPreferences({this.stored = false});
+
+  bool stored;
+  final List<Completer<void>> writes = <Completer<void>>[];
+
+  @override
+  Future<bool> trackChangeNotifications() async => stored;
+
+  @override
+  Future<void> setTrackChangeNotifications(bool enabled) async {
+    final Completer<void> gate = Completer<void>();
+    writes.add(gate);
+    await gate.future;
+    stored = enabled;
+  }
+}
+
+/// Preferences that cannot persist anything, standing in for a plugin hiccup.
+class _ThrowingPreferences implements DesktopNotificationPreferences {
+  @override
+  Future<bool> trackChangeNotifications() async => false;
+
+  @override
+  Future<void> setTrackChangeNotifications(bool enabled) async =>
+      throw StateError('write failed');
+}
+
+void main() {
+  group('TrackChangeNotificationsController', () {
+    test('loads the stored choice', () async {
+      final container = ProviderContainer(
+        overrides: <Override>[
+          desktopNotificationPreferencesProvider
+              .overrideWithValue(_GatedPreferences(stored: true)),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        await container.read(trackChangeNotificationsControllerProvider.future),
+        isTrue,
+      );
+    });
+
+    test('applies the choice before the write has landed', () async {
+      final _GatedPreferences preferences = _GatedPreferences();
+      final container = ProviderContainer(
+        overrides: <Override>[
+          desktopNotificationPreferencesProvider.overrideWithValue(preferences),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(trackChangeNotificationsControllerProvider.future);
+
+      final Future<void> pending = container
+          .read(trackChangeNotificationsControllerProvider.notifier)
+          .setEnabled(true);
+
+      // The notification path reads this live on every track change, so it has
+      // to be true the moment the switch is flipped, not once the platform has
+      // finished writing.
+      expect(
+        container.read(trackChangeNotificationsControllerProvider).valueOrNull,
+        isTrue,
+      );
+      expect(preferences.writes, hasLength(1));
+
+      preferences.writes.single.complete();
+      await pending;
+      expect(
+        container.read(trackChangeNotificationsControllerProvider).valueOrNull,
+        isTrue,
+      );
+      expect(preferences.stored, isTrue);
+    });
+
+    test('a write that fails puts the switch back', () async {
+      final container = ProviderContainer(
+        overrides: <Override>[
+          desktopNotificationPreferencesProvider
+              .overrideWithValue(_ThrowingPreferences()),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(trackChangeNotificationsControllerProvider.future);
+
+      await container
+          .read(trackChangeNotificationsControllerProvider.notifier)
+          .setEnabled(true);
+
+      // A switch left on would disagree with the next launch.
+      expect(
+        container.read(trackChangeNotificationsControllerProvider).valueOrNull,
+        isFalse,
+      );
+    });
+
+    test('a failed write never undoes a choice made after it', () async {
+      final _GatedPreferences preferences = _GatedPreferences();
+      final container = ProviderContainer(
+        overrides: <Override>[
+          desktopNotificationPreferencesProvider.overrideWithValue(preferences),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(trackChangeNotificationsControllerProvider.future);
+
+      final TrackChangeNotificationsController controller =
+          container.read(trackChangeNotificationsControllerProvider.notifier);
+      final Future<void> first = controller.setEnabled(true);
+      // Flipped back before the first write settles.
+      final Future<void> second = controller.setEnabled(false);
+      expect(preferences.writes, hasLength(2));
+
+      // The older write fails, the newer one lands. Rolling the first one back
+      // would put the switch on again, against what was chosen last.
+      preferences.writes[0].completeError(StateError('write failed'));
+      preferences.writes[1].complete();
+      await first;
+      await second;
+
+      expect(
+        container.read(trackChangeNotificationsControllerProvider).valueOrNull,
+        isFalse,
+      );
+      expect(preferences.stored, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Closes #400

Optional native Linux notifications when the current track changes. Off by default: a desktop shell already draws a now-playing card from Linthra's MPRIS session, so a toast per track is an addition someone asks for rather than something a music player should start doing to their screen. Settings → Music & playback → **Desktop notifications** turns it on, and turns it off completely.

## When it notifies

`TrackChangeNotifier` is a pure observer of the playback state stream, the same shape as `PlaybackHistoryRecorder`: it never touches the queue, the controller or the audio engine. Three rules reduce a stream that ticks several times a second to real transitions:

- the track's logical identity has to differ from the last one announced, so position ticks, a pause, a resume, a seek, a volume change, a mid-stream reconnect and a queue rebuild that re-creates the same song all say nothing. Repeat-one is included in that on purpose: starting the same song again is not a new song;
- something has to actually be playing. A queue restored paused at launch, a track loaded but not started and a load that errored are all "nothing is playing";
- at most one notification every five seconds, measured on a monotonic clock so a time correction cannot silence the next one for the length of the correction.

Rapid skipping is coalesced rather than dropped: the newest eligible track replaces whatever is waiting, one timer covers the whole burst, and the track the listener lands on is the one announced. A waiting announcement is only made if it is still true when the window closes, so skipping to a track and back inside those five seconds, or pausing inside them, drops it rather than naming a track the listener has left.

The preference is read live on every candidate, so turning it off silences the next change and a burst already waiting on its timer. The switch also applies before its value is persisted, since persisting is a platform round-trip and a track change inside it would otherwise still see the old answer.

## What it says

`nowPlayingNotification` is the whole of what Linthra is willing to tell a notification daemon, as a pure function, so the rule sits in one readable place instead of inside a D-Bus call. It sends the title and the catalog's "Artist • Album" subtitle. It never sends the track URI (an authenticated stream URL for a remote track, the listener's own file path for a local one), a track or album id, anything naming the server, a cover reference, or a URL of any kind. A track with no title reads as "Unknown track", never as its path.

Because that metadata comes from a configured server rather than from Linthra, the subtitle is escaped for the freedesktop route, whose body is markup-capable: unescaped, an ordinary `&` in a name is invalid markup a daemon may drop, and a server could put formatting or a link in an artist name and have the desktop render it. The portal's body is literal text by contract and is deliberately left alone, since escaping there would show a visible `&amp;`.

Artwork follows the rule MPRIS already publishes `mpris:artUrl` under, narrowed for a consumer that opens files instead of fetching URLs:

- a `file:` cover passes through. Every one in the catalog is a copy Linthra wrote into its own artwork cache, under the application cache directory, which resolves to the same path inside a Flatpak and outside it, so the daemon can actually open it;
- an app-internal reference (`subsonic-cover:`, `plex-thumb:`) goes out only as the local copy the media-artwork cache has already fetched. Nothing is fetched on the track change itself;
- `http(s)` covers are dropped: a daemon does not fetch a URL for an image, and a cover URL is the shape a credentialed one would arrive in;
- `content:` covers are dropped, since that is Android's FileProvider form.

## How it reaches the desktop

A desktop notification is a D-Bus method call, so that is what this makes, over the same `dbus` package MPRIS already uses. No new dependency, no native code, and no subprocess: shelling out to `notify-send` would mean a music player spawning a binary off `PATH` with strings built from track metadata, and it does not exist inside the Flatpak anyway.

`DBusDesktopNotifier` tries two routes and remembers which one answered:

1. `org.freedesktop.portal.Notification`, first, because it is the only route a sandboxed Linthra has.
2. `org.freedesktop.Notifications`, for a host with no portal running (a bare window manager with `dunst`, say).

One notification is kept rather than a pile: a fixed id on the portal route, `replaces_id` on the spec route. The spec route also asks for low urgency and marks the notification transient. The portal is given a cover only when it reports interface version 2, where the `bytes` icon form was added, bounded to 512 KiB.

## Flatpak

No permission changes, and none needed. The portal is tried first precisely because the sandbox has no `--talk-name` and is not going to get one (`scripts/check_flatpak_permissions.py` refuses every spelling of one), and `docs/flatpak-permissions.md` already described notifications as portal-only. That page now points at the code; `check_flatpak_permissions.py` still reports the same eight permissions.

## Failure, and Android

Failure is silent and cannot reach playback: every delivery is guarded and never awaited by playback. Each call also carries a five-second deadline, and because `Future.timeout` ends the wait rather than the D-Bus call underneath it, a timeout drops the connection as well, which is what actually abandons the outstanding call and stops it landing a stale notification later. The next track change opens a fresh one.

Android is untouched. `PlatformDesktopNotifier` answers with the no-op anywhere but Linux, the observer is never created off the desktop, and the settings card renders nothing there, so the per-track notification on Android stays the media session's.

## Tests

`flutter analyze` clean, `dart format` clean, full suite green (5519 tests). New coverage:

- one notification on a track change, and none for position updates, a pause/resume, a repeated state, a queue rebuild, repeat-one or a reconnect;
- nothing announced while loading, paused, idle or errored;
- the preference off, turning it on mid-track, turning it off while a burst waits, and turning it back on afterwards with the same song still playing;
- rapid-skip rate limiting: one notification per window, for the track landed on, with one timer for the burst; a pending announcement dropped when the listener skips back, pauses, or empties the queue inside the window; and a clock that jumps backwards not buying silence;
- a notification backend that throws never reaches the caller and never stops the state stream;
- the metadata and artwork filter, including that no token, URL, path or id can get out, and the markup escaping on the spec body with its absence from the portal body and the summary;
- both transports, portal version 1 versus 2, nothing on the bus, a service that never replies having its connection abandoned, and dispose;
- the platform split, and the preference: loading, applying before the write lands, rolling back a failed write, and not undoing a later tap.

Manual checks a real desktop has to answer are listed in the new **Track change notifications** section of `docs/linux-desktop.md`.
