### PR TITLE
fix(android-auto): stop the car swallowing Next/Previous presses (#638)

### DIFF
--- a/docs/android-auto.md
+++ b/docs/android-auto.md
@@ -99,13 +99,42 @@ repeat stay consistent however you press a button.
   a head unit that caches the capability set when it connects keeps its
   Next / Previous and queue-row buttons live regardless of where you are in the
   queue.
+- While a track change is **opening** the next track, the session reports
+  `AudioProcessingState.buffering` — never `loading`. That distinction is not
+  cosmetic: `loading` is the one value `audio_service` maps to
+  `PlaybackStateCompat.STATE_CONNECTING`, which the platform defines as "this
+  session is connecting to a new destination". Android Auto reads it that way —
+  it shows its connecting placeholder, drops the progress it was drawing, and
+  **stops dispatching transport presses** — so a Next pressed during the change
+  was acknowledged by the car and never reached Linthra. Since Linthra enters
+  the controller's `loading` state on *every* track change (it publishes it
+  while resolving the next track's playable URI, a network round trip on a
+  remote source), that window covered most of the time a listener actually
+  presses Next, which is what made the car's Next/Previous look unreliable
+  (#638). Buffering is also simply the truthful state — the item is being
+  prepared — and the session keeps reporting `playing` through the change, so
+  the foreground service is held exactly as before. Bluetooth/headset and
+  notification buttons never regressed with it: those arrive as media-button
+  intents the session dispatches whatever state it is in.
 - The **visible** notification / lock-screen buttons are still gated: the
   `skipToPrevious` button only appears once a previous track exists and
   `skipToNext` only while one is queued, so no dead button is ever shown.
 - At a queue boundary (Next on the last track, Previous on the first) the action
   is a safe no-op — the queue and the now-playing state are left untouched.
 - Previous always steps to the previous track (it does not restart the current
-  track first); there is no "double-press to go back" behaviour.
+  track first); there is no "double-press to go back" behaviour. The car gets
+  the *shared* policy: `LinthraAudioHandler.skipToPrevious` calls
+  `PlaybackController.skipToPrevious` and nothing else, so if that policy ever
+  changes the car follows it without a second implementation to keep in step.
+- One press is one navigation. The controller moves its queue pointer
+  synchronously before it awaits anything, so two quick presses advance twice
+  and one press can never advance twice.
+- The session handler is attached **once per process**
+  (`connectMediaSession`). A second attach reuses the live handler rather than
+  initialising `audio_service` again, which would leave two handlers mirroring
+  into the same session, and a handler that is detached is inert — a command
+  still in flight across a reconnect can't drive a controller it no longer
+  speaks for.
 
 ### Browse tree
 
@@ -217,6 +246,27 @@ You should see, in order:
 - `play: album-track resolved=true` — a selection resolved to something
   playable. `resolved=false` means a stale id resolved to nothing.
 
+Transport commands are breadcrumbed separately, under the `linthra.stability`
+tag:
+
+```sh
+adb logcat | grep linthra.stability
+```
+
+Those logcat lines are **debug builds only**. In a release build the same
+breadcrumbs are still recorded, in the bounded in-memory event log the "Report a
+bug" flow can attach — so a listener's report can carry them without a laptop.
+
+- `skip command: next` / `skip command: previous` — a Next/Previous arrived
+  through the media session. Android routes the car's on-screen control, a
+  steering-wheel or Bluetooth button, a wired headset and the notification all
+  through the one session, so the specific transport isn't distinguishable —
+  what matters is that the command reached the app at all.
+- `play command: media-session` / `pause command: media-session` — the same for
+  play/pause.
+
+These are secret-free: a fixed label, never a track, id, URL or token.
+
 ## Build / install
 
 ```sh
@@ -259,7 +309,10 @@ Reference: <https://developer.android.com/training/cars/testing/dhu>
 ### B) Real car / head unit
 
 Use the [manual checklist](#manual-checklist) below. You still need Developer
-mode → **Add unknown sources** enabled for a sideloaded build.
+mode → **Add unknown sources** enabled for a sideloaded build. If you only have
+five minutes, run the
+[track navigation smoke test](#track-navigation-smoke-test) instead — it is the
+one that catches a broken Next/Previous.
 
 ## Manual checklist
 
@@ -282,7 +335,10 @@ mode → **Add unknown sources** enabled for a sideloaded build.
 12. Browse **Offline** and play a downloaded track (if you have any) — confirm it
     plays (ideally with the phone offline, to prove no network is needed).
 13. Press the car / head-unit **Next** / **Previous** — confirm Linthra skips
-    correctly (Previous steps back; it does not restart the current track first).
+    correctly (Previous steps back; it does not restart the current track
+    first). The [track navigation smoke test](#track-navigation-smoke-test)
+    below covers this properly; run it on anything that touches the media
+    session, the playback controller, or the queue.
 14. Open the car's **Up Next** list and tap a row — confirm playback jumps to it.
 15. Test **shuffle / repeat** and **Play / Pause** — confirm both stay in sync.
 16. **Lock the phone screen** and press car **Next** — confirm music keeps
@@ -296,6 +352,46 @@ mode → **Add unknown sources** enabled for a sideloaded build.
     ever shown (only titles, artists, albums).
 20. Skim `adb logcat | grep Linthra.AndroidAuto` — confirm **no tokens or
     authenticated stream URLs** appear (only category labels and counts).
+
+## Track navigation smoke test
+
+The short run to make on any build that touches the media session, playback
+controller, or queue. It is the check that would have caught #638, where the
+car's Next/Previous stopped reliably changing the song in v0.2.6.
+
+Takes about five minutes on a real head unit or the DHU.
+
+**Setup.** Install the build, open Linthra once on the phone, and start an album
+or playlist with **at least 3 tracks**. Leave a `adb logcat | grep -E
+"Linthra.AndroidAuto|linthra.stability"` running if you can — it is what turns a
+"nothing happened" into a diagnosis.
+
+| # | Do this | Expect |
+| - | ------- | ------ |
+| 1 | Connect Android Auto and open Linthra's now-playing screen. | The current track, its artist/album, artwork, and a **running progress bar**. |
+| 2 | Press **Next** once. | Exactly **one** track forward. Title, artist, artwork and progress all follow within a second or so. |
+| 3 | Press **Next** three more times, roughly one press per second. | Three tracks forward — not two, not five. Every press lands even though each one starts a new track opening. |
+| 4 | Press **Previous** twice. | Two tracks back. Previous steps back; it does **not** restart the current track first. |
+| 5 | Pause, then press **Next**. | The track changes while still paused, and the card updates. It does not start playing on its own. |
+| 6 | Lock the phone, press **Next** on the head unit. | Music keeps playing and skips cleanly, with no drop-out across the change. |
+| 7 | Go to the **first** track and press **Previous**; go to the **last** and press **Next**. | Both are quiet no-ops. Nothing restarts, nothing jumps to the other end of the queue, and the buttons stay live. |
+| 8 | Turn **shuffle** on, press Next a few times; then **repeat-all**, then **repeat-one**. | Navigation follows the same order the phone shows. Repeat/shuffle state stays in sync between the car and the app. |
+| 9 | Disconnect Android Auto, wait a few seconds, reconnect, press **Next**. | One track forward. Not two — a reconnect must not leave a second handler taking the same press. |
+| 10 | Disconnect Android Auto. Start playback from the phone, **then** connect. Press **Next**. | One track forward, with the session showing the track that was already playing. |
+| 11 | Open the car's **Up Next** list and tap a row. | Playback jumps to that row and the highlight moves to it. |
+| 12 | Back on the phone: use the **notification** Next/Previous, then a **Bluetooth/headset** button. | Both still work, and the car stays in sync with them. |
+| 13 | Reopen Linthra on the phone. | It shows the track the car ended on, and there is no second, duplicate playback. |
+
+**Reading the log when a press seems to do nothing.** Every navigation command
+that reaches the app records a `skip command: next` / `skip command: previous`
+breadcrumb. That is what separates the two very different causes:
+
+- **No breadcrumb** — the press never reached Linthra. The head unit swallowed
+  it, which is the #638 shape: check that the session is not sitting in
+  `STATE_CONNECTING` (i.e. that a track change reports *buffering*, not
+  *loading*).
+- **A breadcrumb, but no track change** — the command arrived and was a
+  legitimate no-op: you are at a queue boundary, or the queue holds one track.
 
 ## Troubleshooting
 
@@ -338,6 +434,34 @@ mode → **Add unknown sources** enabled for a sideloaded build.
 - On Android 13+, the media notification (and some controls) require the
   `POST_NOTIFICATIONS` runtime permission — grant it when prompted on first
   launch, or in system app settings.
+
+### Next / Previous doesn't change the song
+
+Work it in this order — the first step tells you which half of the path is at
+fault, and they need completely different fixes.
+
+1. **Did the command reach the app?** On a debug build,
+   `adb logcat | grep linthra.stability` and press Next; a `skip command: next`
+   line means it did. On a release build, ask for the same breadcrumbs through
+   "Report a bug" with recent app events included.
+2. **No line at all** — the head unit never dispatched the press. That is the
+   #638 failure: the session was reporting `PlaybackStateCompat.STATE_CONNECTING`
+   (from `AudioProcessingState.loading`) for the whole of every track change,
+   and Android Auto suspends its transport row in that state. A track change
+   must report *buffering*. The notification and Bluetooth buttons keep working
+   while this is broken, because a media-button intent is dispatched whatever
+   state the session is in — so "the car is broken but my headphones aren't" is
+   the signature, not a coincidence.
+3. **A line, but no track change** — the command arrived and the controller made
+   it a no-op. Check where you are in the queue: Next on the last track and
+   Previous on the first are deliberate no-ops, and a one-track queue has
+   nowhere to go. Next does not wrap even with repeat-all on; only auto-advance
+   at the end of a track does.
+4. **Two track changes for one press** — something attached the session twice.
+   `connectMediaSession` attaches once per process and logs
+   `media session already attached (reusing the live handler)` if it is asked
+   again; a second `AudioService.init` would leave two handlers mirroring into
+   one session.
 
 ### Cast vs Android Auto
 

--- a/docs/dependency-license-audit.md
+++ b/docs/dependency-license-audit.md
@@ -200,6 +200,7 @@ listed for completeness.
 | `flutter_test`  | (SDK)        | flutter.dev | BSD-3-Clause | Test framework. |
 | `drift_dev`     | `^2.18.0`    | simonbinder.eu | MIT       | Drift code generation. |
 | `build_runner`  | `^2.4.13`    | dart.dev  | BSD-3-Clause   | Runs the code generators. |
+| `audio_service_platform_interface` | `^0.1.3` | ryanheise.com | MIT | Test-only: the Android media-session boundary test. Already in the graph under `audio_service`. |
 
 ## 5. Native / bundled components
 

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:developer' as developer;
 
 import 'package:audio_service/audio_service.dart' as audio;
+import 'package:flutter/foundation.dart' show visibleForTesting;
 
 import '../models/playback_state.dart';
 import '../models/repeat_mode.dart';
@@ -140,6 +141,22 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   Track? _lastBroadcastTrack;
   Duration? _lastBroadcastDuration;
 
+  // Whether this handler has been detached from the session ([dispose]).
+  //
+  // A detached handler must never drive the controller again. `audio_service`
+  // hands a command to whichever handler its callbacks currently point at, and
+  // a rebind installs a new one — but nothing tears the old one down, and a
+  // command already in flight (or a car that still holds a reference across a
+  // reconnect) can still land on it. Forwarding then would run the *same* press
+  // through the controller twice, once per live handler. Every transport
+  // command checks this first, so a superseded handler is inert rather than a
+  // second, invisible driver of the queue (#638).
+  bool _detached = false;
+
+  /// Whether [dispose] has run, i.e. this handler no longer speaks for the
+  /// session and forwards nothing to the controller.
+  bool get isDetached => _detached;
+
   /// The most rows the platform session's queue ever carries.
   ///
   /// The published queue is delivered to every media controller — Android Auto
@@ -166,38 +183,71 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   static const Duration _positionResyncThreshold = Duration(seconds: 1);
 
   @override
-  Future<void> play() {
+  Future<void> play() async {
+    if (_detached) return;
     // A play that arrived through the platform media session: the user tapped
     // the notification / lock-screen play, or Android Auto / Bluetooth / a
     // headset sent PLAY. Breadcrumb it (secret-free) so every legitimate resume
     // is accounted for and distinguishable from an unwanted self-resume — which,
     // with the engine's audio-focus auto-resume disabled, no longer happens.
     StabilityDiagnostics.playCommand('media-session');
-    return _controller.play();
+    await _controller.play();
   }
 
   @override
-  Future<void> pause() {
+  Future<void> pause() async {
+    if (_detached) return;
     // A pause that arrived through the platform media session: the notification
     // / lock-screen pause, or Android Auto / Bluetooth / a headset sending
     // PAUSE. Breadcrumb it (secret-free) so a screen-off "it paused by itself"
     // report can tell a real session PAUSE apart from an audio-focus-loss or
     // becoming-noisy pause (both logged under `audio focus:` by the engine).
     StabilityDiagnostics.pauseCommand('media-session');
-    return _controller.pause();
+    await _controller.pause();
   }
 
   @override
   Future<void> stop() async {
+    if (_detached) return;
     await _controller.stop();
     await super.stop();
   }
 
+  /// Advances one track, on behalf of whoever pressed Next: Android Auto's
+  /// on-screen control, a steering-wheel or Bluetooth button, a wired headset,
+  /// or the notification. They all arrive here, and all of them mean the same
+  /// thing, so this forwards to the one shared [PlaybackController.skipToNext]
+  /// and does nothing else — no Android-Auto-only queue, no index arithmetic.
+  ///
+  /// Exactly one advance per press: the controller moves its queue pointer
+  /// synchronously before it awaits anything, so two presses in quick
+  /// succession advance twice and one press can never advance twice. At the end
+  /// of the queue it is a safe no-op, and the shared repeat/shuffle policy
+  /// applies exactly as it does in the app.
   @override
-  Future<void> skipToNext() => _controller.skipToNext();
+  Future<void> skipToNext() async {
+    if (_detached) return;
+    // Breadcrumb it (secret-free) so a "the car's Next did nothing" report can
+    // tell a command that never arrived (no breadcrumb — the head unit swallowed
+    // it) from one that arrived and was a legitimate queue-boundary no-op.
+    StabilityDiagnostics.skipCommand('next');
+    await _controller.skipToNext();
+  }
 
+  /// Steps back, on behalf of whoever pressed Previous — same transports, same
+  /// shared policy as [skipToNext].
+  ///
+  /// It calls [PlaybackController.skipToPrevious] and nothing else, so the car
+  /// gets whatever Linthra's previous-track behaviour is, and keeps getting it
+  /// if that behaviour ever changes: today the controller steps to the previous
+  /// queue item (it does not restart the current track first), and a Previous on
+  /// the first track is a safe no-op.
   @override
-  Future<void> skipToPrevious() => _controller.skipToPrevious();
+  Future<void> skipToPrevious() async {
+    if (_detached) return;
+    StabilityDiagnostics.skipCommand('previous');
+    await _controller.skipToPrevious();
+  }
 
   /// Jumps to the [index]-th row of the published [queue] — what a head unit /
   /// Android Auto's "Up Next" list reports when tapped.
@@ -224,6 +274,7 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   /// as for a skip.
   @override
   Future<void> skipToQueueItem(int index) async {
+    if (_detached) return;
     // Only rows that exist in the queue this handler last published are real.
     final int publishedLength = _lastQueueTracks?.length ?? 0;
     if (index < 0 || index >= publishedLength) return;
@@ -243,16 +294,21 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   }
 
   @override
-  Future<void> seek(Duration position) => _controller.seek(position);
+  Future<void> seek(Duration position) async {
+    if (_detached) return;
+    await _controller.seek(position);
+  }
 
   @override
   Future<void> setShuffleMode(audio.AudioServiceShuffleMode shuffleMode) async {
+    if (_detached) return;
     _controller
         .setShuffleEnabled(shuffleMode != audio.AudioServiceShuffleMode.none);
   }
 
   @override
   Future<void> setRepeatMode(audio.AudioServiceRepeatMode repeatMode) async {
+    if (_detached) return;
     _controller.setRepeatMode(_repeatModeFrom(repeatMode));
   }
 
@@ -297,6 +353,7 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
     String mediaId, [
     Map<String, dynamic>? extras,
   ]) async {
+    if (_detached) return;
     final request = await _tree.resolve(mediaId, _controller.state);
     // Secret-free selection trace: which category was picked and whether it
     // resolved to something playable — useful when "controls don't work" turns
@@ -756,12 +813,47 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
     ];
   }
 
+  /// The session-level processing state for a controller [status].
+  ///
+  /// Opening a track — [PlaybackStatus.loading] — is reported as *buffering*,
+  /// not as `audio_service`'s `loading` (#638).
+  ///
+  /// `AudioProcessingState.loading` is the one value that becomes
+  /// `PlaybackStateCompat.STATE_CONNECTING`
+  /// (`AudioService.getPlaybackState()`), and `STATE_CONNECTING` does not mean
+  /// "preparing the next item" — the platform defines it as the session
+  /// connecting to a *new destination*. Android Auto reads it that way: while
+  /// the session sits in `STATE_CONNECTING` the head unit shows its connecting
+  /// placeholder, drops the position/progress it was drawing, and stops
+  /// dispatching transport presses — so a Next pressed in that window is
+  /// acknowledged by the car and never reaches this handler at all.
+  ///
+  /// Linthra enters `loading` on *every* track change: the controller's
+  /// `_playCurrent` publishes it before resolving the next track's playable
+  /// URI, which on a remote source is a network round trip. In a car that is
+  /// most of the window a listener actually presses Next in, which is what
+  /// made the car's Next/Previous look like it only worked sometimes.
+  /// Bluetooth/headset buttons and the notification never regressed with it
+  /// because those arrive as media-button intents that the session dispatches
+  /// whatever state it is in.
+  ///
+  /// Buffering is also simply the truthful state: the item is being prepared,
+  /// which is exactly what `STATE_BUFFERING` is for, and the car keeps its
+  /// transport row live and its metadata/progress visible across the change.
+  /// This is a *reporting* change only — nothing about the queue, the
+  /// controller, or [PlaybackStatus] moves — and the session keeps reporting
+  /// `playing` through the transition ([_isSessionPlaying]), so the foreground
+  /// service is held exactly as before.
+  ///
+  /// `STATE_CONNECTING` is never the right answer for this session: it has no
+  /// destination to connect to. Cast routing is resolved by
+  /// `ActivePlaybackController` before any state reaches this bridge, so what
+  /// arrives here is always a local view of one already-chosen output.
   audio.AudioProcessingState _processingStateFor(PlaybackStatus status) {
     switch (status) {
       case PlaybackStatus.idle:
         return audio.AudioProcessingState.idle;
       case PlaybackStatus.loading:
-        return audio.AudioProcessingState.loading;
       case PlaybackStatus.buffering:
       case PlaybackStatus.reconnecting:
         return audio.AudioProcessingState.buffering;
@@ -775,9 +867,18 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
     }
   }
 
-  /// Stops mirroring controller state. Call before disposing the controller.
+  /// Stops mirroring controller state and makes this handler inert.
+  ///
+  /// Call before disposing the controller, and whenever this handler stops being
+  /// the session's handler. Idempotent, and it closes both directions: no
+  /// further state is mirrored *out*, and any command that still arrives *in* —
+  /// from a car that is reconnecting, or one already in flight when the session
+  /// was rebound — is dropped instead of driving a controller this handler no
+  /// longer speaks for.
   Future<void> dispose() async {
+    _detached = true;
     await _coverReadySub?.cancel();
+    _coverReadySub = null;
     await _subscription.cancel();
   }
 }
@@ -805,6 +906,17 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
 /// breaks basic playback. A failure is logged (secret-free) under [_logName] so
 /// a silent "no media session / not in Android Auto" is diagnosable from
 /// `adb logcat`.
+///
+/// **Attaches at most once per process.** A second call returns the handler that
+/// is already attached instead of initialising `audio_service` again (#638).
+/// `AudioService.init` installs a fresh set of platform callbacks and starts a
+/// fresh set of stream observers each time it runs, but it tears none of the
+/// previous ones down: a second init would leave the first handler mirroring
+/// state into the *same* platform session — two writers racing over the
+/// notification, the now-playing metadata and the car's Up Next list — while
+/// commands went to the second. It is an assertion error in debug and silent in
+/// release, which is exactly the shape of a bug that only shows up on a real
+/// head unit, so the guard is here rather than left to the caller.
 Future<LinthraAudioHandler?> connectMediaSession(
   PlaybackController controller,
   MusicLibraryRepository library, {
@@ -813,6 +925,14 @@ Future<LinthraAudioHandler?> connectMediaSession(
   DownloadRepository? downloads,
   MediaArtworkSource? artwork,
 }) async {
+  final LinthraAudioHandler? attached = _attachedHandler;
+  if (attached != null && !attached.isDetached) {
+    _log('media session already attached (reusing the live handler)');
+    return attached;
+  }
+  // A detached handler is never handed back: it forwards nothing, so returning
+  // it would look like a live session and behave like none at all.
+  _attachedHandler = null;
   try {
     final handler = await audio.AudioService.init(
       builder: () => LinthraAudioHandler(
@@ -871,6 +991,7 @@ Future<LinthraAudioHandler?> connectMediaSession(
         artDownscaleHeight: 256,
       ),
     );
+    _attachedHandler = handler;
     _log('media session attached (Android Auto browser ready)');
     return handler;
   } catch (error) {
@@ -881,4 +1002,23 @@ Future<LinthraAudioHandler?> connectMediaSession(
     _log('media session init failed: ${error.runtimeType}');
     return null;
   }
+}
+
+/// The handler currently attached to the platform media session, or null when
+/// none is. Process-scoped because `audio_service`'s session is: it belongs to
+/// the Android foreground service, not to any one app object.
+LinthraAudioHandler? _attachedHandler;
+
+/// Detaches the attached session handler, so a later [connectMediaSession] can
+/// attach a fresh one.
+///
+/// Only for tests. Production never detaches on Android: the session outlives
+/// the app object (see `AudioServiceMediaSessionBinding`). Disposing the old
+/// handler is the point — it makes it inert, so a stale command can't reach a
+/// controller it no longer speaks for.
+@visibleForTesting
+Future<void> resetAttachedMediaSession() async {
+  final LinthraAudioHandler? handler = _attachedHandler;
+  _attachedHandler = null;
+  await handler?.dispose();
 }

--- a/lib/core/services/stability_diagnostics.dart
+++ b/lib/core/services/stability_diagnostics.dart
@@ -168,4 +168,24 @@ abstract final class StabilityDiagnostics {
   }
 
   static String describePauseCommand(String source) => 'pause command: $source';
+
+  /// A track-navigation command that arrived through the platform media session
+  /// — Android Auto's on-screen Next/Previous, a steering-wheel or Bluetooth
+  /// button, a wired headset, or the notification. [direction] is `next` or
+  /// `previous`; Android routes every transport through the one session, so the
+  /// specific hardware isn't distinguishable here.
+  ///
+  /// Recorded because "the car's Next did nothing" has two very different
+  /// causes and only this tells them apart: **no** breadcrumb means the command
+  /// never reached the app (the head unit swallowed the press — the #638
+  /// failure, where the session was reporting `STATE_CONNECTING` across every
+  /// track change), while a breadcrumb with no following track change means it
+  /// arrived and was a legitimate queue-boundary no-op.
+  static void skipCommand(String direction) {
+    SafeEventLog.instance.record('skip', direction);
+    _log(describeSkipCommand(direction));
+  }
+
+  static String describeSkipCommand(String direction) =>
+      'skip command: $direction';
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -58,7 +58,7 @@ packages:
     source: hosted
     version: "0.18.18"
   audio_service_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: audio_service_platform_interface
       sha256: "6283782851f6c8b501b60904a32fc7199dc631172da0629d7301e66f672ab777"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -147,6 +147,13 @@ dev_dependencies:
   # produces the *.g.dart files that back LinthraDatabase.
   drift_dev: ^2.18.0
   build_runner: ^2.4.13
+  # Test-only. audio_service's platform seam, already in the graph as one of its
+  # own dependencies. The Android media-session boundary test needs it directly
+  # to install the *Android* AudioServicePlatform on a Linux test host and to
+  # drive the real handler method channel, so a car's Next/Previous is tested
+  # across the channel the Android plugin actually uses rather than against a
+  # Dart stand-in. Nothing in lib/ imports it.
+  audio_service_platform_interface: ^0.1.3
 
 flutter:
   uses-material-design: true

--- a/test/core/services/android_media_session_boundary_test.dart
+++ b/test/core/services/android_media_session_boundary_test.dart
@@ -1,0 +1,344 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:audio_service_platform_interface/audio_service_platform_interface.dart';
+import 'package:audio_service_platform_interface/method_channel_audio_service.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/linthra_audio_handler.dart';
+
+import '../../features/library/fake_music_library_repository.dart';
+import '../../features/player/fake_playback_controller.dart';
+
+/// The real Android media-session boundary, exercised end to end.
+///
+/// Everything below crosses the *actual* platform channels `audio_service`'s
+/// Android plugin uses, in both directions:
+///
+///  * **inbound** — `AudioService.MediaSessionCallback.onSkipToNext()` calls
+///    `AudioServicePlugin.invokeMethod("skipToNext", mapOf())` on the
+///    `com.ryanheise.audio_service.handler.methods` channel. That is precisely
+///    the message delivered here, encoded with the same standard codec, so the
+///    decode + dispatch path a car's Next press takes is the one under test —
+///    not a Dart stand-in for it.
+///  * **outbound** — what the plugin's `onMethodCall` would then receive
+///    (`setState`, `setMediaItem`, `setQueue`) is captured as the raw argument
+///    maps, so the assertions are about the bytes the Android session is
+///    actually built from (`PlaybackStateCompat`'s action bits, its active
+///    queue item id, its state constant) rather than about Dart objects.
+///
+/// This is the level the #638 regression lived at: the Dart handler forwarded
+/// Next correctly all along, but the session it published told Android Auto it
+/// was `STATE_CONNECTING` for the whole of every track change, and the head
+/// unit stops dispatching transport presses in that state.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const MethodChannel handlerChannel =
+      MethodChannel('com.ryanheise.audio_service.handler.methods');
+  const MethodChannel clientChannel =
+      MethodChannel('com.ryanheise.audio_service.client.methods');
+
+  const MethodChannel pathProviderChannel =
+      MethodChannel('plugins.flutter.io/path_provider');
+
+  /// Every call the plugin would have received since the last reset — used to
+  /// count how many times the session was written to.
+  final List<MethodCall> published = <MethodCall>[];
+
+  /// The `PlaybackStateCompat` inputs of the session's *current* state: the
+  /// last `setState` the plugin was handed, whenever it happened. Kept outside
+  /// [published] because a command that is correctly a no-op publishes nothing,
+  /// and the session still has to be showing the right thing afterwards.
+  Map<Object?, Object?>? sessionState;
+
+  late FakePlaybackController controller;
+
+  Track track(String id) => Track(
+        id: id,
+        title: 'Song $id',
+        uri: '/$id.mp3',
+        artistName: 'Artist $id',
+        albumName: 'Album $id',
+      );
+
+  final List<Track> album = <Track>[track('a'), track('b'), track('c')];
+
+  final TestDefaultBinaryMessenger messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  /// Delivers [method] on the handler channel exactly as the Android
+  /// `MediaSessionCallback` does when a head unit, a steering-wheel button or
+  /// the notification acts on the session.
+  Future<void> fromMediaSession(
+    String method, [
+    Map<String, dynamic> arguments = const <String, dynamic>{},
+  ]) async {
+    await messenger.handlePlatformMessage(
+      handlerChannel.name,
+      const StandardMethodCodec()
+          .encodeMethodCall(MethodCall(method, arguments)),
+      (_) {},
+    );
+    await _settle();
+  }
+
+  /// The argument map of the most recent [method] the plugin would have been
+  /// handed, or null when it was never called.
+  Map<Object?, Object?>? lastPublished(String method) {
+    for (final MethodCall call in published.reversed) {
+      if (call.method == method) return call.arguments as Map<Object?, Object?>;
+    }
+    return null;
+  }
+
+  /// The `PlaybackStateCompat` inputs the Android session currently holds.
+  Map<Object?, Object?> lastState() => sessionState!;
+
+  List<Map<Object?, Object?>> publishedStates() => <Map<Object?, Object?>>[
+        for (final MethodCall call in published)
+          if (call.method == 'setState')
+            (call.arguments as Map<Object?, Object?>)['state']!
+                as Map<Object?, Object?>,
+      ];
+
+  setUpAll(() async {
+    // The Android implementation, not the Linux no-op the test host defaults to.
+    AudioServicePlatform.instance = MethodChannelAudioService();
+    // audio_service builds a DefaultCacheManager for remote artwork during
+    // init; it needs a temp directory and never gets used here (no track in
+    // this suite carries an http cover).
+    messenger.setMockMethodCallHandler(
+        pathProviderChannel,
+        (MethodCall call) async =>
+            Directory.systemTemp.createTempSync('linthra_media_session').path);
+    messenger.setMockMethodCallHandler(clientChannel, (MethodCall call) async {
+      published.add(call);
+      return null;
+    });
+    messenger.setMockMethodCallHandler(handlerChannel, (MethodCall call) async {
+      published.add(call);
+      if (call.method == 'setState') {
+        sessionState = (call.arguments as Map<Object?, Object?>)['state']
+            as Map<Object?, Object?>;
+      }
+      return null;
+    });
+
+    controller = FakePlaybackController();
+    // The app's own attach path — the same call `bootstrapApplication` makes.
+    final handler = await connectMediaSession(
+      controller,
+      FakeMusicLibraryRepository(tracks: album),
+    );
+    expect(handler, isNotNull,
+        reason: 'the media session did not attach at the platform boundary');
+  });
+
+  tearDownAll(() async {
+    await resetAttachedMediaSession();
+    messenger.setMockMethodCallHandler(clientChannel, null);
+    messenger.setMockMethodCallHandler(handlerChannel, null);
+    messenger.setMockMethodCallHandler(pathProviderChannel, null);
+    await controller.dispose();
+  });
+
+  /// Starts [tracks] at [startIndex] and clears everything recorded so far, so
+  /// each test asserts only on what its own command produced.
+  Future<void> startQueue({int startIndex = 0, List<Track>? tracks}) async {
+    await controller.playTracks(tracks ?? album, startIndex: startIndex);
+    await _settle();
+    controller.skipCount = 0;
+    controller.previousCount = 0;
+    published.clear();
+  }
+
+  group('a car Next press crosses the media-session boundary (#638)', () {
+    test('reaches the controller exactly once and advances one track',
+        () async {
+      await startQueue();
+
+      await fromMediaSession('skipToNext');
+
+      expect(controller.skipCount, 1);
+      expect(controller.state.currentTrack?.id, 'b');
+    });
+
+    test('republishes the new track metadata to the session', () async {
+      await startQueue();
+
+      await fromMediaSession('skipToNext');
+
+      final Map<Object?, Object?> item =
+          lastPublished('setMediaItem')!['mediaItem']! as Map<Object?, Object?>;
+      expect(item['id'], 'b');
+      expect(item['title'], 'Song b');
+      expect(item['artist'], 'Artist b');
+      expect(item['album'], 'Album b');
+    });
+
+    test('moves the active queue row the head unit highlights', () async {
+      await startQueue();
+      await fromMediaSession('skipToNext');
+      expect(lastState()['queueIndex'], 1);
+
+      await fromMediaSession('skipToNext');
+      expect(lastState()['queueIndex'], 2);
+
+      await fromMediaSession('skipToPrevious');
+      expect(lastState()['queueIndex'], 1);
+    });
+
+    test('keeps the session out of STATE_CONNECTING while the track opens',
+        () async {
+      // `AudioProcessingStateMessage.loading` is the one value
+      // `AudioService.getPlaybackState()` turns into
+      // PlaybackStateCompat.STATE_CONNECTING, and a session in that state has
+      // its transport suspended by Android Auto — which is how a Next press
+      // could be acknowledged by the car and never arrive here at all.
+      await startQueue();
+
+      await fromMediaSession('skipToNext');
+      // The controller opens the next track before it can play it; this is the
+      // state it publishes while resolving its playable URI.
+      controller
+          .emit(controller.state.copyWith(status: PlaybackStatus.loading));
+      await _settle();
+
+      expect(
+        publishedStates()
+            .map((Map<Object?, Object?> s) => s['processingState']),
+        isNot(contains(AudioProcessingStateMessage.loading.index)),
+      );
+      expect(lastState()['processingState'],
+          AudioProcessingStateMessage.buffering.index);
+      // And the foreground service is still held across the change.
+      expect(lastState()['playing'], isTrue);
+    });
+
+    test('advertises skip to the session even at a queue boundary', () async {
+      // A head unit caches the capability set when it connects, so the actions
+      // must not be toggled off at the ends of the queue or its buttons die.
+      await startQueue(startIndex: album.length - 1);
+      await fromMediaSession('skipToNext');
+
+      final List<Object?> systemActions =
+          lastState()['systemActions']! as List<Object?>;
+      expect(systemActions, contains(MediaActionMessage.skipToNext.index));
+      expect(systemActions, contains(MediaActionMessage.skipToPrevious.index));
+      expect(systemActions, contains(MediaActionMessage.skipToQueueItem.index));
+    });
+
+    test('a Next at the end of the queue changes nothing', () async {
+      await startQueue(startIndex: album.length - 1);
+
+      await fromMediaSession('skipToNext');
+
+      expect(controller.skipCount, 1);
+      expect(controller.state.currentTrack?.id, 'c');
+      expect(lastState()['queueIndex'], 2);
+    });
+
+    test('a Previous at the start of the queue changes nothing', () async {
+      await startQueue();
+
+      await fromMediaSession('skipToPrevious');
+
+      expect(controller.previousCount, 1);
+      expect(controller.state.currentTrack?.id, 'a');
+      expect(lastState()['queueIndex'], 0);
+    });
+
+    test('navigating while paused still changes the track', () async {
+      await startQueue();
+      controller.emit(controller.state.copyWith(status: PlaybackStatus.paused));
+      await _settle();
+      published.clear();
+
+      await fromMediaSession('skipToNext');
+
+      expect(controller.state.currentTrack?.id, 'b');
+      final Map<Object?, Object?> item =
+          lastPublished('setMediaItem')!['mediaItem']! as Map<Object?, Object?>;
+      expect(item['id'], 'b');
+    });
+  });
+
+  group('the other transports keep sharing the same path', () {
+    test('a media-button Next (notification / Bluetooth / steering wheel)',
+        () async {
+      // Hardware and notification buttons arrive as a KeyEvent, which the
+      // plugin forwards as `click` with a MediaButton ordinal rather than as
+      // `skipToNext`. Both must land on the same controller call.
+      await startQueue();
+
+      await fromMediaSession(
+          'click', <String, dynamic>{'button': MediaButtonMessage.next.index});
+
+      expect(controller.skipCount, 1);
+      expect(controller.state.currentTrack?.id, 'b');
+    });
+
+    test('a media-button Previous', () async {
+      await startQueue(startIndex: 1);
+
+      await fromMediaSession('click',
+          <String, dynamic>{'button': MediaButtonMessage.previous.index});
+
+      expect(controller.previousCount, 1);
+      expect(controller.state.currentTrack?.id, 'a');
+    });
+
+    test('tapping a row in the car Up Next list jumps to it', () async {
+      await startQueue();
+
+      await fromMediaSession('skipToQueueItem', <String, dynamic>{'index': 2});
+
+      expect(controller.state.currentTrack?.id, 'c');
+      expect(lastState()['queueIndex'], 2);
+    });
+  });
+
+  group('reconnecting does not duplicate the session', () {
+    test('a second attach reuses the live handler, never a second one',
+        () async {
+      // A second `AudioService.init` would install fresh platform callbacks and
+      // fresh stream observers while leaving the old handler mirroring into the
+      // same session: two writers over one notification and one Up Next list.
+      final handlerAgain = await connectMediaSession(
+        controller,
+        FakeMusicLibraryRepository(tracks: album),
+      );
+      expect(handlerAgain, isNotNull);
+
+      await startQueue();
+      await fromMediaSession('skipToNext');
+
+      // One press, one advance — not two handlers each taking the press.
+      expect(controller.skipCount, 1);
+      expect(controller.state.currentTrack?.id, 'b');
+    });
+
+    test('one media item is published per track change, not two', () async {
+      await startQueue();
+
+      await fromMediaSession('skipToNext');
+
+      final Iterable<MethodCall> items =
+          published.where((MethodCall c) => c.method == 'setMediaItem');
+      expect(items, hasLength(1));
+    });
+  });
+}
+
+/// Lets the controller's broadcast reach the handler and the handler's pushes
+/// reach the (mocked) platform channel before assertions read them.
+Future<void> _settle() async {
+  for (int i = 0; i < 4; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -95,6 +95,365 @@ void main() {
       expect(controller.seeks, [const Duration(seconds: 12)]);
     });
 
+    group('Android Auto track navigation (#638)', () {
+      // The car's Next / Previous must reach Linthra's real queue, exactly
+      // once per press, and leave the session showing the track that is now
+      // playing. Everything here goes through the *shared*
+      // PlaybackController API — there is no Android-Auto queue model and no
+      // index is touched behind the controller.
+
+      final List<Track> album = <Track>[
+        _track('a'),
+        _track('b'),
+        _track('c'),
+      ];
+
+      /// The active row the session is advertising, i.e. what a head unit
+      /// highlights in Up Next. Kept window-relative by the handler.
+      int? publishedQueueIndex() => handler.playbackState.value.queueIndex;
+
+      test('next reaches the controller and advances exactly one track',
+          () async {
+        await controller.playTracks(album);
+        await _settle();
+
+        await handler.skipToNext();
+        await _settle();
+
+        expect(controller.skipCount, 1);
+        expect(controller.state.currentTrack?.id, 'b');
+      });
+
+      test('previous reaches the controller and steps back one track',
+          () async {
+        await controller.playTracks(album, startIndex: 2);
+        await _settle();
+
+        await handler.skipToPrevious();
+        await _settle();
+
+        expect(controller.previousCount, 1);
+        expect(controller.state.currentTrack?.id, 'b');
+      });
+
+      test('previous uses the shared step-back behaviour, not a restart',
+          () async {
+        // Linthra's policy is "Previous goes to the previous queue item"; it
+        // does not restart the current track first. The car must get exactly
+        // that, including from a track that is well past its start.
+        await controller.playTracks(album, startIndex: 1);
+        await _settle();
+        controller.emit(
+            controller.state.copyWith(position: const Duration(seconds: 45)));
+        await _settle();
+
+        await handler.skipToPrevious();
+        await _settle();
+
+        expect(controller.state.currentTrack?.id, 'a');
+      });
+
+      test('one press is one advance; three presses are three', () async {
+        await controller.playTracks(<Track>[
+          _track('a'),
+          _track('b'),
+          _track('c'),
+          _track('d'),
+        ]);
+        await _settle();
+
+        await handler.skipToNext();
+        await _settle();
+        expect(controller.state.currentTrack?.id, 'b');
+
+        await handler.skipToNext();
+        await handler.skipToNext();
+        await _settle();
+
+        expect(controller.skipCount, 3);
+        expect(controller.state.currentTrack?.id, 'd');
+      });
+
+      test('a burst of presses never advances more than it was pressed',
+          () async {
+        // A head unit can deliver presses faster than a track loads. Each one
+        // must still be worth exactly one step — no coalescing, no doubling.
+        await controller.playTracks(<Track>[
+          for (int i = 0; i < 6; i++) _track('t$i'),
+        ]);
+        await _settle();
+
+        await Future.wait(<Future<void>>[
+          handler.skipToNext(),
+          handler.skipToNext(),
+        ]);
+        await _settle();
+
+        expect(controller.skipCount, 2);
+        expect(controller.state.currentTrack?.id, 't2');
+      });
+
+      test('the session queue index follows the controller', () async {
+        await controller.playTracks(album);
+        await _settle();
+        expect(publishedQueueIndex(), 0);
+
+        await handler.skipToNext();
+        await _settle();
+        expect(publishedQueueIndex(), 1);
+
+        await handler.skipToNext();
+        await _settle();
+        expect(publishedQueueIndex(), 2);
+
+        await handler.skipToPrevious();
+        await _settle();
+        expect(publishedQueueIndex(), 1);
+      });
+
+      test('the published row always matches the track actually playing',
+          () async {
+        await controller.playTracks(album);
+        await _settle();
+
+        for (int i = 0; i < 2; i++) {
+          await handler.skipToNext();
+          await _settle();
+          final int row = publishedQueueIndex()!;
+          expect(
+              handler.queue.value[row].id, controller.state.currentTrack?.id);
+        }
+      });
+
+      test('metadata follows the new track after navigating', () async {
+        await controller.playTracks(album);
+        await _settle();
+        expect(handler.mediaItem.value?.title, 'Song a');
+
+        await handler.skipToNext();
+        await _settle();
+
+        final item = handler.mediaItem.value;
+        expect(item?.id, 'b');
+        expect(item?.title, 'Song b');
+        expect(item?.artist, 'Artist b');
+        expect(item?.album, 'Album b');
+      });
+
+      test('navigating while paused still changes the track', () async {
+        await controller.playTracks(album);
+        await _settle();
+        controller
+            .emit(controller.state.copyWith(status: PlaybackStatus.paused));
+        await _settle();
+
+        await handler.skipToNext();
+        await _settle();
+
+        expect(controller.state.currentTrack?.id, 'b');
+        expect(handler.mediaItem.value?.id, 'b');
+      });
+
+      test('next on the last track is a safe no-op', () async {
+        await controller.playTracks(album, startIndex: 2);
+        await _settle();
+        final item = handler.mediaItem.value;
+
+        await handler.skipToNext();
+        await _settle();
+
+        expect(controller.state.currentTrack?.id, 'c');
+        expect(handler.mediaItem.value?.id, item?.id);
+        expect(publishedQueueIndex(), 2);
+      });
+
+      test('previous on the first track is a safe no-op', () async {
+        await controller.playTracks(album);
+        await _settle();
+
+        await handler.skipToPrevious();
+        await _settle();
+
+        expect(controller.state.currentTrack?.id, 'a');
+        expect(publishedQueueIndex(), 0);
+      });
+
+      test('a one-track queue survives navigation in both directions',
+          () async {
+        await controller.playTracks(<Track>[_track('a')]);
+        await _settle();
+
+        await handler.skipToNext();
+        await handler.skipToPrevious();
+        await _settle();
+
+        expect(controller.state.currentTrack?.id, 'a');
+        expect(handler.playbackState.value.playing, isTrue);
+      });
+
+      test('navigating with repeat-all on stays on the shared policy',
+          () async {
+        await controller.playTracks(album);
+        await _settle();
+        await handler.setRepeatMode(audio.AudioServiceRepeatMode.all);
+        await _settle();
+
+        await handler.skipToNext();
+        await _settle();
+
+        expect(controller.state.currentTrack?.id, 'b');
+        expect(handler.playbackState.value.repeatMode,
+            audio.AudioServiceRepeatMode.all);
+        // Repeat-all wraps when a track *finishes*, not when Next is pressed —
+        // the same rule the in-app button follows, unchanged here.
+        await handler.skipToNext();
+        await handler.skipToNext();
+        await _settle();
+        expect(controller.state.currentTrack?.id, 'c');
+      });
+
+      test('navigating with repeat-one on still moves to the next track',
+          () async {
+        await controller.playTracks(album);
+        await _settle();
+        await handler.setRepeatMode(audio.AudioServiceRepeatMode.one);
+        await _settle();
+
+        await handler.skipToNext();
+        await _settle();
+
+        expect(controller.state.currentTrack?.id, 'b');
+      });
+
+      test('navigating with shuffle on follows the shuffled order', () async {
+        await controller.playTracks(album);
+        await _settle();
+        await handler.setShuffleMode(audio.AudioServiceShuffleMode.all);
+        await _settle();
+
+        final List<String> shuffled = <String>[
+          controller.state.currentTrack!.id,
+          ...controller.state.upNext.map((Track t) => t.id),
+        ];
+
+        await handler.skipToNext();
+        await _settle();
+
+        expect(controller.state.currentTrack?.id, shuffled[1]);
+        expect(handler.mediaItem.value?.id, shuffled[1]);
+        expect(handler.playbackState.value.shuffleMode,
+            audio.AudioServiceShuffleMode.all);
+      });
+
+      test('a detached handler never drives the controller again', () async {
+        // A rebind (Android Auto reconnecting, the session re-attaching)
+        // installs a new handler; a command still in flight on the old one must
+        // not run the same press through the controller a second time.
+        await controller.playTracks(album);
+        await _settle();
+        await handler.dispose();
+
+        await handler.skipToNext();
+        await handler.skipToPrevious();
+        await handler.play();
+        await handler.pause();
+        await handler.seek(const Duration(seconds: 5));
+        await handler.skipToQueueItem(1);
+        await _settle();
+
+        expect(controller.skipCount, 0);
+        expect(controller.previousCount, 0);
+        expect(controller.playCount, 0);
+        expect(controller.pauseCount, 0);
+        expect(controller.seeks, isEmpty);
+        expect(controller.state.currentTrack?.id, 'a');
+      });
+
+      test('disposing twice is safe', () async {
+        await handler.dispose();
+        await handler.dispose();
+      });
+    });
+
+    group('the session never reports STATE_CONNECTING (#638)', () {
+      // `AudioProcessingState.loading` is the only value audio_service maps to
+      // PlaybackStateCompat.STATE_CONNECTING. Android Auto reads that as "this
+      // session is connecting to a destination": it shows its connecting
+      // placeholder, drops the progress it was drawing, and stops dispatching
+      // transport presses — so a Next pressed during a track change was
+      // swallowed by the head unit and never reached the handler. Linthra
+      // enters `loading` on *every* track change (the controller publishes it
+      // while it resolves the next playable URI, a network round trip on a
+      // remote source), which is what made the car's Next/Previous work only
+      // sometimes.
+
+      test('a track change reports buffering, never loading', () async {
+        await controller.playTracks(<Track>[_track('a'), _track('b')]);
+        await _settle();
+
+        // Exactly what the controller publishes while it opens the next track.
+        controller.emit(controller.state.copyWith(
+          currentTrack: _track('b'),
+          status: PlaybackStatus.loading,
+        ));
+        await _settle();
+
+        expect(handler.playbackState.value.processingState,
+            audio.AudioProcessingState.buffering);
+        expect(handler.playbackState.value.processingState,
+            isNot(audio.AudioProcessingState.loading));
+      });
+
+      test('no state published across a whole navigation is loading', () async {
+        final List<audio.AudioProcessingState> seen =
+            <audio.AudioProcessingState>[];
+        final sub = handler.playbackState
+            .listen((audio.PlaybackState s) => seen.add(s.processingState));
+        addTearDown(sub.cancel);
+
+        await controller.playTracks(<Track>[_track('a'), _track('b')]);
+        await _settle();
+        controller.emit(controller.state.copyWith(
+          currentTrack: _track('b'),
+          status: PlaybackStatus.loading,
+        ));
+        await _settle();
+        controller
+            .emit(controller.state.copyWith(status: PlaybackStatus.playing));
+        await _settle();
+
+        expect(seen, isNot(contains(audio.AudioProcessingState.loading)));
+        expect(seen, contains(audio.AudioProcessingState.buffering));
+        expect(seen, contains(audio.AudioProcessingState.ready));
+      });
+
+      test('the transport stays advertised across the track change', () async {
+        await controller.playTracks(<Track>[_track('a'), _track('b')]);
+        await _settle();
+        controller.emit(controller.state.copyWith(
+          currentTrack: _track('b'),
+          status: PlaybackStatus.loading,
+        ));
+        await _settle();
+
+        final state = handler.playbackState.value;
+        expect(state.systemActions, contains(audio.MediaAction.skipToNext));
+        expect(state.systemActions, contains(audio.MediaAction.skipToPrevious));
+        // And the service is still held across the transition (#244 / #499).
+        expect(state.playing, isTrue);
+      });
+
+      test('an idle session still reports idle, not buffering', () async {
+        await controller.playTracks(<Track>[_track('a')]);
+        await _settle();
+        controller.emit(const PlaybackState());
+        await _settle();
+
+        expect(handler.playbackState.value.processingState,
+            audio.AudioProcessingState.idle);
+      });
+    });
+
     test('mirrors the current track into the media item', () async {
       await controller.playTracks([_track('a'), _track('b')]);
       await _settle();
@@ -374,7 +733,11 @@ void main() {
 
         final state = handler.playbackState.value;
         expect(state.playing, isTrue);
-        expect(state.processingState, audio.AudioProcessingState.loading);
+        // Buffering, not loading: `loading` is the one processing state
+        // audio_service turns into PlaybackStateCompat.STATE_CONNECTING, which
+        // Android Auto treats as "connecting to a destination" and uses to
+        // suspend its transport row (#638). See the STATE_CONNECTING group.
+        expect(state.processingState, audio.AudioProcessingState.buffering);
       });
 
       test('a car skip that loads the next track stays playing', () async {
@@ -393,7 +756,7 @@ void main() {
 
         final state = handler.playbackState.value;
         expect(state.playing, isTrue);
-        expect(state.processingState, audio.AudioProcessingState.loading);
+        expect(state.processingState, audio.AudioProcessingState.buffering);
         expect(handler.mediaItem.value?.id, 'b');
       });
 

--- a/test/core/services/stability_diagnostics_test.dart
+++ b/test/core/services/stability_diagnostics_test.dart
@@ -145,5 +145,27 @@ void main() {
         'pause: media-session',
       ]);
     });
+
+    test('skip commands record which direction was pressed', () {
+      // The breadcrumb that tells "the car's Next never reached the app" apart
+      // from "it reached the app and was a queue-boundary no-op" (#638).
+      StabilityDiagnostics.skipCommand('next');
+      StabilityDiagnostics.skipCommand('previous');
+      expect(SafeEventLog.instance.lines, <String>[
+        'skip: next',
+        'skip: previous',
+      ]);
+      expect(StabilityDiagnostics.describeSkipCommand('next'),
+          'skip command: next');
+    });
+
+    test('a skip breadcrumb carries no track, id, path or URL', () {
+      StabilityDiagnostics.skipCommand('next');
+      for (final String line in SafeEventLog.instance.lines) {
+        expect(line, isNot(contains('http')));
+        expect(line, isNot(contains('/')));
+        expect(line, isNot(contains('token')));
+      }
+    });
   });
 }


### PR DESCRIPTION
Closes #638

## What was wrong

The command path was never broken. Next and Previous reach `LinthraAudioHandler`, which forwards them to the one shared `PlaybackController` — that part works, and the existing tests were right about it.

What was broken is the state the session reported *while* a track change was in flight.

`LinthraAudioHandler` mapped the controller's `PlaybackStatus.loading` to `AudioProcessingState.loading`. That is the one value audio_service turns into `PlaybackStateCompat.STATE_CONNECTING` (`AudioService.getPlaybackState()`), and STATE_CONNECTING does not mean "preparing the next item" — the platform defines it as the session connecting to a new destination. Android Auto reads it that way: it shows its connecting placeholder, drops the progress it was drawing, and stops dispatching transport presses.

Linthra enters `loading` on *every* track change. The controller publishes it before resolving the next track's playable URI, which on a remote source is a network round trip. So each press opened a window in which the following press was acknowledged by the car and never reached the app at all. That is "works sometimes", which is what the report said.

It also explains the one thing that looked odd about the bug: notification, Bluetooth and headset buttons never regressed. Those arrive as media-button intents, which the session dispatches whatever state it is in.

## The fix

A track change now reports `buffering`, which is also simply the truthful state — the item is being prepared, and that is what `STATE_BUFFERING` is for. The car keeps its transport row live and its metadata and progress visible across the change.

This is a reporting change only:

- the queue, the controller, and `PlaybackStatus` are untouched;
- no Android-Auto queue model, no index touched behind the controller;
- the session keeps reporting `playing` through the transition, so the foreground service is held exactly as before (#244 / #499);
- MPRIS has its own mapping, so Linux is unchanged;
- in-app playback reads the controller, so nothing outside the session moves.

Previous is unchanged in behaviour: `skipToPrevious` calls `PlaybackController.skipToPrevious` and nothing else, so the car gets Linthra's shared policy (step back, no restart-first) and keeps getting it if that policy ever changes.

## Lifecycle guards the audit turned up

None of these is the root cause, all are real and cheap:

- **`connectMediaSession` attaches at most once per process.** A second `AudioService.init` installs fresh platform callbacks and fresh stream observers without tearing the previous ones down, which leaves two handlers mirroring into the same session — two writers over one notification and one Up Next list. It is an assertion error in debug and silent in release, which is the shape of a bug that only shows up on a real head unit. Attaching is asynchronous, so an attach already in flight is *joined* rather than raced.
- **A disposed handler is inert.** It forwards nothing to the controller, so a command still in flight across a reconnect can't drive a controller it no longer speaks for. `playFromMediaId` re-checks after its resolve as well as before it — it is the one command that awaits before touching the controller.
- **A reset settles completely.** The test-only detach supersedes an attach still in flight (generation token) and awaits it, so it never returns while an `AudioService.init` is still running.

Next/Previous also breadcrumb through `StabilityDiagnostics` now. "The car's Next did nothing" has two opposite causes and only this separates them: no breadcrumb means the press never arrived, a breadcrumb with no track change means it arrived and was a legitimate queue-boundary no-op.

## Tests

`test/core/services/android_media_session_boundary_test.dart` is new and works at the real boundary rather than against Dart mocks. It crosses the actual platform channels the Android plugin uses, both ways:

- **inbound** — messages are encoded exactly as `AudioServicePlugin.invokeMethod("skipToNext", mapOf())` sends them from `MediaSessionCallback`, so the decode and dispatch path a car's press takes is the one under test;
- **outbound** — assertions read the raw argument maps the plugin would parse: the `PlaybackStateCompat` action bits, the active queue item id, the state constant.

Without the fix it fails on `processingState: 1` (STATE_CONNECTING). It also covers the media-button `click` path, so the notification/Bluetooth route is pinned against regression, and it attaches twice concurrently to prove one handler and one `configure`.

Dart-level regression coverage added alongside it: next callback, previous callback, exactly-once dispatch, a burst of presses, queue index synchronization, metadata after navigation, paused navigation, repeat and shuffle, first and last queue item, and the stale-handler and reconnect guards — including a gated browse tree that detaches the handler mid-lookup.

`flutter analyze`, `dart format --set-exit-if-changed .`, the secret/privacy scan, the Android channel threading check and the full suite (5556 tests) all pass.

## Docs

`docs/android-auto.md` gains a **track navigation smoke test** — a five-minute run covering the 13 steps from the issue (single press, rapid presses, previous, paused, screen locked, boundaries, repeat/shuffle, reconnect, playback-before-connect, Up Next row, notification/Bluetooth, back to the phone) — plus the breadcrumb reference and a "Next/Previous doesn't change the song" triage that starts by asking whether the command reached the app at all.

## Review round

Three P2 findings from the Codex review, all verified against the code and all real — they were concurrency edges in the new lifecycle guards, not in the fix itself. Fixed in 27ae3a5 and 942ebd7. Two carry tests proven to fail without the fix; the third (reset landing mid-attach) is fixed on reasoning alone, because reproducing its window would mean adding a production seam purely to test a `@visibleForTesting` helper. That is called out on the thread rather than implied to be covered.

## Not done

`pubspec.yaml` gains one **dev** dependency, `audio_service_platform_interface`. It is already in the graph under `audio_service`; the boundary test needs it directly to install the Android `AudioServicePlatform` on a Linux test host. Nothing in `lib/` imports it, and `docs/dependency-license-audit.md` is updated.

I have not changed what Next does at the end of the queue. It stays a no-op and does not wrap under repeat-all, matching the in-app button, the notification and MPRIS — changing it would change shared behaviour on every platform, which is outside this issue.

The manual Android Auto smoke test is documented but has **not** been run on a real head unit or the DHU — no car or Android device in this environment. That is the one acceptance-criteria item still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4aHSnXkWG6CqXQhLxC6ES