### PR TITLE
feat(desktop): make the Linux UI usable from the keyboard (#390)

### DIFF
--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -581,6 +581,7 @@ loaded:
 | Window geometry | Supported | Size and maximized state survive a restart; position too, on X11. A saved position is re-checked against the monitors attached now. See [Window state](#window-state). |
 | Content density | Supported | Compact by default, switchable to Comfortable in Settings → Appearance and remembered across restarts ([issue #395](https://github.com/thezupzup/linthra/issues/395)). Both are Material `VisualDensity` values, so the choice reaches every list row, grid and control at once. Touch builds are unaffected. See [Density (Compact / Comfortable)](#density-compact--comfortable). |
 | Pointer affordances | Supported | Compact content density, visible hover feedback, right-click context menus with a keyboard equivalent, and Ctrl/Shift multi-select in track lists — all keyed on the input rather than the window width. See [Pointer, not width](#pointer-not-width). |
+| Keyboard navigation | Supported | The whole UI is reachable without a pointer: predictable Tab/Shift+Tab order, a strong accent focus ring distinct from hover and selection, Enter/Space activation, arrow keys through lists and grids with Home/End at their ends, and panes and dialogs that hand focus back when they close ([issue #390](https://github.com/TheZupZup/Linthra/issues/390)). Shared helpers in `lib/shared/focus/`, keyed on the input device rather than the platform, so touch is untouched. See [Keyboard navigation](#keyboard-navigation). |
 | Keyboard shortcuts | Partial | Quick search is bound to **Ctrl+K** / **Ctrl+F** ([issue #393](https://github.com/TheZupZup/Linthra/issues/393)) — see [Quick search](#quick-search-ctrlk). The volume control takes the wheel and arrow keys when focused; global transport and volume shortcuts are still later work in #376. |
 
 Nothing in that table is faked. Each one is an explicit implementation behind an
@@ -772,6 +773,71 @@ be acted on. A range is computed over the list the clicked row is in, which for
 the songs tab is the A–Z view's own sorted order rather than whatever the screen
 handed it. Starting a selection hands the screen the keyboard, so Escape leaves
 it. Long-press still does what it always did, so nothing about a phone changes.
+
+### Keyboard navigation
+
+Everything on the Linux UI can be reached and operated without a pointer
+([#390](https://github.com/TheZupZup/Linthra/issues/390)). None of it is a
+Linux branch: the pieces below are keyed on the *input device* or on the box a
+widget is given, the same rule the rest of the desktop work follows, so a phone
+behaves exactly as it always has and an Android tablet with a keyboard case
+gets the lot for free.
+
+- **Tab and Shift+Tab** walk the frame the way it reads: the page pane by pane,
+  then the queue column, the navigation rail and the mini-player. The shell
+  orders those groups explicitly (`HomeShell`), because the default
+  reading-order policy sorts a rail beside a page by geometry and splits it
+  around the content.
+- **A focus ring** in the accent colour marks whatever holds the keyboard.
+  Focus gets its own vocabulary on purpose: hover is a neutral veil and
+  selection is an identity tint, and a third veil would leave all three saying
+  roughly the same thing. `FocusRing`
+  ([`lib/shared/focus/focus_ring.dart`](../lib/shared/focus/focus_ring.dart))
+  draws it as an overlay, so it is visible even on an album cover, where
+  Material's ink highlight is painted on the surface *behind* the card. It is
+  drawn only while the focus manager is in keyboard/mouse mode, which is what
+  keeps it off a touch build without a platform check.
+- **Enter and Space** activate whatever is focused, which is Material's own
+  behaviour for every ink surface and is pinned by tests on the library rows
+  and the album grid.
+- **The arrow keys** move through lists and grids, row by row and cell by cell,
+  scrolling as they go.
+- **Home and End** jump to the ends of a collection. They have to be added:
+  in a lazily-built list the far end has no focus node for a traversal policy
+  to find until something scrolls it into range. `ListKeyboardNavigation`
+  ([`lib/shared/focus/list_keyboard_navigation.dart`](../lib/shared/focus/list_keyboard_navigation.dart))
+  scrolls first and takes the outermost row at that end on the next frame. The
+  same widget lets **← / →** carry on into the next row of a grid of cards, the
+  way a desktop icon grid is walked. A focused text field is left alone
+  outright, so Home, End and the arrows keep meaning what they mean while
+  typing.
+- **Panes hand the keyboard back.** Closing the queue column, the Now Playing
+  queue pane or the Library detail pane disposes everything inside it, and
+  Flutter unwinds focus to the route's scope: nothing is ringed and the next
+  Tab starts again at the top of the page. `FocusHandoff`
+  ([`lib/shared/focus/focus_handoff.dart`](../lib/shared/focus/focus_handoff.dart))
+  puts it back on the control that reopens the pane, or on the list the detail
+  was sitting beside. It fires only when the pane really was holding focus, and
+  a window narrowed past a pane's width floor counts the same as pressing its
+  close button.
+- **Dialogs** trap Tab while they are open and give focus back to the control
+  that opened them, which is Flutter's own modal behaviour; the tests pin it so
+  a future change cannot quietly drop it.
+
+Tests: `test/shared/focus/`, `test/features/library/keyboard_navigation_test.dart`,
+`test/features/library/library_detail_pane_test.dart`,
+`test/features/settings/provider_form_keyboard_test.dart`,
+`test/features/shell/home_shell_focus_order_test.dart`,
+`test/features/shell/queue_side_panel_shell_test.dart`,
+`test/features/player/player_queue_pane_test.dart` and
+`test/shared/widgets/confirm_dialog_test.dart`. Between them they cover forward
+and backward traversal, activation, list and grid movement, the two pane
+closures, dialog trapping and restoration, and a touch build behaving exactly
+as it did before.
+
+Configurable shortcuts are a separate job
+([#391](https://github.com/TheZupZup/Linthra/issues/391)); what is bound today
+is in the row above.
 
 ### Quick search (Ctrl+K)
 

--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -126,6 +126,26 @@ abstract final class AppTheme {
       // reaches every ink surface at once: list rows, buttons, grid cards, the
       // navigation rail's destinations and popup-menu items.
       hoverColor: onSurface.withValues(alpha: 0.07),
+      // Keyboard focus (#390). Material's default is another neutral veil, a
+      // few percent apart from the hover one above and from the selected tint
+      // below: three states saying almost the same thing, which on a keyboard
+      // leaves "where am I" unanswerable without moving and looking again.
+      //
+      // Focus takes the accent instead, and takes it harder: a different hue
+      // from both hover (neutral) and selection (identity violet), so the three
+      // read apart even where all three are true of the same row at once. Like
+      // `hoverColor`, one value here reaches every ink surface (buttons, list
+      // rows, popup-menu items, the navigation rail's destinations), so no
+      // widget carries its own idea of what focus looks like.
+      //
+      // Surfaces that ink cannot reach (an album card, whose cover is painted
+      // over the overlay) draw `FocusRing` on top of this instead; see
+      // `lib/shared/focus/focus_ring.dart`.
+      //
+      // Not gated on the platform: Flutter only paints a focus highlight while
+      // the user is driving with a keyboard or mouse, so a phone never shows
+      // one and mobile is unchanged.
+      focusColor: palette.accent.withValues(alpha: 0.18),
       extensions: <ThemeExtension<dynamic>>[
         LinthraAccents(
           accentBright: palette.accentBright,

--- a/lib/features/library/widgets/album_grid.dart
+++ b/lib/features/library/widgets/album_grid.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../app/dimens.dart';
 import '../../../core/models/album.dart';
+import '../../../shared/focus/list_keyboard_navigation.dart';
 import 'album_grid_card.dart';
 
 /// Narrowest a desktop album card should get before the grid drops a column.
@@ -61,23 +62,29 @@ class AlbumGrid extends StatelessWidget {
         final int columns = albumGridColumnCount(content);
         final double cardWidth =
             (content - _gridGutter * (columns - 1)) / columns;
-        return GridView.builder(
-          key: const Key('library_album_grid'),
-          padding: const EdgeInsets.all(_gridGutter),
-          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: columns,
-            crossAxisSpacing: _gridGutter,
-            mainAxisSpacing: AppSpacing.lg,
-            mainAxisExtent: cardWidth + labelExtent,
+        // A grid of covers is walked the way a desktop icon grid is: the arrow
+        // keys move cell to cell and carry on into the next row at a row's
+        // end, and Home/End go to the ends of the collection (#390).
+        return ListKeyboardNavigation(
+          wrapRows: true,
+          child: GridView.builder(
+            key: const Key('library_album_grid'),
+            padding: const EdgeInsets.all(_gridGutter),
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: columns,
+              crossAxisSpacing: _gridGutter,
+              mainAxisSpacing: AppSpacing.lg,
+              mainAxisExtent: cardWidth + labelExtent,
+            ),
+            itemCount: albums.length,
+            itemBuilder: (BuildContext context, int index) {
+              final Album album = albums[index];
+              return AlbumGridCard(
+                album: album,
+                onTap: () => onOpen(album),
+              );
+            },
           ),
-          itemCount: albums.length,
-          itemBuilder: (BuildContext context, int index) {
-            final Album album = albums[index];
-            return AlbumGridCard(
-              album: album,
-              onTap: () => onOpen(album),
-            );
-          },
         );
       },
     );

--- a/lib/features/library/widgets/album_grid_card.dart
+++ b/lib/features/library/widgets/album_grid_card.dart
@@ -5,6 +5,7 @@ import '../../../app/dimens.dart';
 import '../../../core/catalog/library_grouping.dart';
 import '../../../core/models/album.dart';
 import '../../../core/models/track.dart';
+import '../../../shared/focus/focus_ring.dart';
 import '../../../shared/widgets/context_menu_region.dart';
 import '../../../shared/widgets/hover_highlight.dart';
 import '../../player/widgets/album_artwork.dart';
@@ -71,51 +72,58 @@ class AlbumGridCard extends ConsumerWidget {
           action,
           _tracks(ref),
         ),
-        child: InkWell(
+        // The focus ring wraps the whole card, artwork included: the InkWell's
+        // focus overlay is painted on the Material behind the cover, so a
+        // keyboard user would otherwise see the highlight only on the label
+        // strip, the same blind spot [HoverArtworkVeil] answers for the mouse.
+        child: FocusRing(
           borderRadius: const BorderRadius.all(Radius.circular(AppRadii.md)),
-          onTap: onTap,
-          onLongPress: () => _addAllToPlaylist(context, ref),
-          // The InkWell's own hover overlay is painted on the Material behind the
-          // card, so the cover hides it and a mouse user gets feedback on the
-          // labels and none on the artwork they are pointing at. The veil is that
-          // same hover colour, drawn where it can be seen.
-          child: HoverHighlight(
-            builder: (BuildContext context, bool hovered) => Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Flexible(
-                  child: AspectRatio(
-                    aspectRatio: 1,
-                    child: HoverArtworkVeil(
-                      hovered: hovered,
-                      borderRadius: BorderRadius.circular(AppRadii.md),
-                      child: AlbumArtwork(artworkUri: album.artworkUri),
+          child: InkWell(
+            borderRadius: const BorderRadius.all(Radius.circular(AppRadii.md)),
+            onTap: onTap,
+            onLongPress: () => _addAllToPlaylist(context, ref),
+            // The InkWell's own hover overlay is painted on the Material behind the
+            // card, so the cover hides it and a mouse user gets feedback on the
+            // labels and none on the artwork they are pointing at. The veil is that
+            // same hover colour, drawn where it can be seen.
+            child: HoverHighlight(
+              builder: (BuildContext context, bool hovered) => Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Flexible(
+                    child: AspectRatio(
+                      aspectRatio: 1,
+                      child: HoverArtworkVeil(
+                        hovered: hovered,
+                        borderRadius: BorderRadius.circular(AppRadii.md),
+                        child: AlbumArtwork(artworkUri: album.artworkUri),
+                      ),
                     ),
                   ),
-                ),
-                const SizedBox(height: AppSpacing.sm),
-                Text(
-                  album.title,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                  style: theme.textTheme.titleSmall?.copyWith(
-                    fontWeight: FontWeight.w600,
-                    height: _lineHeight,
+                  const SizedBox(height: AppSpacing.sm),
+                  Text(
+                    album.title,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      height: _lineHeight,
+                    ),
                   ),
-                ),
-                const SizedBox(height: AppSpacing.xs),
-                Text(
-                  album.artistName?.isNotEmpty == true
-                      ? album.artistName!
-                      : kUnknownArtist,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
-                    height: _lineHeight,
+                  const SizedBox(height: AppSpacing.xs),
+                  Text(
+                    album.artistName?.isNotEmpty == true
+                        ? album.artistName!
+                        : kUnknownArtist,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                      height: _lineHeight,
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/features/library/widgets/alphabet_track_list.dart
+++ b/lib/features/library/widgets/alphabet_track_list.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../app/dimens.dart';
 import '../../../core/models/track.dart';
+import '../../../shared/focus/list_keyboard_navigation.dart';
 import 'track_tile.dart';
 
 /// A track list with first-letter section grouping and an A–Z fast-scroll
@@ -196,69 +197,74 @@ class _AlphabetTrackListState extends State<AlphabetTrackList> {
   @override
   Widget build(BuildContext context) {
     final showRail = _letters.length >= 2;
-    return Stack(
-      children: [
-        ListView.builder(
-          key: const Key('library_track_list'),
-          controller: _controller,
-          // Reserve room for the rail so rows never render beneath it.
-          padding:
-              EdgeInsets.only(right: showRail ? _railWidth : AppSpacing.md),
-          itemCount: _entries.length,
-          itemExtentBuilder: (index, _) =>
-              _entries[index].isHeader ? _headerExtent : _trackExtent,
-          itemBuilder: (context, i) {
-            final entry = _entries[i];
-            if (entry.isHeader) {
-              return _SectionHeader(letter: entry.letter!);
-            }
-            final int trackIndex = entry.trackIndex!;
-            final Track track = _sorted[trackIndex];
-            return TrackTile(
-              tracks: _sorted,
-              index: trackIndex,
-              selectable: widget.selectable,
-              selectionActive: widget.selectionActive,
-              selected: widget.selectedUris.contains(track.uri),
-              onSelectToggle: widget.onSelectToggle == null
-                  ? null
-                  : () => widget.onSelectToggle!(track),
-              onSelectStart: widget.onSelectStart == null
-                  ? null
-                  : () => widget.onSelectStart!(track),
-              onSelectRange: widget.onSelectRange,
-              // Resolved from the sorted list the rows are drawn from, so a
-              // drag carries the selection in the order the user sees it.
-              // Only runs when a drag actually starts.
-              dragSelection: () => <Track>[
-                for (final Track candidate in _sorted)
-                  if (widget.selectedUris.contains(candidate.uri)) candidate,
-              ],
-            );
-          },
-        ),
-        if (showRail)
-          Positioned(
-            top: 0,
-            bottom: 0,
-            right: 0,
-            width: _railWidth,
-            child: _AlphabetIndex(
-              letters: _letters,
-              activeLetter: _activeLetter,
-              onSelected: _jumpToLetter,
-              onScrubChanged: (scrubbing) =>
-                  setState(() => _scrubbing = scrubbing),
+    // Home and End jump to the ends of the library the way they do in any
+    // desktop list; the arrow keys already walk it row by row. The A–Z rail
+    // beside it is the pointer's version of the same idea (#390).
+    return ListKeyboardNavigation(
+      child: Stack(
+        children: [
+          ListView.builder(
+            key: const Key('library_track_list'),
+            controller: _controller,
+            // Reserve room for the rail so rows never render beneath it.
+            padding:
+                EdgeInsets.only(right: showRail ? _railWidth : AppSpacing.md),
+            itemCount: _entries.length,
+            itemExtentBuilder: (index, _) =>
+                _entries[index].isHeader ? _headerExtent : _trackExtent,
+            itemBuilder: (context, i) {
+              final entry = _entries[i];
+              if (entry.isHeader) {
+                return _SectionHeader(letter: entry.letter!);
+              }
+              final int trackIndex = entry.trackIndex!;
+              final Track track = _sorted[trackIndex];
+              return TrackTile(
+                tracks: _sorted,
+                index: trackIndex,
+                selectable: widget.selectable,
+                selectionActive: widget.selectionActive,
+                selected: widget.selectedUris.contains(track.uri),
+                onSelectToggle: widget.onSelectToggle == null
+                    ? null
+                    : () => widget.onSelectToggle!(track),
+                onSelectStart: widget.onSelectStart == null
+                    ? null
+                    : () => widget.onSelectStart!(track),
+                onSelectRange: widget.onSelectRange,
+                // Resolved from the sorted list the rows are drawn from, so a
+                // drag carries the selection in the order the user sees it.
+                // Only runs when a drag actually starts.
+                dragSelection: () => <Track>[
+                  for (final Track candidate in _sorted)
+                    if (widget.selectedUris.contains(candidate.uri)) candidate,
+                ],
+              );
+            },
+          ),
+          if (showRail)
+            Positioned(
+              top: 0,
+              bottom: 0,
+              right: 0,
+              width: _railWidth,
+              child: _AlphabetIndex(
+                letters: _letters,
+                activeLetter: _activeLetter,
+                onSelected: _jumpToLetter,
+                onScrubChanged: (scrubbing) =>
+                    setState(() => _scrubbing = scrubbing),
+              ),
             ),
-          ),
-        if (showRail && _scrubbing && _activeLetter != null)
-          Positioned(
-            right: _railWidth + AppSpacing.sm,
-            top: 0,
-            bottom: 0,
-            child: Center(child: _ScrubBubble(letter: _activeLetter!)),
-          ),
-      ],
+          if (showRail && _scrubbing && _activeLetter != null)
+            Positioned(
+              right: _railWidth + AppSpacing.sm,
+              top: 0,
+              bottom: 0,
+              child: Center(child: _ScrubBubble(letter: _activeLetter!)),
+            ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/library/widgets/artist_grid.dart
+++ b/lib/features/library/widgets/artist_grid.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../app/dimens.dart';
 import '../../../core/models/artist.dart';
+import '../../../shared/focus/list_keyboard_navigation.dart';
 import 'artist_tile.dart';
 
 /// Narrowest an artist row may get before the grid drops a column. Below this
@@ -81,30 +82,36 @@ class ArtistGrid extends StatelessWidget {
       builder: (BuildContext context, BoxConstraints constraints) {
         final int columns = artistGridColumnCount(constraints.maxWidth);
         final bool single = columns == 1;
-        return GridView.builder(
-          key: const Key('library_artist_list'),
-          // A single column keeps the edge-to-edge list look phones already
-          // have; only the multi-column desktop layout needs gutters.
-          padding: single
-              ? EdgeInsets.zero
-              : const EdgeInsets.symmetric(
-                  horizontal: _gridPadding,
-                  vertical: _gridPadding,
-                ),
-          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: columns,
-            crossAxisSpacing: single ? 0 : _gridGutter,
-            mainAxisSpacing: 0,
-            mainAxisExtent: extent,
+        // ← / → only mean "the next artist" once there is more than one
+        // column: in the single-column list a phone gets, a row break is the
+        // list itself, not a layout artefact to walk through (#390).
+        return ListKeyboardNavigation(
+          wrapRows: !single,
+          child: GridView.builder(
+            key: const Key('library_artist_list'),
+            // A single column keeps the edge-to-edge list look phones already
+            // have; only the multi-column desktop layout needs gutters.
+            padding: single
+                ? EdgeInsets.zero
+                : const EdgeInsets.symmetric(
+                    horizontal: _gridPadding,
+                    vertical: _gridPadding,
+                  ),
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: columns,
+              crossAxisSpacing: single ? 0 : _gridGutter,
+              mainAxisSpacing: 0,
+              mainAxisExtent: extent,
+            ),
+            itemCount: artists.length,
+            itemBuilder: (BuildContext context, int index) {
+              final Artist artist = artists[index];
+              return ArtistTile(
+                artist: artist,
+                onTap: () => onOpen(artist),
+              );
+            },
           ),
-          itemCount: artists.length,
-          itemBuilder: (BuildContext context, int index) {
-            final Artist artist = artists[index];
-            return ArtistTile(
-              artist: artist,
-              onTap: () => onOpen(artist),
-            );
-          },
         );
       },
     );

--- a/lib/features/library/widgets/artist_tile.dart
+++ b/lib/features/library/widgets/artist_tile.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/catalog/library_grouping.dart';
 import '../../../core/models/artist.dart';
 import '../../../core/models/track.dart';
+import '../../../shared/focus/focus_ring.dart';
 import '../../../shared/widgets/artwork_image.dart';
 import '../../../shared/widgets/context_menu_region.dart';
 import '../../playlists/widgets/add_to_playlist_sheet.dart';
@@ -30,27 +31,29 @@ class ArtistTile extends ConsumerWidget {
       itemBuilder: (BuildContext context) => collectionMenuItems(),
       onSelected: (CollectionAction action) =>
           runCollectionAction(context, ref, action, _tracks(ref)),
-      child: ListTile(
-        leading: _ArtistAvatar(artworkUri: artist.artworkUri),
-        title: Text(
-          artist.name,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: theme.textTheme.titleMedium?.copyWith(
-            fontWeight: FontWeight.w600,
+      child: FocusRing(
+        child: ListTile(
+          leading: _ArtistAvatar(artworkUri: artist.artworkUri),
+          title: Text(
+            artist.name,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
           ),
-        ),
-        subtitle: Text(
-          _subtitle(artist),
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: theme.textTheme.bodyMedium?.copyWith(
-            color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+          subtitle: Text(
+            _subtitle(artist),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+            ),
           ),
+          trailing: const Icon(Icons.chevron_right),
+          onTap: onTap,
+          onLongPress: () => _addAllToPlaylist(context, ref),
         ),
-        trailing: const Icon(Icons.chevron_right),
-        onTap: onTap,
-        onLongPress: () => _addAllToPlaylist(context, ref),
       ),
     );
   }

--- a/lib/features/library/widgets/track_tile.dart
+++ b/lib/features/library/widgets/track_tile.dart
@@ -12,6 +12,7 @@ import '../../../core/repositories/download_repository.dart';
 import '../../../core/repositories/download_store.dart';
 import '../../../data/repositories/download_repository_provider.dart';
 import '../../../data/repositories/favorites_repository_provider.dart';
+import '../../../shared/focus/focus_ring.dart';
 import '../../../shared/widgets/context_menu_region.dart';
 import '../../downloads/download_providers.dart';
 import '../../player/favorites_providers.dart';
@@ -146,82 +147,84 @@ class TrackTile extends ConsumerWidget {
             ?.fraction
         : null;
 
-    final Widget row = ListTile(
-      selected: selectionActive && selected,
-      leading: TrackArtwork(
-        artworkUri: track.artworkUri,
-        nowPlaying: nowPlaying,
-      ),
-      title: Text(
-        track.title,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-        style: theme.textTheme.titleMedium?.copyWith(
-          fontWeight: FontWeight.w600,
+    final Widget row = FocusRing(
+      child: ListTile(
+        selected: selectionActive && selected,
+        leading: TrackArtwork(
+          artworkUri: track.artworkUri,
+          nowPlaying: nowPlaying,
         ),
-      ),
-      subtitle: Text(
-        _subtitle(track),
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-        style: theme.textTheme.bodyMedium?.copyWith(
-          color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+        title: Text(
+          track.title,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
         ),
-      ),
-      trailing: selectionActive
-          // The row itself already carries the selected state (and toggles on
-          // tap), so the box is the visual echo of it: a second, unnamed
-          // checkbox node next to every title would only make the list harder
-          // to move through, not clearer.
-          ? ExcludeSemantics(
-              child: Checkbox(
-                value: selected,
-                onChanged:
-                    onSelectToggle == null ? null : (_) => onSelectToggle!(),
+        subtitle: Text(
+          _subtitle(track),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+          ),
+        ),
+        trailing: selectionActive
+            // The row itself already carries the selected state (and toggles on
+            // tap), so the box is the visual echo of it: a second, unnamed
+            // checkbox node next to every title would only make the list harder
+            // to move through, not clearer.
+            ? ExcludeSemantics(
+                child: Checkbox(
+                  value: selected,
+                  onChanged:
+                      onSelectToggle == null ? null : (_) => onSelectToggle!(),
+                ),
+              )
+            : Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TrackStatusGlyph(
+                    track: track,
+                    isRemote: isRemote,
+                    downloadStatus: status,
+                    downloadProgress: downloadFraction,
+                  ),
+                  _OverflowMenu(
+                    track: track,
+                    status: status,
+                    isRemote: isRemote,
+                  ),
+                ],
               ),
-            )
-          : Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                TrackStatusGlyph(
-                  track: track,
-                  isRemote: isRemote,
-                  downloadStatus: status,
-                  downloadProgress: downloadFraction,
-                ),
-                _OverflowMenu(
-                  track: track,
-                  status: status,
-                  isRemote: isRemote,
-                ),
-              ],
-            ),
-      onTap: () {
-        if (selectable && _extendsSelection) {
-          onSelectRange?.call(tracks, index);
-          return;
-        }
-        // Ctrl (or Cmd) picks this row out on its own, and starts a selection
-        // when there isn't one — the whole point of it on a desktop, where
-        // holding a row down for half a second to begin is not the gesture
-        // anybody reaches for.
-        if (selectable && _togglesSelection) {
+        onTap: () {
+          if (selectable && _extendsSelection) {
+            onSelectRange?.call(tracks, index);
+            return;
+          }
+          // Ctrl (or Cmd) picks this row out on its own, and starts a selection
+          // when there isn't one — the whole point of it on a desktop, where
+          // holding a row down for half a second to begin is not the gesture
+          // anybody reaches for.
+          if (selectable && _togglesSelection) {
+            if (selectionActive) {
+              onSelectToggle?.call();
+            } else {
+              onSelectStart?.call();
+            }
+            return;
+          }
           if (selectionActive) {
             onSelectToggle?.call();
-          } else {
-            onSelectStart?.call();
+            return;
           }
-          return;
-        }
-        if (selectionActive) {
-          onSelectToggle?.call();
-          return;
-        }
-        final controller = ref.read(playbackControllerProvider);
-        controller.playTracks(tracks, startIndex: index);
-        context.push(AppRoutes.player);
-      },
-      onLongPress: (selectable && !selectionActive) ? onSelectStart : null,
+          final controller = ref.read(playbackControllerProvider);
+          controller.playTracks(tracks, startIndex: index);
+          context.push(AppRoutes.player);
+        },
+        onLongPress: (selectable && !selectionActive) ? onSelectStart : null,
+      ),
     );
 
     // The same menu the 3-dot button opens, on right-click and on the

--- a/lib/features/player/mini_player.dart
+++ b/lib/features/player/mini_player.dart
@@ -558,6 +558,12 @@ class _QueueButton extends StatelessWidget {
     final QueueSidePanelScope? panel = QueueSidePanelScope.maybeOf(context);
     if (panel == null || !panel.available) {
       return IconButton(
+        // The same node as the toggle below, so a window narrowed until the
+        // column no longer fits still has somewhere to hand the keyboard back
+        // to: this is the same button in the same place, opening the queue the
+        // only way that width can. Null off the shell, where nothing hands
+        // focus anywhere.
+        focusNode: panel?.toggleFocusNode,
         onPressed: () => showQueueSheet(context),
         icon: const Icon(Icons.queue_music_outlined),
         iconSize: 22,
@@ -566,6 +572,10 @@ class _QueueButton extends StatelessWidget {
       );
     }
     return IconButton(
+      // The column hands the keyboard back to this button when it closes, so
+      // the node has to be the shell's rather than one this button makes and
+      // throws away on every rebuild.
+      focusNode: panel.toggleFocusNode,
       onPressed: panel.onToggle,
       isSelected: panel.visible,
       icon: const Icon(Icons.queue_music_outlined),

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -6,6 +6,7 @@ import '../../core/models/playback_failure.dart';
 import '../../core/models/playback_state.dart';
 import '../../core/models/track.dart';
 import '../../data/repositories/host_platform_provider.dart';
+import '../../shared/focus/focus_handoff.dart';
 import '../../shared/layout/adaptive_layout.dart';
 import '../../shared/widgets/empty_state.dart';
 import 'cast/cast_button.dart';
@@ -159,6 +160,21 @@ class _NowPlayingState extends State<_NowPlaying> {
   /// rather than closed.
   bool _showQueue = false;
 
+  /// The queue button's focus node (#390).
+  ///
+  /// Held by the screen rather than by the button so it outlives the pane: when
+  /// the pane closes (by the button, or because the window narrowed past
+  /// [_queuePaneMinWidth]) the keyboard goes back to the control that opens it
+  /// again instead of unwinding to the page.
+  final FocusNode _queueButtonFocus =
+      FocusNode(debugLabel: 'now playing queue');
+
+  @override
+  void dispose() {
+    _queueButtonFocus.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     return AdaptiveLayoutBuilder(
@@ -244,6 +260,7 @@ class _NowPlayingState extends State<_NowPlaying> {
                     // so the queue is never unreachable at any window size.
                     queueVisible: queueOpen,
                     onToggleQueue: canHostQueue ? _toggleQueue : null,
+                    queueButtonFocusNode: _queueButtonFocus,
                   ),
                 ],
               ),
@@ -254,9 +271,12 @@ class _NowPlayingState extends State<_NowPlaying> {
               // rows, and rows have a width that reads well. Letting it grow
               // with the window would only pull each title away from its
               // handle, and would take the space from the cover.
-              const SizedBox(
-                width: _queuePaneWidth,
-                child: QueueSheet(embedded: true),
+              FocusHandoff(
+                returnFocusTo: () => _queueButtonFocus,
+                child: const SizedBox(
+                  width: _queuePaneWidth,
+                  child: QueueSheet(embedded: true),
+                ),
               ),
             ],
           ],
@@ -339,6 +359,7 @@ class _ActionsBar extends ConsumerWidget {
     required this.onToggleLyrics,
     this.queueVisible = false,
     this.onToggleQueue,
+    this.queueButtonFocusNode,
   });
 
   final Track track;
@@ -351,6 +372,10 @@ class _ActionsBar extends ConsumerWidget {
   final bool queueVisible;
   final VoidCallback? onToggleQueue;
 
+  /// The queue button's focus node, so the screen can hand the keyboard back
+  /// to it when the pane it opened closes (#390).
+  final FocusNode? queueButtonFocusNode;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final Widget actions = NowPlayingActions(
@@ -359,6 +384,7 @@ class _ActionsBar extends ConsumerWidget {
       onToggleLyrics: onToggleLyrics,
       queueVisible: queueVisible,
       onToggleQueue: onToggleQueue,
+      queueButtonFocusNode: queueButtonFocusNode,
     );
     // Falls back to the service's own state until the first stream event, the
     // same way the source/casting line does.

--- a/lib/features/player/widgets/now_playing_actions.dart
+++ b/lib/features/player/widgets/now_playing_actions.dart
@@ -34,6 +34,7 @@ class NowPlayingActions extends ConsumerWidget {
     this.onToggleLyrics,
     this.queueVisible = false,
     this.onToggleQueue,
+    this.queueButtonFocusNode,
   });
 
   final Track track;
@@ -55,6 +56,14 @@ class NowPlayingActions extends ConsumerWidget {
   /// — keeps the queue a modal sheet, which is the right shape on every surface
   /// without the width for a pane.
   final VoidCallback? onToggleQueue;
+
+  /// The queue button's focus node, when the host wants to keep it (#390).
+  ///
+  /// Closing a queue pane disposes whatever inside it had the keyboard, so the
+  /// host hands focus back to this button, which means the node has to belong
+  /// to the host, not to a button that is rebuilt beneath it. Null everywhere
+  /// the queue is a sheet, which takes and returns focus itself.
+  final FocusNode? queueButtonFocusNode;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -105,6 +114,7 @@ class NowPlayingActions extends ConsumerWidget {
         ),
         IconButton(
           iconSize: 22,
+          focusNode: queueButtonFocusNode,
           onPressed: onToggleQueue ?? () => _openQueue(context),
           icon: Icon(
             queueVisible ? Icons.queue_music : Icons.queue_music_outlined,

--- a/lib/features/player/widgets/queue_sheet.dart
+++ b/lib/features/player/widgets/queue_sheet.dart
@@ -9,6 +9,7 @@ import '../../../core/models/track.dart';
 import '../../../core/repositories/playlist_repository.dart';
 import '../../../data/repositories/host_platform_provider.dart';
 import '../../../data/repositories/playlist_repository_provider.dart';
+import '../../../shared/focus/list_keyboard_navigation.dart';
 import '../../../shared/widgets/now_playing_indicator.dart';
 import '../../../shared/widgets/reorder_focus_walk.dart';
 import '../../../shared/widgets/reorder_handle.dart';
@@ -168,49 +169,54 @@ class QueueSheet extends ConsumerWidget {
         Flexible(
           child: current == null
               ? const _EmptyQueue()
-              : CustomScrollView(
-                  slivers: <Widget>[
-                    if (!showRecentHistory && history.isNotEmpty) ...<Widget>[
-                      const _SectionLabel(label: 'Previously played'),
-                      SliverList.builder(
-                        itemCount: history.length,
-                        itemBuilder: (context, index) => _HistoryTile(
-                          track: history[index],
-                          onTap: () => ref
-                              .read(playbackControllerProvider)
-                              .playFromHistory(index),
-                        ),
-                      ),
-                    ],
-                    const _SectionLabel(label: 'Now playing'),
-                    SliverToBoxAdapter(
-                      child: _CurrentTile(track: current),
-                    ),
-                    const _SectionLabel(label: 'Up next'),
-                    if (upNext.isEmpty)
-                      const SliverToBoxAdapter(child: _NothingUpNext())
-                    else
-                      _UpNextList(tracks: upNext),
-                    if (showRecentHistory && recent.isNotEmpty) ...<Widget>[
-                      const _SectionLabel(label: 'Recently played'),
-                      SliverList.builder(
-                        itemCount: recent.length,
-                        itemBuilder: (context, index) => _RecentlyPlayedTile(
-                          entry: recent.entries[index],
-                          onTap: () => playFromRecentHistory(
-                            ref,
-                            recent.entries[index].track,
+              // Home and End reach the ends of a long queue without a pointer;
+              // the arrow keys already walk it, and Ctrl+↑/↓ on a row's handle
+              // still reorders (#388, #390).
+              : ListKeyboardNavigation(
+                  child: CustomScrollView(
+                    slivers: <Widget>[
+                      if (!showRecentHistory && history.isNotEmpty) ...<Widget>[
+                        const _SectionLabel(label: 'Previously played'),
+                        SliverList.builder(
+                          itemCount: history.length,
+                          itemBuilder: (context, index) => _HistoryTile(
+                            track: history[index],
+                            onTap: () => ref
+                                .read(playbackControllerProvider)
+                                .playFromHistory(index),
                           ),
                         ),
-                      ),
+                      ],
+                      const _SectionLabel(label: 'Now playing'),
                       SliverToBoxAdapter(
-                        child: _RecentHistoryFootnote(limit: recent.limit),
+                        child: _CurrentTile(track: current),
+                      ),
+                      const _SectionLabel(label: 'Up next'),
+                      if (upNext.isEmpty)
+                        const SliverToBoxAdapter(child: _NothingUpNext())
+                      else
+                        _UpNextList(tracks: upNext),
+                      if (showRecentHistory && recent.isNotEmpty) ...<Widget>[
+                        const _SectionLabel(label: 'Recently played'),
+                        SliverList.builder(
+                          itemCount: recent.length,
+                          itemBuilder: (context, index) => _RecentlyPlayedTile(
+                            entry: recent.entries[index],
+                            onTap: () => playFromRecentHistory(
+                              ref,
+                              recent.entries[index].track,
+                            ),
+                          ),
+                        ),
+                        SliverToBoxAdapter(
+                          child: _RecentHistoryFootnote(limit: recent.limit),
+                        ),
+                      ],
+                      const SliverToBoxAdapter(
+                        child: SizedBox(height: AppSpacing.md),
                       ),
                     ],
-                    const SliverToBoxAdapter(
-                      child: SizedBox(height: AppSpacing.md),
-                    ),
-                  ],
+                  ),
                 ),
         ),
       ],

--- a/lib/features/player/widgets/queue_side_panel.dart
+++ b/lib/features/player/widgets/queue_side_panel.dart
@@ -93,6 +93,7 @@ class QueueSidePanelScope extends InheritedWidget {
     required this.available,
     required this.visible,
     required this.onToggle,
+    required this.toggleFocusNode,
     required super.child,
     super.key,
   });
@@ -108,6 +109,23 @@ class QueueSidePanelScope extends InheritedWidget {
   /// Opens the panel, or closes it again.
   final VoidCallback onToggle;
 
+  /// The focus node of whichever control offers [onToggle]: today the
+  /// mini-player's queue button, under either of the shapes it takes.
+  ///
+  /// It lives in the shell rather than in that button because it is the shell
+  /// that needs it: closing the column disposes everything inside it, and if
+  /// the keyboard was in there it has to land somewhere. The control that
+  /// opens the column again is where the user is going next anyway, so the
+  /// column hands focus back to this node (see `FocusHandoff`) instead of
+  /// leaving it to unwind to nothing.
+  ///
+  /// The button carries this node whether or not the window is wide enough for
+  /// a column, because the width is exactly what can change underneath: a
+  /// resize that takes the column away is the case the handoff exists for, and
+  /// it would have nowhere to aim if the narrow shape of the button were a
+  /// different node.
+  final FocusNode toggleFocusNode;
+
   /// The nearest scope, or null when nothing above hosts a queue column: a
   /// phone, or any surface outside the shell (the full Now Playing route,
   /// which draws its own pane).
@@ -119,6 +137,7 @@ class QueueSidePanelScope extends InheritedWidget {
   bool updateShouldNotify(QueueSidePanelScope oldWidget) {
     return available != oldWidget.available ||
         visible != oldWidget.visible ||
-        onToggle != oldWidget.onToggle;
+        onToggle != oldWidget.onToggle ||
+        toggleFocusNode != oldWidget.toggleFocusNode;
   }
 }

--- a/lib/features/player/widgets/wavy_seek_bar.dart
+++ b/lib/features/player/widgets/wavy_seek_bar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '../../../app/dimens.dart';
+import '../../../shared/focus/focus_ring.dart';
 import '../../../shared/widgets/wavy_progress_indicator.dart';
 
 /// How much room a [WavySeekBar] is drawn to take.
@@ -220,12 +221,19 @@ class WavySeekBar extends StatelessWidget {
             // A visible focus ring is the keyboard's equivalent of the pointer's
             // marker: without it, Tab moves through the transport with nothing
             // on screen saying where it landed.
+            //
+            // The same ring the rest of the app draws through `FocusRing`
+            // (#390), same accent and same width, but drawn here rather than
+            // wrapped around the bar: the shared widget adds a box of its own,
+            // and this widget's outermost node has to stay the slider
+            // semantics a screen reader reads. The two numbers come from the
+            // shared file so they cannot drift apart.
             decoration: node.hasFocus
                 ? BoxDecoration(
                     borderRadius: BorderRadius.circular(AppRadii.sm),
                     border: Border.all(
                       color: theme.colorScheme.secondary,
-                      width: 2,
+                      width: focusRingWidth,
                     ),
                   )
                 : null,

--- a/lib/features/shell/home_shell.dart
+++ b/lib/features/shell/home_shell.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../shared/focus/focus_handoff.dart';
 import '../player/mini_player.dart';
 import '../player/widgets/queue_side_panel.dart';
 import 'playlist_drag_spring.dart';
@@ -87,6 +88,25 @@ class _HomeShellState extends State<HomeShell> {
   /// closed: the column costs the page a whole column's width, and that is the
   /// listener's call to make, not a default to wake up to.
   bool _queuePanelOpen = false;
+
+  /// The mini-player queue button's focus node, owned here rather than by the
+  /// button (#390).
+  ///
+  /// Closing the column disposes every control in it, the ✕ the user just
+  /// pressed included, so without somewhere to put the keyboard it unwinds to
+  /// the page and the next Tab restarts from the top. Handing it back to the
+  /// button that reopens the column keeps the user exactly where they were, and
+  /// the node has to outlive the panel to be handed anything, which is why the
+  /// shell holds it.
+  final FocusNode _queueToggleFocus = FocusNode(
+    debugLabel: 'queue panel toggle',
+  );
+
+  @override
+  void dispose() {
+    _queueToggleFocus.dispose();
+    super.dispose();
+  }
 
   void _toggleQueuePanel() {
     setState(() => _queuePanelOpen = !_queuePanelOpen);
@@ -236,10 +256,13 @@ class _HomeShellState extends State<HomeShell> {
     return FocusTraversalOrder(
       order: const NumericFocusOrder(2),
       child: FocusTraversalGroup(
-        child: SafeArea(
-          left: false,
-          bottom: false,
-          child: QueueSidePanel(onClose: _toggleQueuePanel),
+        child: FocusHandoff(
+          returnFocusTo: () => _queueToggleFocus,
+          child: SafeArea(
+            left: false,
+            bottom: false,
+            child: QueueSidePanel(onClose: _toggleQueuePanel),
+          ),
         ),
       ),
     );
@@ -275,6 +298,7 @@ class _HomeShellState extends State<HomeShell> {
             available: queuePanelAvailable,
             visible: queuePanelOpen,
             onToggle: _toggleQueuePanel,
+            toggleFocusNode: _queueToggleFocus,
             child: Scaffold(
               body: FocusTraversalGroup(
                 policy: OrderedTraversalPolicy(),

--- a/lib/shared/focus/focus_handoff.dart
+++ b/lib/shared/focus/focus_handoff.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/widgets.dart';
+
+/// Hands the keyboard somewhere sensible when the pane holding it goes away.
+///
+/// Desktop panes in Linthra come and go for two reasons: the user closes one
+/// (the queue column's ✕, the Now Playing queue button), or the window gets
+/// narrow enough that the layout drops it (`ListDetailPanes`, the queue
+/// column's width floor). Either way the widgets inside are disposed, and if
+/// one of them held focus the keyboard is left with nothing: Flutter unwinds to
+/// the enclosing scope, so the ring disappears and the next Tab restarts from
+/// the top of the page rather than continuing from where the user was.
+///
+/// A mouse user never notices. A keyboard user loses their place on a window
+/// resize they did not think of as leaving the screen. It is the same class of
+/// problem `ListDetailPanes` already documents for selection state, and it has
+/// the same answer: the thing that outlives the pane has to hold what the pane
+/// cannot.
+///
+/// So wrap the pane in this, pointing at something that is still on screen once
+/// the pane is gone, normally the control that opens it again, which is where
+/// the user would go next anyway:
+///
+/// ```dart
+/// if (queueOpen)
+///   FocusHandoff(
+///     returnFocusTo: () => _queueButtonFocusNode,
+///     child: QueueSidePanel(...),
+///   )
+/// ```
+///
+/// It only acts when the pane really was holding focus, so a pane closed while
+/// the user was typing somewhere else never yanks the keyboard away from them.
+class FocusHandoff extends StatefulWidget {
+  const FocusHandoff({
+    required this.returnFocusTo,
+    required this.child,
+    super.key,
+  });
+
+  /// Where the keyboard goes when this subtree leaves the tree holding it.
+  ///
+  /// Resolved after the pane is gone rather than while it is still up, which is
+  /// what lets a caller answer with something that only exists once the layout
+  /// has settled: the first row of the list a detail pane was sitting beside,
+  /// say, rather than a control it can name in advance.
+  ///
+  /// Answer null, or a node that went away with the pane, and nothing is done:
+  /// a layout change that dropped both leaves focus where Flutter put it
+  /// instead of arming a request that would fire whenever that control came
+  /// back, long afterwards.
+  final ValueGetter<FocusNode?> returnFocusTo;
+
+  final Widget child;
+
+  @override
+  State<FocusHandoff> createState() => _FocusHandoffState();
+}
+
+class _FocusHandoffState extends State<FocusHandoff> {
+  /// Whether anything inside currently holds the keyboard. Read at dispose,
+  /// when the nodes below are already being detached and cannot answer.
+  bool _hadFocus = false;
+
+  @override
+  void dispose() {
+    if (_hadFocus) {
+      final ValueGetter<FocusNode?> resolve = widget.returnFocusTo;
+      // After the frame that removes the pane: the framework unfocuses the
+      // detaching node as part of it, a request made now would be undone by
+      // that unwind, and what is left on screen is not laid out until then
+      // anyway.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        final FocusNode? target = resolve();
+        if (target == null || target.context == null) return;
+        target.requestFocus();
+      });
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      // Observes, never lands: an extra stop in front of every pane is exactly
+      // the kind of unexplained Tab that this issue is about removing.
+      canRequestFocus: false,
+      skipTraversal: true,
+      includeSemantics: false,
+      onFocusChange: (bool focused) => _hadFocus = focused,
+      child: widget.child,
+    );
+  }
+}

--- a/lib/shared/focus/focus_reading_order.dart
+++ b/lib/shared/focus/focus_reading_order.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/widgets.dart';
+
+/// The rows inside [region] that the keyboard can land on, in reading order.
+///
+/// "Row" means a row, a grid cell, a card (the thing a user would say they are
+/// *on*), and not the controls it carries. A track row holds an overflow menu,
+/// a queue row holds a remove button and a drag handle, and a jump that landed
+/// on the last row's ⋮ rather than on the row would be a strange place to
+/// arrive. Those controls are focus-tree descendants of the row they belong to,
+/// so keeping only the outermost candidate of each nest is exactly the rows.
+/// Tab still reaches everything inside them, as it always did.
+///
+/// Ordered by where the rows actually are, not by their order in the focus
+/// tree. A sliver builds rows as scrolling reaches them, so the tree order of a
+/// list the user has scrolled through is the order the rows were *first seen*,
+/// which, after scrolling back up, is not the order they are read in. Geometry
+/// cannot drift that way.
+///
+/// [region] is normally a [Focus] node that cannot be focused itself, parked
+/// around a list or a pane purely to be asked this question.
+List<FocusNode> focusableRowsIn(FocusNode region, {required bool rtl}) {
+  if (region.context == null) return const <FocusNode>[];
+  final Set<FocusNode> candidates = <FocusNode>{
+    for (final FocusNode node in region.traversalDescendants)
+      // A row that is still in the tree but no longer laid out (a sliver keeps
+      // the focused one alive as it scrolls away) reports a non-finite rect.
+      // It is nowhere on screen, so it is no place to send the keyboard, and
+      // left in it would sort past every real row.
+      if (node.context != null && node.rect.isFinite) node,
+  };
+  final List<FocusNode> rows = <FocusNode>[
+    for (final FocusNode node in candidates)
+      if (!node.ancestors.any(candidates.contains)) node,
+  ];
+  rows.sort((FocusNode a, FocusNode b) {
+    final Rect first = a.rect;
+    final Rect second = b.rect;
+    // Band first: the cells of one grid row share a top edge, and it is the
+    // horizontal order that separates them.
+    if (first.top != second.top) return first.top.compareTo(second.top);
+    return rtl
+        ? second.left.compareTo(first.left)
+        : first.left.compareTo(second.left);
+  });
+  return rows;
+}
+
+/// A [Focus] node parked around [child] only so it can be asked what is
+/// focusable inside it.
+///
+/// It is never a stop of its own and can never hold the keyboard itself: it
+/// exists so a pane that is going away has somewhere to point (see
+/// `FocusHandoff`), and so a list can answer a key its rows know nothing about.
+class FocusRegion extends StatelessWidget {
+  const FocusRegion({required this.node, required this.child, super.key});
+
+  final FocusNode node;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      focusNode: node,
+      canRequestFocus: false,
+      skipTraversal: true,
+      includeSemantics: false,
+      child: child,
+    );
+  }
+}

--- a/lib/shared/focus/focus_ring.dart
+++ b/lib/shared/focus/focus_ring.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+
+import '../../app/dimens.dart';
+
+/// How thick Linthra draws the keyboard focus ring.
+///
+/// Two logical pixels is the thinnest ring that still reads as deliberate at
+/// desktop density, where a row is already only 56 px tall.
+const double focusRingWidth = 2;
+
+/// Identifies the drawn ring.
+///
+/// A row is full of decorations (artwork placeholders, status glyphs, a
+/// selection tint), so "is this surface showing a focus ring" is not a question
+/// a test can answer by looking for a bordered box. This key answers it
+/// exactly.
+const Key focusRingKey = Key('focus-ring');
+
+/// Whether [mode] is the one where a focus ring belongs on screen.
+///
+/// This is the whole reason nothing in this file asks which platform it is on.
+/// Flutter tracks *how the user is driving*: a touch means
+/// [FocusHighlightMode.touch], a key or a mouse means
+/// [FocusHighlightMode.traditional]. So "show a focus ring" is a question
+/// about the input device, which is the question we actually mean. A phone
+/// never leaves touch mode on its own, so mobile is unchanged by construction;
+/// an Android tablet with a keyboard case starts showing rings the moment Tab
+/// is pressed, which is exactly right and costs nothing to support.
+bool showsFocusRing(FocusHighlightMode mode) =>
+    mode == FocusHighlightMode.traditional;
+
+/// Draws Linthra's keyboard focus ring around whatever inside it holds focus.
+///
+/// Material's own focus feedback is an ink overlay, and Linthra has two
+/// problems with it. It is a veil, so the album grid hides it: ink is painted
+/// on the [Material] *behind* the card, and an opaque cover sits over it, the
+/// same blind spot [HoverHighlight] exists for. And a veil is the wrong shape
+/// for the job anyway: hover is already a veil (`hoverColor`) and selection is
+/// already a tint (`selectedTileColor`), so a third veil would leave the three
+/// states telling the user roughly the same thing at three alphas.
+///
+/// So focus gets its own vocabulary: an outline, in the accent colour, that
+/// nothing else in the app uses. It is drawn as an overlay rather than as a
+/// border in the layout, so a control does not resize or shift the row around
+/// it as focus arrives.
+///
+/// It takes no focus node. The ring watches a [Focus] node of its own that
+/// cannot be focused itself, which reports `hasFocus` whenever *anything
+/// inside* holds the keyboard, so it wraps a [ListTile], an [InkWell], a card
+/// or a whole row without the widget inside having to be rewritten to hand a
+/// node out. The ring around a row therefore also lights up for a control
+/// inside that row (its overflow menu, say), which is the right answer: it
+/// says where in the list the keyboard is.
+///
+/// That node is a real one, so `Focus.of` from somewhere under a ring answers
+/// with it rather than with whatever holds the keyboard. Anything that needs a
+/// surface's own node should read it where it is created, not look it up from
+/// deep inside. That is the same care any widget that wraps another in a
+/// [Focus] already calls for.
+class FocusRing extends StatefulWidget {
+  const FocusRing({
+    required this.child,
+    this.borderRadius,
+    this.enabled = true,
+    super.key,
+  });
+
+  final Widget child;
+
+  /// Corner radius of the ring. Defaults to [AppRadii.sm], the radius list
+  /// rows and small controls already use.
+  final BorderRadius? borderRadius;
+
+  /// Lets a host turn the ring off without dropping this widget from the tree
+  /// (and with it the element identity of everything below).
+  final bool enabled;
+
+  @override
+  State<FocusRing> createState() => _FocusRingState();
+}
+
+class _FocusRingState extends State<FocusRing> {
+  bool _focused = false;
+  late bool _keyboardDriven;
+
+  @override
+  void initState() {
+    super.initState();
+    _keyboardDriven = showsFocusRing(FocusManager.instance.highlightMode);
+    FocusManager.instance.addHighlightModeListener(_onHighlightModeChanged);
+  }
+
+  @override
+  void dispose() {
+    FocusManager.instance.removeHighlightModeListener(_onHighlightModeChanged);
+    super.dispose();
+  }
+
+  void _onHighlightModeChanged(FocusHighlightMode mode) {
+    final bool keyboardDriven = showsFocusRing(mode);
+    if (!mounted || keyboardDriven == _keyboardDriven) return;
+    setState(() => _keyboardDriven = keyboardDriven);
+  }
+
+  void _onFocusChange(bool focused) {
+    if (focused == _focused) return;
+    setState(() => _focused = focused);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool visible = widget.enabled && _focused && _keyboardDriven;
+    final BorderRadius radius =
+        widget.borderRadius ?? BorderRadius.circular(AppRadii.sm);
+    return Focus(
+      // Somewhere focus is *observed*, never somewhere it lands: the node must
+      // not become a stop of its own on the way through the page.
+      canRequestFocus: false,
+      skipTraversal: true,
+      includeSemantics: false,
+      onFocusChange: _onFocusChange,
+      child: Stack(
+        fit: StackFit.passthrough,
+        children: <Widget>[
+          widget.child,
+          if (visible)
+            Positioned.fill(
+              child: IgnorePointer(
+                child: DecoratedBox(
+                  key: focusRingKey,
+                  decoration: BoxDecoration(
+                    borderRadius: radius,
+                    border: Border.all(
+                      color: Theme.of(context).colorScheme.secondary,
+                      width: focusRingWidth,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/shared/focus/list_keyboard_navigation.dart
+++ b/lib/shared/focus/list_keyboard_navigation.dart
@@ -1,0 +1,174 @@
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+import 'focus_reading_order.dart';
+
+/// The list and grid keys a desktop user expects, on top of the ones Flutter
+/// already handles.
+///
+/// Most of a collection's keyboard behaviour comes for free and is deliberately
+/// left alone: the arrow keys already move focus row by row (and cell by cell)
+/// through a `ListView` or `GridView`, scrolling as they go, and Page Up/Down
+/// already scroll by a screen. What no amount of framework default can supply
+/// are the jumps that mean "the other end of this collection", because in a
+/// lazily-built list the other end has not been built yet: there is no focus
+/// node at the bottom of a 200k-track library for a traversal policy to find.
+///
+/// So this adds what is missing, for a list *or* a grid:
+///
+///  * **Home**: the top of the collection, and its first row.
+///  * **End**: the bottom of the collection, and its last row.
+///  * **← / →** past the end of a row, with [wrapRows]: the next (or previous)
+///    cell in reading order, which is how an icon grid is walked on every
+///    desktop. Off by default: in a single column of rows, ← and → belong to
+///    the controls inside a row, not to the list.
+///
+/// It scrolls first and moves focus on the next frame, once the sliver has
+/// built the rows the jump brought into range. The keyboard therefore lands on
+/// a real, visible row rather than on whatever happened to be built before.
+///
+/// Nothing here is gated on the platform. The keys only arrive from a real
+/// keyboard, so a phone is unaffected and a tablet with a keyboard case gets
+/// them for free, the same rule the rest of Linthra's desktop work follows.
+/// Typing wins outright: while an [EditableText] holds focus every key is left
+/// alone, so Home and End keep meaning "start/end of line" in a search box that
+/// happens to live inside a list.
+class ListKeyboardNavigation extends StatefulWidget {
+  const ListKeyboardNavigation({
+    required this.child,
+    this.wrapRows = false,
+    super.key,
+  });
+
+  /// Whether ← and → continue into the neighbouring row once a row runs out.
+  ///
+  /// True for grids of cards, where a row break is a layout artefact and not
+  /// something the user arranged. False for a column of rows.
+  final bool wrapRows;
+
+  final Widget child;
+
+  @override
+  State<ListKeyboardNavigation> createState() => _ListKeyboardNavigationState();
+}
+
+class _ListKeyboardNavigationState extends State<ListKeyboardNavigation> {
+  /// Observes the rows without ever being a stop of its own: key events travel
+  /// up from the focused row through this node, which is how the list gets to
+  /// answer a key its rows know nothing about, and `traversalDescendants` gives
+  /// the ordered rows without the list having to hold a node per row.
+  final FocusNode _node = FocusNode(
+    debugLabel: 'list keyboard navigation',
+    canRequestFocus: false,
+    skipTraversal: true,
+  );
+
+  @override
+  void dispose() {
+    _node.dispose();
+    super.dispose();
+  }
+
+  KeyEventResult _onKeyEvent(FocusNode node, KeyEvent event) {
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+    final FocusNode? focused = FocusManager.instance.primaryFocus;
+    final BuildContext? focusedContext = focused?.context;
+    if (focused == null || focusedContext == null) {
+      return KeyEventResult.ignored;
+    }
+    // Typing first, always: in a text field Home and End are the ends of the
+    // line and the arrow keys move the caret.
+    if (_isEditingText(focusedContext)) return KeyEventResult.ignored;
+
+    final LogicalKeyboardKey key = event.logicalKey;
+    if (key == LogicalKeyboardKey.home) return _jumpToEdge(focused, end: false);
+    if (key == LogicalKeyboardKey.end) return _jumpToEdge(focused, end: true);
+    if (!widget.wrapRows) return KeyEventResult.ignored;
+    if (key == LogicalKeyboardKey.arrowRight) {
+      return _step(focused, forward: !_isRtl);
+    }
+    if (key == LogicalKeyboardKey.arrowLeft) {
+      return _step(focused, forward: _isRtl);
+    }
+    return KeyEventResult.ignored;
+  }
+
+  bool get _isRtl => Directionality.of(context) == TextDirection.rtl;
+
+  /// Whether the keyboard is in a text field rather than on a row.
+  ///
+  /// Checked through the ancestors as well as the focused widget itself: a
+  /// field's focus node is attached to the [Focus] inside its [EditableText],
+  /// so the widget directly under the node is one step below the thing the
+  /// question is actually about.
+  static bool _isEditingText(BuildContext context) =>
+      context.widget is EditableText ||
+      context.findAncestorWidgetOfExactType<EditableText>() != null;
+
+  /// Home / End: scroll the collection to one end, then take its outermost row.
+  KeyEventResult _jumpToEdge(FocusNode focused, {required bool end}) {
+    final ScrollableState? scrollable = Scrollable.maybeOf(focused.context!);
+    if (scrollable == null) return KeyEventResult.ignored;
+    final ScrollPosition position = scrollable.position;
+    if (!position.hasContentDimensions) return KeyEventResult.ignored;
+    position.jumpTo(end ? position.maxScrollExtent : position.minScrollExtent);
+    // Next frame: until the jump has been laid out, the rows at that end of the
+    // collection do not exist and there is nothing there to focus.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final List<FocusNode> rows = _rowsInOrder();
+      if (rows.isEmpty) return;
+      (end ? rows.last : rows.first).requestFocus();
+    });
+    return KeyEventResult.handled;
+  }
+
+  /// ← / → in a grid: the cell the row break hid, one step away in reading
+  /// order.
+  ///
+  /// Tried only once the ordinary geometric move has failed, so moving *within*
+  /// a row, and onto whatever controls a row carries, is untouched. Bounded to
+  /// this collection by construction: the candidates are its own descendants,
+  /// so the last cell of the grid cannot hand focus on to the page beyond it.
+  KeyEventResult _step(FocusNode focused, {required bool forward}) {
+    final TraversalDirection direction =
+        forward ? TraversalDirection.right : TraversalDirection.left;
+    if (focused.focusInDirection(direction)) return KeyEventResult.handled;
+
+    final List<FocusNode> cells = _rowsInOrder();
+    final int index = cells.indexOf(focused);
+    if (index < 0) return KeyEventResult.ignored;
+    final int target = forward ? index + 1 : index - 1;
+    if (target < 0 || target >= cells.length) return KeyEventResult.ignored;
+
+    final FocusNode next = cells[target];
+    final BuildContext? nextContext = next.context;
+    if (nextContext != null) {
+      Scrollable.ensureVisible(
+        nextContext,
+        alignmentPolicy: forward
+            ? ScrollPositionAlignmentPolicy.keepVisibleAtEnd
+            : ScrollPositionAlignmentPolicy.keepVisibleAtStart,
+      );
+    }
+    next.requestFocus();
+    return KeyEventResult.handled;
+  }
+
+  /// This collection's rows, in the order they read.
+  List<FocusNode> _rowsInOrder() => focusableRowsIn(_node, rtl: _isRtl);
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      focusNode: _node,
+      canRequestFocus: false,
+      skipTraversal: true,
+      includeSemantics: false,
+      onKeyEvent: _onKeyEvent,
+      child: widget.child,
+    );
+  }
+}

--- a/lib/shared/layout/pane_layout.dart
+++ b/lib/shared/layout/pane_layout.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 
 import '../../app/dimens.dart';
+import '../focus/focus_handoff.dart';
+import '../focus/focus_reading_order.dart';
 import 'adaptive_layout.dart';
 
 /// Width of a fixed side pane that holds one thing's header: a cover, a title
@@ -49,7 +51,13 @@ const double listDetailMinWidth = detailPaneWidth + mediumWindowWidth;
 /// including a track selection in progress, goes with it on a resize the user
 /// never thought of as leaving the screen. State that has to outlive the pane
 /// belongs to the host and is passed down (see `LibraryScreen`).
-class ListDetailPanes extends StatelessWidget {
+///
+/// Keyboard focus is the one piece of that this widget can hold itself (#390).
+/// When the pane goes and the keyboard was in it, focus would otherwise unwind
+/// to the route's scope: nothing on screen carries a ring, and the next Tab
+/// starts again at the top of the page. So it lands on the list instead, which
+/// is now the whole screen, and is where the detail was opened from.
+class ListDetailPanes extends StatefulWidget {
   const ListDetailPanes({
     required this.listBuilder,
     required this.detailBuilder,
@@ -76,16 +84,60 @@ class ListDetailPanes extends StatelessWidget {
   final double minWidthForPane;
 
   @override
+  State<ListDetailPanes> createState() => _ListDetailPanesState();
+}
+
+class _ListDetailPanesState extends State<ListDetailPanes> {
+  /// Parked around the list so the pane has somewhere to hand the keyboard
+  /// back to. Never focusable itself.
+  final FocusNode _listRegion = FocusNode(
+    debugLabel: 'list beside detail pane',
+    canRequestFocus: false,
+    skipTraversal: true,
+  );
+
+  @override
+  void dispose() {
+    _listRegion.dispose();
+    super.dispose();
+  }
+
+  /// The first row of the list, resolved after the pane has gone and the list
+  /// has been laid out at its new width.
+  ///
+  /// The row the detail was opened from would be the ideal landing place, but
+  /// the list owns no handle on it, and after a resize it may not even be on
+  /// screen. The top of the list always is, and it is somewhere the ring is
+  /// visible and Tab carries on sensibly from.
+  FocusNode? _firstRowOfList() {
+    // The list can have gone with the pane (the whole screen left, or the tab
+    // changed under it), in which case there is nothing here to hand back to.
+    if (!mounted) return null;
+    final List<FocusNode> rows = focusableRowsIn(
+      _listRegion,
+      rtl: Directionality.of(context) == TextDirection.rtl,
+    );
+    return rows.isEmpty ? null : rows.first;
+  }
+
+  @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
-        final bool paneVisible = constraints.maxWidth >= minWidthForPane;
-        final Widget list = listBuilder(context, paneVisible);
+        final bool paneVisible = constraints.maxWidth >= widget.minWidthForPane;
+        final Widget list = FocusRegion(
+          node: _listRegion,
+          child: widget.listBuilder(context, paneVisible),
+        );
         if (!paneVisible) return list;
 
         return SplitPanes(
-          fixed: detailBuilder(context) ?? placeholderBuilder(context),
-          fixedWidth: paneWidth,
+          fixed: FocusHandoff(
+            returnFocusTo: _firstRowOfList,
+            child: widget.detailBuilder(context) ??
+                widget.placeholderBuilder(context),
+          ),
+          fixedWidth: widget.paneWidth,
           flexible: list,
           fixedFirst: false,
           // A grid is happy at any width — it answers extra room with more

--- a/lib/shared/widgets/reorder_handle.dart
+++ b/lib/shared/widgets/reorder_handle.dart
@@ -3,6 +3,7 @@ import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 
 import '../../app/dimens.dart';
+import '../focus/focus_ring.dart';
 
 /// The modifier the move chord is spelled with on [platform].
 ///
@@ -128,12 +129,16 @@ class ReorderHandle extends StatelessWidget {
               const CustomSemanticsAction(label: 'Move down'): () =>
                   onMoveBy(1),
           },
-          child: Focus(
-            focusNode: focusNode,
-            child: Builder(
-              builder: (BuildContext context) {
-                final bool focused = Focus.of(context).hasFocus;
-                return MouseRegion(
+          child: Padding(
+            padding: const EdgeInsets.only(left: AppSpacing.xs),
+            // The shared ring (#390): the handle is a focusable control like
+            // any other, and says so the same way the rows around it do. Drawn
+            // as an overlay outside the node, so arriving on it never nudges
+            // the row's layout and `Focus.of` below still finds the handle.
+            child: FocusRing(
+              child: Focus(
+                focusNode: focusNode,
+                child: MouseRegion(
                   cursor: SystemMouseCursors.grab,
                   child: ReorderableDragStartListener(
                     index: index,
@@ -147,27 +152,17 @@ class ReorderHandle extends StatelessWidget {
                       // desktop trigger anyway, and the handle is still named
                       // for screen readers either way.
                       triggerMode: TooltipTriggerMode.manual,
-                      child: Container(
-                        margin: const EdgeInsets.only(left: AppSpacing.xs),
-                        padding: const EdgeInsets.all(AppSpacing.xs),
-                        decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(AppRadii.sm),
-                          border: Border.all(
-                            width: 2,
-                            color: focused
-                                ? theme.colorScheme.primary
-                                : Colors.transparent,
-                          ),
-                        ),
-                        child: const Icon(
+                      child: const Padding(
+                        padding: EdgeInsets.all(AppSpacing.xs),
+                        child: Icon(
                           Icons.drag_handle,
                           semanticLabel: 'Reorder',
                         ),
                       ),
                     ),
                   ),
-                );
-              },
+                ),
+              ),
             ),
           ),
         ),

--- a/test/features/library/keyboard_navigation_test.dart
+++ b/test/features/library/keyboard_navigation_test.dart
@@ -1,0 +1,356 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:linthra/app/brand_theme.dart';
+import 'package:linthra/app/routes.dart';
+import 'package:linthra/app/theme.dart';
+import 'package:linthra/core/models/album.dart';
+import 'package:linthra/core/models/artist.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/library/library_screen.dart';
+import 'package:linthra/features/library/widgets/album_grid.dart';
+import 'package:linthra/features/library/widgets/album_grid_card.dart';
+import 'package:linthra/features/library/widgets/artist_grid.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/player_screen.dart';
+import 'package:linthra/shared/focus/focus_ring.dart';
+
+import '../player/fake_playback_controller.dart';
+import 'fake_music_library_repository.dart';
+
+/// Browsing the library without a mouse (#390).
+///
+/// The rules pinned here are the ones a desktop user brings with them: the
+/// arrow keys walk a list of songs and a grid of covers, Home and End are its
+/// two ends, Enter and Space open what is focused, and whatever is focused says
+/// so loudly enough to find, including on an album card, where Material's own
+/// ink highlight is painted underneath the cover and cannot be seen at all.
+///
+/// None of it is gated on Linux, and the last test says why that is safe: on a
+/// touch build the same widgets behave exactly as they did before.
+
+final List<Track> _songs = <Track>[
+  for (int i = 0; i < 40; i++)
+    Track(
+      id: 'song-$i',
+      title: 'Song ${i.toString().padLeft(2, '0')}',
+      uri: 'jellyfin:song-$i',
+      albumName: 'Album ${i ~/ 4}',
+      artistName: 'Artist ${i ~/ 8}',
+    ),
+];
+
+final List<Album> _albums = <Album>[
+  for (int i = 0; i < 24; i++)
+    Album(
+      id: 'album-$i',
+      title: 'Album ${i.toString().padLeft(2, '0')}',
+      artistName: 'Artist $i',
+      trackCount: 4,
+    ),
+];
+
+final List<Artist> _artists = <Artist>[
+  for (int i = 0; i < 12; i++)
+    Artist(
+      id: 'artist-$i',
+      name: 'Artist ${i.toString().padLeft(2, '0')}',
+      albumCount: 2,
+      trackCount: 8,
+    ),
+];
+
+GoRouter _router() {
+  return GoRouter(
+    initialLocation: AppRoutes.library,
+    routes: <RouteBase>[
+      GoRoute(
+        path: AppRoutes.library,
+        builder: (_, __) => const LibraryScreen(),
+      ),
+      GoRoute(
+        path: AppRoutes.player,
+        builder: (_, __) => const PlayerScreen(),
+      ),
+    ],
+  );
+}
+
+Future<FakePlaybackController> _pumpLibrary(
+  WidgetTester tester, {
+  Size size = const Size(1280, 900),
+}) async {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = size;
+  addTearDown(tester.view.reset);
+
+  final FakePlaybackController controller = FakePlaybackController();
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        musicLibraryRepositoryProvider
+            .overrideWithValue(FakeMusicLibraryRepository(tracks: _songs)),
+        playbackControllerProvider.overrideWithValue(controller),
+      ],
+      child: MaterialApp.router(
+        theme: AppTheme.dark(BrandPalettes.classic),
+        routerConfig: _router(),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return controller;
+}
+
+Future<void> _pumpAlbums(
+  WidgetTester tester, {
+  void Function(Album album)? onOpen,
+}) async {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = const Size(1280, 900);
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        theme: AppTheme.dark(BrandPalettes.classic),
+        home: Scaffold(
+          body: AlbumGrid(albums: _albums, onOpen: onOpen ?? (_) {}),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// The label of whatever holds the keyboard, or null when it carries no text.
+String? _focusedLabel() {
+  final BuildContext? context = FocusManager.instance.primaryFocus?.context;
+  if (context == null) return null;
+  final Finder text = find.descendant(
+    of: find.byWidget(context.widget),
+    matching: find.byType(Text),
+  );
+  if (text.evaluate().isEmpty) return null;
+  return (text.evaluate().first.widget as Text).data;
+}
+
+Future<void> _press(WidgetTester tester, LogicalKeyboardKey key) async {
+  await tester.sendKeyEvent(key);
+  // One frame for the move (and any scroll it caused), one for the rows that
+  // scroll built.
+  await tester.pump();
+  await tester.pump();
+}
+
+/// How many columns the grid chose, so a test never re-derives the breakpoint
+/// arithmetic the grid already owns.
+int _albumColumns(WidgetTester tester) {
+  final GridView grid = tester.widget<GridView>(
+    find.byKey(const Key('library_album_grid')),
+  );
+  return (grid.gridDelegate as SliverGridDelegateWithFixedCrossAxisCount)
+      .crossAxisCount;
+}
+
+/// The label of album [index], as the grid draws it.
+String _album(int index) => 'Album ${index.toString().padLeft(2, '0')}';
+
+/// Whether a focus ring is drawn anywhere on screen.
+bool _ringVisible(WidgetTester tester) =>
+    find.byKey(focusRingKey).evaluate().isNotEmpty;
+
+/// Whether the focus ring is drawn around the row or card carrying [label].
+bool _ringAround(WidgetTester tester, String label) {
+  final Finder surface = find.ancestor(
+    of: find.text(label),
+    matching: find.byType(FocusRing),
+  );
+  if (surface.evaluate().isEmpty) return false;
+  return find
+      .descendant(of: surface.first, matching: find.byKey(focusRingKey))
+      .evaluate()
+      .isNotEmpty;
+}
+
+void main() {
+  group('the songs list', () {
+    testWidgets('the arrow keys walk it row by row', (tester) async {
+      await _pumpLibrary(tester);
+      Focus.of(tester.element(find.text('Song 00'))).requestFocus();
+      await tester.pump();
+
+      await _press(tester, LogicalKeyboardKey.arrowDown);
+      expect(_focusedLabel(), 'Song 01');
+      await _press(tester, LogicalKeyboardKey.arrowDown);
+      expect(_focusedLabel(), 'Song 02');
+      await _press(tester, LogicalKeyboardKey.arrowUp);
+      expect(_focusedLabel(), 'Song 01');
+    });
+
+    testWidgets('End and Home reach both ends of the library', (tester) async {
+      await _pumpLibrary(tester);
+      Focus.of(tester.element(find.text('Song 00'))).requestFocus();
+      await tester.pump();
+      expect(find.text('Song 39'), findsNothing);
+
+      await _press(tester, LogicalKeyboardKey.end);
+      expect(_focusedLabel(), 'Song 39');
+
+      await _press(tester, LogicalKeyboardKey.home);
+      expect(_focusedLabel(), 'Song 00');
+    });
+
+    testWidgets('the focused row is ringed, and only that row', (tester) async {
+      await _pumpLibrary(tester);
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      Focus.of(tester.element(find.text('Song 01'))).requestFocus();
+      await tester.pump();
+
+      expect(_ringAround(tester, 'Song 01'), isTrue);
+      expect(_ringAround(tester, 'Song 02'), isFalse);
+    });
+
+    testWidgets('Enter plays the focused row', (tester) async {
+      final FakePlaybackController controller = await _pumpLibrary(tester);
+      Focus.of(tester.element(find.text('Song 03'))).requestFocus();
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+
+      expect(controller.playedTracks.single.title, 'Song 03');
+      expect(find.text('Now Playing'), findsOneWidget);
+    });
+
+    testWidgets('Space plays it too', (tester) async {
+      final FakePlaybackController controller = await _pumpLibrary(tester);
+      Focus.of(tester.element(find.text('Song 05'))).requestFocus();
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.space);
+      await tester.pumpAndSettle();
+
+      expect(controller.playedTracks.single.title, 'Song 05');
+    });
+  });
+
+  group('the albums grid', () {
+    testWidgets('the arrow keys move across and down the grid', (tester) async {
+      await _pumpAlbums(tester);
+      Focus.of(tester.element(find.text('Album 00'))).requestFocus();
+      await tester.pump();
+
+      await _press(tester, LogicalKeyboardKey.arrowRight);
+      expect(_focusedLabel(), 'Album 01');
+
+      await _press(tester, LogicalKeyboardKey.arrowDown);
+      expect(_focusedLabel(), _album(1 + _albumColumns(tester)));
+    });
+
+    testWidgets('→ carries on into the next row at a row break',
+        (tester) async {
+      await _pumpAlbums(tester);
+      final int columns = _albumColumns(tester);
+      final String lastOfRow = _album(columns - 1);
+      final String firstOfNext = _album(columns);
+      Focus.of(tester.element(find.text(lastOfRow))).requestFocus();
+      await tester.pump();
+
+      await _press(tester, LogicalKeyboardKey.arrowRight);
+
+      expect(_focusedLabel(), firstOfNext);
+    });
+
+    testWidgets('the ring is drawn over the cover, not behind it',
+        (tester) async {
+      await _pumpAlbums(tester);
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+
+      expect(_ringVisible(tester), isTrue);
+      // Over the whole card, the cover included, rather than only the label
+      // strip Material's ink can reach.
+      final Finder ring = find.ancestor(
+        of: find.text('Album 00'),
+        matching: find.byType(FocusRing),
+      );
+      final Finder card = find.ancestor(
+        of: find.text('Album 00'),
+        matching: find.byType(AlbumGridCard),
+      );
+      expect(
+        tester.getRect(ring.first).height,
+        closeTo(tester.getRect(card.first).height, 1),
+      );
+    });
+
+    testWidgets('Enter opens the focused album', (tester) async {
+      Album? opened;
+      await _pumpAlbums(tester, onOpen: (Album album) => opened = album);
+      Focus.of(tester.element(find.text('Album 02'))).requestFocus();
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+
+      expect(opened?.title, 'Album 02');
+    });
+  });
+
+  group('the artists grid', () {
+    testWidgets('a single column does not wrap on →', (tester) async {
+      tester.view.devicePixelRatio = 1.0;
+      tester.view.physicalSize = const Size(500, 900);
+      addTearDown(tester.view.reset);
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            theme: AppTheme.dark(BrandPalettes.classic),
+            home: Scaffold(
+              body: ArtistGrid(artists: _artists, onOpen: (_) {}),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      Focus.of(tester.element(find.text('Artist 00'))).requestFocus();
+      await tester.pump();
+
+      await _press(tester, LogicalKeyboardKey.arrowRight);
+
+      // One column is a list, and in a list → is not "the next artist".
+      expect(_focusedLabel(), 'Artist 00');
+    });
+  });
+
+  testWidgets('a touch build behaves exactly as before', (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    try {
+      final FakePlaybackController controller = await _pumpLibrary(
+        tester,
+        size: const Size(420, 900),
+      );
+      // Touch keeps the focus manager out of keyboard mode, so no ring is
+      // painted anywhere, so the phone looks exactly as it did.
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTouch;
+      await tester.pump();
+
+      await tester.tap(find.text('Song 01'));
+      await tester.pumpAndSettle();
+
+      expect(controller.playedTracks.single.title, 'Song 01');
+      expect(_ringVisible(tester), isFalse);
+    } finally {
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.automatic;
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+}

--- a/test/features/library/library_detail_pane_test.dart
+++ b/test/features/library/library_detail_pane_test.dart
@@ -11,6 +11,7 @@ import 'package:linthra/data/repositories/playlist_repository_provider.dart';
 import 'package:linthra/features/library/album_detail_screen.dart';
 import 'package:linthra/features/library/artist_detail_screen.dart';
 import 'package:linthra/features/library/library_screen.dart';
+import 'package:linthra/features/library/widgets/album_grid_card.dart';
 import 'package:linthra/features/library/widgets/track_tile.dart';
 import 'package:linthra/features/player/player_providers.dart';
 import 'package:linthra/features/player/player_screen.dart';
@@ -87,6 +88,12 @@ Future<void> _pumpLibrary(WidgetTester tester, Size size) async {
 Future<void> _openTab(WidgetTester tester, String tab) async {
   await tester.tap(find.text(tab));
   await tester.pumpAndSettle();
+}
+
+/// Whether whatever holds focus sits inside a [T].
+bool _focusedInside<T extends Widget>() {
+  final BuildContext? context = FocusManager.instance.primaryFocus?.context;
+  return context != null && context.findAncestorWidgetOfExactType<T>() != null;
 }
 
 void main() {
@@ -174,6 +181,30 @@ void main() {
       tester.view.physicalSize = _paneWindow;
       await tester.pumpAndSettle();
       expect(find.text('Song 0'), findsOneWidget);
+    });
+
+    testWidgets('narrowing gives the keyboard back to the grid (#390)',
+        (tester) async {
+      await _pumpLibrary(tester, _paneWindow);
+      await _openTab(tester, 'Albums');
+      await tester.tap(find.text('Discovery').first);
+      await tester.pumpAndSettle();
+
+      // The keyboard is on a track in the pane when the window narrows.
+      Focus.of(tester.element(find.text('Song 0'))).requestFocus();
+      await tester.pump();
+      expect(_focusedInside<TrackTile>(), isTrue);
+
+      tester.view.physicalSize = _narrowWindow;
+      await tester.pumpAndSettle();
+
+      // Not the route's scope, which is where it unwinds to on its own: that
+      // leaves nothing ringed on screen and sends the next Tab back to the top
+      // of the page.
+      final FocusNode? focused = FocusManager.instance.primaryFocus;
+      expect(focused, isNot(isA<FocusScopeNode>()));
+      expect(focused?.rect.isFinite, isTrue);
+      expect(_focusedInside<AlbumGridCard>(), isTrue);
     });
 
     testWidgets('a search that hides the album clears the pane with it',

--- a/test/features/player/player_queue_pane_test.dart
+++ b/test/features/player/player_queue_pane_test.dart
@@ -53,6 +53,25 @@ const Lyrics _lyrics = Lyrics(
   ],
 );
 
+/// Whether whatever holds focus sits inside a [T].
+bool _focusedInside<T extends Widget>() {
+  final BuildContext? context = FocusManager.instance.primaryFocus?.context;
+  return context != null && context.findAncestorWidgetOfExactType<T>() != null;
+}
+
+/// The icon button behind a tooltip. `find.byTooltip` lands on the [Tooltip]
+/// the button builds, which is one step below the button itself.
+IconButton _queueButton(WidgetTester tester, String tooltip) {
+  return tester.widget<IconButton>(
+    find
+        .ancestor(
+          of: find.byTooltip(tooltip),
+          matching: find.byType(IconButton),
+        )
+        .first,
+  );
+}
+
 /// Just above `_queuePaneMinWidth` (1000 + 340 + 24).
 const Size _paneWindow = Size(1400, 900);
 
@@ -217,6 +236,47 @@ void main() {
       expect(saved.single.name, 'My Queue');
       expect(saved.single.trackIds, <String>[_track.uri, _next.uri]);
       expect(tester.takeException(), isNull);
+    });
+  });
+
+  group('closing the pane keeps the keyboard (#390)', () {
+    testWidgets('the toggle takes focus back from inside the pane',
+        (tester) async {
+      await _pumpPlayer(tester, size: _paneWindow);
+      await tester.tap(find.byTooltip('Show queue'));
+      await tester.pumpAndSettle();
+
+      // The keyboard is on a queue row when the pane goes.
+      Focus.of(tester.element(find.text('Song Two'))).requestFocus();
+      await tester.pump();
+      expect(_focusedInside<QueueSheet>(), isTrue);
+
+      await tester.tap(find.byTooltip('Hide queue'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(QueueSheet), findsNothing);
+      expect(
+        FocusManager.instance.primaryFocus,
+        _queueButton(tester, 'Show queue').focusNode,
+      );
+    });
+
+    testWidgets('narrowing the window does the same', (tester) async {
+      await _pumpPlayer(tester, size: _paneWindow);
+      await tester.tap(find.byTooltip('Show queue'));
+      await tester.pumpAndSettle();
+      Focus.of(tester.element(find.text('Song Two'))).requestFocus();
+      await tester.pump();
+
+      await _resize(tester, _twoColumnWindow);
+
+      expect(find.byType(QueueSheet), findsNothing);
+      // The button is the sheet's now, but it is the same control in the same
+      // place and it carries the same node.
+      expect(
+        FocusManager.instance.primaryFocus,
+        _queueButton(tester, 'Queue').focusNode,
+      );
     });
   });
 }

--- a/test/features/settings/provider_form_keyboard_test.dart
+++ b/test/features/settings/provider_form_keyboard_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/data/repositories/in_memory_jellyfin_session_store.dart';
+import 'package:linthra/data/repositories/jellyfin_session_store_provider.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_settings_providers.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_settings_section.dart';
+
+import '../../core/sources/jellyfin/fake_jellyfin_client.dart';
+import 'jellyfin/fake_jellyfin_authenticator.dart';
+
+/// Connecting a music provider without a mouse (#390).
+///
+/// A provider card is the one place in Linthra where a keyboard user has to
+/// type as well as navigate, which makes it the surface where "keyboard
+/// navigation" is easiest to break: a stray shortcut above the page would eat a
+/// character or move focus mid-word. The rules here are the plain ones: Tab
+/// walks the fields in the order they read, typing is typing, and Enter on the
+/// last field submits the form.
+
+Future<FakeJellyfinAuthenticator> _pumpSection(WidgetTester tester) async {
+  final FakeJellyfinAuthenticator authenticator = FakeJellyfinAuthenticator();
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        jellyfinAuthenticatorProvider.overrideWithValue(authenticator),
+        jellyfinSessionStoreProvider
+            .overrideWithValue(InMemoryJellyfinSessionStore()),
+        jellyfinClientProvider.overrideWithValue(FakeJellyfinClient()),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(body: JellyfinSettingsSection()),
+      ),
+    ),
+  );
+  await tester.pump();
+  return authenticator;
+}
+
+/// The label of the field that currently holds the keyboard, or null when the
+/// focus is not in one.
+String? _focusedField(WidgetTester tester) {
+  final BuildContext? context = FocusManager.instance.primaryFocus?.context;
+  if (context == null) return null;
+  final EditableText? field =
+      context.findAncestorWidgetOfExactType<EditableText>();
+  if (field == null) return null;
+  for (final TextField candidate in tester.widgetList<TextField>(
+    find.byType(TextField),
+  )) {
+    if (candidate.controller == field.controller) {
+      return (candidate.decoration?.labelText);
+    }
+  }
+  return null;
+}
+
+Future<void> _tab(WidgetTester tester) async {
+  await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('Tab walks the form in the order it reads', (tester) async {
+    await _pumpSection(tester);
+
+    await tester.tap(find.byType(TextField).first);
+    await tester.pump();
+    expect(_focusedField(tester), 'Server URL');
+
+    await _tab(tester);
+    expect(_focusedField(tester), 'Username');
+
+    await _tab(tester);
+    expect(_focusedField(tester), 'Password');
+  });
+
+  testWidgets('Shift+Tab retraces it', (tester) async {
+    await _pumpSection(tester);
+    await tester.tap(find.byType(TextField).at(2));
+    await tester.pump();
+    expect(_focusedField(tester), 'Password');
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+    await _tab(tester);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+
+    expect(_focusedField(tester), 'Username');
+  });
+
+  testWidgets('typing and editing are untouched', (tester) async {
+    await _pumpSection(tester);
+    final Finder url = find.byType(TextField).first;
+
+    await tester.enterText(url, 'https://music.example.com');
+    await tester.pump();
+
+    // The arrow keys move the caret rather than the focus: nothing added for
+    // lists or panes reaches into a field.
+    final EditableTextState state = tester.state(
+      find.byType(EditableText).first,
+    );
+    expect(state.textEditingValue.text, 'https://music.example.com');
+    state.userUpdateTextEditingValue(
+      state.textEditingValue.copyWith(
+        selection: const TextSelection.collapsed(offset: 8),
+      ),
+      SelectionChangedCause.keyboard,
+    );
+    await tester.pump();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+    await tester.pump();
+
+    expect(_focusedField(tester), 'Server URL');
+    expect(state.textEditingValue.selection.baseOffset, 7);
+  });
+
+  testWidgets('Enter on the last field signs in', (tester) async {
+    final FakeJellyfinAuthenticator authenticator = await _pumpSection(tester);
+
+    await tester.enterText(
+      find.byType(TextField).at(0),
+      'https://music.example.com',
+    );
+    await tester.enterText(find.byType(TextField).at(1), 'alice');
+    await tester.enterText(find.byType(TextField).at(2), 'secret');
+    await tester.pump();
+
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pumpAndSettle();
+
+    // No trip to the Sign in button needed: the form submits from the field
+    // the user is already in, which is what every desktop login does.
+    expect(authenticator.lastSignInUrl, 'https://music.example.com');
+    expect(authenticator.lastUsername, 'alice');
+  });
+}

--- a/test/features/shell/queue_side_panel_shell_test.dart
+++ b/test/features/shell/queue_side_panel_shell_test.dart
@@ -165,6 +165,31 @@ bool _focusedInside<T extends Widget>() {
   return context != null && context.findAncestorWidgetOfExactType<T>() != null;
 }
 
+/// The icon button behind a tooltip. `find.byTooltip` lands on the [Tooltip]
+/// the button builds, which is one step below the button itself.
+IconButton _button(WidgetTester tester, String tooltip) {
+  return tester.widget<IconButton>(
+    find
+        .ancestor(
+          of: find.byTooltip(tooltip),
+          matching: find.byType(IconButton),
+        )
+        .first,
+  );
+}
+
+/// Puts the keyboard on the control behind [tooltip], the way Tab would.
+void _focusButton(WidgetTester tester, String tooltip) {
+  Focus.of(
+    tester.element(
+      find.descendant(
+        of: find.byTooltip(tooltip),
+        matching: find.byType(Icon),
+      ),
+    ),
+  ).requestFocus();
+}
+
 void main() {
   testWidgets('a wide desktop window can keep the queue beside the page',
       (WidgetTester tester) async {
@@ -324,5 +349,79 @@ void main() {
     expect(panelStop, isNonNegative, reason: 'the column is never reached');
     expect(railStop, isNonNegative, reason: 'the rail is never reached');
     expect(panelStop, lessThan(railStop));
+  });
+
+  group('closing the column keeps the keyboard (#390)', () {
+    testWidgets('the ✕ hands focus back to the button that reopens it',
+        (WidgetTester tester) async {
+      await _pumpShell(
+        tester,
+        platform: TargetPlatform.linux,
+        size: _wideWindow,
+      );
+      await tester.tap(find.byTooltip('Show queue'));
+      await tester.pumpAndSettle();
+
+      // Reach the ✕ the way a keyboard user would, then press it.
+      _focusButton(tester, 'Close queue');
+      await tester.pump();
+      expect(_focusedInside<QueueSidePanel>(), isTrue);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(QueueSidePanel), findsNothing);
+      // Not nowhere, and not back at the top of the page: the control that
+      // opens the column again, which is where the user is standing.
+      expect(find.byTooltip('Show queue'), findsOneWidget);
+      expect(
+        FocusManager.instance.primaryFocus,
+        _button(tester, 'Show queue').focusNode,
+      );
+    });
+
+    testWidgets('narrowing the window past the column does the same',
+        (WidgetTester tester) async {
+      await _pumpShell(
+        tester,
+        platform: TargetPlatform.linux,
+        size: _wideWindow,
+      );
+      await tester.tap(find.byTooltip('Show queue'));
+      await tester.pumpAndSettle();
+      _focusButton(tester, 'Close queue');
+      await tester.pump();
+
+      // A resize is not something the user thought of as leaving the column,
+      // so it must not be what loses their place in the frame.
+      await _resize(tester, _narrowDesktopWindow);
+
+      expect(find.byType(QueueSidePanel), findsNothing);
+      expect(
+        FocusManager.instance.primaryFocus,
+        _button(tester, 'Queue').focusNode,
+      );
+    });
+
+    testWidgets('opening it leaves focus on the button', (tester) async {
+      await _pumpShell(
+        tester,
+        platform: TargetPlatform.linux,
+        size: _wideWindow,
+      );
+      _focusButton(tester, 'Show queue');
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(QueueSidePanel), findsOneWidget);
+      // Opening a pane is not a reason to move the keyboard into it: the next
+      // Tab walks into the column, which is the ordinary way in.
+      expect(
+        FocusManager.instance.primaryFocus,
+        _button(tester, 'Hide queue').focusNode,
+      );
+    });
   });
 }

--- a/test/shared/focus/focus_handoff_test.dart
+++ b/test/shared/focus/focus_handoff_test.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/shared/focus/focus_handoff.dart';
+
+/// Closing a desktop pane must not cost the keyboard its place (#390). What the
+/// framework does on its own is unwind to the enclosing scope, which leaves no
+/// ring on screen and restarts the next Tab from the top of the page. It is the
+/// kind of thing a mouse user never notices and a keyboard user hits every time
+/// they resize a window.
+
+class _Host extends StatefulWidget {
+  const _Host();
+
+  @override
+  State<_Host> createState() => _HostState();
+}
+
+class _HostState extends State<_Host> {
+  final FocusNode _toggle = FocusNode(debugLabel: 'toggle');
+  bool _paneOpen = false;
+
+  @override
+  void dispose() {
+    _toggle.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Row(
+          children: <Widget>[
+            TextButton(
+              focusNode: _toggle,
+              onPressed: () => setState(() => _paneOpen = !_paneOpen),
+              child: const Text('toggle'),
+            ),
+            TextButton(onPressed: () {}, child: const Text('elsewhere')),
+            if (_paneOpen)
+              FocusHandoff(
+                returnFocusTo: () => _toggle,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    TextButton(onPressed: () {}, child: const Text('in pane')),
+                  ],
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String? _focusedLabel() {
+  final BuildContext? context = FocusManager.instance.primaryFocus?.context;
+  if (context == null) return null;
+  final Finder text = find.descendant(
+    of: find.byWidget(context.widget),
+    matching: find.byType(Text),
+  );
+  if (text.evaluate().isEmpty) return null;
+  return (text.evaluate().first.widget as Text).data;
+}
+
+void main() {
+  testWidgets('a pane holding the keyboard hands it back on close',
+      (tester) async {
+    await tester.pumpWidget(const _Host());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('toggle'));
+    await tester.pumpAndSettle();
+    Focus.of(tester.element(find.text('in pane'))).requestFocus();
+    await tester.pump();
+    expect(_focusedLabel(), 'in pane');
+
+    await tester.tap(find.text('toggle'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('in pane'), findsNothing);
+    expect(_focusedLabel(), 'toggle');
+  });
+
+  testWidgets('a pane that was not holding it leaves focus alone',
+      (tester) async {
+    await tester.pumpWidget(const _Host());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('toggle'));
+    await tester.pumpAndSettle();
+    Focus.of(tester.element(find.text('elsewhere'))).requestFocus();
+    await tester.pump();
+    expect(_focusedLabel(), 'elsewhere');
+
+    await tester.tap(find.text('toggle'));
+    await tester.pumpAndSettle();
+
+    // Someone typing in another pane must not have the keyboard pulled off
+    // them because an unrelated column closed.
+    expect(_focusedLabel(), 'elsewhere');
+  });
+
+  testWidgets('a target that went away with the pane is left alone',
+      (tester) async {
+    final FocusNode target = FocusNode(debugLabel: 'gone');
+    addTearDown(target.dispose);
+    bool mounted = true;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Scaffold(
+              body: Column(
+                children: <Widget>[
+                  TextButton(
+                    onPressed: () => setState(() => mounted = false),
+                    child: const Text('drop both'),
+                  ),
+                  if (mounted) ...<Widget>[
+                    TextButton(
+                      focusNode: target,
+                      onPressed: () {},
+                      child: const Text('target'),
+                    ),
+                    FocusHandoff(
+                      returnFocusTo: () => target,
+                      child: TextButton(
+                        onPressed: () {},
+                        child: const Text('in pane'),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    Focus.of(tester.element(find.text('in pane'))).requestFocus();
+    await tester.pump();
+
+    await tester.tap(find.text('drop both'));
+    await tester.pumpAndSettle();
+
+    // No deferred request left armed on a node that is no longer on screen: it
+    // would fire whenever that control came back, stealing focus long after.
+    expect(tester.takeException(), isNull);
+    expect(target.hasFocus, isFalse);
+  });
+}

--- a/test/shared/focus/focus_ring_test.dart
+++ b/test/shared/focus/focus_ring_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/app/brand_theme.dart';
+import 'package:linthra/app/theme.dart';
+import 'package:linthra/shared/focus/focus_ring.dart';
+
+/// The focus ring is what makes "where is the keyboard" answerable at a glance
+/// (#390), and it has exactly one rule that keeps mobile out of it: it is drawn
+/// for the input mode, not for the platform. Touch never shows one; a keyboard
+/// always does, on Linux and on an Android tablet with a keyboard case alike.
+
+BoxDecoration? _ring(WidgetTester tester) {
+  final Finder drawn = find.byKey(focusRingKey);
+  if (drawn.evaluate().isEmpty) return null;
+  return tester.widget<DecoratedBox>(drawn.first).decoration as BoxDecoration;
+}
+
+Future<void> _pump(WidgetTester tester) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: AppTheme.dark(BrandPalettes.classic),
+      home: Scaffold(
+        body: Column(
+          children: <Widget>[
+            FocusRing(
+              child: ListTile(title: const Text('row'), onTap: () {}),
+            ),
+            TextButton(onPressed: () {}, child: const Text('after')),
+          ],
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('a keyboard-driven focus draws the ring', (tester) async {
+    await _pump(tester);
+    expect(_ring(tester), isNull, reason: 'nothing is focused yet');
+
+    // Tab is what puts the focus manager into keyboard mode in the first place.
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+
+    final BoxDecoration? ring = _ring(tester);
+    expect(ring, isNotNull);
+    expect(
+      (ring!.border! as Border).top.color,
+      AppTheme.dark(BrandPalettes.classic).colorScheme.secondary,
+      reason: 'focus speaks with the accent, not with hover neutral or the '
+          'identity tint selection uses',
+    );
+    expect((ring.border! as Border).top.width, focusRingWidth);
+  });
+
+  testWidgets('moving on takes the ring with it', (tester) async {
+    await _pump(tester);
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+    expect(_ring(tester), isNotNull);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+
+    expect(find.text('after'), findsOneWidget);
+    expect(_ring(tester), isNull);
+  });
+
+  testWidgets('a touch never draws one', (tester) async {
+    await _pump(tester);
+    // What a phone does: the app is driven by taps, so the focus manager stays
+    // in touch mode and a tap that happens to focus a row must not light it up.
+    FocusManager.instance.highlightStrategy =
+        FocusHighlightStrategy.alwaysTouch;
+    addTearDown(() {
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.automatic;
+    });
+    await tester.pump();
+
+    await tester.tap(find.text('row'));
+    await tester.pumpAndSettle();
+
+    expect(_ring(tester), isNull);
+  });
+
+  testWidgets('the ring is not a stop of its own', (tester) async {
+    await _pump(tester);
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+    expect(find.byType(ListTile), findsOneWidget);
+    final FocusNode? first = FocusManager.instance.primaryFocus;
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+    final FocusNode? second = FocusManager.instance.primaryFocus;
+
+    // Two stops for two controls: the wrapper never inserts a third.
+    expect(first, isNot(second));
+    expect(
+      second?.context?.findAncestorWidgetOfExactType<TextButton>(),
+      isNotNull,
+    );
+  });
+}

--- a/test/shared/focus/list_keyboard_navigation_test.dart
+++ b/test/shared/focus/list_keyboard_navigation_test.dart
@@ -1,0 +1,206 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/shared/focus/list_keyboard_navigation.dart';
+
+/// Home, End, and a grid's row wrap (#390): the collection keys Flutter's
+/// traversal cannot supply, because in a lazily-built list the far end has no
+/// focus node to find until something has scrolled it into range.
+
+String? _focusedLabel() {
+  final BuildContext? context = FocusManager.instance.primaryFocus?.context;
+  if (context == null) return null;
+  final Finder text = find.descendant(
+    of: find.byWidget(context.widget),
+    matching: find.byType(Text),
+  );
+  if (text.evaluate().isEmpty) return null;
+  return (text.evaluate().first.widget as Text).data;
+}
+
+Future<void> _press(WidgetTester tester, LogicalKeyboardKey key) async {
+  await tester.sendKeyEvent(key);
+  // One frame to scroll, one for the rows the scroll built.
+  await tester.pump();
+  await tester.pump();
+}
+
+Future<void> _pumpList(WidgetTester tester, {int count = 200}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          height: 300,
+          child: ListKeyboardNavigation(
+            child: ListView.builder(
+              itemExtent: 50,
+              itemCount: count,
+              itemBuilder: (BuildContext context, int index) =>
+                  ListTile(title: Text('row $index'), onTap: () {}),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// A 4-wide grid, which is what makes a row break something to walk through.
+Future<void> _pumpGrid(WidgetTester tester, {required bool wrapRows}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          height: 300,
+          width: 400,
+          child: ListKeyboardNavigation(
+            wrapRows: wrapRows,
+            child: GridView.builder(
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 4,
+                mainAxisExtent: 100,
+              ),
+              itemCount: 80,
+              itemBuilder: (BuildContext context, int index) => InkWell(
+                onTap: () {},
+                child: Center(child: Text('cell $index')),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('a long list', () {
+    testWidgets('End reaches the last row, which was never built',
+        (tester) async {
+      await _pumpList(tester);
+      Focus.of(tester.element(find.text('row 0'))).requestFocus();
+      await tester.pump();
+      expect(find.text('row 199'), findsNothing);
+
+      await _press(tester, LogicalKeyboardKey.end);
+
+      expect(_focusedLabel(), 'row 199');
+    });
+
+    testWidgets('Home comes back to the first', (tester) async {
+      await _pumpList(tester);
+      Focus.of(tester.element(find.text('row 0'))).requestFocus();
+      await tester.pump();
+      await _press(tester, LogicalKeyboardKey.end);
+      expect(_focusedLabel(), 'row 199');
+
+      await _press(tester, LogicalKeyboardKey.home);
+
+      expect(_focusedLabel(), 'row 0');
+    });
+
+    testWidgets('the arrow keys still walk it row by row', (tester) async {
+      await _pumpList(tester);
+      Focus.of(tester.element(find.text('row 0'))).requestFocus();
+      await tester.pump();
+
+      for (int i = 0; i < 12; i++) {
+        await _press(tester, LogicalKeyboardKey.arrowDown);
+      }
+
+      expect(_focusedLabel(), 'row 12');
+    });
+  });
+
+  group('a grid', () {
+    testWidgets('→ carries on into the next row', (tester) async {
+      await _pumpGrid(tester, wrapRows: true);
+      Focus.of(tester.element(find.text('cell 3'))).requestFocus();
+      await tester.pump();
+
+      await _press(tester, LogicalKeyboardKey.arrowRight);
+
+      expect(_focusedLabel(), 'cell 4');
+    });
+
+    testWidgets('← comes back over the same break', (tester) async {
+      await _pumpGrid(tester, wrapRows: true);
+      Focus.of(tester.element(find.text('cell 4'))).requestFocus();
+      await tester.pump();
+
+      await _press(tester, LogicalKeyboardKey.arrowLeft);
+
+      expect(_focusedLabel(), 'cell 3');
+    });
+
+    testWidgets('→ inside a row is still the plain move', (tester) async {
+      await _pumpGrid(tester, wrapRows: true);
+      Focus.of(tester.element(find.text('cell 1'))).requestFocus();
+      await tester.pump();
+
+      await _press(tester, LogicalKeyboardKey.arrowRight);
+
+      expect(_focusedLabel(), 'cell 2');
+    });
+
+    testWidgets('a column of rows does not wrap', (tester) async {
+      await _pumpGrid(tester, wrapRows: false);
+      Focus.of(tester.element(find.text('cell 3'))).requestFocus();
+      await tester.pump();
+
+      await _press(tester, LogicalKeyboardKey.arrowRight);
+
+      expect(_focusedLabel(), 'cell 3');
+    });
+  });
+
+  testWidgets('typing keeps Home and End', (tester) async {
+    // Home/End only mean "start/end of line" on the desktop bindings, which is
+    // the case this guard exists for.
+    debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+    final TextEditingController controller = TextEditingController(
+      text: 'hello',
+    );
+    addTearDown(controller.dispose);
+    try {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ListKeyboardNavigation(
+              child: ListView(
+                children: <Widget>[
+                  TextField(controller: controller),
+                  for (int i = 0; i < 40; i++)
+                    ListTile(title: Text('row $i'), onTap: () {}),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(TextField));
+      await tester.pumpAndSettle();
+      controller.selection = const TextSelection.collapsed(offset: 5);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.home);
+      await tester.pumpAndSettle();
+
+      // Start of the line, not the top of the list: a search box inside a list
+      // is still a text field first.
+      expect(controller.selection.baseOffset, 0);
+      expect(
+        FocusManager.instance.primaryFocus?.context
+            ?.findAncestorWidgetOfExactType<EditableText>(),
+        isNotNull,
+        reason: 'the keyboard never left the field',
+      );
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+}

--- a/test/shared/widgets/confirm_dialog_test.dart
+++ b/test/shared/widgets/confirm_dialog_test.dart
@@ -99,6 +99,50 @@ void main() {
     expect(Focus.of(tester.element(find.text('Cancel'))).hasFocus, isTrue);
   });
 
+  testWidgets('Tab never escapes the dialog while it is open', (tester) async {
+    await pumpButton(tester, onResult: (_) {});
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    final Set<String> visited = <String>{};
+    for (int i = 0; i < 6; i++) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      final BuildContext? context = FocusManager.instance.primaryFocus?.context;
+      final Finder label = find.descendant(
+        of: find.byWidget(context!.widget),
+        matching: find.byType(Text),
+      );
+      if (label.evaluate().isNotEmpty) {
+        visited.add((label.evaluate().first.widget as Text).data!);
+      }
+    }
+
+    // Only the dialog's own two actions, however long Tab is held: a modal that
+    // leaks focus to the page under it is a keyboard user typing into
+    // something they cannot see.
+    expect(visited, <String>{'Cancel', 'Delete'});
+  });
+
+  testWidgets('closing it puts the keyboard back where it came from',
+      (tester) async {
+    await pumpButton(tester, onResult: (_) {});
+    Focus.of(tester.element(find.text('open'))).requestFocus();
+    await tester.pump();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expect(find.text('Delete 12 files?'), findsOneWidget);
+    expect(Focus.of(tester.element(find.text('Cancel'))).hasFocus, isTrue);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+
+    // Back on the control that opened it, not at the top of the page.
+    expect(find.text('Delete 12 files?'), findsNothing);
+    expect(Focus.of(tester.element(find.text('open'))).hasFocus, isTrue);
+  });
+
   testWidgets('a non-destructive dialog focuses the action instead',
       (tester) async {
     await tester.pumpWidget(


### PR DESCRIPTION
Closes #390

Makes the Linux UI reachable and operable without a pointer. Focus behaviour and navigation only, so configurable shortcuts (#391) and transport bindings (#392) are untouched.

## The rule

Nothing branches on Linux. Every piece keys on the input device or on the box a widget is given, which is the same rule the density, layout and quick-search work already follow. An Android phone is unchanged by construction, and a tablet with a keyboard case gets all of it for free.

## What was actually broken

Auditing the shell first turned up four things, and confirmed a fifth that already worked and only needed pinning down:

- Focus was nearly invisible. Material's default focus overlay is a neutral veil a few percent apart from the hover one and from the selected tint, so all three states said roughly the same thing. On an album card it was worse than that: ink is painted on the `Material` *behind* the card, so the cover hid the highlight entirely.
- Closing a pane dropped the keyboard. The queue column, Now Playing's queue pane and the library detail pane all dispose everything inside them; Flutter unwinds focus to the route's scope, which leaves nothing ringed and sends the next Tab back to the top of the page. A resize that narrowed past a pane's width floor did the same thing to someone who never thought of it as leaving the screen.
- The ends of a long collection were unreachable. In a lazily-built list the far end has no focus node for a traversal policy to find until something has scrolled it into range, so no arrow key gets there.
- A grid stopped at the end of each row instead of carrying on into the next one.
- The arrow keys, Enter/Space, dialog focus trapping and dialog focus restoration all already worked. They are now covered by tests rather than left to chance.

## Shared helpers (`lib/shared/focus/`)

- **`FocusRing`** draws one strong, accent-coloured outline around whatever holds the keyboard. Focus gets its own vocabulary rather than a third veil, and the outline is an overlay, so it is visible on artwork and never shifts the layout it appears on. It takes no focus node: a `Focus` node that cannot be focused itself reports when anything inside holds the keyboard, so it wraps a row, a card or a control without that widget being rewritten. It only draws while the focus manager is in keyboard/mouse mode, which is exactly what keeps it off a touch build without a platform check.
- **`FocusHandoff`** gives the keyboard back when a pane closes, to the control that reopens it. It fires only when the pane really was holding focus, so a pane closing while you are typing elsewhere never yanks it away, and it resolves its target after the pane is gone so a caller can answer with something that only exists once the layout has settled.
- **`ListKeyboardNavigation`** adds Home and End to a list or grid, scrolling first and taking the outermost row at that end on the next frame. The same widget lets the left and right arrows carry on into the neighbouring row of a grid of cards, off by default because in a single column of rows those keys belong to the controls inside a row. A focused text field is left alone outright.
- **`focusableRowsIn`** orders a collection's rows by where they actually are, because focus-tree order drifts as a sliver builds rows, and keeps only the outermost node of each nest so a jump lands on a row rather than on the overflow menu inside it.

## Surfaces

| Surface | What changed |
| --- | --- |
| Theme | One `focusColor` reaches every ink surface at once: list rows, buttons, popup-menu items, the navigation rail's destinations |
| Track rows, artist rows, album cards | Carry the shared ring, so the focused row or card is unmistakable even over a cover |
| Songs list, albums grid, artists grid, queue | Home and End reach both ends; the two grids wrap rows on the left and right arrows |
| Queue column, Now Playing queue pane | Hand focus back to the button that reopens them, whether it was the close button or a resize that took the pane |
| Library detail pane | Hands focus to the list beside it when a resize drops the pane |
| Sidebar, dialogs, provider forms | Already correct; now covered by tests |
| Reorder handle | Draws the shared ring instead of its own |
| Seek bar | Keeps drawing its own ring, because the shared widget would displace the slider semantics a screen reader reads, but takes its width from the shared file so the two cannot drift |

## Tests

`flutter analyze`, `dart format --set-exit-if-changed .` and the full suite (5469 tests) are green locally, and CI is green on this head.

New and extended coverage: forward and backward traversal, Enter and Space activation, arrow movement through a list and a grid, Home and End past the built range, the grid row wrap, dialog focus trapping and restoration, the three pane closures, a provider sign-in form typed end to end, and a touch build behaving exactly as it did before.

## Notes for review

- Making each list a single Tab stop (roving focus) was considered and rejected: it would cost every row's overflow menu its keyboard path, which trades one accessible behaviour for another. Tab keeps walking rows in visual reading order, which is predictable; the arrows and Home/End are what make a long list quick.
- `FocusRing` parks a real focus node, so `Focus.of` called from deep inside a ring answers with that node. Three test helpers reached for a widget's own node that way and now read it where it is created instead. Production code was already doing the right thing.

Docs: `docs/linux-desktop.md` gains a **Keyboard navigation** section and a support-table row.